### PR TITLE
Channels: don't recommend a measurably-worse channel, and prompt a re-scan when scan data is stale

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -133,9 +133,9 @@
                     <div class="alert-info scan-gap-banner">
                         <div class="scan-gap-text">
                             <strong>@_scanGaps.Count @(_scanGaps.Count == 1 ? "radio needs" : "radios need") a scan.</strong>
-                            Their channel congestion is estimated from nearby networks, not measured. @ScanDisruptionNote()
+                            Their channel congestion is estimated from nearby networks, not measured. @ScanDisruptionNote(_scanGaps)
                         </div>
-                        <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@_scanningGaps"
+                        <button class="btn btn-primary btn-sm" @onclick="RunGapScans" disabled="@(_scanningGaps || _scanningStale)"
                                 data-tooltip="Runs a quick RF scan to measure the real airtime and noise floor on these channels, so the recommendations reflect what's actually on the air instead of a guess.">
                             @if (_scanningGaps)
                             {
@@ -151,6 +151,35 @@
                     @if (_scanError is not null)
                     {
                         <div class="alert-danger scan-error-banner">@_scanError</div>
+                    }
+                }
+
+                @* Present-but-stale-AND-material: a re-scan could actually change a recommendation
+                   (a stale, uncorroborated spectrum reading is holding or deciding a channel). Kept
+                   separate from the missing-data gap banner above so that flow is unchanged. *@
+                @if (_staleScanTargets.Count > 0)
+                {
+                    <div class="alert-info scan-gap-banner">
+                        <div class="scan-gap-text">
+                            <strong>@_staleScanTargets.Count @(_staleScanTargets.Count == 1 ? "radio's scan is" : "radios' scans are") aging and affecting a recommendation.</strong>
+                            A stale spectrum reading the neighbor scan no longer backs is steering a channel choice; a fresh scan may change it. @ScanDisruptionNote(_staleScanTargets)
+                        </div>
+                        <button class="btn btn-primary btn-sm" @onclick="RunStaleScans" disabled="@(_scanningGaps || _scanningStale)"
+                                data-tooltip="Re-measures the real airtime and noise floor on these channels. The current recommendation is resting on an older scan that nearby networks no longer corroborate, so a fresh one may change the advice.">
+                            @if (_scanningStale)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                                <span>@ScanProgressLabel()</span>
+                            }
+                            else
+                            {
+                                <span>Re-scan</span>
+                            }
+                        </button>
+                    </div>
+                    @if (_staleScanError is not null)
+                    {
+                        <div class="alert-danger scan-error-banner">@_staleScanError</div>
                     }
                 }
 
@@ -929,6 +958,7 @@
             _showRecommendations = _channelPlans.Count > 0;
             AutoSelectBandWithRecommendations();
             await LoadScanGapsAsync();
+            await LoadStaleScanTargetsAsync();
         }
         finally
         {
@@ -941,6 +971,11 @@
     // per-channel spectrum measurement. A quick-scan fills them.
     private List<SpectrumScanGap> _scanGaps = new();
     private bool _scanningGaps;
+    // (AP, band) pairs that DO have scan data, but it's stale AND load-bearing on the recommendation
+    // (an uncorroborated reading is holding/deciding a channel), so a re-scan could change the advice.
+    private List<SpectrumScanGap> _staleScanTargets = new();
+    private bool _scanningStale;
+    private string? _staleScanError;
     // Progress for the running gap scan: bands started so far, and the total to scan. Drives the
     // "Scanning… X/N bands" label so a multi-minute serial scan reads as working, not hung.
     private int _scanCompletedBands;
@@ -953,14 +988,14 @@
             ? $"Scanning… {Math.Clamp(_scanCompletedBands, 1, _scanTotalBands)}/{_scanTotalBands} bands"
             : "Scanning…";
 
-    // Disruption note tailored to the gapped APs' scan hardware: an AP with a dedicated scan radio
+    // Disruption note tailored to the targets' scan hardware: an AP with a dedicated scan radio
     // measures without touching its serving radios (no client impact); without one, scanning briefly
     // steps the serving radio off-channel and a mesh parent can drop the devices meshed through it.
-    private string ScanDisruptionNote()
+    private static string ScanDisruptionNote(List<SpectrumScanGap> targets)
     {
-        var clean = _scanGaps.Count(g => g.HasDedicatedScanRadio);
-        var disruptive = _scanGaps.Count - clean;
-        var meshNote = _scanGaps.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
+        var clean = targets.Count(g => g.HasDedicatedScanRadio);
+        var disruptive = targets.Count - clean;
+        var meshNote = targets.Any(g => g.IsMeshParent && !g.HasDedicatedScanRadio)
             ? " (and devices meshed through an AP)" : "";
 
         if (disruptive == 0)
@@ -977,6 +1012,20 @@
         catch
         {
             _scanGaps = new();
+        }
+    }
+
+    // Stale-and-material targets are derived from the already-computed plan, so this is called right
+    // after each recommendation load (never blocks or alters the gap flow above).
+    private async Task LoadStaleScanTargetsAsync()
+    {
+        try
+        {
+            _staleScanTargets = await WiFiService.GetStaleScanTargetsAsync(_channelPlans);
+        }
+        catch
+        {
+            _staleScanTargets = new();
         }
     }
 
@@ -1005,6 +1054,7 @@
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };
             _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
             await LoadScanGapsAsync();
+            await LoadStaleScanTargetsAsync();
         }
         catch (ScanPermissionException ex)
         {
@@ -1013,6 +1063,42 @@
         finally
         {
             _scanningGaps = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task RunStaleScans()
+    {
+        if (_scanningGaps || _scanningStale || _staleScanTargets.Count == 0) return;
+
+        _scanningStale = true;
+        _staleScanError = null;
+        _scanCompletedBands = 0;
+        _scanTotalBands = _staleScanTargets.Count; // one band scan per stale (AP, band)
+        StateHasChanged();
+        try
+        {
+            var targets = _staleScanTargets.Select(g => (g.ApMac, g.BandCode)).ToList();
+            var progress = new Progress<int>(n =>
+            {
+                _scanCompletedBands = Math.Max(_scanCompletedBands, n);
+                InvokeAsync(StateHasChanged);
+            });
+            await WiFiService.RunQuickScansAsync(targets, progress);
+
+            // Re-run recommendations on the fresh spectrum data, then re-evaluate both banners.
+            var options = new RecommendationOptions { DfsPreference = _dfsPreference };
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+            await LoadScanGapsAsync();
+            await LoadStaleScanTargetsAsync();
+        }
+        catch (ScanPermissionException ex)
+        {
+            _staleScanError = ex.Message;
+        }
+        finally
+        {
+            _scanningStale = false;
             StateHasChanged();
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -161,8 +161,8 @@
                 {
                     <div class="alert-info scan-gap-banner">
                         <div class="scan-gap-text">
-                            <strong>@_staleScanTargets.Count @(_staleScanTargets.Count == 1 ? "radio's scan is" : "radios' scans are") aging and affecting a recommendation.</strong>
-                            A stale spectrum reading the neighbor scan no longer backs is steering a channel choice; a fresh scan may change it. @ScanDisruptionNote(_staleScanTargets)
+                            <strong>@_staleScanTargets.Count @(_staleScanTargets.Count == 1 ? "radio has" : "radios have") stale scan data.</strong>
+                            Their recommendation is based on an old reading that may no longer reflect what's on the air. @ScanDisruptionNote(_staleScanTargets)
                         </div>
                         <button class="btn btn-primary btn-sm" @onclick="RunStaleScans" disabled="@(_scanningGaps || _scanningStale)"
                                 data-tooltip="Re-measures the real airtime and noise floor on these channels. The current recommendation is resting on an older scan that nearby networks no longer corroborate, so a fresh one may change the advice.">

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -663,6 +663,44 @@ public class WiFiOptimizerService
             .ToList();
     }
 
+    /// <summary>
+    /// (AP, band) pairs whose recommendation is being driven or held by a STALE, uncorroborated
+    /// spectrum-scan reading (see <see cref="ApChannelRecommendation.ScanRescanRecommended"/>), so a
+    /// fresh quick-scan could actually change the answer. Distinct from
+    /// <see cref="GetSpectrumScanGapsAsync"/>, which surfaces (AP, band) with NO scan data at all; this
+    /// is present-but-aging-AND-material. Derived from an already-computed plan set, so it only costs
+    /// one AP fetch for the scan-hardware enrichment, not a second recommendation pass. Mesh children
+    /// are excluded - they can't quick-scan without dropping their uplink.
+    /// </summary>
+    public async Task<List<SpectrumScanGap>> GetStaleScanTargetsAsync(
+        IReadOnlyDictionary<RadioBand, ChannelPlan> plans)
+    {
+        var flagged = plans.Values
+            .SelectMany(p => p.Recommendations)
+            .Where(r => r.ScanRescanRecommended)
+            .ToList();
+        if (flagged.Count == 0) return new();
+
+        var provider = CreateProvider();
+        var aps = await provider.GetAccessPointsAsync();
+        var apByMac = aps.ToDictionary(a => a.Mac, StringComparer.OrdinalIgnoreCase);
+        var meshChildMacs = aps.Where(a => a.IsMeshChild)
+            .Select(a => a.Mac)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        return flagged
+            .Where(r => !meshChildMacs.Contains(r.ApMac))
+            .Select(r =>
+            {
+                apByMac.TryGetValue(r.ApMac, out var ap);
+                var hasScanRadio = ap?.HasDedicatedScanRadio ?? false;
+                var isMeshParent = (ap?.MeshChildren.Count ?? 0) > 0;
+                return new SpectrumScanGap(
+                    r.ApMac, r.ApName, r.Band, r.Band.ToUniFiCode(), hasScanRadio, isMeshParent);
+            })
+            .ToList();
+    }
+
     private const int QuickScanPollIntervalSeconds = 3;
     private const int QuickScanPerBandTimeoutSeconds = 150;
 

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -855,6 +855,7 @@ public class WiFiOptimizerService
                     ApName = scan.ApName,
                     Band = scan.Band,
                     ScanTime = scan.ScanTime,
+                    SpectrumTableTime = scan.SpectrumTableTime,
                     Channels = scan.Channels,
                     Neighbors = neighbors
                 });

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -309,6 +309,7 @@ public static class ChannelMemoryHelper
                 ApName = scan.ApName,
                 Band = scan.Band,
                 ScanTime = scan.ScanTime,
+                SpectrumTableTime = scan.SpectrumTableTime,
                 Channels = scan.Channels,
                 Neighbors = scan.Neighbors.Concat(added).ToList()
             });

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -52,6 +52,27 @@ public class ApChannelRecommendation
 
     /// <summary>True when soak suppression narrowed this AP's candidate channels.</summary>
     public bool IsSoaking => SoakSuppressedChannels.Count > 0;
+
+    /// <summary>
+    /// When this AP's per-channel spectrum scan for this band was taken (UniFi
+    /// <c>spectrum_table_time</c>), or null when unknown. Drives the "how stale is the scan" display
+    /// and the <see cref="ScanRescanRecommended"/> gate.
+    /// </summary>
+    public DateTimeOffset? SpectrumScanTime { get; set; }
+
+    /// <summary>
+    /// True when the recommendation is being driven or held by a STALE, uncorroborated spectrum-scan
+    /// reading, so a fresh quick-scan could actually change the answer: the scan is older than the
+    /// staleness threshold, its noise-floor/utilization term is load-bearing (the measured-worse guard
+    /// held this AP on its noise-floor arm, or the scan term was decisive for the pick), and the
+    /// fresher neighbor scan no longer corroborates it. Deliberately NOT set for corroborated or
+    /// interference-arm holds - a re-scan wouldn't change those, so we don't nag. Distinct from a scan
+    /// GAP (no data at all); see <c>WiFiOptimizerService.GetStaleScanTargetsAsync</c>.
+    /// </summary>
+    public bool ScanRescanRecommended { get; set; }
+
+    /// <summary>Short human explanation for <see cref="ScanRescanRecommended"/>, for a UI tooltip.</summary>
+    public string? ScanRescanReason { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -221,6 +221,14 @@ public class ApNode
     /// </summary>
     public Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>? PropagatedStress { get; set; }
 
+    /// <summary>
+    /// When this AP's per-channel spectrum scan for this band was actually taken (UniFi
+    /// <c>spectrum_table_time</c>), or null when unknown. Diagnostics only: lets the engine log how
+    /// stale the measured airtime/noise-floor data feeding a recommendation (or a measured-worse
+    /// hold) is. Never read by scoring.
+    /// </summary>
+    public DateTimeOffset? SpectrumScanTime { get; set; }
+
     /// <summary>Index of this AP's mesh group leader, or -1 if not in a mesh group</summary>
     public int MeshGroupLeader { get; set; } = -1;
 

--- a/src/NetworkOptimizer.WiFi/Models/ChannelScanResult.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelScanResult.cs
@@ -14,8 +14,19 @@ public class ChannelScanResult
     /// <summary>Radio band scanned</summary>
     public RadioBand Band { get; set; }
 
-    /// <summary>When the scan was performed</summary>
+    /// <summary>When we FETCHED this scan (not when the radio measured it).</summary>
     public DateTimeOffset ScanTime { get; set; }
+
+    /// <summary>
+    /// When the AP's per-channel spectrum scan was actually TAKEN, from UniFi's
+    /// <c>spectrum_table_time</c>. This is the true age of the measured airtime/noise-floor data in
+    /// <see cref="Channels"/> - distinct from <see cref="ScanTime"/> (our fetch moment), which stays
+    /// "now" even when the underlying scan is hours old. Null when the controller reported no
+    /// timestamp or the band was never scanned. Diagnostics only today (how stale the scan feeding a
+    /// recommendation is); the neighbor (rogue) sighting recency lives on
+    /// <see cref="NeighborNetwork.LastSeen"/> instead.
+    /// </summary>
+    public DateTimeOffset? SpectrumTableTime { get; set; }
 
     /// <summary>Per-channel scan data</summary>
     public List<ChannelInfo> Channels { get; set; } = new();

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -807,6 +807,11 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                 // spectrum-scan endpoint (the populated source); fall back to scan_radio_table.
                 var scanRadio = spectrumScan?.Scans?.FirstOrDefault(sr => sr.Radio == bandCode)
                     ?? ap.ScanRadioTable?.FirstOrDefault(sr => sr.Radio == bandCode);
+
+                // True age of the scan (when the radio measured it), distinct from our fetch time.
+                if (scanRadio?.SpectrumTableTime is long stt && stt > 0)
+                    result.SpectrumTableTime = DateTimeOffset.FromUnixTimeSeconds(stt);
+
                 if (scanRadio?.SpectrumTable != null)
                 {
                     foreach (var spectrum in scanRadio.SpectrumTable)

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -3297,6 +3297,16 @@ public class ChannelRecommendationService
                 continue;
             }
 
+            // A mesh child's channel is dictated by its leader, and the stale-target service excludes
+            // it (it can't be re-scanned without dropping its uplink), so the decisive/re-scan analysis
+            // doesn't apply - and its per-channel trials get reset by ApplyMeshConstraints anyway, which
+            // would make the "decisive" verdict meaningless. Skip it.
+            if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i)
+            {
+                sb?.AppendLine($"  {node.Name} (scan {age}): mesh child, follows leader");
+                continue;
+            }
+
             // General case: only stale APs can be prompt-material, so skip the decisive check's cost
             // for fresh scans unless debug wants the full breakdown.
             if (!stale && !debug) continue;

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -197,6 +197,15 @@ public class ChannelRecommendationService
     private const double MeasurablyWorseInterferencePct = 5.0;
 
     /// <summary>
+    /// Scan-materiality diagnostics: minimum pooled external-neighbor weight on a channel for its
+    /// elevated noise floor to count as "corroborated" by the (fresher) neighbor scan. Below this, a
+    /// loud floor with no Wi-Fi neighbors to explain it is EITHER a stale spectrum reading OR genuine
+    /// non-Wi-Fi energy (radar, microwave) - the log flags it "uncorroborated" so we can tell the two
+    /// apart on live sites. Diagnostic threshold only; never gates a recommendation.
+    /// </summary>
+    private const double CorroborationMinExternalWeight = 1.0;
+
+    /// <summary>
     /// Converts a measured channel occupancy percentage (0-100) to the per-AP score scale used by
     /// the absolute gates, for the measured-congestion floor (#2). Anchored to those gates rather
     /// than to the (over-stated) external proxy: ~40% airtime lands near <see cref="MinApScoreToMove"/>
@@ -1265,6 +1274,10 @@ public class ChannelRecommendationService
         // badness gates (see the guard constants) keep it inert on clean bands, where 5/6 GHz moves
         // between two quiet channels are the norm - it engages only when a real interferer or genuinely
         // high airtime sits on the destination, where suppressing the move is correct on any band.
+        // Records each AP the guard held and why (rejected channel + which arm tripped), for the
+        // scan-materiality diagnostics logged at the end - a guard hold is the strongest signal that
+        // a possibly-stale scan is load-bearing in the plan.
+        var measuredWorseHolds = new Dictionary<int, (int RejectedChannel, MeasuredWorseReason Reason)>();
         bool worseReverted;
         do
         {
@@ -1277,7 +1290,7 @@ public class ChannelRecommendationService
                     continue;
                 if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
                 if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
-                if (!IsRecommendedChannelMeasurablyWorse(graph, band, i, rec.RecommendedChannel, rec.RecommendedWidth))
+                if (EvaluateMeasuredWorse(graph, band, i, rec.RecommendedChannel, rec.RecommendedWidth) is not { } worse)
                     continue;
 
                 // Same internal-benefit escape as the comfort anchor: a move that genuinely unsticks a
@@ -1296,12 +1309,14 @@ public class ChannelRecommendationService
                 }
                 if (othersReverted - othersWithMove >= MinApAbsoluteImprovement) continue;
 
+                var rejectedChannel = rec.RecommendedChannel;
                 _logger.LogDebug(
                     "[ChannelRec] Measured-worse guard: keeping {ApName} on ch{Cur} (proposed ch{Rec} " +
-                    "measures worse at this AP - louder noise floor or more external airtime - and " +
-                    "didn't reduce co-channel interference to our own APs)",
-                    node.Name, node.CurrentChannel, rec.RecommendedChannel);
+                    "measures worse at this AP [{Arms}] - and didn't reduce co-channel interference to " +
+                    "our own APs)",
+                    node.Name, node.CurrentChannel, rejectedChannel, DescribeMeasuredWorseArms(worse));
 
+                measuredWorseHolds[i] = (rejectedChannel, worse);
                 rec.RecommendedChannel = node.CurrentChannel;
                 rec.RecommendedWidth = node.CurrentWidth;
                 finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
@@ -1377,6 +1392,12 @@ public class ChannelRecommendationService
 
         // Log final recommendation summary
         LogRecommendationSummary(plan, currentAssignment, bestAssignment);
+
+        // Diagnostics: how stale each AP's scan is, and whether that staleness could matter - the scan
+        // term was decisive for the recommendation, or a measured-worse hold is resting on it, plus
+        // whether the neighbor scan still corroborates it. Lets us see on live sites how often "old"
+        // coincides with "material" before designing a staleness-driven re-scan prompt.
+        LogScanMateriality(graph, band, finalAssignment, measuredWorseHolds);
 
         return plan;
     }
@@ -1653,10 +1674,11 @@ public class ChannelRecommendationService
     /// </list>
     /// The absolute gates keep the guard from blocking a move between two clean channels - the common
     /// 5/6 GHz case, where floors sit far below the elevated threshold and interference in the low
-    /// single digits. Returns false when neither channel has the needed measurement (nothing to
-    /// compare - let the move stand).
+    /// single digits. Returns null when neither arm trips (nothing measurably worse - let the move
+    /// stand); otherwise a <see cref="MeasuredWorseReason"/> naming the arm(s) and the compared values,
+    /// so the caller can both act on it and log why (feeding the scan-materiality diagnostics).
     /// </summary>
-    private bool IsRecommendedChannelMeasurablyWorse(
+    private MeasuredWorseReason? EvaluateMeasuredWorse(
         InterferenceGraph graph, RadioBand band, int apIndex, int recChannel, int recWidth)
     {
         var node = graph.Nodes[apIndex];
@@ -1665,20 +1687,33 @@ public class ChannelRecommendationService
         // Higher (less negative) dBm = louder = worse.
         var curNf = ScanOverSpan(graph, band, apIndex, node.CurrentChannel, node.CurrentWidth)?.NoiseFloor;
         var recNf = ScanOverSpan(graph, band, apIndex, recChannel, recWidth)?.NoiseFloor;
-        if (curNf is int cnf && recNf is int rnf &&
+        var noiseFloorArm = curNf is int cnf && recNf is int rnf &&
             rnf >= ElevatedNoiseFloorDbm &&
-            rnf - cnf >= MeasurablyWorseNoiseFloorMarginDb)
-            return true;
+            rnf - cnf >= MeasurablyWorseNoiseFloorMarginDb;
 
         // Interference arm: measured external-network airtime, current vs candidate.
-        if (TryGetMeasuredInterference(node, band, node.CurrentChannel, out var curInt) &&
-            TryGetMeasuredInterference(node, band, recChannel, out var recInt) &&
-            recInt >= ComfortableInterferencePct &&
-            recInt - curInt >= MeasurablyWorseInterferencePct)
-            return true;
+        double? curInt = TryGetMeasuredInterference(node, band, node.CurrentChannel, out var ci) ? ci : null;
+        double? recInt = TryGetMeasuredInterference(node, band, recChannel, out var ri) ? ri : null;
+        var interferenceArm = curInt is double c && recInt is double r &&
+            r >= ComfortableInterferencePct &&
+            r - c >= MeasurablyWorseInterferencePct;
 
-        return false;
+        if (!noiseFloorArm && !interferenceArm) return null;
+        return new MeasuredWorseReason(noiseFloorArm, interferenceArm, curNf, recNf, curInt, recInt);
     }
+
+    /// <summary>
+    /// Why the measured-worse guard considers a candidate channel worse than the AP's current one:
+    /// which arm(s) tripped, and the values compared. Carried out of <see cref="EvaluateMeasuredWorse"/>
+    /// so the hold can be logged with its rationale (scan-materiality diagnostics).
+    /// </summary>
+    private readonly record struct MeasuredWorseReason(
+        bool NoiseFloorArm,
+        bool InterferenceArm,
+        int? CurrentNoiseFloor,
+        int? RecommendedNoiseFloor,
+        double? CurrentInterferencePct,
+        double? RecommendedInterferencePct);
 
     /// <summary>
     /// Measured external interference (%) for a channel at this AP, preferring ground-truth measured
@@ -2462,6 +2497,11 @@ public class ChannelRecommendationService
             if (!macToIndex.TryGetValue(scan.ApMac, out var apIndex))
                 continue;
 
+            // Record the scan's true age for diagnostics (keep the freshest if several map here).
+            if (scan.SpectrumTableTime is { } stt &&
+                (graph.Nodes[apIndex].SpectrumScanTime is not { } existing || stt > existing))
+                graph.Nodes[apIndex].SpectrumScanTime = stt;
+
             foreach (var chInfo in scan.Channels)
             {
                 if (chInfo.Utilization.HasValue || chInfo.NoiseFloor.HasValue)
@@ -3054,19 +3094,21 @@ public class ChannelRecommendationService
             sb.AppendLine($"    {graph.Nodes[i].Name}: {string.Join(", ", loads)}");
         }
 
-        // Scan channel data per AP
+        // Scan channel data per AP (with the scan's true age, so a stale reading is visible here).
+        var scanNow = DateTimeOffset.UtcNow;
         sb.AppendLine("  Scan channel metrics (utilization / noise floor):");
         for (int i = 0; i < n; i++)
         {
+            var scanAge = FormatScanAge(graph.Nodes[i].SpectrumScanTime, scanNow);
             if (graph.ScanChannelData[i].Count == 0)
             {
-                sb.AppendLine($"    {graph.Nodes[i].Name}: (no scan channel data)");
+                sb.AppendLine($"    {graph.Nodes[i].Name} ({scanAge}): (no scan channel data)");
                 continue;
             }
             var metrics = graph.ScanChannelData[i]
                 .OrderBy(kv => kv.Key.Channel).ThenBy(kv => kv.Key.Width)
                 .Select(kv => $"ch{kv.Key.Channel}/{kv.Key.Width}=util:{kv.Value.Utilization}%/nf:{(kv.Value.NoiseFloor.HasValue ? kv.Value.NoiseFloor + "dBm" : "n/a")}");
-            sb.AppendLine($"    {graph.Nodes[i].Name}: {string.Join(", ", metrics)}");
+            sb.AppendLine($"    {graph.Nodes[i].Name} ({scanAge}): {string.Join(", ", metrics)}");
         }
 
         // Mesh constraints
@@ -3185,5 +3227,124 @@ public class ChannelRecommendationService
         }
 
         _logger.LogDebug("{RecommendationSummary}", sb.ToString());
+    }
+
+    /// <summary>
+    /// Diagnostics for the scan-staleness question: for each AP, log how old its spectrum scan is and
+    /// whether that age could MATTER - either the guard held it off a channel using scan data
+    /// (strongest signal), or the scan term was decisive in picking its recommended channel - together
+    /// with whether the fresher neighbor scan still corroborates the reading. Debug-gated so the extra
+    /// scoring never runs in production with debug off. This is instrumentation to gather real
+    /// materiality data before we design a staleness-driven re-scan prompt; it changes no decisions.
+    /// </summary>
+    private void LogScanMateriality(
+        InterferenceGraph graph,
+        RadioBand band,
+        (int Channel, int Width)[] finalAssignment,
+        IReadOnlyDictionary<int, (int RejectedChannel, MeasuredWorseReason Reason)> measuredWorseHolds)
+    {
+        if (!_logger.IsEnabled(LogLevel.Debug)) return;
+        var n = graph.Nodes.Count;
+        if (n == 0) return;
+
+        var now = DateTimeOffset.UtcNow;
+        var sb = new StringBuilder();
+        sb.AppendLine($"[ChannelRec] === SCAN MATERIALITY ({band}) ===");
+
+        for (int i = 0; i < n; i++)
+        {
+            var node = graph.Nodes[i];
+            var age = FormatScanAge(node.SpectrumScanTime, now);
+
+            // Held-by-guard case: the scan (or measured interference) is directly load-bearing.
+            if (measuredWorseHolds.TryGetValue(i, out var hold))
+            {
+                var (rejectedCh, reason) = hold;
+                var ext = ExternalNeighborWeightOn(graph, band, i, rejectedCh, node.CurrentWidth);
+                var corroborated = ext >= CorroborationMinExternalWeight ? "CORROBORATED" : "UNCORROBORATED";
+                sb.AppendLine(
+                    $"  {node.Name} (scan {age}): HELD off ch{rejectedCh} by measured-worse guard " +
+                    $"[{DescribeMeasuredWorseArms(reason)}]; ch{rejectedCh} floor {corroborated} by neighbors (ext={ext:F2})");
+                continue;
+            }
+
+            // General case: is the scan term what tips this AP's recommended channel over its best
+            // alternative? Strip the scan term from both and see whether the ranking flips.
+            var recCh = finalAssignment[i].Channel;
+            var recWidth = finalAssignment[i].Width;
+            var recTotal = ScoreAp(graph, finalAssignment, i, band);
+            var recScan = ComputeScanScore(graph, band, i, recCh, recWidth);
+
+            int altCh = -1;
+            double altTotal = double.MaxValue, altScan = 0;
+            foreach (var ch in node.ValidChannels)
+            {
+                if (ch == recCh) continue;
+                var trial = ((int Channel, int Width)[])finalAssignment.Clone();
+                trial[i] = (ch, recWidth);
+                ApplyMeshConstraints(graph, trial);
+                var t = ScoreAp(graph, trial, i, band);
+                if (t < altTotal) { altTotal = t; altCh = ch; altScan = ComputeScanScore(graph, band, i, ch, recWidth); }
+            }
+
+            var ago = ExternalNeighborWeightOn(graph, band, i, recCh, recWidth);
+            if (altCh < 0)
+            {
+                sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, no alternative channel");
+                continue;
+            }
+
+            // Decisive = rec currently wins, but with the scan term removed the alternative would.
+            var decisive = recTotal <= altTotal && (recTotal - recScan) > (altTotal - altScan);
+            var verdict = decisive
+                ? $"scan term DECISIVE over alt ch{altCh} (ch{recCh} {recTotal:F2} vs ch{altCh} {altTotal:F2}; without scan the alt wins)"
+                : $"scan term not decisive (best alt ch{altCh})";
+            sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, {verdict}; ch{recCh} ext={ago:F2}");
+        }
+
+        _logger.LogDebug("{ScanMateriality}", sb.ToString());
+    }
+
+    /// <summary>Short human label for which measured-worse arm(s) tripped, with the compared values.</summary>
+    private static string DescribeMeasuredWorseArms(MeasuredWorseReason r)
+    {
+        var parts = new List<string>(2);
+        if (r.NoiseFloorArm)
+            parts.Add($"noise-floor {r.RecommendedNoiseFloor}dBm vs {r.CurrentNoiseFloor}dBm");
+        if (r.InterferenceArm)
+            parts.Add($"interference {r.RecommendedInterferencePct:F0}% vs {r.CurrentInterferencePct:F0}%");
+        return parts.Count > 0 ? string.Join("; ", parts) : "no arm";
+    }
+
+    /// <summary>The scan-derived score term (utilization + noise floor, band-weighted) an AP would carry
+    /// on a channel - the same computation <see cref="ScoreAp"/> adds, isolated so materiality can strip it.</summary>
+    private double ComputeScanScore(InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        var bandStress = GetBandStressMultiplier(band);
+        if (ScanReadingForScoring(graph, band, apIndex, channel, width) is { } s)
+            return s.Utilization * ScanUtilizationWeight * bandStress + ScanNoiseFloorPenalty(s.NoiseFloor) * bandStress;
+        return 0;
+    }
+
+    /// <summary>Total pooled external-neighbor weight overlapping a channel span, for corroboration checks.</summary>
+    private double ExternalNeighborWeightOn(InterferenceGraph graph, RadioBand band, int apIndex, int channel, int width)
+    {
+        var span = ChannelSpanHelper.GetChannelSpan(band, channel, width);
+        double w = 0;
+        foreach (var (extSpan, extWeight) in ExternalContributors(graph, band, apIndex))
+            if (ChannelSpanHelper.SpansOverlap(span, extSpan))
+                w += extWeight;
+        return w;
+    }
+
+    /// <summary>Human-readable age of a scan timestamp relative to now, for debug logs.</summary>
+    private static string FormatScanAge(DateTimeOffset? scanTime, DateTimeOffset now)
+    {
+        if (scanTime is not { } t) return "age unknown";
+        var age = now - t;
+        if (age < TimeSpan.Zero) return "just now";
+        if (age.TotalMinutes < 90) return $"{age.TotalMinutes:F0}m old";
+        if (age.TotalHours < 48) return $"{age.TotalHours:F1}h old";
+        return $"{age.TotalDays:F1}d old";
     }
 }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -169,6 +169,34 @@ public class ChannelRecommendationService
     private const double ComfortableInterferencePct = 20.0;
 
     /// <summary>
+    /// Measured-worse guard: minimum dB by which a candidate channel's spectrum-scan noise floor must
+    /// exceed (be louder than) the AP's current channel's before the channel counts as measurably
+    /// worse on the noise-floor signal. A margin, not a hair-trigger - small floor wobble between two
+    /// otherwise-fine channels shouldn't hold an AP put. Noise floor is ambient RF (not the AP's own
+    /// traffic), so the AP's own read of both channels is directly comparable. Tunable.
+    /// </summary>
+    private const double MeasurablyWorseNoiseFloorMarginDb = 6.0;
+
+    /// <summary>
+    /// Measured-worse guard: a candidate channel's noise floor only counts as "worse" when it is at
+    /// least this loud in absolute terms - i.e. a real interferer is present, not two quiet floors a
+    /// few dB apart. Keeps the guard from blocking a move between two clean channels (common on 5/6
+    /// GHz), where floors sit far below this. -70 dBm is well above a clean floor (~-90) yet only
+    /// reached when a genuine emitter occupies the channel. Tunable.
+    /// </summary>
+    private const double ElevatedNoiseFloorDbm = -70.0;
+
+    /// <summary>
+    /// Measured-worse guard: minimum percentage-point margin by which a candidate channel's measured
+    /// external interference must exceed the AP's current channel's to count as measurably worse on the
+    /// interference signal. Paired with an absolute floor of <see cref="ComfortableInterferencePct"/>
+    /// on the candidate, so the destination must be both meaningfully worse AND genuinely
+    /// not-comfortable - never trips on the low-single-digit interference typical of clean 5/6 GHz
+    /// bands. Tunable.
+    /// </summary>
+    private const double MeasurablyWorseInterferencePct = 5.0;
+
+    /// <summary>
     /// Converts a measured channel occupancy percentage (0-100) to the per-AP score scale used by
     /// the absolute gates, for the measured-congestion floor (#2). Anchored to those gates rather
     /// than to the (over-stated) external proxy: ~40% airtime lands near <see cref="MinApScoreToMove"/>
@@ -1224,6 +1252,64 @@ public class ChannelRecommendationService
             }
         } while (comfortReverted);
 
+        // Measured "don't move onto a worse channel" guard. The external neighbor-scan proxy dominates
+        // the score (~15-30) over every measured signal (~1-2), so it can steer an AP onto a channel
+        // the AP's OWN radio measures as worse: fewer beaconing BSSIDs there, yet a louder noise floor
+        // and/or more external-network airtime (the exact ch6->ch11 case where a -37 dBm interferer sat
+        // on the "quieter" channel). Reject such a move when it buys no co-channel relief for our own
+        // APs. Ground-truth only, at the AP's own vantage - spectrum-scan noise floor (ambient RF, not
+        // the AP's own traffic) and time-averaged external interference - and only ever HOLDS an AP
+        // put, so it can never create new churn. It complements the comfort anchor above: that fires
+        // only when the CURRENT channel is already quiet (< ComfortableInterferencePct); this fires
+        // whenever the DESTINATION measures worse, even from a middling current channel. Absolute
+        // badness gates (see the guard constants) keep it inert on clean bands, where 5/6 GHz moves
+        // between two quiet channels are the norm - it engages only when a real interferer or genuinely
+        // high airtime sits on the destination, where suppressing the move is correct on any band.
+        bool worseReverted;
+        do
+        {
+            worseReverted = false;
+            for (int i = 0; i < n; i++)
+            {
+                var node = graph.Nodes[i];
+                var rec = plan.Recommendations[i];
+                if (rec.RecommendedChannel == node.CurrentChannel && rec.RecommendedWidth == node.CurrentWidth)
+                    continue;
+                if (node.MeshGroupLeader >= 0 && node.MeshGroupLeader != i) continue;
+                if (!node.ValidChannels.Contains(node.CurrentChannel)) continue;
+                if (!IsRecommendedChannelMeasurablyWorse(graph, band, i, rec.RecommendedChannel, rec.RecommendedWidth))
+                    continue;
+
+                // Same internal-benefit escape as the comfort anchor: a move that genuinely unsticks a
+                // co-channel pair among our OWN always-on APs still goes through despite the louder
+                // ambient reading - resolving our own permanent collision can outweigh a strong neighbor.
+                var revertTrial = ((int Channel, int Width)[])finalAssignment.Clone();
+                revertTrial[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, revertTrial);
+
+                double othersWithMove = 0, othersReverted = 0;
+                for (int j = 0; j < n; j++)
+                {
+                    if (j == i) continue;
+                    othersWithMove += ScoreAp(graph, finalAssignment, j, band);
+                    othersReverted += ScoreAp(graph, revertTrial, j, band);
+                }
+                if (othersReverted - othersWithMove >= MinApAbsoluteImprovement) continue;
+
+                _logger.LogDebug(
+                    "[ChannelRec] Measured-worse guard: keeping {ApName} on ch{Cur} (proposed ch{Rec} " +
+                    "measures worse at this AP - louder noise floor or more external airtime - and " +
+                    "didn't reduce co-channel interference to our own APs)",
+                    node.Name, node.CurrentChannel, rec.RecommendedChannel);
+
+                rec.RecommendedChannel = node.CurrentChannel;
+                rec.RecommendedWidth = node.CurrentWidth;
+                finalAssignment[i] = (node.CurrentChannel, node.CurrentWidth);
+                ApplyMeshConstraints(graph, finalAssignment);
+                worseReverted = true;
+            }
+        } while (worseReverted);
+
         // Sync mesh children to their leader's final channel. The leader may have moved or
         // been reverted during reconciliation; the child must mirror wherever it landed so the
         // displayed plan is physically valid (a backhaul pair shares one channel) and the
@@ -1547,6 +1633,80 @@ public class ChannelRecommendationService
             if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
                 return stress.Interference < ComfortableInterferencePct;
         }
+        return false;
+    }
+
+    /// <summary>
+    /// Whether a proposed channel measures WORSE than the AP's current channel at the AP's own
+    /// location, on ground-truth signals the dominant neighbor-scan proxy ignores. Two independent
+    /// arms, either of which trips the guard:
+    /// <list type="bullet">
+    /// <item>Spectrum-scan noise floor: the candidate's floor is at least
+    /// <see cref="MeasurablyWorseNoiseFloorMarginDb"/> dB louder than the current channel's AND itself
+    /// above <see cref="ElevatedNoiseFloorDbm"/> (a real interferer present, not two quiet floors).
+    /// Noise floor is ambient RF, not the AP's own traffic, so the AP's own read of BOTH channels is
+    /// directly comparable.</item>
+    /// <item>Measured external interference (time-averaged, from measured history or, failing that, the
+    /// neighbor-propagated estimate the scorer already uses): the candidate exceeds the current channel
+    /// by at least <see cref="MeasurablyWorseInterferencePct"/> points AND is itself at or above
+    /// <see cref="ComfortableInterferencePct"/> (the destination is genuinely not comfortable).</item>
+    /// </list>
+    /// The absolute gates keep the guard from blocking a move between two clean channels - the common
+    /// 5/6 GHz case, where floors sit far below the elevated threshold and interference in the low
+    /// single digits. Returns false when neither channel has the needed measurement (nothing to
+    /// compare - let the move stand).
+    /// </summary>
+    private bool IsRecommendedChannelMeasurablyWorse(
+        InterferenceGraph graph, RadioBand band, int apIndex, int recChannel, int recWidth)
+    {
+        var node = graph.Nodes[apIndex];
+
+        // Noise-floor arm: the AP's OWN scan of each channel (ambient, uncontaminated by own traffic).
+        // Higher (less negative) dBm = louder = worse.
+        var curNf = ScanOverSpan(graph, band, apIndex, node.CurrentChannel, node.CurrentWidth)?.NoiseFloor;
+        var recNf = ScanOverSpan(graph, band, apIndex, recChannel, recWidth)?.NoiseFloor;
+        if (curNf is int cnf && recNf is int rnf &&
+            rnf >= ElevatedNoiseFloorDbm &&
+            rnf - cnf >= MeasurablyWorseNoiseFloorMarginDb)
+            return true;
+
+        // Interference arm: measured external-network airtime, current vs candidate.
+        if (TryGetMeasuredInterference(node, band, node.CurrentChannel, out var curInt) &&
+            TryGetMeasuredInterference(node, band, recChannel, out var recInt) &&
+            recInt >= ComfortableInterferencePct &&
+            recInt - curInt >= MeasurablyWorseInterferencePct)
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Measured external interference (%) for a channel at this AP, preferring ground-truth measured
+    /// history and falling back to the neighbor-propagated estimate (the same effective source
+    /// <see cref="ComputeStressPenalty"/> scores) for a channel the AP never occupied. Returns false
+    /// when neither has an overlapping entry.
+    /// </summary>
+    private static bool TryGetMeasuredInterference(ApNode node, RadioBand band, int channel, out double interferencePct)
+    {
+        interferencePct = 0;
+        var span = ChannelSpanHelper.GetChannelSpan(band, channel, node.CurrentWidth);
+
+        if (node.HistoricalStress != null)
+            foreach (var (ch, stress) in node.HistoricalStress)
+                if (ChannelSpanHelper.SpansOverlap(span, ChannelSpanHelper.GetChannelSpan(band, ch, node.CurrentWidth)))
+                {
+                    interferencePct = stress.Interference;
+                    return true;
+                }
+
+        if (node.PropagatedStress != null)
+            foreach (var (ch, stress) in node.PropagatedStress)
+                if (ChannelSpanHelper.SpansOverlap(span, ChannelSpanHelper.GetChannelSpan(band, ch, node.CurrentWidth)))
+                {
+                    interferencePct = stress.Interference;
+                    return true;
+                }
+
         return false;
     }
 

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -206,6 +206,16 @@ public class ChannelRecommendationService
     private const double CorroborationMinExternalWeight = 1.0;
 
     /// <summary>
+    /// How old a spectrum scan must be before a re-scan is worth SUGGESTING (never before it's also
+    /// material - see <see cref="ApChannelRecommendation.ScanRescanRecommended"/>). Deliberately in
+    /// days, not hours: a fixed interferer's noise floor and the neighbor-network picture are stable
+    /// over hours, so re-scanning a same-day reading rarely changes anything and just churns clients on
+    /// APs without a dedicated scan radio. The materiality gate does the real filtering; this is only a
+    /// coarse "enough time has passed that the RF picture plausibly moved." Tunable.
+    /// </summary>
+    private static readonly TimeSpan SpectrumScanStaleAfter = TimeSpan.FromHours(72);
+
+    /// <summary>
     /// Converts a measured channel occupancy percentage (0-100) to the per-AP score scale used by
     /// the absolute gates, for the measured-congestion floor (#2). Anchored to those gates rather
     /// than to the (over-stated) external proxy: ~40% airtime lands near <see cref="MinApScoreToMove"/>
@@ -1393,11 +1403,11 @@ public class ChannelRecommendationService
         // Log final recommendation summary
         LogRecommendationSummary(plan, currentAssignment, bestAssignment);
 
-        // Diagnostics: how stale each AP's scan is, and whether that staleness could matter - the scan
-        // term was decisive for the recommendation, or a measured-worse hold is resting on it, plus
-        // whether the neighbor scan still corroborates it. Lets us see on live sites how often "old"
-        // coincides with "material" before designing a staleness-driven re-scan prompt.
-        LogScanMateriality(graph, band, finalAssignment, measuredWorseHolds);
+        // Record per-AP scan staleness/materiality onto the plan (drives the re-scan prompt) and, when
+        // debug is on, log the full breakdown: how stale each AP's scan is, whether that staleness is
+        // load-bearing (a measured-worse hold rests on it, or the scan term was decisive), and whether
+        // the fresher neighbor scan still corroborates it.
+        RecordAndLogScanMateriality(plan, graph, band, finalAssignment, measuredWorseHolds);
 
         return plan;
     }
@@ -3230,30 +3240,36 @@ public class ChannelRecommendationService
     }
 
     /// <summary>
-    /// Diagnostics for the scan-staleness question: for each AP, log how old its spectrum scan is and
-    /// whether that age could MATTER - either the guard held it off a channel using scan data
-    /// (strongest signal), or the scan term was decisive in picking its recommended channel - together
-    /// with whether the fresher neighbor scan still corroborates the reading. Debug-gated so the extra
-    /// scoring never runs in production with debug off. This is instrumentation to gather real
-    /// materiality data before we design a staleness-driven re-scan prompt; it changes no decisions.
+    /// Records per-AP scan staleness/materiality onto the plan and, when debug is on, logs the full
+    /// breakdown. For each AP: how old its spectrum scan is; whether that age is load-bearing (the
+    /// measured-worse guard held it on its noise-floor arm, or the scan term was decisive in the pick);
+    /// and whether the fresher neighbor scan still corroborates the reading. Sets
+    /// <see cref="ApChannelRecommendation.ScanRescanRecommended"/> when the scan is stale AND material
+    /// AND uncorroborated - the only case where a re-scan could change the answer. The expensive
+    /// decisive check only runs for stale APs (the only ones that can be prompt-material) unless debug
+    /// is on and wants the full diagnostic. Changes no recommendation.
     /// </summary>
-    private void LogScanMateriality(
+    private void RecordAndLogScanMateriality(
+        ChannelPlan plan,
         InterferenceGraph graph,
         RadioBand band,
         (int Channel, int Width)[] finalAssignment,
         IReadOnlyDictionary<int, (int RejectedChannel, MeasuredWorseReason Reason)> measuredWorseHolds)
     {
-        if (!_logger.IsEnabled(LogLevel.Debug)) return;
         var n = graph.Nodes.Count;
         if (n == 0) return;
 
         var now = DateTimeOffset.UtcNow;
-        var sb = new StringBuilder();
-        sb.AppendLine($"[ChannelRec] === SCAN MATERIALITY ({band}) ===");
+        var debug = _logger.IsEnabled(LogLevel.Debug);
+        StringBuilder? sb = debug ? new StringBuilder() : null;
+        sb?.AppendLine($"[ChannelRec] === SCAN MATERIALITY ({band}) ===");
 
         for (int i = 0; i < n; i++)
         {
             var node = graph.Nodes[i];
+            var rec = plan.Recommendations[i];
+            rec.SpectrumScanTime = node.SpectrumScanTime;
+            var stale = node.SpectrumScanTime is { } t && (now - t) > SpectrumScanStaleAfter;
             var age = FormatScanAge(node.SpectrumScanTime, now);
 
             // Held-by-guard case: the scan (or measured interference) is directly load-bearing.
@@ -3261,15 +3277,32 @@ public class ChannelRecommendationService
             {
                 var (rejectedCh, reason) = hold;
                 var ext = ExternalNeighborWeightOn(graph, band, i, rejectedCh, node.CurrentWidth);
-                var corroborated = ext >= CorroborationMinExternalWeight ? "CORROBORATED" : "UNCORROBORATED";
-                sb.AppendLine(
+                var corroborated = ext >= CorroborationMinExternalWeight;
+
+                // A re-scan can only change a NOISE-FLOOR-arm hold on a STALE, UNCORROBORATED channel:
+                // an interference-arm hold reads measured history (a spectrum re-scan won't refresh it),
+                // and a corroborated floor is confirmed by the fresher neighbor scan.
+                if (reason.NoiseFloorArm && stale && !corroborated)
+                {
+                    rec.ScanRescanRecommended = true;
+                    rec.ScanRescanReason =
+                        $"held off ch{rejectedCh} by a {age} spectrum reading the neighbor scan no longer corroborates";
+                }
+
+                sb?.AppendLine(
                     $"  {node.Name} (scan {age}): HELD off ch{rejectedCh} by measured-worse guard " +
-                    $"[{DescribeMeasuredWorseArms(reason)}]; ch{rejectedCh} floor {corroborated} by neighbors (ext={ext:F2})");
+                    $"[{DescribeMeasuredWorseArms(reason)}]; ch{rejectedCh} floor " +
+                    $"{(corroborated ? "CORROBORATED" : "UNCORROBORATED")} by neighbors (ext={ext:F2})" +
+                    $"{(rec.ScanRescanRecommended ? " -> RE-SCAN RECOMMENDED" : "")}");
                 continue;
             }
 
-            // General case: is the scan term what tips this AP's recommended channel over its best
-            // alternative? Strip the scan term from both and see whether the ranking flips.
+            // General case: only stale APs can be prompt-material, so skip the decisive check's cost
+            // for fresh scans unless debug wants the full breakdown.
+            if (!stale && !debug) continue;
+
+            // Is the scan term what tips this AP's recommended channel over its best alternative? Strip
+            // the scan term from both and see whether the ranking flips.
             var recCh = finalAssignment[i].Channel;
             var recWidth = finalAssignment[i].Width;
             var recTotal = ScoreAp(graph, finalAssignment, i, band);
@@ -3283,26 +3316,38 @@ public class ChannelRecommendationService
                 var trial = ((int Channel, int Width)[])finalAssignment.Clone();
                 trial[i] = (ch, recWidth);
                 ApplyMeshConstraints(graph, trial);
-                var t = ScoreAp(graph, trial, i, band);
-                if (t < altTotal) { altTotal = t; altCh = ch; altScan = ComputeScanScore(graph, band, i, ch, recWidth); }
+                var t2 = ScoreAp(graph, trial, i, band);
+                if (t2 < altTotal) { altTotal = t2; altCh = ch; altScan = ComputeScanScore(graph, band, i, ch, recWidth); }
             }
 
             var ago = ExternalNeighborWeightOn(graph, band, i, recCh, recWidth);
-            if (altCh < 0)
+            // Decisive = rec currently wins, but with the scan term removed the alternative would.
+            var decisive = altCh >= 0 && recTotal <= altTotal && (recTotal - recScan) > (altTotal - altScan);
+            var recCorroborated = ago >= CorroborationMinExternalWeight;
+
+            if (decisive && stale && !recCorroborated)
             {
-                sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, no alternative channel");
-                continue;
+                rec.ScanRescanRecommended = true;
+                rec.ScanRescanReason =
+                    $"a {age} spectrum reading the neighbor scan no longer corroborates is deciding ch{recCh}";
             }
 
-            // Decisive = rec currently wins, but with the scan term removed the alternative would.
-            var decisive = recTotal <= altTotal && (recTotal - recScan) > (altTotal - altScan);
-            var verdict = decisive
-                ? $"scan term DECISIVE over alt ch{altCh} (ch{recCh} {recTotal:F2} vs ch{altCh} {altTotal:F2}; without scan the alt wins)"
-                : $"scan term not decisive (best alt ch{altCh})";
-            sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, {verdict}; ch{recCh} ext={ago:F2}");
+            if (sb != null)
+            {
+                if (altCh < 0)
+                    sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, no alternative channel");
+                else
+                {
+                    var verdict = decisive
+                        ? $"scan term DECISIVE over alt ch{altCh} (ch{recCh} {recTotal:F2} vs ch{altCh} {altTotal:F2}; without scan the alt wins)"
+                        : $"scan term not decisive (best alt ch{altCh})";
+                    sb.AppendLine($"  {node.Name} (scan {age}): rec ch{recCh}, {verdict}; ch{recCh} ext={ago:F2}" +
+                        $"{(rec.ScanRescanRecommended ? " -> RE-SCAN RECOMMENDED" : "")}");
+                }
+            }
         }
 
-        _logger.LogDebug("{ScanMateriality}", sb.ToString());
+        if (sb != null) _logger.LogDebug("{ScanMateriality}", sb.ToString());
     }
 
     /// <summary>Short human label for which measured-worse arm(s) tripped, with the compared values.</summary>

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -49,6 +49,89 @@ public class ChannelRecommendationServiceTests
         }
         };
 
+    [Fact]
+    public void Optimize_LargeSite_GuardHoldsAtScaleWithoutBlockingLegitimateSpread()
+    {
+        // A 25-AP 2.4 GHz site is past the exhaustive-search cap (3^25), so this exercises the greedy
+        // path with the measured-worse guard applied to its result. It confirms, at scale: the optimizer
+        // completes quickly and emits only valid 1/6/11 assignments; a genuine co-channel collision is
+        // still spread apart (the guard doesn't blanket-suppress and the plan isn't globally reverted);
+        // and isolated APs in a measured-worse trap are held off the loud channel the proxy prefers.
+        //
+        // The site is kept UNcrowded (most APs quiet and content) so the 2.4 GHz whole-site guardrails
+        // (crowding friction, the 8% band-improvement bar) stay out of the way and each behaviour is
+        // observable on its own rather than masked by a blanket revert.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        const int n = 25;
+        var cluster = new[] { 0, 1, 2 };       // co-channel on ch1, mutually heard -> must spread
+        var trapped = new[] { 9, 12, 16 };     // isolated, measured-worse trap on ch11 -> must hold (none start on ch11)
+
+        var aps = new List<AccessPointSnapshot>();
+        for (int i = 0; i < n; i++)
+        {
+            var ch = cluster.Contains(i) ? 1 : new[] { 1, 6, 11 }[i % 3];
+            aps.Add(CreateAp($"aa:bb:cc:00:00:{i:x2}", $"AP-{i}", RadioBand.Band2_4GHz, ch, width: 20));
+        }
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+
+        // Baseline: every AP quiet on every channel and isolated (BuildInterferenceGraph seeds a default
+        // weight for every pair, so zero the whole matrix first). Nobody has a reason to move.
+        for (int a = 0; a < n; a++)
+        {
+            for (int b = 0; b < n; b++)
+            {
+                graph.InternalWeights[a, b] = 0;
+                graph.DirectionalWeights[a, b] = 0;
+            }
+            graph.ExternalLoad[a] = new() { { 1, 1.0 }, { 6, 1.0 }, { 11, 1.0 } };
+            graph.DirectlyObservedChannels[a] = new() { 1, 6, 11 };
+        }
+
+        // The cluster: three APs that all hear each other on ch1. Splitting them across 1/6/11 is a big
+        // internal win that dominates the (otherwise quiet) site, so it clears the 8% bar on its own -
+        // the guard holding the trapped APs can't sink it.
+        foreach (var a in cluster)
+            foreach (var b in cluster)
+                if (a != b) { graph.InternalWeights[a, b] = 1.0; graph.DirectionalWeights[a, b] = 1.0; }
+
+        // The trap: isolated APs whose proxy makes ch11 look cleanest, but whose own spectrum scan shows
+        // a -37 dBm interferer there. With no own-AP co-channel relief to gain, the guard's
+        // internal-benefit escape can't fire, so it must hold each on its current channel. (When such
+        // relief IS available the guard yields by design - covered by the 2-AP tests, not this one.)
+        foreach (var t in trapped)
+        {
+            graph.ExternalLoad[t] = new() { { 1, 3.0 }, { 6, 3.0 }, { 11, 0.5 } }; // ch11 looks best
+            graph.ScanChannelData[t] = new()
+            {
+                { (graph.Nodes[t].CurrentChannel, 20), (25, (int?)(-58)) },
+                { (11, 20), (25, (int?)(-37)) }
+            };
+        }
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+        sw.Stop();
+
+        plan.Recommendations.Should().HaveCount(n);
+        plan.Recommendations.Should().OnlyContain(r => r.RecommendedChannel == 1 || r.RecommendedChannel == 6 || r.RecommendedChannel == 11,
+            "every 2.4 GHz recommendation must land on a non-overlapping channel");
+
+        sw.ElapsedMilliseconds.Should().BeLessThan(5000,
+            "a 25-AP greedy optimization (guard included) must stay well within interactive time");
+
+        // Legitimate moves still surface: the co-channel cluster is spread across >1 channel, which also
+        // proves the plan wasn't globally reverted - so the trapped holds below are the guard's doing.
+        cluster.Select(i => plan.Recommendations[i].RecommendedChannel).Distinct().Count()
+            .Should().BeGreaterThan(1, "clustered APs must still be spread despite the guard");
+
+        // Trapped APs must NOT be moved onto the measured-loud ch11.
+        trapped.Count(t =>
+            plan.Recommendations[t].RecommendedChannel == 11 &&
+            graph.Nodes[t].CurrentChannel != 11)
+            .Should().Be(0, "the guard must hold every trapped AP off the -37 dBm ch11 at scale too");
+    }
+
     // --- Graph Building ---
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1311,6 +1311,83 @@ public class ChannelRecommendationServiceTests
             .And.Contain("old", "Downstairs' scan age (3h) must be rendered, not 'age unknown'");
     }
 
+    /// <summary>
+    /// The reported topology with a noise-floor trap on ch11, parameterized so tests can vary ch11's
+    /// corroborating external weight and the spectrum-scan age to exercise the re-scan gate.
+    /// </summary>
+    private InterferenceGraph BuildNoiseFloorHoldGraph(
+        double downstairsCh11Ext, DateTimeOffset scanTime, RegulatoryChannelData reg, RecommendationOptions options)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Living Room", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Downstairs", RadioBand.Band2_4GHz, 6, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 1.0;
+        graph.DirectionalWeights[0, 1] = graph.DirectionalWeights[1, 0] = 1.0;
+        graph.ExternalLoad[0] = new() { { 1, 0.2 }, { 6, 30.0 }, { 11, 10.0 } }; // Living Room stays ch1
+        graph.DirectlyObservedChannels[0] = new() { 1, 6, 11 };
+        graph.ExternalLoad[1] = new() { { 1, 18.0 }, { 6, 30.0 }, { 11, downstairsCh11Ext } }; // proxy wants ch11
+        graph.DirectlyObservedChannels[1] = new() { 1, 6, 11 };
+        graph.ScanChannelData[1] = new()
+        {
+            { (6, 20), (26, (int?)(-58)) },
+            { (11, 20), (25, (int?)(-37)) } // loud interferer on the "cleaner" channel
+        };
+        graph.Nodes[1].SpectrumScanTime = scanTime;
+        return graph;
+    }
+
+    [Fact]
+    public void Optimize_StaleUncorroboratedNoiseFloorHold_FlagsRescanRecommended()
+    {
+        // The re-scan-worthy case: the guard holds Downstairs off ch11 on a -37 dBm floor, that floor
+        // is 5 days old, and the neighbor scan no longer corroborates it (ch11 ext 0.3). A fresh scan
+        // could clear it, so the recommendation is flagged for a re-scan prompt.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildNoiseFloorHoldGraph(0.3, DateTimeOffset.UtcNow.AddDays(-5), reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(6, "the guard still holds it off the loud ch11");
+        downstairs.ScanRescanRecommended.Should().BeTrue(
+            "the hold rests on a 5-day-old noise-floor reading the neighbor scan no longer corroborates");
+    }
+
+    [Fact]
+    public void Optimize_StaleButCorroboratedNoiseFloorHold_DoesNotFlagRescan()
+    {
+        // Same stale floor, but ch11 carries heavy neighbor weight (ext 15) - the fresher neighbor scan
+        // confirms it's really loud, so a re-scan wouldn't change the answer. No prompt.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildNoiseFloorHoldGraph(15.0, DateTimeOffset.UtcNow.AddDays(-5), reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(6);
+        downstairs.ScanRescanRecommended.Should().BeFalse("neighbors corroborate the loud floor, so a re-scan can't change it");
+    }
+
+    [Fact]
+    public void Optimize_FreshUncorroboratedNoiseFloorHold_DoesNotFlagRescan()
+    {
+        // Same uncorroborated hold, but the scan is fresh (1h) - nothing to re-scan yet.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildNoiseFloorHoldGraph(0.3, DateTimeOffset.UtcNow.AddHours(-1), reg, options);
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(6);
+        downstairs.ScanRescanRecommended.Should().BeFalse("a 1h-old scan is not stale, so no re-scan is suggested");
+    }
+
     /// <summary>Captures formatted log messages and reports debug as enabled, for asserting diagnostics.</summary>
     private sealed class ListLogger<T> : ILogger<T>
     {

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1102,6 +1102,98 @@ public class ChannelRecommendationServiceTests
         subject.IsChanged.Should().BeFalse();
     }
 
+    /// <summary>
+    /// Builds the reported ch6-vs-ch11 topology: Living Room parked on a clean ch1, Downstairs on ch6,
+    /// the two hearing each other. The neighbor-scan proxy makes ch6 look busiest and ch11 cleanest for
+    /// Downstairs (the trap), so the optimizer wants to move it onto ch11. Callers layer the ground-truth
+    /// measurement (scan noise floor and/or measured interference) that reveals ch11 is actually worse.
+    /// </summary>
+    private InterferenceGraph BuildCh6VsCh11Graph(RegulatoryChannelData reg, RecommendationOptions options)
+    {
+        var aps = new List<AccessPointSnapshot>
+        {
+            CreateAp("aa:bb:cc:dd:ee:01", "Living Room", RadioBand.Band2_4GHz, 1, width: 20),
+            CreateAp("aa:bb:cc:dd:ee:02", "Downstairs", RadioBand.Band2_4GHz, 6, width: 20)
+        };
+        var graph = _service.BuildInterferenceGraph(aps, RadioBand.Band2_4GHz, null, null, reg, options);
+        graph.InternalWeights[0, 1] = graph.InternalWeights[1, 0] = 1.0;
+        graph.DirectionalWeights[0, 1] = graph.DirectionalWeights[1, 0] = 1.0;
+        // Neighbor-scan proxy: Living Room best on ch1; Downstairs sees ch6 busiest, ch11 cleanest.
+        graph.ExternalLoad[0] = new() { { 1, 5.0 }, { 6, 30.0 }, { 11, 20.0 } };
+        graph.DirectlyObservedChannels[0] = new() { 1, 6, 11 };
+        graph.ExternalLoad[1] = new() { { 1, 18.0 }, { 6, 30.0 }, { 11, 15.0 } };
+        graph.DirectlyObservedChannels[1] = new() { 1, 6, 11 };
+        return graph;
+    }
+
+    [Fact]
+    public void Optimize_MoveOntoLouderNoiseFloor_KeepsApOnCurrentChannel()
+    {
+        // The reported ch6->ch11 nonsense (Mac site). The neighbor scan counts fewer beaconing BSSIDs
+        // on ch11 (proxy 15) than ch6 (proxy 30), so the optimizer wants to move Downstairs onto ch11 -
+        // but ch11 carries a -37 dBm noise floor (two strong HUMAX boxes) vs ch6's -58 dBm. The AP's own
+        // spectrum scan is ground truth the proxy ignores; the measured-worse guard must hold it on ch6.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildCh6VsCh11Graph(reg, options);
+        graph.ScanChannelData[1] = new()
+        {
+            { (1, 20), (42, (int?)(-55)) },
+            { (6, 20), (26, (int?)(-58)) },
+            { (11, 20), (25, (int?)(-37)) } // loud interferer sitting on the "cleaner" channel
+        };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var downstairs = plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02");
+        downstairs.RecommendedChannel.Should().Be(6,
+            "ch11 measures far louder (-37 dBm vs -58) at this AP, so the neighbor-scan proxy must not move it there");
+        plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:01").RecommendedChannel.Should().Be(1);
+    }
+
+    [Fact]
+    public void Optimize_MoveOntoHigherMeasuredInterference_KeepsApOnCurrentChannel()
+    {
+        // Interference arm (no spectrum-scan noise floor to lean on): the AP's own measured 1d/7d
+        // external interference records ch11 at 34% vs ch6 at 28% - worse, and above the comfortable
+        // bar - so the proxy-driven move to ch11 is held even though ch6 itself isn't "comfortable".
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildCh6VsCh11Graph(reg, options);
+        graph.Nodes[1].HistoricalStress = new Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>
+        {
+            { 6, (36.0, 28.0, 15.0) },
+            { 11, (41.0, 34.0, 21.0) }
+        };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02").RecommendedChannel.Should().Be(6,
+            "the AP's own measurement puts ch11 (34%) above ch6 (28%), so it must not be moved to the worse channel");
+    }
+
+    [Fact]
+    public void Optimize_MoveOntoMeasuredCleanerChannel_StillLeavesCongestedChannel()
+    {
+        // Control: same proxy trap, but this time ch11 genuinely IS cleaner - low noise floor and no
+        // elevated interference. The guard must stay inert (absolute badness gates unmet) and let the
+        // congested AP escape ch6, proving the guard suppresses only measurably-worse moves.
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildCh6VsCh11Graph(reg, options);
+        graph.ScanChannelData[1] = new()
+        {
+            { (1, 20), (42, (int?)(-55)) },
+            { (6, 20), (26, (int?)(-58)) },
+            { (11, 20), (20, (int?)(-85)) } // quiet destination
+        };
+
+        var plan = _service.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02").RecommendedChannel.Should().Be(11,
+            "ch11 measures clean here, so the guard stays out of the way and the congested AP moves off ch6");
+    }
+
     [Fact]
     public void Optimize_PinnedAp_ChannelUnchanged()
     {

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.WiFi.Data;
@@ -1275,6 +1276,55 @@ public class ChannelRecommendationServiceTests
 
         plan.Recommendations.First(r => r.ApMac == "aa:bb:cc:dd:ee:02").RecommendedChannel.Should().Be(11,
             "ch11 measures clean here, so the guard stays out of the way and the congested AP moves off ch6");
+    }
+
+    [Fact]
+    public void Optimize_ScanMaterialityLog_ReportsGuardHoldWithAgeArmAndCorroboration()
+    {
+        // The scan-materiality diagnostics are debug-gated, so exercise them with a real (capturing)
+        // logger: a guard hold on the -37 dBm ch11 must be reported with the scan age, the arm that
+        // tripped, and whether the neighbor scan still corroborates the loud floor.
+        var logger = new ListLogger<ChannelRecommendationService>();
+        var loader = new AntennaPatternLoader(NullLogger<AntennaPatternLoader>.Instance);
+        var prop = new PropagationService(loader, NullLogger<PropagationService>.Instance);
+        var svc = new ChannelRecommendationService(prop, logger);
+
+        var reg = StdUsRegulatory();
+        var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };
+        var graph = BuildCh6VsCh11Graph(reg, options);
+        graph.ScanChannelData[1] = new()
+        {
+            { (1, 20), (42, (int?)(-55)) },
+            { (6, 20), (26, (int?)(-58)) },
+            { (11, 20), (25, (int?)(-37)) }
+        };
+        graph.Nodes[1].SpectrumScanTime = DateTimeOffset.UtcNow.AddHours(-3);
+
+        svc.Optimize(graph, RadioBand.Band2_4GHz, reg, options);
+
+        var materiality = logger.Messages.FirstOrDefault(m => m.Contains("SCAN MATERIALITY"));
+        materiality.Should().NotBeNull("the diagnostics block must be logged when debug is enabled");
+        materiality.Should()
+            .Contain("HELD off ch11")
+            .And.Contain("noise-floor -37dBm vs -58dBm")
+            .And.Contain("CORROBORATED", "ch11 carries substantial external neighbor weight here")
+            .And.Contain("old", "Downstairs' scan age (3h) must be rendered, not 'age unknown'");
+    }
+
+    /// <summary>Captures formatted log messages and reports debug as enabled, for asserting diagnostics.</summary>
+    private sealed class ListLogger<T> : ILogger<T>
+    {
+        public readonly List<string> Messages = new();
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => Messages.Add(formatter(state, exception));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -1215,7 +1215,7 @@ public class ChannelRecommendationServiceTests
     {
         // The reported ch6->ch11 nonsense (Mac site). The neighbor scan counts fewer beaconing BSSIDs
         // on ch11 (proxy 15) than ch6 (proxy 30), so the optimizer wants to move Downstairs onto ch11 -
-        // but ch11 carries a -37 dBm noise floor (two strong HUMAX boxes) vs ch6's -58 dBm. The AP's own
+        // but ch11 carries a -37 dBm noise floor (two strong neighbor APs) vs ch6's -58 dBm. The AP's own
         // spectrum scan is ground truth the proxy ignores; the measured-worse guard must hold it on ch6.
         var reg = StdUsRegulatory();
         var options = new RecommendationOptions { DfsPreference = DfsPreference.IncludeWithPenalty };


### PR DESCRIPTION
Channel recommendations were sometimes moving an AP onto a channel its own radio measured as worse, and gave no way to refresh an aging scan that was steering the advice. This tightens both.

## Wi-Fi Optimizer - Channels

- **Measured-worse channel guard** - the recommender no longer moves an AP onto a channel its own radio measures as worse (a louder spectrum-scan noise floor, or more measured airtime) when the move buys no co-channel relief for your own APs. This fixes a 2.4 GHz case where an AP was pushed onto a channel with a strong interferer simply because the neighbor scan counted fewer networks there. It only ever holds an AP put, so it can never create new churn, and it stays inert on clean 5/6 GHz where moves between two quiet channels are normal. A move that genuinely unsticks a co-channel collision among your own APs still goes through.

- **Re-scan prompt when a stale scan is steering the advice** - the recommendations now surface a **Re-scan** option when an AP's spectrum scan is old (3+ days) AND that stale reading is actually holding or deciding a channel AND nearby networks no longer corroborate it - the one case where a fresh scan could change the answer. It deliberately stays quiet when the reading is corroborated by neighbors or the hold is driven by measured history, since a re-scan wouldn't change those. This is separate from, and additive to, the existing "radios need a scan" prompt for radios with no scan data at all, which is unchanged.

- **True scan age** - the age of each AP's per-channel spectrum scan now comes from the console's actual scan timestamp rather than assuming every fetch is current, so "how stale is this reading" is accurate and drives the re-scan prompt above.
