### PR TITLE
Fix reversed throughput on grouped-port hub nodes (Live View flow map)

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -977,7 +977,10 @@ class LanFlowMap2D {
         // Rates: fabric devices use badge, clients use link rates
         const isFab=d.kind===NK.Gateway||d.kind===NK.Switch||d.kind===NK.AP;
         let inBps=0,outBps=0,any=false;
-        if(isFab&&b){
+        if(d.kind===NK.VirtualHub){
+            // Hub throughput is its upstream port link, not the summed members.
+            const hr=this._virtualHubRates(d.id);inBps=hr.down;outBps=hr.up;any=hr.any;
+        }else if(isFab&&b){
             if(b.fabricIngressBps!=null||b.fabricEgressBps!=null){
                 inBps=b.fabricIngressBps||0;outBps=b.fabricEgressBps||0;any=true;
             }else if(b.aggregateInBps!=null||b.aggregateOutBps!=null){
@@ -1893,6 +1896,27 @@ class LanFlowMap2D {
             ctx.textAlign='center'; ctx.textBaseline='top';
             ctx.fillText(dn,x,y+r+3);
         }
+    }
+
+    // A VirtualHub groups several wired clients sharing one physical switch port
+    // (a server's VLAN sub-interfaces, etc.). Its own throughput is the parent
+    // switch -> hub port link (direction-correct), not the summed member leaf links.
+    // Prefer that upstream link; fall back to summing members only when it has no
+    // rate. down=downstream / up=upstream on every WiredClient link, so no flip.
+    _virtualHubRates(nodeId){
+        let upDown=0,upUp=0,upHas=false,sumDown=0,sumUp=0,sumHas=false;
+        for(const e of this._edges){
+            const lk=e.lk;
+            if(lk.toNodeId!==nodeId&&lk.fromNodeId!==nodeId)continue;
+            const r=this._liveRates[lk.portKey]||this._liveRates[lk.id];
+            if(!r)continue;
+            const dn=r.downstreamBps||0,up=r.upstreamBps||0;
+            if(lk.toNodeId===nodeId){upDown+=dn;upUp+=up;upHas=true;}
+            else{sumDown+=dn;sumUp+=up;sumHas=true;}
+        }
+        if(upHas)return{down:upDown,up:upUp,any:upDown>0||upUp>0};
+        if(sumHas)return{down:sumDown,up:sumUp,any:sumDown>0||sumUp>0};
+        return{down:0,up:0,any:false};
     }
 
     // ---- Rate labels on links + nodes ----

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2935,6 +2935,31 @@ export class LanFlowMap {
         }
     }
 
+    // Resolve a VirtualHub's own throughput. The hub groups several wired clients
+    // that share one physical switch port (a server's VLAN sub-interfaces, etc.);
+    // the parent switch -> hub link carries the real, direction-correct port rate
+    // while the hub -> member leaf links carry per-client rates. The hub's boundary
+    // throughput IS its upstream port link, so prefer it and only fall back to
+    // summing the members when that port link has no rate (e.g. an SNMP-free parent
+    // port). On every WiredClient link downstreamBps is the toward-leaf (download)
+    // value and upstreamBps the toward-gateway (upload) value, so both the port link
+    // and the member links map down=downstream / up=upstream with no end-based flip.
+    _virtualHubRates(nodeId) {
+        let upDown = 0, upUp = 0, upHas = false;
+        let sumDown = 0, sumUp = 0, sumHas = false;
+        for (const [linkId, lm] of this._linkMeshes) {
+            const lk = lm.link;
+            const r = this._currentRates?.[linkId];
+            if (!r) continue;
+            const dn = r.downstreamBps || 0, up = r.upstreamBps || 0;
+            if (lk.toNodeId === nodeId) { upDown += dn; upUp += up; upHas = true; }
+            else if (lk.fromNodeId === nodeId) { sumDown += dn; sumUp += up; sumHas = true; }
+        }
+        if (upHas) return { down: upDown, up: upUp, any: (upDown > 0 || upUp > 0) };
+        if (sumHas) return { down: sumDown, up: sumUp, any: (sumDown > 0 || sumUp > 0) };
+        return { down: 0, up: 0, any: false };
+    }
+
     _refreshDeviceLabelRates() {
         // Floating labels render only on infrastructure (gateway / switch / AP).
         // Aggregate across adjacent links using internet-centric direction:
@@ -2948,6 +2973,7 @@ export class LanFlowMap {
             let downBps = 0;
             let upBps = 0;
             let anyData = false;
+            const node = this._nodeMeshes.get(nodeId)?.userData?.node;
             // Prefer the per-device aggregate badge if the server published one.
             // For switches the server emits fabric ingress/egress (sum across
             // every port_table entry) so multi-trunk switches don't under-
@@ -2957,7 +2983,17 @@ export class LanFlowMap {
             const badge = this._currentBadges?.[nodeId];
             const hasFabric = badge && (badge.fabricIngressBps != null || badge.fabricEgressBps != null);
             const hasAggregate = badge && (badge.aggregateInBps != null || badge.aggregateOutBps != null);
-            if (hasFabric) {
+            if (node?.kind === NODE_KIND.VirtualHub) {
+                // A VirtualHub's own throughput is the rate on its single upstream
+                // port link (parent switch -> hub), which carries direction-correct
+                // port stats. Summing the member leaf links here would double-count
+                // and read the members with the wrong orientation, so use the port
+                // link and only fall back to the members when it has no rate.
+                const hr = this._virtualHubRates(nodeId);
+                downBps = hr.down;
+                upBps = hr.up;
+                anyData = hr.any;
+            } else if (hasFabric) {
                 downBps = badge.fabricIngressBps || 0;
                 upBps = badge.fabricEgressBps || 0;
                 anyData = (downBps > 0 || upBps > 0);
@@ -2971,7 +3007,6 @@ export class LanFlowMap {
                 // label is gateway-relative though - blue down arrow is
                 // always data flowing FROM the gateway - so for APs the
                 // mapping has to swap.
-                const node = this._nodeMeshes.get(nodeId)?.userData?.node;
                 if (node?.kind === NODE_KIND.AccessPoint) {
                     downBps = badge.aggregateOutBps || 0;
                     upBps = badge.aggregateInBps || 0;
@@ -3147,7 +3182,15 @@ export class LanFlowMap {
             || node.kind === NODE_KIND.Switch
             || node.kind === NODE_KIND.AccessPoint;
         let ingressBps = 0, egressBps = 0, anyData = false;
-        if (isFabric) {
+        if (node.kind === NODE_KIND.VirtualHub) {
+            // Hub throughput is its upstream port link, direction-correct; only fall
+            // back to the members when that link has no rate. down = download-to-hub
+            // (ingress), up = upload-from-hub (egress), so no end-based flip.
+            const hr = this._virtualHubRates(node.id);
+            ingressBps = hr.down;
+            egressBps = hr.up;
+            anyData = hr.any;
+        } else if (isFabric) {
             const badge = this._currentBadges?.[node.id];
             if (badge && (badge.fabricIngressBps != null || badge.fabricEgressBps != null)) {
                 ingressBps = badge.fabricIngressBps || 0;


### PR DESCRIPTION
## Monitoring - Live View

- **Grouped-port hub nodes reported the wrong throughput** - When several wired clients share one physical switch port (a server or hypervisor with multiple VLAN sub-interfaces, each with its own MAC), the flow map rolls them up under a single hub node. That hub's floating label and hover tooltip were aggregating every adjacent link - the upstream switch port plus each member interface - which double-counted the traffic and, because the members hang off the opposite end of the hub, showed their up/down reversed.

  The hub now reads its throughput from its upstream switch-port link, which already carries the correct, direction-aware rate. It only falls back to summing the member interfaces when that port link has no rate available (e.g. a switch without SNMP), and that fallback keeps the same direction mapping so up/down stays correct either way.

  Applies to the 3D map (floating label and tooltip) and the 2D map (tooltip).
