### PR TITLE
Add Nokia XS-010X-Q ONT support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -379,6 +379,14 @@ The duplicate-reachable-IP case shipped: `AliasIp` on `MonitoringInterface` with
   through the marker DTOs and color markers yellow (provisioning) / red (error) instead of the
   binary bool. The status-dot/badge/card spots already do this - only the JS map markers remain.
 
+### Nokia ONT: confirm coverage across other models
+
+`NokiaXs010xOntProvider` was built and verified against one XGS-PON **XS-010X-Q** (owner-confirmed). The `GponForm` web API (`Login_GetConfig` nonce/salt SHA-256 login -> `getUpdateinfo`) appears common to Nokia's box ONTs, but this is unconfirmed on any other unit, and the provider hardcodes both the model string and `PonType = "XGS-PON"` because the device reports neither its own model nor a line rate.
+
+- [ ] Confirm whether the same flow works on Nokia's **GPON box siblings** (e.g. G-010G-Q). If yes, either relax the hardcoded XGS-PON label or split into a GPON variant - a GPON unit on this provider would currently be mislabeled XGS-PON.
+- [ ] Confirm whether it works on Nokia's **SFP-form ONTs** (the SFP stick modules), which may expose a different web/telnet interface entirely.
+- [ ] If coverage is broader than one model, revisit the dropdown label ("Nokia XS-010X-Q (HTTP)") and the hardcoded `DeviceModel` so multi-model units aren't misreported.
+
 ## Multi-Tenant / Multi-Site Support
 
 ### Multi-Tenant Architecture

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1563,6 +1563,7 @@
                                 <option value="8311">8311 Community Firmware (HTTP)</option>
                                 <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
                                 <option value="telekom-modem2">Telekom Glasfaser-Modem 2 (HTTP)</option>
+                                <option value="nokia-xs010x-q">Nokia XS-010X-Q (HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -5838,6 +5839,7 @@
         "8311" => "8311 Community Firmware (HTTP)",
         "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "telekom-modem2" => "Telekom Glasfaser-Modem 2 (HTTP)",
+        "nokia-xs010x-q" => "Nokia XS-010X-Q (HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -352,6 +352,7 @@ builder.Services.AddSingleton<IOntProvider, Lantiq8311OntProvider>();
 builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<IOntProvider, TelekomModem2OntProvider>();
+builder.Services.AddSingleton<IOntProvider, NokiaXs010xOntProvider>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).Ont);
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -1,0 +1,278 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for the Nokia (Alcatel-Lucent, vendor ID "ALCL") XS-010X-Q XGS-PON
+/// SFP+ ONT stick and its GponForm web siblings. The device serves a plain-HTTP nginx
+/// UI whose only data-bearing page is moreinfo.html, backed by a small JSON API:
+///
+///   1. POST /GponForm/Login_GetConfig (token=token) -> {"nonce":..,"saltval":..}
+///   2. cmt = sha256(username + saltval + password), lowercase hex
+///   3. POST /GponForm/LoginForm (cmt=..&nonce=..) -> {"login_result":..,"cookieid":..}
+///   4. POST /GponForm/getUpdateinfo (token=token) with Cookie: sessionid=&lt;cookieid&gt;
+///      -> {"CurrentPonPw","VendorID","VersionID","SerialNum","Mac","ActiveSwVer",
+///          "StandbySwVer","RxOptPwr"}
+///
+/// The device exposes no TX power, temperature, or explicit link state; the receive
+/// optical power (RxOptPwr, dBm) is the one health metric it reports. Login credentials
+/// default to admin/1234 on these units but are user-configurable.
+/// </summary>
+public sealed class NokiaXs010xOntProvider : IOntProvider
+{
+    public string ProviderKey => "nokia-xs010x-q";
+    public string DisplayName => "Nokia XS-010X-Q (HTTP)";
+
+    private const int TimeoutSeconds = 15;
+    private const string LoginConfigPath = "/GponForm/Login_GetConfig";
+    private const string LoginPath = "/GponForm/LoginForm";
+    private const string UpdateInfoPath = "/GponForm/getUpdateinfo";
+    private const string FormContentType = "application/x-www-form-urlencoded";
+
+    private readonly ILogger<NokiaXs010xOntProvider> _logger;
+
+    public NokiaXs010xOntProvider(ILogger<NokiaXs010xOntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            using var client = CreateClient();
+            var baseUrl = BuildBaseUrl(context);
+
+            var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
+            if (cookieId is null)
+            {
+                _logger.LogWarning("Nokia XS-010X-Q ONT {Name}: login failed", context.Name);
+                return null;
+            }
+
+            var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, cancellationToken);
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
+                DeviceName = context.Name,
+                DeviceModel = "Nokia XS-010X-Q",
+            };
+            ApplyUpdateInfo(infoJson, stats);
+
+            _logger.LogDebug(
+                "Nokia XS-010X-Q ONT {Name} polled: Rx={Rx} dBm, SN={Sn}, Link={Link}",
+                context.Name, stats.RxPowerDbm?.ToString("F1") ?? "-",
+                stats.VendorSn ?? "-", stats.LinkState ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Nokia XS-010X-Q ONT {Name} at {Host}",
+                context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            using var client = CreateClient();
+            var baseUrl = BuildBaseUrl(context);
+
+            var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
+            if (cookieId is null)
+                return (false, "Login failed - check username/password (default is admin/1234)");
+
+            var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, cancellationToken);
+
+            var stats = new OntStats();
+            ApplyUpdateInfo(infoJson, stats);
+
+            if (stats.RxPowerDbm is null)
+                return (false, "Logged in but response did not contain the expected RxOptPwr field");
+
+            return (true, $"Connected (HTTP) - Nokia XS-010X-Q, RX: {stats.RxPowerDbm.Value:F1} dBm");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Runs the three-step GponForm login and returns the session cookie id, or null if
+    /// authentication fails. The cookie is delivered inside the LoginForm JSON body (the
+    /// page's script clears the Set-Cookie header), so it is threaded back manually as a
+    /// Cookie header on the data request rather than via a CookieContainer.
+    /// </summary>
+    private async Task<string?> LoginAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
+
+        string configJson;
+        using (var content = new StringContent("token=token", Encoding.UTF8, FormContentType))
+        using (var response = await client.PostAsync($"{baseUrl}{LoginConfigPath}", content, ct))
+            configJson = await response.Content.ReadAsStringAsync(ct);
+
+        var (nonce, saltval) = ParseLoginConfig(configJson);
+        if (string.IsNullOrEmpty(nonce))
+            return null;
+
+        var cmt = ComputeCmt(username, saltval ?? "", password);
+        var body = $"cmt={cmt}&nonce={Uri.EscapeDataString(nonce)}";
+
+        string loginJson;
+        using (var content = new StringContent(body, Encoding.UTF8, FormContentType))
+        using (var response = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct))
+            loginJson = await response.Content.ReadAsStringAsync(ct);
+
+        return ParseCookieId(loginJson);
+    }
+
+    private static async Task<string> GetUpdateInfoAsync(
+        HttpClient client, string baseUrl, string cookieId, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{UpdateInfoPath}")
+        {
+            Content = new StringContent("token=token", Encoding.UTF8, FormContentType),
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
+
+        using var response = await client.SendAsync(request, ct);
+        return await response.Content.ReadAsStringAsync(ct);
+    }
+
+    /// <summary>
+    /// cmt = sha256(username + saltval + password) as lowercase hex. Verified against a live
+    /// unit: sha256("admin" + "ea" + "1234") == b7290cb3...f22fc7.
+    /// </summary>
+    internal static string ComputeCmt(string username, string saltval, string password)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(username + saltval + password));
+        return Convert.ToHexStringLower(bytes);
+    }
+
+    /// <summary>Extracts nonce and saltval from the Login_GetConfig JSON response.</summary>
+    internal static (string? Nonce, string? Salt) ParseLoginConfig(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return (null, null);
+
+            return (GetStringProp(doc.RootElement, "nonce"), GetStringProp(doc.RootElement, "saltval"));
+        }
+        catch (JsonException)
+        {
+            return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Reads the session cookie id from the LoginForm JSON response. Returns null when the
+    /// device reports a login error ({"login_result":"error"}) or omits the cookie.
+    /// </summary>
+    internal static string? ParseCookieId(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+
+            var result = GetStringProp(doc.RootElement, "login_result");
+            if (string.Equals(result, "error", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            var cookieId = GetStringProp(doc.RootElement, "cookieid");
+            return string.IsNullOrWhiteSpace(cookieId) ? null : cookieId;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Maps the getUpdateinfo JSON onto OntStats. Only RxOptPwr, VendorID, VersionID and
+    /// SerialNum carry monitoring value; the device reports no TX power, temperature, or
+    /// explicit link state, so operational status is inferred from a present RX reading.
+    /// </summary>
+    internal static void ApplyUpdateInfo(string json, OntStats stats)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind != JsonValueKind.Object)
+                return;
+
+            var root = doc.RootElement;
+
+            stats.RxPowerDbm = ParseDouble(GetStringProp(root, "RxOptPwr")) ?? stats.RxPowerDbm;
+
+            if (GetStringProp(root, "VendorID") is { Length: > 0 } vendor)
+                stats.VendorName = vendor;
+
+            if (GetStringProp(root, "VersionID") is { Length: > 0 } version)
+                stats.VendorPn = version;
+
+            if (GetStringProp(root, "SerialNum") is { Length: > 0 } serial)
+                stats.VendorSn = serial;
+
+            // XS-010X-Q is a 10G-symmetric XGS-PON stick; the device exposes no line rate,
+            // so the PON type is taken from the model rather than derived from a rate field.
+            stats.PonType = "XGS-PON";
+
+            // No link-state field is exposed. A successful authenticated read that returns a
+            // real optical-power value means the ONU is powered and seeing downstream light,
+            // which we surface as Up; without an RxOptPwr reading we leave status unknown.
+            if (stats.RxPowerDbm is not null)
+            {
+                stats.OperationalStatus = "Up";
+                stats.LinkState = "Up";
+            }
+        }
+        catch (JsonException) { }
+    }
+
+    private static string? GetStringProp(JsonElement element, string name) =>
+        element.TryGetProperty(name, out var prop) && prop.ValueKind == JsonValueKind.String
+            ? prop.GetString()
+            : null;
+
+    private static double? ParseDouble(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
+
+    internal static HttpClient CreateClient() =>
+        new() { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+
+    private static string BuildBaseUrl(OntPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        return $"http://{context.Host}{portSuffix}";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -9,7 +9,10 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 
 /// <summary>
 /// ONT provider for the Nokia (Alcatel-Lucent, vendor ID "ALCL") XS-010X-Q XGS-PON
-/// ONT and its GponForm web siblings. The device serves a plain-HTTP nginx
+/// ONT. The GponForm web API is shared across Nokia's box ONTs, so the reported model
+/// and XGS-PON type are hardcoded to the XS-010X-Q (the device reports neither its own
+/// model nor a line rate); a GPON sibling like the G-010G-Q would need those adjusted.
+/// The device serves a plain-HTTP nginx
 /// UI whose only data-bearing page is moreinfo.html, backed by a small JSON API:
 ///
 ///   1. POST /GponForm/Login_GetConfig (token=token) -> {"nonce":..,"saltval":..}

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -9,7 +9,7 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 
 /// <summary>
 /// ONT provider for the Nokia (Alcatel-Lucent, vendor ID "ALCL") XS-010X-Q XGS-PON
-/// SFP+ ONT stick and its GponForm web siblings. The device serves a plain-HTTP nginx
+/// ONT and its GponForm web siblings. The device serves a plain-HTTP nginx
 /// UI whose only data-bearing page is moreinfo.html, backed by a small JSON API:
 ///
 ///   1. POST /GponForm/Login_GetConfig (token=token) -> {"nonce":..,"saltval":..}
@@ -242,7 +242,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
             if (GetStringProp(root, "SerialNum") is { Length: > 0 } serial)
                 stats.VendorSn = serial;
 
-            // XS-010X-Q is a 10G-symmetric XGS-PON stick; the device exposes no line rate,
+            // XS-010X-Q is a 10G-symmetric XGS-PON ONT; the device exposes no line rate,
             // so the PON type is taken from the model rather than derived from a rate field.
             stats.PonType = "XGS-PON";
 

--- a/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
@@ -1,0 +1,117 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class NokiaXs010xOntProviderTests
+{
+    // Shape captured from a live XS-010X-Q's /GponForm/getUpdateinfo response; identifying
+    // serial/MAC replaced with generic placeholders per the no-PII-in-tests rule.
+    private const string FullUpdateInfoJson = """
+        {
+          "CurrentPonPw" : "000000000000000000000000000000000000000000000000000000000000000000000000",
+          "VendorID" : "ALCL",
+          "VersionID" : "3FE49331AAAA01",
+          "SerialNum" : "ALCLaabbccdd",
+          "Mac" : "001122334455",
+          "ActiveSwVer" : "3FE49337BOCK48",
+          "StandbySwVer" : "3FE49337BOCK35",
+          "RxOptPwr" : "-13.3"
+        }
+        """;
+
+    [Fact]
+    public void ApplyUpdateInfo_FullFixture_MapsAllFields()
+    {
+        var stats = new OntStats();
+
+        NokiaXs010xOntProvider.ApplyUpdateInfo(FullUpdateInfoJson, stats);
+
+        stats.RxPowerDbm.Should().BeApproximately(-13.3, 0.0001);
+        stats.VendorName.Should().Be("ALCL");
+        stats.VendorPn.Should().Be("3FE49331AAAA01");
+        stats.VendorSn.Should().Be("ALCLaabbccdd");
+        stats.PonType.Should().Be("XGS-PON");
+        stats.OperationalStatus.Should().Be("Up");
+        stats.LinkState.Should().Be("Up");
+        stats.TxPowerDbm.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyUpdateInfo_MissingRxPower_LeavesStatusUnknown()
+    {
+        var stats = new OntStats();
+        var json = """{"VendorID":"ALCL","SerialNum":"ALCLaabbccdd"}""";
+
+        NokiaXs010xOntProvider.ApplyUpdateInfo(json, stats);
+
+        stats.RxPowerDbm.Should().BeNull();
+        stats.OperationalStatus.Should().BeNull();
+        stats.LinkState.Should().BeNull();
+        stats.VendorName.Should().Be("ALCL");
+    }
+
+    [Fact]
+    public void ApplyUpdateInfo_MalformedJson_DoesNotThrowAndLeavesDefaults()
+    {
+        var stats = new OntStats();
+
+        var act = () => NokiaXs010xOntProvider.ApplyUpdateInfo("not json", stats);
+
+        act.Should().NotThrow();
+        stats.RxPowerDbm.Should().BeNull();
+        stats.OperationalStatus.Should().BeNull();
+    }
+
+    [Fact]
+    public void ComputeCmt_MatchesLiveDeviceDigest()
+    {
+        // Verified against a live unit: sha256("admin" + "ea" + "1234").
+        NokiaXs010xOntProvider.ComputeCmt("admin", "ea", "1234")
+            .Should().Be("b7290cb39156057010fd604590fe9c01ee72d700cf20f301a51d8fdef3f22fc7");
+    }
+
+    [Fact]
+    public void ParseLoginConfig_ReturnsNonceAndSalt()
+    {
+        var json = """
+            {"XError":0,"XStopTime":300,"XPasswdTip":" ","nonce":"AbCdEfGhIjKlMnOpQrStUvWxYz012345","saltval":"ea"}
+            """;
+
+        var (nonce, salt) = NokiaXs010xOntProvider.ParseLoginConfig(json);
+
+        nonce.Should().Be("AbCdEfGhIjKlMnOpQrStUvWxYz012345");
+        salt.Should().Be("ea");
+    }
+
+    [Fact]
+    public void ParseLoginConfig_MalformedJson_ReturnsNulls()
+    {
+        var (nonce, salt) = NokiaXs010xOntProvider.ParseLoginConfig("not json");
+
+        nonce.Should().BeNull();
+        salt.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseCookieId_SuccessResponse_ReturnsCookie()
+    {
+        var json = """{"login_result":"success","cookieid":"deadbeefcafe0123"}""";
+
+        NokiaXs010xOntProvider.ParseCookieId(json).Should().Be("deadbeefcafe0123");
+    }
+
+    [Fact]
+    public void ParseCookieId_ErrorResponse_ReturnsNull()
+    {
+        NokiaXs010xOntProvider.ParseCookieId("""{"login_result":"error"}""").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseCookieId_MissingCookie_ReturnsNull()
+    {
+        NokiaXs010xOntProvider.ParseCookieId("""{"login_result":"success"}""").Should().BeNull();
+    }
+}


### PR DESCRIPTION
Adds external ONT monitoring for the Nokia (Alcatel-Lucent, vendor ID `ALCL`) XS-010X-Q XGS-PON ONT, requested in #929.

## Monitoring - ONT Stats

- **Nokia XS-010X-Q (HTTP)** - a new ONT provider selectable in Settings when adding an ONT. It logs into the device's `GponForm` web API (nonce + salted SHA-256 handshake) and reads the receive optical power (the one health metric this ONT reports), along with vendor ID, hardware version, and serial number. Link status is surfaced as Up whenever a valid RX reading comes back, since the device exposes no explicit link-state field.

Thanks to @jakerobb for the research and HAR trace!

Closes #929
