### PR TITLE
Adaptive SQM: opt-in rate-proportional download burst (experimental per-WAN setting)

### DIFF
--- a/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
+++ b/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
@@ -33,6 +33,16 @@ public class SqmConfiguration
     public bool ShapeUpload { get; set; } = false;
 
     /// <summary>
+    /// Opt-in: size the download (IFB) HTB burst proportionally to the shaped rate
+    /// (~1 ms of line time) instead of the conservative 5 KB clamp. Off by default.
+    /// Helps on paths where the conservative bucket is only a few packets and throughput
+    /// tracks scheduling latency rather than the configured rate; can worsen the loaded
+    /// latency tail and interact with an upstream policer, so it is not a default.
+    /// Egress is unaffected either way.
+    /// </summary>
+    public bool RateProportionalDownloadBurst { get; set; } = false;
+
+    /// <summary>
     /// WAN interface name (e.g., "eth2", "eth4")
     /// </summary>
     public string Interface { get; set; } = "eth2";

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -244,6 +244,7 @@ public class ScriptGenerator
         sb.AppendLine($"MIN_DOWNLOAD_SPEED=\"{_config.MinDownloadSpeed}\"");
         sb.AppendLine($"UPLOAD_SPEED=\"{_config.NominalUploadSpeed}\"");
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
+        sb.AppendLine($"DOWNLOAD_BURST_MODE={(_config.RateProportionalDownloadBurst ? "1" : "0")}");
         sb.AppendLine($"DOWNLOAD_SPEED_MULTIPLIER=\"{Inv(_config.OverheadMultiplier)}\"");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
         // Physical link speed final clamp (0 = unknown, skip clamp). LINK_SPEED_HEADROOM reserves
@@ -288,7 +289,10 @@ public class ScriptGenerator
 
         // Set probe rate slightly above max shaping rate before speedtest so TC never engages
         sb.AppendLine("# Set SQM to probe rate (3% above max shaping rate) before speedtest for unshaped measurement");
-        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE");
+        // The probe runs with the configured burst mode too: with the conservative bucket a
+        // throughput-limited path under-measures itself here, and that low number is what the
+        // adaptive rate is derived from.
+        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE $DOWNLOAD_BURST_MODE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
         sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
@@ -346,7 +350,7 @@ public class ScriptGenerator
         sb.AppendLine("echo \"Measured download speed: $download_speed_mbps Mbps\" > \"$RESULT_FILE\"");
         sb.AppendLine();
         sb.AppendLine("# Apply TC classes (downstream and upstream)");
-        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $download_speed_mbps");
+        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $download_speed_mbps $DOWNLOAD_BURST_MODE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
         sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
@@ -389,6 +393,7 @@ public class ScriptGenerator
         sb.AppendLine($"MAX_DOWNLOAD_SPEED_CONFIG=\"{_config.MaxDownloadSpeed}\"");
         sb.AppendLine($"UPLOAD_SPEED=\"{_config.NominalUploadSpeed}\"");
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
+        sb.AppendLine($"DOWNLOAD_BURST_MODE={(_config.RateProportionalDownloadBurst ? "1" : "0")}");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
         sb.AppendLine($"NOMINAL_SPEED=\"{_config.NominalDownloadSpeed}\"");
         // Physical link speed final clamp (0 = unknown, skip clamp). LINK_SPEED_HEADROOM reserves
@@ -558,7 +563,7 @@ public class ScriptGenerator
         sb.AppendLine("fi");
         sb.AppendLine();
 
-        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $new_rate_int");
+        sb.AppendLine("update_all_tc_classes $IFB_DEVICE $new_rate_int $DOWNLOAD_BURST_MODE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
         sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
@@ -580,13 +585,29 @@ public class ScriptGenerator
     /// </summary>
     private string GetTcUpdateFunction()
     {
-        return @"# 5KB burst eliminates downstream drop_overmemory for bulk flows at gig speeds.
-# 8KB+ creates bursty HTB send patterns that increase queue depth variance in fq_codel.
+        return @"# Burst sizing. Mode 0 (default) is the conservative sizing: 5KB burst eliminates
+# downstream drop_overmemory for bulk flows at gig speeds, and 8KB+ creates bursty HTB
+# send patterns that increase queue depth variance in fq_codel.
+#
+# Mode 1 is the opt-in rate-proportional sizing (~1 ms of line time), for paths where the
+# conservative bucket is only 1-3 packets: at 900 Mbit, 5KB is ~44 us of line time, so HTB
+# releases only a few packets per timer wakeup and throughput degenerates into a function
+# of scheduling latency. It is off by default because it showed no gain on other platforms,
+# raised the loaded latency tail on the path where it did help, and can compound with an
+# upstream token-bucket policer. Download (IFB) path only; egress always uses mode 0.
 calc_burst() {
     local rate_mbps=$1
-    local burst=$((rate_mbps * 5))
-    [ ""$burst"" -lt 1500 ] && burst=1500
-    [ ""$burst"" -gt 5000 ] && burst=5000
+    local mode=${2:-0}
+    local burst
+    if [ ""$mode"" = ""1"" ]; then
+        burst=$((rate_mbps * 125))
+        [ ""$burst"" -lt 1500 ] && burst=1500
+        [ ""$burst"" -gt 131072 ] && burst=131072
+    else
+        burst=$((rate_mbps * 5))
+        [ ""$burst"" -lt 1500 ] && burst=1500
+        [ ""$burst"" -gt 5000 ] && burst=5000
+    fi
     echo ""$burst""
 }
 
@@ -631,7 +652,10 @@ calc_fq_limit() {
 update_all_tc_classes() {
     local device=$1
     local new_rate=$2
-    local burst=$(calc_burst $new_rate)
+    # Burst mode is opt-in and download-only: callers on the IFB pass $DOWNLOAD_BURST_MODE,
+    # egress callers omit it and stay on the conservative sizing.
+    local burst_mode=${3:-0}
+    local burst=$(calc_burst $new_rate $burst_mode)
     local fq_mem=$(calc_fq_mem $new_rate)
     local fq_limit=$(calc_fq_limit $new_rate)
 

--- a/src/NetworkOptimizer.Storage/Migrations/20260726091714_AddSqmRateProportionalDownloadBurst.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260726091714_AddSqmRateProportionalDownloadBurst.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260726091714_AddSqmRateProportionalDownloadBurst")]
+    partial class AddSqmRateProportionalDownloadBurst
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260726091714_AddSqmRateProportionalDownloadBurst.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260726091714_AddSqmRateProportionalDownloadBurst.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSqmRateProportionalDownloadBurst : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RateProportionalDownloadBurst",
+                table: "SqmWanConfigurations",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RateProportionalDownloadBurst",
+                table: "SqmWanConfigurations");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/SqmWanConfiguration.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmWanConfiguration.cs
@@ -70,6 +70,9 @@ public class SqmWanConfiguration
     /// <summary>Delay in seconds before running the first speedtest after deploy/boot. Null = use default (5s solo, staggered for dual-WAN).</summary>
     public int? BootDelaySeconds { get; set; }
 
+    /// <summary>Opt-in rate-proportional download burst (~1 ms of line time) instead of the conservative 5 KB clamp. False = conservative (default).</summary>
+    public bool RateProportionalDownloadBurst { get; set; } = false;
+
     /// <summary>When this configuration was created</summary>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Repositories/SpeedTestRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/SpeedTestRepository.cs
@@ -447,6 +447,7 @@ public class SpeedTestRepository : ISpeedTestRepository
                 existing.CongestionSeverity = config.CongestionSeverity;
                 existing.LinkSpeedOverrideMbps = config.LinkSpeedOverrideMbps;
                 existing.BootDelaySeconds = config.BootDelaySeconds;
+                existing.RateProportionalDownloadBurst = config.RateProportionalDownloadBurst;
                 existing.UpdatedAt = DateTime.UtcNow;
             }
             else

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -659,6 +659,13 @@
                         <span class="form-hint" style="margin: 0;">seconds</span>
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="toggle-label">
+                        <input type="checkbox" @bind="wan1Config.RateProportionalDownloadBurst" />
+                        <span>Experimental: rate-proportional download burst</span>
+                    </label>
+                    <small class="form-hint">@BurstOptInHint</small>
+                </div>
             </div>
                 </div>
             </div>
@@ -840,6 +847,13 @@
                                @onchange="@(e => wan2Config.BootDelaySeconds = ParseNullableInt(e.Value?.ToString(), 0, 600))" />
                         <span class="form-hint" style="margin: 0;">seconds</span>
                     </div>
+                </div>
+                <div class="form-group">
+                    <label class="toggle-label">
+                        <input type="checkbox" @bind="wan2Config.RateProportionalDownloadBurst" />
+                        <span>Experimental: rate-proportional download burst</span>
+                    </label>
+                    <small class="form-hint">@BurstOptInHint</small>
                 </div>
             </div>
                 </div>
@@ -1560,6 +1574,16 @@
 @code {
     private bool IsLicenseRestricted => !LicenseState.IsSiteOperational(SiteContext.Slug);
 
+    // Deliberately states both sides of the measured tradeoff: this option helped a lot on one
+    // path and not at all on others, and it cost loaded-latency tail on the path it helped.
+    private const string BurstOptInHint =
+        "Sizes the download burst to roughly 1 ms of line time instead of the 5 KB default. " +
+        "On one UCG Fiber (PPPoE, 894 Mbit cap) mean download rose from 579 to 792 Mbit, but the " +
+        "saturated-download latency tail rose with it (p99 26.5 to 48.4 ms). Other platforms measured " +
+        "no gain at all, and a larger burst can interact badly with an ISP-side policer. Leave this off " +
+        "unless your shaped download stays well below the configured rate, and compare loaded latency " +
+        "before and after enabling it. Upload is not affected.";
+
     // Cache settings
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
     private static DateTime _lastStatusCheck = DateTime.MinValue;
@@ -1924,6 +1948,7 @@
                     config.WanLinkSpeedMbps = matchingWan?.LinkSpeedMbps;
                     config.LinkSpeedOverrideMbps = saved.LinkSpeedOverrideMbps;
                     config.BootDelaySeconds = saved.BootDelaySeconds;
+                    config.RateProportionalDownloadBurst = saved.RateProportionalDownloadBurst;
 
                     UpdateCalculatedSpeeds(config);
 
@@ -1981,6 +2006,7 @@
                     CongestionSeverity = wan1Config.CongestionSeverity,
                     LinkSpeedOverrideMbps = wan1Config.LinkSpeedOverrideMbps,
                     BootDelaySeconds = wan1Config.BootDelaySeconds,
+                    RateProportionalDownloadBurst = wan1Config.RateProportionalDownloadBurst,
                     SpeedtestMorningHour = wan1Config.MorningHour,
                     SpeedtestMorningMinute = wan1Config.MorningMinute,
                     SpeedtestEveningHour = wan1Config.EveningHour,
@@ -2010,6 +2036,7 @@
                     CongestionSeverity = wan2Config.CongestionSeverity,
                     LinkSpeedOverrideMbps = wan2Config.LinkSpeedOverrideMbps,
                     BootDelaySeconds = wan2Config.BootDelaySeconds,
+                    RateProportionalDownloadBurst = wan2Config.RateProportionalDownloadBurst,
                     SpeedtestMorningHour = wan2Config.MorningHour,
                     SpeedtestMorningMinute = wan2Config.MorningMinute,
                     SpeedtestEveningHour = wan2Config.EveningHour,
@@ -2224,6 +2251,7 @@
         wan1Config.EveningHour = 19;
         wan1Config.EveningMinute = 0;
         wan1Config.BootDelaySeconds = null;
+        wan1Config.RateProportionalDownloadBurst = false;
         UpdateCalculatedSpeeds(wan1Config);
 
         // Reset WAN2 to defaults
@@ -2240,6 +2268,7 @@
         wan2Config.EveningHour = 18;
         wan2Config.EveningMinute = 0;
         wan2Config.BootDelaySeconds = null;
+        wan2Config.RateProportionalDownloadBurst = false;
         UpdateCalculatedSpeeds(wan2Config);
     }
 
@@ -3126,6 +3155,7 @@
             NominalDownloadSpeed = model.NominalDownload,
             NominalUploadSpeed = model.NominalUpload,
             ShapeUpload = true,
+            RateProportionalDownloadBurst = model.RateProportionalDownloadBurst,
             PingHost = model.PingHost,
             PreferredSpeedtestServerId = model.SpeedtestServerId,
             // Use user-configured schedule times
@@ -3258,6 +3288,9 @@
         // Delay before first speedtest after deploy/boot (null = use default)
         public int? BootDelaySeconds { get; set; }
 
+        // Opt-in rate-proportional download burst (~1 ms of line time) instead of the 5 KB clamp
+        public bool RateProportionalDownloadBurst { get; set; }
+
         // Physical WAN port link speed (null if unknown, e.g., GRE tunnels)
         public int? WanLinkSpeedMbps { get; set; }
 
@@ -3346,7 +3379,7 @@
             Enabled, Name, Interface, ConnectionType, NominalDownload, NominalUpload,
             PingHost, SpeedtestServerId, MorningHour, MorningMinute, EveningHour, EveningMinute,
             BaselineLatency, LatencyThreshold, CongestionSeverity, LinkSpeedOverrideMbps,
-            BootDelaySeconds);
+            BootDelaySeconds, RateProportionalDownloadBurst);
 
         // Check if current config differs from a snapshot
         public bool DiffersFrom(WanConfigSnapshot? snapshot)
@@ -3368,7 +3401,8 @@
                    Math.Abs(LatencyThreshold - snapshot.LatencyThreshold) > 0.01 ||
                    Math.Abs(CongestionSeverity - snapshot.CongestionSeverity) > 0.001 ||
                    LinkSpeedOverrideMbps != snapshot.LinkSpeedOverrideMbps ||
-                   BootDelaySeconds != snapshot.BootDelaySeconds;
+                   BootDelaySeconds != snapshot.BootDelaySeconds ||
+                   RateProportionalDownloadBurst != snapshot.RateProportionalDownloadBurst;
         }
     }
 
@@ -3378,7 +3412,7 @@
         int NominalDownload, int NominalUpload, string PingHost, string? SpeedtestServerId,
         int MorningHour, int MorningMinute, int EveningHour, int EveningMinute,
         double BaselineLatency, double LatencyThreshold, double CongestionSeverity,
-        int? LinkSpeedOverrideMbps, int? BootDelaySeconds);
+        int? LinkSpeedOverrideMbps, int? BootDelaySeconds, bool RateProportionalDownloadBurst);
 
     public void Dispose()
     {

--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -342,6 +342,147 @@ public class ScriptGeneratorTests
         Assert.Null(config.WanLinkSpeedMbps);
     }
 
+    [Fact]
+    public void SqmConfiguration_DefaultsToConservativeBurst()
+    {
+        // Guards the property initializer itself: the generator tests below set the flag
+        // explicitly, so a default flipped to true would not show up there.
+        Assert.False(new SqmConfiguration().RateProportionalDownloadBurst);
+    }
+
+    [Fact]
+    public void GenerateAllScripts_ByDefault_SelectsConservativeBurstMode()
+    {
+        var scripts = GenerateWithBurstOptIn(false);
+
+        // Every script that carries the burst machinery must select mode 0.
+        var withMode = scripts.Values.Where(s => s.Contains("DOWNLOAD_BURST_MODE=")).ToList();
+        Assert.NotEmpty(withMode);
+        foreach (var script in withMode)
+        {
+            Assert.Contains("DOWNLOAD_BURST_MODE=0", script);
+            Assert.DoesNotContain("DOWNLOAD_BURST_MODE=1", script);
+        }
+    }
+
+    [Fact]
+    public void GenerateAllScripts_WithBurstOptIn_SelectsRateProportionalMode()
+    {
+        var scripts = GenerateWithBurstOptIn(true);
+
+        var withMode = scripts.Values.Where(s => s.Contains("DOWNLOAD_BURST_MODE=")).ToList();
+        Assert.NotEmpty(withMode);
+        foreach (var script in withMode)
+        {
+            Assert.Contains("DOWNLOAD_BURST_MODE=1", script);
+            Assert.DoesNotContain("DOWNLOAD_BURST_MODE=0", script);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CalcBurst_CarriesBothFormulas_InEveryEmbeddedCopy(bool optIn)
+    {
+        var scripts = GenerateWithBurstOptIn(optIn);
+
+        // calc_burst is embedded into more than one generated script (speedtest + ping).
+        // A copy that carries the definition but not both branches would silently shape
+        // one code path differently from the other.
+        var copies = scripts.Values.Where(s => s.Contains("calc_burst()")).ToList();
+        Assert.NotEmpty(copies);
+        foreach (var script in copies)
+        {
+            Assert.Contains("burst=$((rate_mbps * 5))", script);
+            Assert.Contains("-gt 5000 ] && burst=5000", script);
+            Assert.Contains("burst=$((rate_mbps * 125))", script);
+            Assert.Contains("-gt 131072 ] && burst=131072", script);
+            Assert.Contains("-lt 1500 ] && burst=1500", script);
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void BurstMode_AppliesToDownloadPathOnly(bool optIn)
+    {
+        var scripts = GenerateWithBurstOptIn(optIn);
+        var all = string.Join("\n", scripts.Values);
+
+        // Egress: the upload calls must not carry a burst mode argument, so they stay on the
+        // conservative sizing regardless of the setting (no upload evidence supports changing it).
+        Assert.Contains("update_all_tc_classes $INTERFACE $UPLOAD_SPEED\n", all + "\n");
+        Assert.DoesNotContain("update_all_tc_classes $INTERFACE $UPLOAD_SPEED $DOWNLOAD_BURST_MODE", all);
+
+        // tune_tc_performance only ever runs on the WAN device and must stay conservative too.
+        Assert.Contains("update_all_tc_classes $device $current_rate\n", all);
+        Assert.DoesNotContain("update_all_tc_classes $device $current_rate $", all);
+
+        // Ingress/IFB: every call passes the mode through.
+        foreach (var line in all.Split('\n').Where(l => l.Contains("update_all_tc_classes $IFB_DEVICE")))
+        {
+            Assert.EndsWith("$DOWNLOAD_BURST_MODE", line.TrimEnd());
+        }
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SpeedtestProbe_UsesTheConfiguredBurstMode(bool optIn)
+    {
+        var scripts = GenerateWithBurstOptIn(optIn);
+        var all = string.Join("\n", scripts.Values);
+
+        // The probe rate is applied before measuring. Running it with a different bucket than
+        // normal operation would let a throughput-limited path under-measure itself, and that
+        // number is what the adaptive rate is derived from.
+        Assert.Contains(
+            "update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE $DOWNLOAD_BURST_MODE",
+            all);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void EveryScriptReferencingBurstMode_AlsoDefinesIt(bool optIn)
+    {
+        var scripts = GenerateWithBurstOptIn(optIn);
+
+        // An undefined $DOWNLOAD_BURST_MODE expands to the empty string, which calc_burst
+        // treats as conservative - the opt-in would silently do nothing instead of failing.
+        // The speedtest and ping scripts are written as separate heredocs into one boot
+        // script, so each heredoc has to carry its own definition; checking the boot script
+        // as a whole would let one heredoc's definition cover for the other's omission.
+        var bootScript = Assert.Single(scripts.Values);
+
+        foreach (var delimiter in new[] { "SPEEDTEST_EOF", "PING_EOF" })
+        {
+            var section = ExtractHeredocSection(bootScript, delimiter);
+            if (!section.Contains("$DOWNLOAD_BURST_MODE"))
+                continue;
+
+            Assert.True(
+                section.Contains("DOWNLOAD_BURST_MODE=0") || section.Contains("DOWNLOAD_BURST_MODE=1"),
+                $"Heredoc '{delimiter}' expands $DOWNLOAD_BURST_MODE without defining it");
+        }
+    }
+
+    private static Dictionary<string, string> GenerateWithBurstOptIn(bool optIn)
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionName = "Burst WAN",
+            Interface = "eth0",
+            NominalDownloadSpeed = 900,
+            NominalUploadSpeed = 550,
+            PingHost = "1.1.1.1",
+            RateProportionalDownloadBurst = optIn
+        };
+
+        var generator = new ScriptGenerator(config);
+        return generator.GenerateAllScripts(new Dictionary<string, string> { ["0_12"] = "880" });
+    }
+
     /// <summary>
     /// Extracts the content between heredoc delimiters (e.g., between 'SPEEDTEST_EOF' markers).
     /// </summary>


### PR DESCRIPTION
Addresses #1006. Reworked from a default change into an opt-in, following your call that this belongs behind a power-user option rather than in `calc_burst` for everyone. Base moved from `main` to `dev`.

## What this does now

`calc_burst()` takes a mode argument. Mode 0 is the existing conservative sizing (`rate_mbps * 5`, capped at 5000) and stays the default everywhere. Mode 1 is the rate-proportional sizing (`rate_mbps * 125`, about 1 ms of line time, capped at 131072). `update_all_tc_classes()` takes the mode as an optional third argument, so any caller that omits it gets the conservative bucket.

The calculated value is applied as both `burst` and `cburst`, on the root class `1:1` and on every best-effort child class that `update_all_tc_classes` touches. That is unchanged from today, but worth stating since the opt-in scales all of them at once. I kept `burst` and `cburst` coupled because that is the configuration I measured.

**Download only.** The IFB call sites pass `$DOWNLOAD_BURST_MODE`; the egress calls and `tune_tc_performance` omit it and stay conservative in both modes. My runs showed no upload effect at a 550 Mbit cap, so there is no evidence that would justify touching the egress bucket.

**The speedtest probe uses the configured mode as well.** It reshapes the IFB to the probe rate before measuring, so running the probe conservatively while normal operation runs rate-proportional would let a throughput-limited path under-measure itself, and that measurement is what the adaptive rate is derived from.

**Persistence** is per WAN (`SqmWanConfiguration.RateProportionalDownloadBurst`), written through the existing save/deploy path like the other per-WAN fields. The migration defaults the column to false, so existing deployments keep exactly today's behavior after an upgrade. The control is an Experimental checkbox on each WAN card, next to the per-WAN advanced fields.

## Correction to the original description

The first version of this PR said p99 stayed flat. Later TCP-connect A/B runs, posted in #1006, contradicted that. At a 894 Mbit cap: mean download 579 -> 792 Mbit, but the saturated-download tail p95 19.3 -> 29.1 ms and p99 26.5 -> 48.4 ms.

Both sides are now in the generated script comment and in the UI hint, along with the facts that your platforms measured no throughput gain at all and that a larger burst can compound with an upstream token-bucket policer.

Those runs do not isolate the effect of bucket size from the additional delivered load: the faster cell also carried about 213 Mbit more and ran closer to this box's processing ceiling. The comment says as much rather than attributing the tail to the bucket.

## Testing

`NetworkOptimizer.Sqm.Tests` 267/267, full solution 7907 green.

The new assertions were checked against mutations rather than just observed to be green: dropping the mode argument from an IFB call site fails the suite, and dropping the mode definition from one of the two heredocs fails it as well. The second case is the one I would otherwise have missed, since an undefined `$DOWNLOAD_BURST_MODE` expands to an empty string and `calc_burst` treats that as conservative, so the opt-in would silently do nothing.

Coverage is on script generation plus the property default. I did not add persistence or UI tests for the new field; it follows the same save/load path as the existing per-WAN settings.
