### PR TITLE
Security Audit: recognize raw-MAC firewall sources and fix cross-zone eclipse false positive

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -1556,6 +1556,18 @@ public class FirewallRuleAnalyzer
     /// <returns>True if the block rule affects the same source as the allow rule</returns>
     private static bool BlockRuleAffectsSameSource(FirewallRule blockRule, FirewallRule allowRule)
     {
+        // Rules scoped to different source zones cannot affect each other's sources.
+        // An ANY source is ANY within its zone, not global - a broad block in zone A
+        // never covers an allow whose source lives in zone B. Zone-based rules always
+        // carry a source zone ID; an empty one only occurs on pre-Zone-Based (legacy)
+        // sites (unmapped rulesets parse with no zone), where the check must not apply.
+        if (!string.IsNullOrEmpty(blockRule.SourceZoneId) &&
+            !string.IsNullOrEmpty(allowRule.SourceZoneId) &&
+            !string.Equals(blockRule.SourceZoneId, allowRule.SourceZoneId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
         // Block rule with ANY source affects all sources
         if (blockRule.IsAnySource())
             return true;

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleOverlapDetector.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleOverlapDetector.cs
@@ -183,6 +183,14 @@ public static class FirewallRuleOverlapDetector
             return ListsOverlapWithOpposite(ips1, opposite1, ips2, opposite2, IpRangesOverlap);
         }
 
+        // Both are CLIENT (MAC-scoped) - check for common MAC addresses
+        if (target1 == "CLIENT")
+        {
+            var macs1 = rule1.SourceClientMacs ?? new List<string>();
+            var macs2 = rule2.SourceClientMacs ?? new List<string>();
+            return StringListsIntersect(macs1, macs2);
+        }
+
         return false;
     }
 

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
@@ -193,6 +193,26 @@ public class FirewallRuleParser
                     .ToList();
             }
 
+            // Newer UniFi releases emit matching_target "MAC" with a "macs" array instead of
+            // "CLIENT" with "client_macs". Same semantics - normalize to the canonical CLIENT form
+            // so downstream scope scoring and overlap detection treat them identically.
+            if (source.TryGetProperty("macs", out var macList) && macList.ValueKind == JsonValueKind.Array)
+            {
+                var parsedMacs = macList.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString()!)
+                    .ToList();
+                if (parsedMacs.Count > 0)
+                {
+                    sourceClientMacs = sourceClientMacs == null
+                        ? parsedMacs
+                        : sourceClientMacs.Concat(parsedMacs).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                }
+            }
+
+            if (string.Equals(sourceMatchingTarget, "MAC", StringComparison.OrdinalIgnoreCase))
+                sourceMatchingTarget = "CLIENT";
+
             // Flatten IP group reference (matching_target_type == "OBJECT" with ip_group_id)
             var matchingTargetType = source.GetStringOrNull("matching_target_type");
             var ipGroupId = source.GetStringOrNull("ip_group_id");
@@ -443,6 +463,14 @@ public class FirewallRuleParser
             ? srcPortProp.GetString()
             : null;
 
+        // Legacy rules can restrict the source to a single device MAC
+        var srcMacAddress = rule.TryGetProperty("src_mac_address", out var srcMacProp)
+            ? srcMacProp.GetString()
+            : null;
+        List<string>? sourceClientMacs = null;
+        if (!string.IsNullOrEmpty(srcMacAddress))
+            sourceClientMacs = new List<string> { srcMacAddress };
+
         // Destination information
         var destType = rule.TryGetProperty("dst_type", out var dstTypeProp)
             ? dstTypeProp.GetString()
@@ -606,12 +634,17 @@ public class FirewallRuleParser
         // Map legacy ruleset to zone IDs for compatibility with zone-based analysis
         var (sourceZoneId, destZoneId) = MapRulesetToZones(ruleset);
 
-        // Determine matching targets based on resolved fields
+        // Determine matching targets based on resolved fields.
+        // IP/NETWORK take precedence over CLIENT so a rule with both an address and a MAC
+        // restriction keeps participating in IP/network overlap checks (a MAC further narrows
+        // the rule; it never broadens it).
         string? sourceMatchingTarget = null;
         if (sourceIps is { Count: > 0 })
             sourceMatchingTarget = "IP";
         else if (sourceNetworkIds is { Count: > 0 })
             sourceMatchingTarget = "NETWORK";
+        else if (sourceClientMacs is { Count: > 0 })
+            sourceMatchingTarget = "CLIENT";
 
         string? destMatchingTarget = null;
         if (destIps is { Count: > 0 })
@@ -673,6 +706,7 @@ public class FirewallRuleParser
             SourceNetworkIds = sourceNetworkIds,
             SourceMatchingTarget = sourceMatchingTarget,
             SourceIps = sourceIps,
+            SourceClientMacs = sourceClientMacs,
             DestinationNetworkIds = destinationNetworkIds,
             DestinationMatchingTarget = destMatchingTarget,
             DestinationIps = destIps,

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
@@ -193,9 +193,11 @@ public class FirewallRuleParser
                     .ToList();
             }
 
-            // Newer UniFi releases emit matching_target "MAC" with a "macs" array instead of
-            // "CLIENT" with "client_macs". Same semantics - normalize to the canonical CLIENT form
-            // so downstream scope scoring and overlap detection treat them identically.
+            // UniFi's newer raw source MAC restriction feature emits matching_target "MAC" with
+            // a "macs" array; the older client-based restriction uses "CLIENT" with "client_macs".
+            // Both shapes coexist in one response (verified on UniFi Network 10.5.62 EA). Both are
+            // device-scoped sources, so normalize to the canonical CLIENT form and downstream
+            // scope scoring and overlap detection treat them identically.
             if (source.TryGetProperty("macs", out var macList) && macList.ValueKind == JsonValueKind.Array)
             {
                 var parsedMacs = macList.EnumerateArray()

--- a/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
+++ b/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
@@ -123,8 +123,9 @@ public class FirewallRule
 
     /// <summary>
     /// Source matching target type (ANY, IP, NETWORK, CLIENT).
-    /// CLIENT is the canonical form for MAC-scoped sources: the parser normalizes the
-    /// "MAC"/"macs" shape emitted by newer UniFi releases to CLIENT/SourceClientMacs.
+    /// CLIENT is the canonical form for device-scoped sources: the parser normalizes the
+    /// "MAC"/"macs" shape (UniFi's raw source MAC restriction feature) to
+    /// CLIENT/SourceClientMacs, alongside the older client-based "CLIENT"/"client_macs" shape.
     /// </summary>
     public string? SourceMatchingTarget { get; init; }
 

--- a/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
+++ b/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
@@ -122,7 +122,9 @@ public class FirewallRule
     // === Extended Matching Criteria for Overlap Detection ===
 
     /// <summary>
-    /// Source matching target type (ANY, IP, NETWORK)
+    /// Source matching target type (ANY, IP, NETWORK, CLIENT).
+    /// CLIENT is the canonical form for MAC-scoped sources: the parser normalizes the
+    /// "MAC"/"macs" shape emitted by newer UniFi releases to CLIENT/SourceClientMacs.
     /// </summary>
     public string? SourceMatchingTarget { get; init; }
 
@@ -132,7 +134,8 @@ public class FirewallRule
     public List<string>? SourceIps { get; init; }
 
     /// <summary>
-    /// Source client MAC addresses (when SourceMatchingTarget is CLIENT)
+    /// Source client MAC addresses (when SourceMatchingTarget is CLIENT).
+    /// Populated from v2 "client_macs" or "macs", or legacy "src_mac_address".
     /// </summary>
     public List<string>? SourceClientMacs { get; init; }
 

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -1527,6 +1527,136 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void DetectShadowedRules_MacScopedAllowBeforeZoneWideDeny_ReturnsExceptionPattern()
+    {
+        // Issue #1011: a one-MAC allow (newer "MAC"/"macs" JSON shape) preceding a zone-wide
+        // ANY deny is an intentional narrow exception (FW-EXCEPTION-001), not FW-SUBVERT-001
+        var allowJson = System.Text.Json.JsonDocument.Parse(@"{
+            ""_id"": ""allow-failover"",
+            ""name"": ""Allow Failover Device to External"",
+            ""action"": ""ALLOW"",
+            ""enabled"": true,
+            ""index"": 10000,
+            ""protocol"": ""all"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""macs"": [""aa:bb:cc:dd:ee:ff""],
+                ""zone_id"": ""mgmt-zone""
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""external-zone""
+            }
+        }").RootElement;
+        var denyJson = System.Text.Json.JsonDocument.Parse(@"{
+            ""_id"": ""block-mgmt-external"",
+            ""name"": ""Block Management to External"",
+            ""action"": ""BLOCK"",
+            ""enabled"": true,
+            ""index"": 10008,
+            ""protocol"": ""all"",
+            ""source"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""mgmt-zone""
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""external-zone""
+            }
+        }").RootElement;
+
+        var rules = new List<FirewallRule>
+        {
+            _analyzer.ParseFirewallPolicy(allowJson)!,
+            _analyzer.ParseFirewallPolicy(denyJson)!
+        };
+
+        var issues = _analyzer.DetectShadowedRules(rules, networkConfigs: null, externalZoneId: "external-zone");
+
+        issues.Should().NotContain(i => i.Type == "ALLOW_SUBVERTS_DENY");
+        var issue = issues.FirstOrDefault(i => i.Type == "ALLOW_EXCEPTION_PATTERN");
+        issue.Should().NotBeNull();
+        issue!.Severity.Should().Be(AuditSeverity.Informational);
+        issue.RuleId.Should().Be("FW-EXCEPTION-001");
+        issue.Description.Should().Be("External Access");
+    }
+
+    [Fact]
+    public void DetectShadowedRules_MacScopedDenyBeforeMacScopedAllow_SameDevice_ReturnsShadowedIssue()
+    {
+        // Two MAC-scoped rules for the SAME device previously never overlapped
+        // (CLIENT vs CLIENT fell through to no-overlap), hiding real shadowing
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "deny-device",
+                Name = "Block Device",
+                Action = "block",
+                Enabled = true,
+                Index = 1,
+                Protocol = "all",
+                SourceMatchingTarget = "CLIENT",
+                SourceClientMacs = new List<string> { "aa:bb:cc:dd:ee:ff" },
+                DestinationMatchingTarget = "ANY"
+            },
+            new FirewallRule
+            {
+                Id = "allow-device",
+                Name = "Allow Device",
+                Action = "allow",
+                Enabled = true,
+                Index = 2,
+                Protocol = "all",
+                SourceMatchingTarget = "CLIENT",
+                SourceClientMacs = new List<string> { "aa:bb:cc:dd:ee:ff" },
+                DestinationMatchingTarget = "ANY"
+            }
+        };
+
+        var issues = _analyzer.DetectShadowedRules(rules);
+
+        issues.Should().ContainSingle();
+        issues.First().Type.Should().Be("DENY_SHADOWS_ALLOW");
+    }
+
+    [Fact]
+    public void DetectShadowedRules_MacScopedRulesForDifferentDevices_ReturnsNoIssues()
+    {
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "deny-device-a",
+                Name = "Block Device A",
+                Action = "block",
+                Enabled = true,
+                Index = 1,
+                Protocol = "all",
+                SourceMatchingTarget = "CLIENT",
+                SourceClientMacs = new List<string> { "aa:bb:cc:dd:ee:01" },
+                DestinationMatchingTarget = "ANY"
+            },
+            new FirewallRule
+            {
+                Id = "allow-device-b",
+                Name = "Allow Device B",
+                Action = "allow",
+                Enabled = true,
+                Index = 2,
+                Protocol = "all",
+                SourceMatchingTarget = "CLIENT",
+                SourceClientMacs = new List<string> { "aa:bb:cc:dd:ee:02" },
+                DestinationMatchingTarget = "ANY"
+            }
+        };
+
+        var issues = _analyzer.DetectShadowedRules(rules);
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
     public void DetectShadowedRules_BroadBlockToNetworkBeforeNarrowAllowToIp_ReturnsShadowedIssue()
     {
         // This tests the scenario where a broad BLOCK rule to NETWORKs eclipses
@@ -2601,6 +2731,33 @@ public class FirewallRuleAnalyzerTests
         var issues = _analyzer.DetectPermissiveRules(rules);
 
         // Not flagged because specific source IPs make the rule restrictive
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void DetectPermissiveRules_MacScopedSourceWithAnyDestination_NotFlagged()
+    {
+        // A MAC-scoped source (newer "MAC"/"macs" shape) restricts the rule to specific
+        // devices, so ANY destination is not broad. Parse from JSON to prove the shape
+        // normalizes to CLIENT and hits the IsSourceMacBased guard.
+        var json = System.Text.Json.JsonDocument.Parse(@"{
+            ""_id"": ""mac-any-dest"",
+            ""name"": ""Allow Failover Device to External"",
+            ""action"": ""ALLOW"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""macs"": [""aa:bb:cc:dd:ee:ff""]
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY""
+            }
+        }").RootElement;
+        var rules = new List<FirewallRule> { _analyzer.ParseFirewallPolicy(json)! };
+
+        var issues = _analyzer.DetectPermissiveRules(rules);
+
         issues.Should().BeEmpty();
     }
 

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -1300,8 +1300,8 @@ public class FirewallRuleAnalyzerTests
     public void AnalyzeManagementNetworkFirewallAccess_CrossZoneBroadBlock_DoesNotEclipse5GAllow()
     {
         // A zone-wide ANY block in a DIFFERENT source zone must not eclipse the 5G allow:
-        // ANY source is scoped to its zone, not global. Live repro: an unrelated
-        // work-zone -> external block falsely triggered FW-MGMT-003 for Management.
+        // ANY source is scoped to its zone, not global. A broad guest-zone -> external
+        // block must never raise FW-MGMT-003 against the Management zone's 5G allow.
         var mgmtNetworkId = "mgmt-network-123";
         var externalZoneId = "external-zone-123";
         var networks = new List<NetworkInfo>
@@ -1314,14 +1314,14 @@ public class FirewallRuleAnalyzerTests
             // Broad block scoped to a completely different source zone
             new FirewallRule
             {
-                Id = "block-work-internet",
-                Name = "Block Work Internet",
+                Id = "block-guest-internet",
+                Name = "Block Guest Internet",
                 Action = "BLOCK",
                 Enabled = true,
                 Index = 100,
                 Protocol = "all",
                 SourceMatchingTarget = "ANY",
-                SourceZoneId = "work-zone",
+                SourceZoneId = "guest-zone",
                 DestinationMatchingTarget = "ANY",
                 DestinationZoneId = externalZoneId
             },

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -1297,6 +1297,157 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void AnalyzeManagementNetworkFirewallAccess_CrossZoneBroadBlock_DoesNotEclipse5GAllow()
+    {
+        // A zone-wide ANY block in a DIFFERENT source zone must not eclipse the 5G allow:
+        // ANY source is scoped to its zone, not global. Live repro: an unrelated
+        // work-zone -> external block falsely triggered FW-MGMT-003 for Management.
+        var mgmtNetworkId = "mgmt-network-123";
+        var externalZoneId = "external-zone-123";
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: mgmtNetworkId,
+                networkIsolationEnabled: true, internetAccessEnabled: false, firewallZoneId: "internal-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            // Broad block scoped to a completely different source zone
+            new FirewallRule
+            {
+                Id = "block-work-internet",
+                Name = "Block Work Internet",
+                Action = "BLOCK",
+                Enabled = true,
+                Index = 100,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "work-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = externalZoneId
+            },
+            CreateFirewallRule("UniFi Cloud", action: "allow", index: 200,
+                sourceNetworkIds: new List<string> { mgmtNetworkId },
+                webDomains: new List<string> { "ui.com" }),
+            CreateFirewallRule("AFC Traffic", action: "allow", index: 201,
+                sourceNetworkIds: new List<string> { mgmtNetworkId },
+                webDomains: new List<string> { "afcapi.qcs.qualcomm.com" }),
+            CreateFirewallRule("NTP", action: "allow", index: 202,
+                sourceNetworkIds: new List<string> { mgmtNetworkId },
+                destinationPort: "123", protocol: "udp"),
+            new FirewallRule
+            {
+                Id = "allow-5g",
+                Name = "5G Modem Registration",
+                Action = "ALLOW",
+                Enabled = true,
+                Index = 300,
+                SourceMatchingTarget = "IP",
+                SourceIps = new List<string> { "192.168.99.5" },
+                SourceZoneId = "internal-zone",
+                WebDomains = new List<string> { "t-mobile.com" },
+                Protocol = "tcp"
+            }
+        };
+
+        var issues = _analyzer.AnalyzeManagementNetworkFirewallAccess(rules, networks, has5GDevice: true, externalZoneId: externalZoneId);
+
+        issues.Should().NotContain(i => i.Type == "MGMT_MISSING_5G_ACCESS");
+    }
+
+    [Fact]
+    public void AnalyzeManagementNetworkFirewallAccess_SameZoneBroadBlock_StillEclipses5GAllow()
+    {
+        // Regression guard for the zone check: a broad ANY block in the SAME source zone
+        // as the 5G allow must still eclipse it and report FW-MGMT-003
+        var mgmtNetworkId = "mgmt-network-123";
+        var externalZoneId = "external-zone-123";
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: mgmtNetworkId,
+                networkIsolationEnabled: true, internetAccessEnabled: false, firewallZoneId: "internal-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "block-internal-internet",
+                Name = "Block Internal Internet",
+                Action = "BLOCK",
+                Enabled = true,
+                Index = 100,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "internal-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = externalZoneId
+            },
+            new FirewallRule
+            {
+                Id = "allow-5g",
+                Name = "5G Modem Registration",
+                Action = "ALLOW",
+                Enabled = true,
+                Index = 300,
+                SourceMatchingTarget = "IP",
+                SourceIps = new List<string> { "192.168.99.5" },
+                SourceZoneId = "internal-zone",
+                WebDomains = new List<string> { "t-mobile.com" },
+                Protocol = "tcp"
+            }
+        };
+
+        var issues = _analyzer.AnalyzeManagementNetworkFirewallAccess(rules, networks, has5GDevice: true, externalZoneId: externalZoneId);
+
+        issues.Should().Contain(i => i.Type == "MGMT_MISSING_5G_ACCESS");
+    }
+
+    [Fact]
+    public void AnalyzeManagementNetworkFirewallAccess_ZonelessLegacyRules_BroadBlockStillEclipses()
+    {
+        // Regression guard for legacy rules: zone IDs are a v2 concept. Legacy rules with
+        // unmapped rulesets have no source zone at all, so the zone check must not apply
+        // and the conservative eclipse behavior is preserved.
+        var mgmtNetworkId = "mgmt-network-123";
+        var externalZoneId = "external-zone-123";
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: mgmtNetworkId,
+                networkIsolationEnabled: true, internetAccessEnabled: false)
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "block-internet",
+                Name = "Block Internet",
+                Action = "BLOCK",
+                Enabled = true,
+                Index = 100,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = externalZoneId
+            },
+            new FirewallRule
+            {
+                Id = "allow-5g",
+                Name = "5G Modem Registration",
+                Action = "ALLOW",
+                Enabled = true,
+                Index = 300,
+                SourceMatchingTarget = "IP",
+                SourceIps = new List<string> { "192.168.99.5" },
+                WebDomains = new List<string> { "t-mobile.com" },
+                Protocol = "tcp"
+            }
+        };
+
+        var issues = _analyzer.AnalyzeManagementNetworkFirewallAccess(rules, networks, has5GDevice: true, externalZoneId: externalZoneId);
+
+        issues.Should().Contain(i => i.Type == "MGMT_MISSING_5G_ACCESS");
+    }
+
+    [Fact]
     public void AnalyzeManagementNetworkFirewallAccess_OppositeIpsBlockRuleEclipsesAllow_Reports5GIssue()
     {
         // Arrange - Block rule uses SourceMatchOppositeIps: blocks all EXCEPT 192.168.50.0/24

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -1582,6 +1582,65 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void DetectShadowedRules_MacScopedAllowWithInterleavedServiceBlocks_NoSubvertIssues()
+    {
+        // Full policy order from issue #1011: the MAC-scoped allow at 10000 is followed by
+        // DNS, DoT/DoQ, and NTP block rules BEFORE the zone-wide deny at 10008. The allow
+        // overlaps every one of those denies; none of the pairs may degrade to FW-SUBVERT-001.
+        FirewallRule MakeBlock(string id, string name, int index, string? protocol, string? port) => new FirewallRule
+        {
+            Id = id,
+            Name = name,
+            Action = "BLOCK",
+            Enabled = true,
+            Index = index,
+            Protocol = protocol,
+            DestinationPort = port,
+            SourceMatchingTarget = "ANY",
+            SourceZoneId = "mgmt-zone",
+            DestinationMatchingTarget = "ANY",
+            DestinationZoneId = "external-zone"
+        };
+
+        var macAllowJson = System.Text.Json.JsonDocument.Parse(@"{
+            ""_id"": ""allow-failover"",
+            ""name"": ""Allow Failover Device to External"",
+            ""action"": ""ALLOW"",
+            ""enabled"": true,
+            ""index"": 10000,
+            ""protocol"": ""all"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""matching_target_type"": ""SPECIFIC"",
+                ""macs"": [""aa:bb:cc:dd:ee:ff""],
+                ""zone_id"": ""mgmt-zone""
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""external-zone""
+            }
+        }").RootElement;
+
+        var rules = new List<FirewallRule>
+        {
+            _analyzer.ParseFirewallPolicy(macAllowJson)!,
+            MakeBlock("block-dns", "Block Management DNS to External", 10002, "tcp_udp", "53"),
+            MakeBlock("block-dot", "Block Management DoT/DoQ to External", 10004, "tcp_udp", "853"),
+            MakeBlock("block-ntp", "Block Management NTP to External", 10006, "udp", "123"),
+            MakeBlock("block-all", "Block Management to External", 10008, "all", null)
+        };
+
+        var issues = _analyzer.DetectShadowedRules(rules, networkConfigs: null, externalZoneId: "external-zone");
+
+        issues.Should().NotContain(i => i.Type == "ALLOW_SUBVERTS_DENY");
+        issues.Should().NotContain(i => i.Type == "DENY_SHADOWS_ALLOW");
+        issues.Should().OnlyContain(i => i.Type == "ALLOW_EXCEPTION_PATTERN");
+        issues.Should().OnlyContain(i => i.Severity == AuditSeverity.Informational);
+        // The allow overlaps each of the four deny rules - all classified as exceptions
+        issues.Should().HaveCount(4);
+    }
+
+    [Fact]
     public void DetectShadowedRules_MacScopedDenyBeforeMacScopedAllow_SameDevice_ReturnsShadowedIssue()
     {
         // Two MAC-scoped rules for the SAME device previously never overlapped

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleOverlapDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleOverlapDetectorTests.cs
@@ -214,6 +214,25 @@ public class FirewallRuleOverlapDetectorTests
     }
 
     [Fact]
+    public void SourcesOverlap_BothClient_SharedMac_ReturnsTrue()
+    {
+        // Two MAC-scoped rules targeting the same device overlap (case-insensitive)
+        var rule1 = CreateRule(sourceMatchingTarget: "CLIENT", sourceClientMacs: new List<string> { "AA:BB:CC:DD:EE:FF" });
+        var rule2 = CreateRule(sourceMatchingTarget: "CLIENT", sourceClientMacs: new List<string> { "aa:bb:cc:dd:ee:ff", "11:22:33:44:55:66" });
+
+        FirewallRuleOverlapDetector.SourcesOverlap(rule1, rule2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SourcesOverlap_BothClient_DifferentMacs_ReturnsFalse()
+    {
+        var rule1 = CreateRule(sourceMatchingTarget: "CLIENT", sourceClientMacs: new List<string> { "aa:bb:cc:dd:ee:ff" });
+        var rule2 = CreateRule(sourceMatchingTarget: "CLIENT", sourceClientMacs: new List<string> { "11:22:33:44:55:66" });
+
+        FirewallRuleOverlapDetector.SourcesOverlap(rule1, rule2).Should().BeFalse();
+    }
+
+    [Fact]
     public void SourcesOverlap_SameNetworkIds_ReturnsTrue()
     {
         var rule1 = CreateRule(sourceMatchingTarget: "NETWORK", sourceNetworkIds: new List<string> { "net1", "net2" });

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
@@ -356,7 +356,7 @@ public class FirewallRuleParserTests
         // restriction feature ("MAC"/"macs" with matching_target_type SPECIFIC), which
         // coexists in one response with older client-based "CLIENT"/"client_macs" rules
         var json = JsonDocument.Parse(@"{
-            ""_id"": ""6a5b8920e205f79b9b565917"",
+            ""_id"": ""raw-mac-rule-1"",
             ""action"": ""ALLOW"",
             ""connection_state_type"": ""ALL"",
             ""connection_states"": [],

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
@@ -350,6 +350,90 @@ public class FirewallRuleParserTests
     }
 
     [Fact]
+    public void ParseFirewallPolicy_RawSourceMacRule_FullRealShape_ParsesCorrectly()
+    {
+        // Full rule shape captured from UniFi Network 10.5.62 EA: the raw source MAC
+        // restriction feature ("MAC"/"macs" with matching_target_type SPECIFIC), which
+        // coexists in one response with older client-based "CLIENT"/"client_macs" rules
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""6a5b8920e205f79b9b565917"",
+            ""action"": ""ALLOW"",
+            ""connection_state_type"": ""ALL"",
+            ""connection_states"": [],
+            ""create_allow_respond"": true,
+            ""description"": """",
+            ""destination"": {
+                ""match_opposite_ports"": false,
+                ""matching_target"": ""ANY"",
+                ""port_matching_type"": ""ANY"",
+                ""zone_id"": ""external-zone""
+            },
+            ""enabled"": true,
+            ""icmp_typename"": ""ANY"",
+            ""icmp_v6_typename"": ""ANY"",
+            ""index"": 10021,
+            ""ip_version"": ""BOTH"",
+            ""logging"": false,
+            ""match_ip_sec"": false,
+            ""match_opposite_protocol"": false,
+            ""name"": ""Allow Failover Device"",
+            ""predefined"": false,
+            ""protocol"": ""all"",
+            ""schedule"": { ""mode"": ""ALWAYS"" },
+            ""source"": {
+                ""macs"": [""aa:bb:cc:dd:ee:01"", ""aa:bb:cc:dd:ee:02""],
+                ""match_opposite_ports"": false,
+                ""matching_target"": ""MAC"",
+                ""matching_target_type"": ""SPECIFIC"",
+                ""port_matching_type"": ""ANY"",
+                ""zone_id"": ""mgmt-zone""
+            }
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallPolicy(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("CLIENT");
+        rule.SourceClientMacs.Should().BeEquivalentTo("aa:bb:cc:dd:ee:01", "aa:bb:cc:dd:ee:02");
+        rule.SourceZoneId.Should().Be("mgmt-zone");
+        rule.DestinationMatchingTarget.Should().Be("ANY");
+        rule.DestinationZoneId.Should().Be("external-zone");
+        rule.Enabled.Should().BeTrue();
+        rule.Index.Should().Be(10021);
+    }
+
+    [Fact]
+    public void ExtractFirewallPolicies_MixedClientAndMacShapes_BothNormalizeToClient()
+    {
+        // One response can contain BOTH device-scoped shapes (verified on 10.5.62 EA):
+        // older client-based rules and newer raw-MAC rules must both land on CLIENT
+        var json = JsonDocument.Parse(@"[{
+            ""_id"": ""old-shape"",
+            ""name"": ""Client Based Rule"",
+            ""source"": {
+                ""matching_target"": ""CLIENT"",
+                ""client_macs"": [""aa:bb:cc:dd:ee:01""]
+            }
+        },
+        {
+            ""_id"": ""new-shape"",
+            ""name"": ""Raw MAC Rule"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""matching_target_type"": ""SPECIFIC"",
+                ""macs"": [""aa:bb:cc:dd:ee:02""]
+            }
+        }]").RootElement;
+
+        var rules = _parser.ExtractFirewallPolicies(json);
+
+        rules.Should().HaveCount(2);
+        rules.Should().OnlyContain(r => r.SourceMatchingTarget == "CLIENT");
+        rules[0].SourceClientMacs.Should().ContainSingle().Which.Should().Be("aa:bb:cc:dd:ee:01");
+        rules[1].SourceClientMacs.Should().ContainSingle().Which.Should().Be("aa:bb:cc:dd:ee:02");
+    }
+
+    [Fact]
     public void ExtractFirewallPolicies_MacMatchingTargetWithMultipleMacs_ParsesAll()
     {
         var json = JsonDocument.Parse(@"[{

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
@@ -329,6 +329,46 @@ public class FirewallRuleParserTests
     }
 
     [Fact]
+    public void ExtractFirewallPolicies_WithMacMatchingTarget_NormalizesToClient()
+    {
+        // Newer UniFi releases emit matching_target "MAC" with a "macs" array
+        // instead of "CLIENT" with "client_macs" (issue #1011)
+        var json = JsonDocument.Parse(@"[{
+            ""_id"": ""policy1"",
+            ""name"": ""Allow Failover Device"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""macs"": [""aa:bb:cc:dd:ee:ff""]
+            }
+        }]").RootElement;
+
+        var rules = _parser.ExtractFirewallPolicies(json);
+
+        rules.Should().ContainSingle();
+        rules[0].SourceMatchingTarget.Should().Be("CLIENT");
+        rules[0].SourceClientMacs.Should().ContainSingle().Which.Should().Be("aa:bb:cc:dd:ee:ff");
+    }
+
+    [Fact]
+    public void ExtractFirewallPolicies_MacMatchingTargetWithMultipleMacs_ParsesAll()
+    {
+        var json = JsonDocument.Parse(@"[{
+            ""_id"": ""policy1"",
+            ""name"": ""Allow Devices"",
+            ""source"": {
+                ""matching_target"": ""MAC"",
+                ""macs"": [""aa:bb:cc:dd:ee:01"", ""aa:bb:cc:dd:ee:02"", ""aa:bb:cc:dd:ee:03""]
+            }
+        }]").RootElement;
+
+        var rules = _parser.ExtractFirewallPolicies(json);
+
+        rules.Should().ContainSingle();
+        rules[0].SourceMatchingTarget.Should().Be("CLIENT");
+        rules[0].SourceClientMacs.Should().HaveCount(3);
+    }
+
+    [Fact]
     public void ExtractFirewallPolicies_PredefinedRule_MarksAsPredefined()
     {
         var json = JsonDocument.Parse(@"[{
@@ -648,6 +688,47 @@ public class FirewallRuleParserTests
 
         rule.Should().NotBeNull();
         rule!.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ParseFirewallRule_WithSrcMacAddress_SetsClientMatchingTarget()
+    {
+        // Legacy rules can restrict source by device MAC - must not degrade to ANY source
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""legacy-mac"",
+            ""name"": ""Allow Failover Device"",
+            ""action"": ""accept"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_mac_address"": ""aa:bb:cc:dd:ee:ff""
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("CLIENT");
+        rule.SourceClientMacs.Should().ContainSingle().Which.Should().Be("aa:bb:cc:dd:ee:ff");
+    }
+
+    [Fact]
+    public void ParseFirewallRule_WithSrcMacAddressAndSrcAddress_KeepsIpTargetAndMacs()
+    {
+        // When both an IP and a MAC restriction are present, IP stays the matching target
+        // (so IP overlap checks still apply) but the MAC list is retained
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""legacy-mac-ip"",
+            ""name"": ""Allow Device by IP and MAC"",
+            ""action"": ""accept"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_address"": ""192.0.2.50"",
+            ""src_mac_address"": ""aa:bb:cc:dd:ee:ff""
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallRule(json);
+
+        rule.Should().NotBeNull();
+        rule!.SourceMatchingTarget.Should().Be("IP");
+        rule.SourceIps.Should().ContainSingle().Which.Should().Be("192.0.2.50");
+        rule.SourceClientMacs.Should().ContainSingle().Which.Should().Be("aa:bb:cc:dd:ee:ff");
     }
 
     #endregion


### PR DESCRIPTION
Fixes #1011.

## Security Audit

- **Raw-MAC policy sources recognized** - UniFi's newer raw source MAC restriction (`matching_target: "MAC"` with a `macs` array) now parses alongside the older client-based `CLIENT`/`client_macs` shape; both normalize to one canonical device-scoped form for scope scoring and overlap detection. A one-device allow ahead of a zone-wide deny is now classified as an intentional exception (Informational) instead of a Recommended rule-order warning (#1011, thanks @jimstrang for the report and sample policy JSON). List-size scoring is preserved, so a large MAC list is still assessed proportionally.
- **Legacy MAC-restricted rules** - pre-Zone-Based rules with `src_mac_address` no longer parse as an unrestricted (ANY) source.
- **Same-device rule shadowing detected** - two MAC-scoped rules were never considered overlapping, even for the same device, so a deny eclipsing a later allow for that device went unreported. MAC lists are now intersected (case-insensitive).
- **Firewall: Missing 5G/LTE Access** - a broad block rule in an unrelated firewall zone could eclipse the Management network's 5G/LTE registration allow and raise this finding falsely. An ANY source is scoped to its zone, not global: source zones must now match before a block can eclipse an allow. Pre-Zone-Based sites (no zone IDs) keep the conservative eclipse behavior.

All changes are covered by tests, including full-rule fixtures captured from UniFi Network 10.5.62 EA showing both MAC shapes coexisting in one response.
