### PR TITLE
3D LAN Flow Map: property-scaled sizing, link speed tooltips, precise device height

### DIFF
--- a/src/NetworkOptimizer.Storage/Migrations/20260718161500_AddApLocationHeightM.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260718161500_AddApLocationHeightM.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718161500_AddApLocationHeightM")]
+    partial class AddApLocationHeightM
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260718161500_AddApLocationHeightM.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260718161500_AddApLocationHeightM.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <summary>
+/// Adds ApLocations.HeightM: precise height in metres above the assigned floor's
+/// base elevation, written by 3D map repositioning. Nullable - existing rows keep
+/// deriving height from MountType / device kind.
+/// </summary>
+public partial class AddApLocationHeightM : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<double>(
+            name: "HeightM",
+            table: "ApLocations",
+            type: "REAL",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "HeightM",
+            table: "ApLocations");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/ApLocation.cs
+++ b/src/NetworkOptimizer.Storage/Models/ApLocation.cs
@@ -32,6 +32,10 @@ public class ApLocation
     [MaxLength(20)]
     public string? MountType { get; set; }
 
+    /// <summary>Precise height in metres above the assigned floor's base elevation, set by
+    /// 3D map repositioning. Null = derive height from MountType / device kind (legacy).</summary>
+    public double? HeightM { get; set; }
+
     /// <summary>When this location was last updated</summary>
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
 }

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -277,6 +277,10 @@
                     opts.trigger = 'mouseenter';
                     opts.touch = false;
                 }
+                var delayMs = parseInt(el.dataset.tooltipDelay, 10);
+                if (!isNaN(delayMs)) {
+                    opts.delay = [delayMs, 200];
+                }
                 tippy(el, opts);
             });
         }
@@ -330,6 +334,10 @@
                 if (el.hasAttribute('data-tooltip-hover-only') || el.tagName === 'BUTTON') {
                     opts.trigger = 'mouseenter';
                     opts.touch = false;
+                }
+                var delayMs = parseInt(el.dataset.tooltipDelay, 10);
+                if (!isNaN(delayMs)) {
+                    opts.delay = [delayMs, 200];
                 }
                 if (el._tippy) {
                     // Update existing tooltip if content changed

--- a/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/LanFlowMapEndpoints.cs
@@ -6,7 +6,7 @@ namespace NetworkOptimizer.Web.Endpoints;
 
 public static class LanFlowMapEndpoints
 {
-    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude, int? Floor);
+    private record DevicePlacementRequest(string Mac, double Latitude, double Longitude, int? Floor, double? HeightM);
 
     public static void Map(WebApplication app)
     {
@@ -73,7 +73,7 @@ public static class LanFlowMapEndpoints
             {
                 if (string.IsNullOrWhiteSpace(req.Mac))
                     return Results.BadRequest("mac is required");
-                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude, req.Floor);
+                await apMap.SaveApLocationAsync(req.Mac, req.Latitude, req.Longitude, req.Floor, req.HeightM);
                 svc.InvalidateCache();
                 return Results.Ok();
             });

--- a/src/NetworkOptimizer.Web/Services/ApMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/ApMapService.cs
@@ -103,9 +103,11 @@ public class ApMapService
     }
 
     /// <summary>
-    /// Save an AP's map location (upsert by MAC address).
+    /// Save an AP's map location (upsert by MAC address). heightM is the precise
+    /// height above the floor's base elevation from 3D repositioning; callers that
+    /// don't know it (Signal Map drags) omit it and any stored value is preserved.
     /// </summary>
-    public async Task SaveApLocationAsync(string mac, double lat, double lng, int? floor = null)
+    public async Task SaveApLocationAsync(string mac, double lat, double lng, int? floor = null, double? heightM = null)
     {
         var normalizedMac = mac.ToLowerInvariant();
 
@@ -116,6 +118,7 @@ public class ApMapService
             existing.Latitude = lat;
             existing.Longitude = lng;
             if (floor.HasValue) existing.Floor = floor.Value;
+            if (heightM.HasValue) existing.HeightM = heightM.Value;
             existing.UpdatedAt = DateTime.UtcNow;
         }
         else
@@ -126,6 +129,7 @@ public class ApMapService
                 Latitude = lat,
                 Longitude = lng,
                 Floor = floor ?? 1,
+                HeightM = heightM,
                 UpdatedAt = DateTime.UtcNow
             });
         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -133,6 +133,13 @@ public class LanLink
     /// <summary>Capacity (PHY/negotiated/port speed) in bps. Backdrop pipe radius scales from this.</summary>
     public long? CapacityBps { get; set; }
 
+    /// <summary>Downstream (toward the leaf/device) capacity in bps for asymmetric links
+    /// (WiFi PHY, ISP-provisioned WAN). Null for symmetric links - use CapacityBps.</summary>
+    public long? CapacityDownBps { get; set; }
+
+    /// <summary>Upstream (toward the gateway/ISP) capacity in bps for asymmetric links.</summary>
+    public long? CapacityUpBps { get; set; }
+
     /// <summary>Wireless band ("2.4"/"5"/"6") for wifi-client and mesh links.</summary>
     public string? Band { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -105,6 +105,10 @@ public class LanPlacement
     public double Y { get; set; }
     public double Z { get; set; }
     public LanPlacementSource Source { get; set; }
+
+    /// <summary>Precise height in metres above the floor's base elevation (Z), from 3D
+    /// repositioning. Null = the JS layout applies its MountType / device-kind offset.</summary>
+    public double? HeightM { get; set; }
 }
 
 public enum LanLinkKind

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1332,6 +1332,10 @@ public class LanFlowMapService
                 // PHY rate (kbps) acts as the WiFi link capacity (spec 3.5 - PHY is capacity).
                 long maxPhyKbps = Math.Max(c.TxRate, c.RxRate);
                 if (maxPhyKbps > 0) link.CapacityBps = maxPhyKbps * 1_000L;
+                // Directional PHY: AP TX rate limits traffic toward the client
+                // (downstream), RX rate limits traffic from the client (upstream).
+                if (c.TxRate > 0) link.CapacityDownBps = c.TxRate * 1_000L;
+                if (c.RxRate > 0) link.CapacityUpBps = c.RxRate * 1_000L;
             }
 
             snapshot.Nodes.Add(node);
@@ -1528,6 +1532,10 @@ public class LanFlowMapService
                 ToNodeId = gwId,
                 Kind = LanLinkKind.Wan,
                 CapacityBps = wan.LinkSpeedMbps.HasValue ? (long)wan.LinkSpeedMbps.Value * 1_000_000L : null,
+                // ISP-provisioned speeds are the real (asymmetric) WAN capacity;
+                // the port PHY above only sizes the pipe.
+                CapacityDownBps = wanNet?.WanDownloadMbps > 0 ? (long)wanNet.WanDownloadMbps! * 1_000_000L : null,
+                CapacityUpBps = wanNet?.WanUploadMbps > 0 ? (long)wanNet.WanUploadMbps! * 1_000_000L : null,
             };
             if (!string.IsNullOrEmpty(wan.GatewayPortName))
             {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1534,8 +1534,15 @@ public class LanFlowMapService
 
             snapshot.Clouds.Add(accessCloud);
 
-            // WAN link: gateway -> access cloud directly. Capacity from WanSummary,
-            // PortKey for live SNMP rate seeding from the gateway's WAN port.
+            // WAN link: gateway -> access cloud directly. PortKey for live SNMP
+            // rate seeding from the gateway's WAN port. The pipe diameter sizes
+            // from the ISP-provisioned plan (larger of down/up) - the port PHY
+            // is only the fallback when no plan speeds are configured.
+            var ispDownBps = wanNet?.WanDownloadMbps > 0 ? (long)wanNet.WanDownloadMbps! * 1_000_000L : (long?)null;
+            var ispUpBps = wanNet?.WanUploadMbps > 0 ? (long)wanNet.WanUploadMbps! * 1_000_000L : (long?)null;
+            var ispMaxBps = ispDownBps.HasValue || ispUpBps.HasValue
+                ? Math.Max(ispDownBps ?? 0, ispUpBps ?? 0)
+                : (long?)null;
             var wanLink = new LanLink
             {
                 Id = $"wan-link-{wan.WanInterface}",
@@ -1548,11 +1555,9 @@ public class LanFlowMapService
                 FromNodeId = accessCloud.Id,
                 ToNodeId = gwId,
                 Kind = LanLinkKind.Wan,
-                CapacityBps = wan.LinkSpeedMbps.HasValue ? (long)wan.LinkSpeedMbps.Value * 1_000_000L : null,
-                // ISP-provisioned speeds are the real (asymmetric) WAN capacity;
-                // the port PHY above only sizes the pipe.
-                CapacityDownBps = wanNet?.WanDownloadMbps > 0 ? (long)wanNet.WanDownloadMbps! * 1_000_000L : null,
-                CapacityUpBps = wanNet?.WanUploadMbps > 0 ? (long)wanNet.WanUploadMbps! * 1_000_000L : null,
+                CapacityBps = ispMaxBps ?? (wan.LinkSpeedMbps.HasValue ? (long)wan.LinkSpeedMbps.Value * 1_000_000L : null),
+                CapacityDownBps = ispDownBps,
+                CapacityUpBps = ispUpBps,
             };
             if (!string.IsNullOrEmpty(wan.GatewayPortName))
             {

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -110,14 +110,23 @@ public class LanFlowMapService
 
         var anchors = ProjectAnchors(markers, deviceLocations, heightByMac,
             out var centerLat, out var centerLng, out var lngScale);
-        var droppedAnchors = PruneAnchorOutliers(anchors);
+        // AP anchors define the reference frame (centroid, scene radius, and the
+        // set eligible for outlier pruning). Non-AP device placements are
+        // deliberate user drags: they ride within the frame but must never
+        // perturb the scale or be pruned, or a device placed toward a building
+        // could shift or fall back to scatter on the next load. Keyed to match
+        // the anchor dictionary (NormalizeMac).
+        var apAnchorMacs = new HashSet<string>(
+            markers.Where(m => m.Latitude.HasValue && m.Longitude.HasValue)
+                   .Select(m => NormalizeMac(m.Mac)));
+        var droppedAnchors = PruneAnchorOutliers(anchors, apAnchorMacs);
         if (droppedAnchors.Count > 0)
         {
             _logger.LogDebug(
                 "LAN map: dropped {Count} outlier anchor(s) far outside the cluster (bad/stale placement): {Macs}",
                 droppedAnchors.Count, string.Join(", ", droppedAnchors));
         }
-        snapshot.Bounds = ComputeBounds(anchors, centerLat, centerLng, lngScale);
+        snapshot.Bounds = ComputeBounds(anchors, apAnchorMacs, centerLat, centerLng, lngScale);
         snapshot.Buildings = await BuildBuildingsAsync(centerLat, centerLng, lngScale, ct);
         snapshot.MaterialColors = new Dictionary<string, string>(
             WiFi.Data.MaterialAttenuation.MaterialColors, StringComparer.OrdinalIgnoreCase);
@@ -993,14 +1002,20 @@ public class LanFlowMapService
     private const double OutlierMedianFactor = 6.0;
     private const double OutlierAbsoluteMetres = 200.0;
 
-    private static List<string> PruneAnchorOutliers(Dictionary<string, LanPlacement> anchors)
+    private static List<string> PruneAnchorOutliers(
+        Dictionary<string, LanPlacement> anchors, IReadOnlySet<string> apAnchorMacs)
     {
         var removed = new List<string>();
+        // Only AP anchors are eligible: they define the frame, and a bad AP
+        // geocode is what this guards against. User-placed device anchors
+        // (switches, cameras) are deliberate drags - pruning one would silently
+        // scatter it far from its building, so they're exempt entirely.
+        var apAnchors = anchors.Where(kv => apAnchorMacs.Contains(kv.Key)).ToList();
         // Need enough anchors for a median to be meaningful; with 1-2 we can't tell
         // which one is the outlier, so leave them alone.
-        if (anchors.Count < 3) return removed;
+        if (apAnchors.Count < 3) return removed;
 
-        var distances = anchors.ToDictionary(
+        var distances = apAnchors.ToDictionary(
             kv => kv.Key,
             kv => Math.Sqrt(kv.Value.X * kv.Value.X + kv.Value.Y * kv.Value.Y));
 
@@ -1018,6 +1033,7 @@ public class LanFlowMapService
 
     private static LanFlowMapBounds ComputeBounds(
         Dictionary<string, LanPlacement> anchors,
+        IReadOnlySet<string> apAnchorMacs,
         double centerLat, double centerLng, double lngScale)
     {
         var bounds = new LanFlowMapBounds
@@ -1029,8 +1045,15 @@ public class LanFlowMapService
             bounds.Radius = 1.0;
             return bounds;
         }
+        // Radius (and thus the global scale) is defined by AP anchors only,
+        // mirroring the AP-only centroid. If a non-AP device set the radius,
+        // placing it would change the scale on the next load and shift every
+        // already-placed device. Fall back to all anchors when no APs exist.
+        var radiusAnchors = anchors.Where(kv => apAnchorMacs.Contains(kv.Key))
+            .Select(kv => kv.Value).ToList();
+        if (radiusAnchors.Count == 0) radiusAnchors = anchors.Values.ToList();
         double maxR = 0;
-        foreach (var p in anchors.Values)
+        foreach (var p in radiusAnchors)
         {
             var r = Math.Sqrt(p.X * p.X + p.Y * p.Y + p.Z * p.Z);
             if (r > maxR) maxR = r;

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -102,8 +102,13 @@ public class LanFlowMapService
         var deviceLocations = allLocations
             .Where(l => !apMacs.Contains(l.ApMac.ToLowerInvariant()))
             .ToList();
+        // Precise heights come straight off the ApLocations rows; the marker DTO
+        // doesn't carry HeightM, so ProjectAnchors looks it up by MAC for APs.
+        var heightByMac = allLocations
+            .Where(l => l.HeightM.HasValue)
+            .ToDictionary(l => NormalizeMac(l.ApMac), l => l.HeightM!.Value);
 
-        var anchors = ProjectAnchors(markers, deviceLocations,
+        var anchors = ProjectAnchors(markers, deviceLocations, heightByMac,
             out var centerLat, out var centerLng, out var lngScale);
         var droppedAnchors = PruneAnchorOutliers(anchors);
         if (droppedAnchors.Count > 0)
@@ -916,6 +921,7 @@ public class LanFlowMapService
     private static Dictionary<string, LanPlacement> ProjectAnchors(
         IReadOnlyList<Web.Models.ApMapMarker> markers,
         IReadOnlyList<Storage.Models.ApLocation> deviceLocations,
+        IReadOnlyDictionary<string, double> heightByMac,
         out double centerLat, out double centerLng, out double lngScale)
     {
         centerLat = 0;
@@ -945,13 +951,15 @@ public class LanFlowMapService
 
         foreach (var m in withCoords)
         {
+            var mac = NormalizeMac(m.Mac);
             var (x, y) = ProjectLatLng(m.Latitude!.Value, m.Longitude!.Value, centerLat, centerLng, lngScale);
-            anchors[NormalizeMac(m.Mac)] = new LanPlacement
+            anchors[mac] = new LanPlacement
             {
                 X = x,
                 Y = y,
                 Z = (m.Floor ?? 1) * FloorHeightMetres,
                 Source = LanPlacementSource.Anchor,
+                HeightM = heightByMac.TryGetValue(mac, out var hm) ? hm : null,
             };
         }
 
@@ -966,6 +974,7 @@ public class LanFlowMapService
                 Y = y,
                 Z = (d.Floor ?? 1) * FloorHeightMetres,
                 Source = LanPlacementSource.Anchor,
+                HeightM = d.HeightM,
             };
         }
 
@@ -1220,6 +1229,14 @@ public class LanFlowMapService
                 CapacityBps = ResolveUplinkCapacityBps(d),
                 Band = isWirelessBackhaul ? NormalizeBand(d.UplinkRadioBand) : null,
             };
+            if (isWirelessBackhaul)
+            {
+                // Mesh PHY is asymmetric: the child's uplink RX rate caps traffic
+                // toward it (downstream), its TX rate caps traffic toward the
+                // parent (upstream).
+                if (d.UplinkRxRateKbps > 0) link.CapacityDownBps = d.UplinkRxRateKbps * 1_000L;
+                if (d.UplinkTxRateKbps > 0) link.CapacityUpBps = d.UplinkTxRateKbps * 1_000L;
+            }
 
             // For wired uplinks, the parent switch port carries the throughput we want.
             // Resolve ifName via UniFi port number -> InterfaceNameMap (3.7 chain).

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15925,6 +15925,8 @@ tr.stats-row-filtered {
     display: inline-flex;
     gap: 0.55rem;
     pointer-events: auto;
+    cursor: help;
+    user-select: none;
 }
 .lan-flow-map-link-label .down {
     color: var(--speed-download-color);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15924,6 +15924,7 @@ tr.stats-row-filtered {
 .lan-flow-map-link-label.is-visible {
     display: inline-flex;
     gap: 0.55rem;
+    pointer-events: auto;
 }
 .lan-flow-map-link-label .down {
     color: var(--speed-download-color);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1622,8 +1622,10 @@ export class LanFlowMap {
                 // across property sizes (a fixed scene-unit step covered many
                 // real meters per tick on large, heavily-normalized maps).
                 if (this._keys) {
+                    // Dulled by the property factor too: on large maps the same
+                    // scene distance spans far more real-world meters.
                     const camDist = this.camera.position.distanceTo(this._repositionGroup.position);
-                    const step = Math.max(0.02, camDist * 0.005);
+                    const step = Math.max(0.01, camDist * 0.00375 * this._deviceScale);
                     const cam = this.camera;
                     const forward = new THREE.Vector3();
                     cam.getWorldDirection(forward);
@@ -2887,10 +2889,18 @@ export class LanFlowMap {
             // top-left (CSS default 0,0).
             el.style.left = '-9999px';
             el.style.top = '-9999px';
-            // Hover tooltip with the link's negotiated capacity. Long delay so
-            // it doesn't fire while just moving around the map.
-            if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
-                el.setAttribute('data-tooltip', `Link speed: ${formatBps(link.capacityBps)}`);
+            // Hover tooltip with the link's negotiated capacity - both
+            // directions when asymmetric (WiFi PHY, ISP-provisioned WAN).
+            // Long delay so it doesn't fire while just moving around the map.
+            const capDown = link.capacityDownBps, capUp = link.capacityUpBps;
+            let capTip = null;
+            if (capDown > 0 && capUp > 0 && capDown !== capUp) {
+                capTip = `Link speed: ↓ ${formatBps(capDown)} / ↑ ${formatBps(capUp)}`;
+            } else if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
+                capTip = `Link speed: ${formatBps(link.capacityBps)}`;
+            }
+            if (capTip) {
+                el.setAttribute('data-tooltip', capTip);
                 el.setAttribute('data-tooltip-hover-only', '');
                 el.setAttribute('data-tooltip-delay', '500');
             }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2955,8 +2955,11 @@ export class LanFlowMap {
         const MAX_SCALE = 1.2;
         // On large properties the shrink floor scales down with the devices,
         // so labels keep receding when zoomed out instead of flooring early
-        // and dominating the shrunken scene. Single-home sites are unchanged.
+        // and dominating the shrunken scene. The max cap comes down too (by
+        // sqrt, gentler) so mid-zoom building-overview views don't crowd with
+        // full-size labels over shrunken devices. Single-home is unchanged.
         const minScale = MIN_SCALE * this._deviceScale;
+        const maxScale = MAX_SCALE * Math.sqrt(this._deviceScale);
 
         for (const [nodeId, { el }] of this._floatingLabels) {
             const group = this._nodeMeshes.get(nodeId);
@@ -2972,7 +2975,7 @@ export class LanFlowMap {
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(minScale, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1)));
             el.style.transform = `translate(-50%, -100%) scale(${scale.toFixed(3)})`;
             el.style.transformOrigin = 'center bottom';
             el.style.left = `${x}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -137,6 +137,10 @@ const LABEL_ZOOM_MIN = 0.25;
 // they'd be illegible smudges, so ramp opacity down and hide.
 const LABEL_FADE_START_DIST = 110;
 const LABEL_FADE_END_DIST = 170;
+// Throughput pills fade earlier than device labels - when pulling back,
+// device identity should outlive the rate readouts.
+const LINK_LABEL_FADE_START_DIST = 90;
+const LINK_LABEL_FADE_END_DIST = 140;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -3095,6 +3099,10 @@ export class LanFlowMap {
             }
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
+            const fade = 1 - Math.min(1, Math.max(0,
+                (dist - LINK_LABEL_FADE_START_DIST) / (LINK_LABEL_FADE_END_DIST - LINK_LABEL_FADE_START_DIST)));
+            if (fade <= 0.01) { el.classList.remove('is-visible'); continue; }
+            el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
             const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1)));

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -114,7 +114,7 @@ const DEVICE_ZOOM_MAX = 1.6;
 // Pipes/particles get the same treatment on a tighter band: a decent floor so
 // they never go skinny, and a capped ceiling zoomed out - just fat enough to
 // still see what's flowing without turning into hoses.
-const LINK_ZOOM_MIN = 0.75;
+const LINK_ZOOM_MIN = 0.5;
 const LINK_ZOOM_MAX = 1.35;
 // The zoom-out ceiling is relative to property size: property factor x zoom
 // boost never exceeds this multiple of an object's designed size. Single-home

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -137,10 +137,14 @@ const LABEL_ZOOM_MIN = 0.25;
 // they'd be illegible smudges, so ramp opacity down and hide.
 const LABEL_FADE_START_DIST = 82;
 const LABEL_FADE_END_DIST = 128;
-// Throughput pills fade earlier than device labels - when pulling back,
-// device identity should outlive the rate readouts.
-const LINK_LABEL_FADE_START_DIST = 68;
-const LINK_LABEL_FADE_END_DIST = 105;
+// Network device (DOM) labels fade sooner than the client sprites above -
+// they're denser (name + rate badge) and crowd the view faster.
+const NET_LABEL_FADE_START_DIST = 66;
+const NET_LABEL_FADE_END_DIST = 102;
+// Throughput pills fade earlier still - when pulling back, device identity
+// should outlive the rate readouts.
+const LINK_LABEL_FADE_START_DIST = 54;
+const LINK_LABEL_FADE_END_DIST = 84;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -3017,8 +3021,8 @@ export class LanFlowMap {
         const camPos = this.camera.position;
         // Reference distance: roughly the fly-in camera target distance (~60u).
         // At this distance labels render at 100%. Farther = smaller, closer = larger.
-        const REF_DIST = 45;
-        const MIN_SCALE = 0.32;
+        const REF_DIST = 36;
+        const MIN_SCALE = 0.24;
         const MAX_SCALE = 1.2;
         // On large properties the shrink floor scales down with the devices,
         // so labels keep receding when zoomed out instead of flooring early
@@ -3041,7 +3045,7 @@ export class LanFlowMap {
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
             const fade = 1 - Math.min(1, Math.max(0,
-                (dist - LABEL_FADE_START_DIST) / (LABEL_FADE_END_DIST - LABEL_FADE_START_DIST)));
+                (dist - NET_LABEL_FADE_START_DIST) / (NET_LABEL_FADE_END_DIST - NET_LABEL_FADE_START_DIST)));
             if (fade <= 0.01) { el.classList.remove('is-visible'); continue; }
             el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1581,9 +1581,15 @@ export class LanFlowMap {
                 }
                 this.camera.lookAt(this.controls.target);
             } else if (this._repositionMode && this._repositionGroup) {
-                // In reposition mode WASD nudges the device on the XZ plane
+                // In reposition mode WASD nudges the device on the XZ plane.
+                // Step is proportional to camera-to-device distance so nudges
+                // track what you see: fine control zoomed in for room-level
+                // placement, faster traversal zoomed out - and consistent
+                // across property sizes (a fixed scene-unit step covered many
+                // real meters per tick on large, heavily-normalized maps).
                 if (this._keys) {
-                    const step = 0.35;
+                    const camDist = this.camera.position.distanceTo(this._repositionGroup.position);
+                    const step = Math.max(0.02, camDist * 0.005);
                     const cam = this.camera;
                     const forward = new THREE.Vector3();
                     cam.getWorldDirection(forward);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -133,6 +133,10 @@ const ZOOM_EFFECTIVE_CEIL = 1.0;
 // collapse entirely. Beyond REF they behave exactly as today.
 const LABEL_ZOOM_REF_DIST = 60;
 const LABEL_ZOOM_MIN = 0.25;
+// Distant device labels fade out entirely - past these camera distances
+// they'd be illegible smudges, so ramp opacity down and hide.
+const LABEL_FADE_START_DIST = 110;
+const LABEL_FADE_END_DIST = 170;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -1780,6 +1784,10 @@ export class LanFlowMap {
             const kind = group.userData?.node?.kind;
             const z = Math.max(DEVICE_ZOOM_MIN, Math.min(devMax, dist / DEVICE_ZOOM_REF_DIST));
             sprite.position.y = this._nodeTopHalfHeight(kind) * z + 0.35 * this._deviceScale;
+            const fade = 1 - Math.min(1, Math.max(0,
+                (dist - LABEL_FADE_START_DIST) / (LABEL_FADE_END_DIST - LABEL_FADE_START_DIST)));
+            sprite.material.opacity = fade;
+            sprite.visible = fade > 0.01;
         }
     }
 
@@ -2958,7 +2966,7 @@ export class LanFlowMap {
         // Reference distance: roughly the fly-in camera target distance (~60u).
         // At this distance labels render at 100%. Farther = smaller, closer = larger.
         const REF_DIST = 60;
-        const MIN_SCALE = 0.4;
+        const MIN_SCALE = 0.32;
         const MAX_SCALE = 1.2;
         // On large properties the shrink floor scales down with the devices,
         // so labels keep receding when zoomed out instead of flooring early
@@ -2980,6 +2988,10 @@ export class LanFlowMap {
             tmp.y += this._nodeTopHalfHeight(group.userData?.node?.kind) * zDev + 0.35 * this._deviceScale;
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
+            const fade = 1 - Math.min(1, Math.max(0,
+                (dist - LABEL_FADE_START_DIST) / (LABEL_FADE_END_DIST - LABEL_FADE_START_DIST)));
+            if (fade <= 0.01) { el.classList.remove('is-visible'); continue; }
+            el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
             const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1)));

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -135,12 +135,12 @@ const LABEL_ZOOM_REF_DIST = 60;
 const LABEL_ZOOM_MIN = 0.25;
 // Distant device labels fade out entirely - past these camera distances
 // they'd be illegible smudges, so ramp opacity down and hide.
-const LABEL_FADE_START_DIST = 110;
-const LABEL_FADE_END_DIST = 170;
+const LABEL_FADE_START_DIST = 82;
+const LABEL_FADE_END_DIST = 128;
 // Throughput pills fade earlier than device labels - when pulling back,
 // device identity should outlive the rate readouts.
-const LINK_LABEL_FADE_START_DIST = 90;
-const LINK_LABEL_FADE_END_DIST = 140;
+const LINK_LABEL_FADE_START_DIST = 68;
+const LINK_LABEL_FADE_END_DIST = 105;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -2969,7 +2969,7 @@ export class LanFlowMap {
         const camPos = this.camera.position;
         // Reference distance: roughly the fly-in camera target distance (~60u).
         // At this distance labels render at 100%. Farther = smaller, closer = larger.
-        const REF_DIST = 60;
+        const REF_DIST = 45;
         const MIN_SCALE = 0.32;
         const MAX_SCALE = 1.2;
         // On large properties the shrink floor scales down with the devices,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -892,9 +892,13 @@ export class LanFlowMap {
             this.nodeGroup.add(group);
             this._nodeMeshes.set(node.id, group);
 
-            // Sprite labels for all devices. Infrastructure devices also get DOM
-            // labels (with rate badges) but sprites provide 3D depth sorting.
-            if (node.name) {
+            // Sprite labels for clients only. Infrastructure devices get DOM
+            // labels (with rate badges); their sprite twin used to hide exactly
+            // behind the DOM pill at the old shared anchor height, but with
+            // labels anchored to the mesh top the two would both show, so
+            // infra skips the sprite entirely.
+            const isClientNode = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
+            if (node.name && isClientNode) {
                 const sprite = this._makeLabelSprite(node.name);
                 sprite.position.set(0, this._nodeTopHalfHeight(node.kind) + 0.35 * this._deviceScale, 0);
                 group.add(sprite);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -691,7 +691,11 @@ export class LanFlowMap {
                 } else if (p.source === PLACEMENT_SOURCE.Anchor) {
                     const isClient = node.kind === NODE_KIND.WiredClient || node.kind === NODE_KIND.WifiClient;
                     const isInfra = node.kind === NODE_KIND.Switch || node.kind === NODE_KIND.Gateway;
-                    const mountM = node.mountType ? (mountOffsetM[node.mountType] || 0)
+                    // Precise saved height (3D reposition) wins over the
+                    // MountType / device-kind estimate. p.z is the floor's base
+                    // elevation in metres; heightM is metres above that.
+                    const mountM = Number.isFinite(p.heightM) ? p.heightM
+                        : node.mountType ? (mountOffsetM[node.mountType] || 0)
                         : isClient ? WALL_H_M * 0.5
                         : isInfra ? WALL_H_M * 0.15
                         : 0;
@@ -2892,10 +2896,14 @@ export class LanFlowMap {
             // Hover tooltip with the link's negotiated capacity - both
             // directions when asymmetric (WiFi PHY, ISP-provisioned WAN).
             // Long delay so it doesn't fire while just moving around the map.
+            // Directional capacities always win over the symmetric PHY figure -
+            // a symmetric ISP plan must still show the plan, not the port speed.
             const capDown = link.capacityDownBps, capUp = link.capacityUpBps;
             let capTip = null;
-            if (capDown > 0 && capUp > 0 && capDown !== capUp) {
+            if (capDown > 0 && capUp > 0) {
                 capTip = `Link speed: ↓ ${formatBps(capDown)} / ↑ ${formatBps(capUp)}`;
+            } else if (capDown > 0 || capUp > 0) {
+                capTip = `Link speed: ${formatBps(capDown > 0 ? capDown : capUp)}`;
             } else if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
                 capTip = `Link speed: ${formatBps(link.capacityBps)}`;
             }
@@ -3767,15 +3775,20 @@ export class LanFlowMap {
         const lat = bounds.centerLat + dLat * 180 / Math.PI;
         const lng = bounds.centerLng + dLng * 180 / Math.PI;
 
-        // Reverse Y → floor: posY = floor * 3.0 * scale * 0.8
-        const floor = Math.round(pos.y / (scale * 0.8) / 2.9);
+        // Reverse Y exactly: rendered y = (floor * 2.9 + heightM) * scale * 0.8.
+        // Floor = the story the device is physically in (carries through to the
+        // Signal Map); heightM = metres above that floor's base, so the next
+        // load reproduces this position bit-for-bit.
+        const totalM = pos.y / (scale * 0.8);
+        const floor = Math.floor(totalM / 2.9);
+        const heightM = totalM - floor * 2.9;
 
         try {
             await fetch(`${this.apiBase}/device-placement`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'same-origin',
-                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng, floor }),
+                body: JSON.stringify({ mac: node.mac, latitude: lat, longitude: lng, floor, heightM }),
             });
         } catch (err) {
             console.error('[LanFlowMap] Failed to save placement:', err);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -883,7 +883,7 @@ export class LanFlowMap {
             // labels (with rate badges) but sprites provide 3D depth sorting.
             if (node.name) {
                 const sprite = this._makeLabelSprite(node.name);
-                sprite.position.set(0, radius + 0.8 * this._deviceScale, 0);
+                sprite.position.set(0, this._nodeTopHalfHeight(node.kind) + 0.35 * this._deviceScale, 0);
                 group.add(sprite);
                 this._labelSprites.set(node.id, sprite);
             }
@@ -1216,6 +1216,20 @@ export class LanFlowMap {
 
     _cloudRadius() {
         return NODE_RADIUS.cloud * this._cloudScale;
+    }
+
+    // Approximate half-height of the rendered core mesh, for anchoring labels
+    // just above the top. Radius alone overshoots badly for the flat shapes
+    // (an AP disc is only 0.45r tall), which left labels floating far above.
+    _nodeTopHalfHeight(kind) {
+        const r = this._nodeRadius(kind);
+        switch (kind) {
+            case NODE_KIND.Gateway: return r * 0.65;       // box height 1.3r
+            case NODE_KIND.Switch: return r * 0.35;        // box height 0.7r
+            case NODE_KIND.AccessPoint: return r * 0.225;  // disc height 0.45r
+            case NODE_KIND.VirtualHub: return r * 0.55;    // squat torus
+            default: return r * 0.95;                      // client polyhedra
+        }
     }
 
     _nodeColor(kind) {
@@ -1739,13 +1753,22 @@ export class LanFlowMap {
             down?.setZoom(z);
             up?.setZoom(z);
         }
+        // Sprite labels: reference distance stretches with property size so the
+        // apparent size (and the point where they lock at max) stays
+        // proportional to the shrunken devices instead of locking too early.
+        // The Y offset tracks the rendered top of the core mesh each frame.
+        const labelRef = LABEL_ZOOM_REF_DIST / this._deviceScale;
+        this._devZoomMax = devMax;
         for (const [nodeId, sprite] of this._labelSprites) {
             const base = sprite.userData?.baseScale;
             const group = this._nodeMeshes.get(nodeId);
             if (!base || !group) continue;
             const dist = camPos.distanceTo(group.position);
-            const f = Math.max(LABEL_ZOOM_MIN, Math.min(1.0, dist / LABEL_ZOOM_REF_DIST));
+            const f = Math.max(LABEL_ZOOM_MIN, Math.min(1.0, dist / labelRef));
             sprite.scale.set(base.x * f, base.y * f, 1);
+            const kind = group.userData?.node?.kind;
+            const z = Math.max(DEVICE_ZOOM_MIN, Math.min(devMax, dist / DEVICE_ZOOM_REF_DIST));
+            sprite.position.y = this._nodeTopHalfHeight(kind) * z + 0.35 * this._deviceScale;
         }
     }
 
@@ -1844,7 +1867,7 @@ export class LanFlowMap {
         this._nodeMeshes.set(node.id, group);
         if (node.name) {
             const sprite = this._makeLabelSprite(node.name);
-            sprite.position.set(0, radius + 0.8 * this._deviceScale, 0);
+            sprite.position.set(0, this._nodeTopHalfHeight(node.kind) + 0.35 * this._deviceScale, 0);
             group.add(sprite);
             this._labelSprites.set(node.id, sprite);
         }
@@ -2919,19 +2942,26 @@ export class LanFlowMap {
         const REF_DIST = 60;
         const MIN_SCALE = 0.4;
         const MAX_SCALE = 1.2;
+        // On large properties the shrink floor scales down with the devices,
+        // so labels keep receding when zoomed out instead of flooring early
+        // and dominating the shrunken scene. Single-home sites are unchanged.
+        const minScale = MIN_SCALE * this._deviceScale;
 
         for (const [nodeId, { el }] of this._floatingLabels) {
             const group = this._nodeMeshes.get(nodeId);
             if (!group) { el.classList.remove('is-visible'); continue; }
             if (!group.visible) { el.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y += 1.8 * this._deviceScale;  // anchor above the node sphere
             const dist = tmp.distanceTo(camPos);
+            // Anchor just above the rendered top of the core mesh (tracks the
+            // per-frame zoom scale) instead of a fixed offset above center.
+            const zDev = Math.max(DEVICE_ZOOM_MIN, Math.min(this._devZoomMax ?? 1, dist / DEVICE_ZOOM_REF_DIST));
+            tmp.y += this._nodeTopHalfHeight(group.userData?.node?.kind) * zDev + 0.35 * this._deviceScale;
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(minScale, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
             el.style.transform = `translate(-50%, -100%) scale(${scale.toFixed(3)})`;
             el.style.transformOrigin = 'center bottom';
             el.style.left = `${x}px`;
@@ -3034,7 +3064,7 @@ export class LanFlowMap {
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(MIN_SCALE, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(minScale, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
             el.style.transform = `translate(-50%, -50%) scale(${scale.toFixed(3)})`;
             el.style.left = `${x}px`;
             el.style.top = `${y}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2871,6 +2871,13 @@ export class LanFlowMap {
             // top-left (CSS default 0,0).
             el.style.left = '-9999px';
             el.style.top = '-9999px';
+            // Hover tooltip with the link's negotiated capacity. Long delay so
+            // it doesn't fire while just moving around the map.
+            if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
+                el.setAttribute('data-tooltip', `Link speed: ${formatBps(link.capacityBps)}`);
+                el.setAttribute('data-tooltip-hover-only', '');
+                el.setAttribute('data-tooltip-delay', '500');
+            }
             this._labelsLayer.appendChild(el);
             this._linkLabels.set(link.id, { el, kind: link.kind });
         }
@@ -3078,7 +3085,7 @@ export class LanFlowMap {
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(minScale, Math.min(MAX_SCALE, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1)));
             el.style.transform = `translate(-50%, -50%) scale(${scale.toFixed(3)})`;
             el.style.left = `${x}px`;
             el.style.top = `${y}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2941,7 +2941,27 @@ export class LanFlowMap {
             el.appendChild(nameEl);
             el.appendChild(rateEl);
             this._labelsLayer.appendChild(el);
-            this._floatingLabels.set(node.id, { el, nameEl, rateEl });
+            this._floatingLabels.set(node.id, { el, nameEl, rateEl, crowdScale: 1 });
+        }
+
+        // Local-density label shrink: infra devices clustered together (rack
+        // areas) get proportionally smaller labels so they don't pile up.
+        // Computed once per layout in world space - stable across camera moves,
+        // unlike per-frame screen-space overlap testing which jitters.
+        const CROWD_RADIUS = 8;
+        const labelIds = Array.from(this._floatingLabels.keys());
+        for (const id of labelIds) {
+            const p = this._positions.get(id);
+            if (!p) continue;
+            let neighbors = 0;
+            for (const otherId of labelIds) {
+                if (otherId === id) continue;
+                const q = this._positions.get(otherId);
+                if (!q) continue;
+                const dx = p.x - q.x, dy = p.y - q.y, dz = p.z - q.z;
+                if (dx * dx + dy * dy + dz * dz < CROWD_RADIUS * CROWD_RADIUS) neighbors += 1;
+            }
+            this._floatingLabels.get(id).crowdScale = Math.max(0.6, 1 - 0.12 * neighbors);
         }
 
         // WAN speed test pills: one per access-ISP cloud, anchored to the cloud mesh.
@@ -3008,7 +3028,7 @@ export class LanFlowMap {
         const minScale = MIN_SCALE * this._deviceScale;
         const maxScale = MAX_SCALE * Math.sqrt(this._deviceScale);
 
-        for (const [nodeId, { el }] of this._floatingLabels) {
+        for (const [nodeId, { el, crowdScale }] of this._floatingLabels) {
             const group = this._nodeMeshes.get(nodeId);
             if (!group) { el.classList.remove('is-visible'); continue; }
             if (!group.visible) { el.classList.remove('is-visible'); continue; }
@@ -3026,7 +3046,7 @@ export class LanFlowMap {
             el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1)));
+            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1))) * (crowdScale ?? 1);
             el.style.transform = `translate(-50%, -100%) scale(${scale.toFixed(3)})`;
             el.style.transformOrigin = 'center bottom';
             el.style.left = `${x}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -116,6 +116,11 @@ const DEVICE_ZOOM_MAX = 1.6;
 // still see what's flowing without turning into hoses.
 const LINK_ZOOM_MIN = 0.5;
 const LINK_ZOOM_MAX = 1.35;
+// Links ramp against a shorter reference than devices: at the mid-zoom range
+// (buildings-and-the-space-between view) pipes were sagging too thin between
+// their floor and ceiling, so they reach full girth earlier while zooming
+// out. The floor and ceiling clamps themselves are unchanged.
+const LINK_ZOOM_REF_DIST = 45;
 // The zoom-out ceiling is relative to property size: property factor x zoom
 // boost never exceeds this multiple of an object's designed size. Single-home
 // maps (factor 1.0) top out at design size, while large campuses keep their
@@ -1194,9 +1199,12 @@ export class LanFlowMap {
     _pipeRadiusForCapacity(capacityBps) {
         if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10 * this._linkScale;
         // Log scale: 100 Mbps -> 0.13, 1 Gbps -> 0.18, 10 Gbps -> 0.24, 25 Gbps -> 0.28.
+        // The base thins fully with the property factor, but the capacity term
+        // only by sqrt of it - the full factor squeezed the speed-driven girth
+        // differences below what the eye can resolve on shrunken maps.
         const gbps = capacityBps / 1_000_000_000;
         const t = Math.log10(Math.max(gbps, 0.01)) + 2;  // 1 Mbps -> 0, 10 Gbps -> 3
-        return (0.10 + Math.min(t, 3.5) * 0.05) * this._linkScale;
+        return 0.10 * this._linkScale + Math.min(t, 3.5) * 0.05 * Math.sqrt(this._linkScale);
     }
 
     _nodeRadius(kind) {
@@ -1750,7 +1758,7 @@ export class LanFlowMap {
         for (const { pipe, down, up } of this._linkMeshes.values()) {
             if (!pipe) continue;
             const dist = camPos.distanceTo(pipe.position);
-            const z = Math.max(linkMin, Math.min(linkMax, dist / DEVICE_ZOOM_REF_DIST));
+            const z = Math.max(linkMin, Math.min(linkMax, dist / LINK_ZOOM_REF_DIST));
             pipe.scale.x = z;
             pipe.scale.z = z;
             down?.setZoom(z);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -121,6 +121,13 @@ const LINK_ZOOM_MAX = 1.35;
 // maps (factor 1.0) top out at design size, while large campuses keep their
 // full zoom boost since their objects start shrunken.
 const ZOOM_EFFECTIVE_CEIL = 1.0;
+// Sprite labels are world-sized, so perspective balloons them as the camera
+// closes in (the DOM labels already clamp their screen-space scale). Shrink
+// them proportionally inside the reference distance - apparent size then
+// stays constant once you're closer than REF, with a floor so they never
+// collapse entirely. Beyond REF they behave exactly as today.
+const LABEL_ZOOM_REF_DIST = 60;
+const LABEL_ZOOM_MIN = 0.25;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -1263,6 +1270,7 @@ export class LanFlowMap {
         const scaleY = 1.2 * (h / (fontSize + pad * 2));
         const scaleX = scaleY * (w / h);
         sprite.scale.set(scaleX, scaleY, 1);
+        sprite.userData.baseScale = { x: scaleX, y: scaleY };
         return sprite;
     }
 
@@ -1724,6 +1732,14 @@ export class LanFlowMap {
             pipe.scale.z = z;
             down?.setZoom(z);
             up?.setZoom(z);
+        }
+        for (const [nodeId, sprite] of this._labelSprites) {
+            const base = sprite.userData?.baseScale;
+            const group = this._nodeMeshes.get(nodeId);
+            if (!base || !group) continue;
+            const dist = camPos.distanceTo(group.position);
+            const f = Math.max(LABEL_ZOOM_MIN, Math.min(1.0, dist / LABEL_ZOOM_REF_DIST));
+            sprite.scale.set(base.x * f, base.y * f, 1);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2890,6 +2890,12 @@ export class LanFlowMap {
                 el.setAttribute('data-tooltip-hover-only', '');
                 el.setAttribute('data-tooltip-delay', '500');
             }
+            // Pills accept pointer events for the tooltip, which would swallow
+            // the scroll wheel - forward it to the canvas so zoom keeps working.
+            el.addEventListener('wheel', (e) => {
+                e.preventDefault();
+                this.canvas.dispatchEvent(new WheelEvent('wheel', e));
+            }, { passive: false });
             this._labelsLayer.appendChild(el);
             this._linkLabels.set(link.id, { el, kind: link.kind });
         }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -116,6 +116,11 @@ const DEVICE_ZOOM_MAX = 1.6;
 // still see what's flowing without turning into hoses.
 const LINK_ZOOM_MIN = 0.75;
 const LINK_ZOOM_MAX = 1.35;
+// The zoom-out ceiling is relative to property size: property factor x zoom
+// boost never exceeds this multiple of an object's designed size. Single-home
+// maps (factor 1.0) top out at design size, while large campuses keep their
+// full zoom boost since their objects start shrunken.
+const ZOOM_EFFECTIVE_CEIL = 1.0;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -1701,18 +1706,20 @@ export class LanFlowMap {
     // and particle streams follow via a shader zoom uniform.
     _applyZoomScaling() {
         const camPos = this.camera.position;
+        const devMax = Math.max(1.0, Math.min(DEVICE_ZOOM_MAX, ZOOM_EFFECTIVE_CEIL / this._deviceScale));
+        const linkMax = Math.max(1.0, Math.min(LINK_ZOOM_MAX, ZOOM_EFFECTIVE_CEIL / this._linkScale));
         for (const group of this._nodeMeshes.values()) {
             const { core, halo } = group.userData ?? {};
             if (!core) continue;
             const dist = camPos.distanceTo(group.position);
-            const z = Math.max(DEVICE_ZOOM_MIN, Math.min(DEVICE_ZOOM_MAX, dist / DEVICE_ZOOM_REF_DIST));
+            const z = Math.max(DEVICE_ZOOM_MIN, Math.min(devMax, dist / DEVICE_ZOOM_REF_DIST));
             core.scale.setScalar(z);
             if (halo) halo.scale.setScalar(z);
         }
         for (const { pipe, down, up } of this._linkMeshes.values()) {
             if (!pipe) continue;
             const dist = camPos.distanceTo(pipe.position);
-            const z = Math.max(LINK_ZOOM_MIN, Math.min(LINK_ZOOM_MAX, dist / DEVICE_ZOOM_REF_DIST));
+            const z = Math.max(LINK_ZOOM_MIN, Math.min(linkMax, dist / DEVICE_ZOOM_REF_DIST));
             pipe.scale.x = z;
             pipe.scale.z = z;
             down?.setZoom(z);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -883,7 +883,7 @@ export class LanFlowMap {
             // labels (with rate badges) but sprites provide 3D depth sorting.
             if (node.name) {
                 const sprite = this._makeLabelSprite(node.name);
-                sprite.position.set(0, radius + 0.8, 0);
+                sprite.position.set(0, radius + 0.8 * this._deviceScale, 0);
                 group.add(sprite);
                 this._labelSprites.set(node.id, sprite);
             }
@@ -1838,7 +1838,7 @@ export class LanFlowMap {
         this._nodeMeshes.set(node.id, group);
         if (node.name) {
             const sprite = this._makeLabelSprite(node.name);
-            sprite.position.set(0, radius + 0.8, 0);
+            sprite.position.set(0, radius + 0.8 * this._deviceScale, 0);
             group.add(sprite);
             this._labelSprites.set(node.id, sprite);
         }
@@ -2919,7 +2919,7 @@ export class LanFlowMap {
             if (!group) { el.classList.remove('is-visible'); continue; }
             if (!group.visible) { el.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y += 1.8;  // anchor above the node sphere
+            tmp.y += 1.8 * this._deviceScale;  // anchor above the node sphere
             const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -87,6 +87,27 @@ const NODE_RADIUS = {
     virtualHub: 0.55,
 };
 
+// NODE_RADIUS was tuned against a single-home property, whose meters->scene
+// factor works out to about REF_WORLD_SCALE. Larger properties squeeze more
+// meters into the same ~30-unit scene, so fixed scene-unit devices end up
+// towering over the shrunken buildings. Devices therefore keep a fixed
+// physical size: their radii shrink with the same meters->scene factor the
+// buildings use, capped at 1.0 (small sites render exactly as before) and
+// floored so devices stay readable on very large campuses. WAN globes float
+// outside the structures, so they only breathe a little around design size.
+const REF_WORLD_SCALE = 2.25;
+const DEVICE_SCALE_MIN = 0.35;
+const CLOUD_SCALE_MIN = 0.75;
+const CLOUD_SCALE_MAX = 1.1;
+
+// Camera-distance compensation for device meshes (labels have their own DOM
+// equivalent and are untouched): neutral at the fly-in viewing distance,
+// growing toward a ceiling as you zoom out (visibility at property level)
+// and shrinking toward a floor as you zoom in (no room-filling routers).
+const DEVICE_ZOOM_REF_DIST = 60;
+const DEVICE_ZOOM_MIN = 0.6;
+const DEVICE_ZOOM_MAX = 1.6;
+
 const LINK_KIND = {
     Uplink: 0,
     WiredClient: 1,
@@ -150,6 +171,8 @@ export class LanFlowMap {
         this._signalHintEnabled = options.signalHint ?? true;
 
         this._snapshot = null;
+        this._deviceScale = 1;          // property-size factor for device radii (set in _layoutNodes)
+        this._cloudScale = 1;           // gentler property-size factor for WAN globes
         this._nodesByLink = new Map();
         this._nodeMeshes = new Map();   // nodeId -> THREE.Group
         this._linkMeshes = new Map();   // linkId -> { pipe, particlesDown, particlesUp }
@@ -608,6 +631,13 @@ export class LanFlowMap {
         const boundsR = Number.isFinite(bounds.radius) ? bounds.radius : 1.0;
         const scale = (sceneRadius / Math.max(boundsR, 1.0)) * ANCHOR_SPREAD_FACTOR;
 
+        // Pin devices to a fixed physical size relative to the buildings (which
+        // are built in meters * this same factor). Unanchored sites have a tiny
+        // default bounds radius, so the ratio clamps to 1.0 and nothing changes.
+        const sizeRatio = scale / REF_WORLD_SCALE;
+        this._deviceScale = Math.max(DEVICE_SCALE_MIN, Math.min(1.0, sizeRatio));
+        this._cloudScale = Math.max(CLOUD_SCALE_MIN, Math.min(CLOUD_SCALE_MAX, sizeRatio));
+
         const positions = new Map();
         const anchors = new Map();
 
@@ -887,7 +917,7 @@ export class LanFlowMap {
             let effA = a, effB = b;
             const isWan = link.kind === LINK_KIND.Wan || link.kind === LINK_KIND.Transit;
             if (isWan) {
-                const r = NODE_RADIUS.cloud;
+                const r = this._cloudRadius();
                 const cloudEnd = this._cloudMeshes.has(link.toNodeId) ? 'b'
                     : this._cloudMeshes.has(link.fromNodeId) ? 'a' : null;
                 if (cloudEnd) {
@@ -1036,7 +1066,7 @@ export class LanFlowMap {
             // Wireframe globe - no solid sphere, just the lat/lng grid lines.
             // LineBasicMaterial.linewidth doesn't work on WebGL, so we use
             // thin tube geometry for each line to get visible thickness.
-            const r = NODE_RADIUS.cloud;
+            const r = this._cloudRadius();
             const gridColor = tier === CLOUD_TIER.Unresolved ? 0x3a4455 : 0x3385d6;
             const tubeMat = new THREE.MeshBasicMaterial({
                 color: gridColor,
@@ -1086,7 +1116,7 @@ export class LanFlowMap {
             const labelText = cloud.name || (cloud.asn ? `AS${cloud.asn}` : 'Cloud');
             const subText = this._buildCloudSubLabel(cloud, tier);
             const label = this._makeLabelSprite(labelText, subText);
-            label.position.set(0, NODE_RADIUS.cloud + 1.2, 0);
+            label.position.set(0, this._cloudRadius() + 1.2, 0);
             group.add(label);
 
             group.position.set(pos.x, pos.y, pos.z);
@@ -1147,15 +1177,22 @@ export class LanFlowMap {
     }
 
     _nodeRadius(kind) {
-        switch (kind) {
-            case NODE_KIND.Gateway: return NODE_RADIUS.gateway;
-            case NODE_KIND.Switch: return NODE_RADIUS.switch;
-            case NODE_KIND.AccessPoint: return NODE_RADIUS.ap;
-            case NODE_KIND.WiredClient: return NODE_RADIUS.wiredClient;
-            case NODE_KIND.WifiClient: return NODE_RADIUS.wifiClient;
-            case NODE_KIND.VirtualHub: return NODE_RADIUS.virtualHub;
-            default: return 0.6;
-        }
+        const base = (() => {
+            switch (kind) {
+                case NODE_KIND.Gateway: return NODE_RADIUS.gateway;
+                case NODE_KIND.Switch: return NODE_RADIUS.switch;
+                case NODE_KIND.AccessPoint: return NODE_RADIUS.ap;
+                case NODE_KIND.WiredClient: return NODE_RADIUS.wiredClient;
+                case NODE_KIND.WifiClient: return NODE_RADIUS.wifiClient;
+                case NODE_KIND.VirtualHub: return NODE_RADIUS.virtualHub;
+                default: return 0.6;
+            }
+        })();
+        return base * this._deviceScale;
+    }
+
+    _cloudRadius() {
+        return NODE_RADIUS.cloud * this._cloudScale;
     }
 
     _nodeColor(kind) {
@@ -1611,6 +1648,9 @@ export class LanFlowMap {
             // scenes still feel alive.
             this._pulseNodes(now);
 
+            // Camera-distance size compensation for device meshes.
+            this._scaleNodesForZoom();
+
             // Render through the composer so bloom + tone mapping apply.
             this.composer.render();
             // After the render we have up-to-date matrixWorld for every node group;
@@ -1639,6 +1679,22 @@ export class LanFlowMap {
                 core.material.opacity = Math.max(0.15, t);
                 if (t >= 1) this._roamFade3D.delete(id);
             }
+        }
+    }
+
+    // Scale device cores/halos with camera distance: up toward a ceiling when
+    // zoomed out so devices stay visible at property level, down toward a floor
+    // when zoomed in so they don't fill a room. Only the core and halo scale -
+    // sprite labels are siblings in the same group and keep today's behavior.
+    _scaleNodesForZoom() {
+        const camPos = this.camera.position;
+        for (const group of this._nodeMeshes.values()) {
+            const { core, halo } = group.userData ?? {};
+            if (!core) continue;
+            const dist = camPos.distanceTo(group.position);
+            const z = Math.max(DEVICE_ZOOM_MIN, Math.min(DEVICE_ZOOM_MAX, dist / DEVICE_ZOOM_REF_DIST));
+            core.scale.setScalar(z);
+            if (halo) halo.scale.setScalar(z);
         }
     }
 
@@ -1732,7 +1788,7 @@ export class LanFlowMap {
             core.material.transparent = true;
             halo.material.opacity = 0.05;
         }
-        group.userData = { node, core, baseEmissive };
+        group.userData = { node, core, halo, baseEmissive };
         this.nodeGroup.add(group);
         this._nodeMeshes.set(node.id, group);
         if (node.name) {
@@ -2836,7 +2892,7 @@ export class LanFlowMap {
             const group = this._cloudMeshes.get(`cloud-access-${wanIface}`);
             if (!group) { pill.classList.remove('is-visible'); continue; }
             tmp.setFromMatrixPosition(group.matrixWorld);
-            tmp.y -= NODE_RADIUS.cloud + 0.5;
+            tmp.y -= this._cloudRadius() + 0.5;
             const dist = tmp.distanceTo(camPos);
             tmp.project(this.camera);
             if (tmp.z > 1) { pill.classList.remove('is-visible'); continue; }
@@ -2857,7 +2913,7 @@ export class LanFlowMap {
                 const group = this._cloudMeshes.get(cloudId);
                 if (!group) { lbl.classList.remove('is-visible'); continue; }
                 tmp.setFromMatrixPosition(group.matrixWorld);
-                tmp.y -= NODE_RADIUS.cloud + 0.5;
+                tmp.y -= this._cloudRadius() + 0.5;
                 const dist = tmp.distanceTo(camPos);
                 tmp.project(this.camera);
                 if (tmp.z > 1) { lbl.classList.remove('is-visible'); continue; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1199,12 +1199,12 @@ export class LanFlowMap {
     _pipeRadiusForCapacity(capacityBps) {
         if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10 * this._linkScale;
         // Log scale: 100 Mbps -> 0.13, 1 Gbps -> 0.18, 10 Gbps -> 0.24, 25 Gbps -> 0.28.
-        // The base thins fully with the property factor, but the capacity term
-        // only by sqrt of it - the full factor squeezed the speed-driven girth
-        // differences below what the eye can resolve on shrunken maps.
+        // Only the base thins with the property factor; the capacity term stays
+        // at designed size so speed-driven girth (and the contrast between
+        // speeds) reads the same on shrunken maps as on a single home.
         const gbps = capacityBps / 1_000_000_000;
         const t = Math.log10(Math.max(gbps, 0.01)) + 2;  // 1 Mbps -> 0, 10 Gbps -> 3
-        return 0.10 * this._linkScale + Math.min(t, 3.5) * 0.05 * Math.sqrt(this._linkScale);
+        return 0.10 * this._linkScale + Math.min(t, 3.5) * 0.05;
     }
 
     _nodeRadius(kind) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3046,7 +3046,12 @@ export class LanFlowMap {
             el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;
             const y = -(tmp.y * halfH) + halfH;
-            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1))) * (crowdScale ?? 1);
+            // Crowd shrink only matters where labels can actually collide -
+            // zoomed out. Up close the cluster spreads across the screen, so
+            // blend the factor out below 25 units and fully in past 60.
+            const crowdT = Math.min(1, Math.max(0, (dist - 25) / 35));
+            const crowdF = 1 - (1 - (crowdScale ?? 1)) * crowdT;
+            const scale = Math.max(minScale, Math.min(maxScale, REF_DIST / Math.max(dist, 1))) * crowdF;
             el.style.transform = `translate(-50%, -100%) scale(${scale.toFixed(3)})`;
             el.style.transformOrigin = 'center bottom';
             el.style.left = `${x}px`;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -99,6 +99,10 @@ const REF_WORLD_SCALE = 2.25;
 const DEVICE_SCALE_MIN = 0.35;
 const CLOUD_SCALE_MIN = 0.75;
 const CLOUD_SCALE_MAX = 1.1;
+// Pipes and particle dots track the property shrink too, but on a tighter
+// clamp: they are thin already and carry the flow readability, so they only
+// come down far enough to not read as oversized against small buildings.
+const LINK_SCALE_MIN = 0.6;
 
 // Camera-distance compensation for device meshes (labels have their own DOM
 // equivalent and are untouched): neutral at the fly-in viewing distance,
@@ -107,6 +111,11 @@ const CLOUD_SCALE_MAX = 1.1;
 const DEVICE_ZOOM_REF_DIST = 60;
 const DEVICE_ZOOM_MIN = 0.6;
 const DEVICE_ZOOM_MAX = 1.6;
+// Pipes/particles get the same treatment on a tighter band: a decent floor so
+// they never go skinny, and a capped ceiling zoomed out - just fat enough to
+// still see what's flowing without turning into hoses.
+const LINK_ZOOM_MIN = 0.75;
+const LINK_ZOOM_MAX = 1.35;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -173,6 +182,7 @@ export class LanFlowMap {
         this._snapshot = null;
         this._deviceScale = 1;          // property-size factor for device radii (set in _layoutNodes)
         this._cloudScale = 1;           // gentler property-size factor for WAN globes
+        this._linkScale = 1;            // gentler property-size factor for pipes + particle dots
         this._nodesByLink = new Map();
         this._nodeMeshes = new Map();   // nodeId -> THREE.Group
         this._linkMeshes = new Map();   // linkId -> { pipe, particlesDown, particlesUp }
@@ -637,6 +647,7 @@ export class LanFlowMap {
         const sizeRatio = scale / REF_WORLD_SCALE;
         this._deviceScale = Math.max(DEVICE_SCALE_MIN, Math.min(1.0, sizeRatio));
         this._cloudScale = Math.max(CLOUD_SCALE_MIN, Math.min(CLOUD_SCALE_MAX, sizeRatio));
+        this._linkScale = Math.max(LINK_SCALE_MIN, Math.min(1.0, sizeRatio));
 
         const positions = new Map();
         const anchors = new Map();
@@ -934,10 +945,10 @@ export class LanFlowMap {
             this.linkGroup.add(pipe);
 
             const down = new ParticleStream({
-                from: effA, to: effB, color: COLORS.downstream, particleCount: 0,
+                from: effA, to: effB, color: COLORS.downstream, particleCount: 0, sizeScale: this._linkScale,
             });
             const up = new ParticleStream({
-                from: effB, to: effA, color: COLORS.upstream, particleCount: 0,
+                from: effB, to: effA, color: COLORS.upstream, particleCount: 0, sizeScale: this._linkScale,
             });
             this.particleGroup.add(down.mesh, up.mesh);
 
@@ -1169,11 +1180,11 @@ export class LanFlowMap {
     }
 
     _pipeRadiusForCapacity(capacityBps) {
-        if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10;
+        if (typeof capacityBps !== 'number' || !Number.isFinite(capacityBps) || capacityBps <= 0) return 0.10 * this._linkScale;
         // Log scale: 100 Mbps -> 0.13, 1 Gbps -> 0.18, 10 Gbps -> 0.24, 25 Gbps -> 0.28.
         const gbps = capacityBps / 1_000_000_000;
         const t = Math.log10(Math.max(gbps, 0.01)) + 2;  // 1 Mbps -> 0, 10 Gbps -> 3
-        return 0.10 + Math.min(t, 3.5) * 0.05;
+        return (0.10 + Math.min(t, 3.5) * 0.05) * this._linkScale;
     }
 
     _nodeRadius(kind) {
@@ -1416,8 +1427,8 @@ export class LanFlowMap {
             const pipe = this._makePipeMesh(apPos, pos, old.link);
             pipe.visible = wasVisible;
             this.linkGroup.add(pipe);
-            const down = new ParticleStream({ from: apPos, to: pos, color: COLORS.downstream, particleCount: 0 });
-            const up = new ParticleStream({ from: pos, to: apPos, color: COLORS.upstream, particleCount: 0 });
+            const down = new ParticleStream({ from: apPos, to: pos, color: COLORS.downstream, particleCount: 0, sizeScale: this._linkScale });
+            const up = new ParticleStream({ from: pos, to: apPos, color: COLORS.upstream, particleCount: 0, sizeScale: this._linkScale });
             down.mesh.visible = wasVisible;
             up.mesh.visible = wasVisible;
             this.particleGroup.add(down.mesh, up.mesh);
@@ -1648,8 +1659,8 @@ export class LanFlowMap {
             // scenes still feel alive.
             this._pulseNodes(now);
 
-            // Camera-distance size compensation for device meshes.
-            this._scaleNodesForZoom();
+            // Camera-distance size compensation for devices, pipes, particles.
+            this._applyZoomScaling();
 
             // Render through the composer so bloom + tone mapping apply.
             this.composer.render();
@@ -1686,7 +1697,9 @@ export class LanFlowMap {
     // zoomed out so devices stay visible at property level, down toward a floor
     // when zoomed in so they don't fill a room. Only the core and halo scale -
     // sprite labels are siblings in the same group and keep today's behavior.
-    _scaleNodesForZoom() {
+    // Pipes fatten/thin on a tighter clamp (X/Z only - Y is the pipe length),
+    // and particle streams follow via a shader zoom uniform.
+    _applyZoomScaling() {
         const camPos = this.camera.position;
         for (const group of this._nodeMeshes.values()) {
             const { core, halo } = group.userData ?? {};
@@ -1695,6 +1708,15 @@ export class LanFlowMap {
             const z = Math.max(DEVICE_ZOOM_MIN, Math.min(DEVICE_ZOOM_MAX, dist / DEVICE_ZOOM_REF_DIST));
             core.scale.setScalar(z);
             if (halo) halo.scale.setScalar(z);
+        }
+        for (const { pipe, down, up } of this._linkMeshes.values()) {
+            if (!pipe) continue;
+            const dist = camPos.distanceTo(pipe.position);
+            const z = Math.max(LINK_ZOOM_MIN, Math.min(LINK_ZOOM_MAX, dist / DEVICE_ZOOM_REF_DIST));
+            pipe.scale.x = z;
+            pipe.scale.z = z;
+            down?.setZoom(z);
+            up?.setZoom(z);
         }
     }
 
@@ -1805,8 +1827,8 @@ export class LanFlowMap {
         if (a && b) {
             pipe = this._makePipeMesh(a, b, link);
             this.linkGroup.add(pipe);
-            down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0 });
-            up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0 });
+            down = new ParticleStream({ from: a, to: b, color: COLORS.downstream, particleCount: 0, sizeScale: this._linkScale });
+            up = new ParticleStream({ from: b, to: a, color: COLORS.upstream, particleCount: 0, sizeScale: this._linkScale });
             this.particleGroup.add(down.mesh, up.mesh);
             this._linkMeshes.set(link.id, { pipe, down, up, link });
             this._nodesByLink.set(link.id, [link.fromNodeId, link.toNodeId]);
@@ -3710,7 +3732,7 @@ function _getDotTexture() {
 }
 
 class ParticleStream {
-    constructor({ from, to, color, particleCount = 0 }) {
+    constructor({ from, to, color, particleCount = 0, sizeScale = 1 }) {
         const fromV = new THREE.Vector3(from.x, from.y, from.z);
         const toV = new THREE.Vector3(to.x, to.y, to.z);
         this._from = fromV;
@@ -3760,13 +3782,15 @@ class ParticleStream {
                 color: { value: new THREE.Color(color) },
                 map: { value: _getDotTexture() },
                 scale: { value: 600.0 },
+                zoom: { value: 1.0 },
             },
             vertexShader: `
                 attribute float size;
                 uniform float scale;
+                uniform float zoom;
                 void main() {
                     vec4 mv = modelViewMatrix * vec4(position, 1.0);
-                    gl_PointSize = size * (scale / max(-mv.z, 1.0));
+                    gl_PointSize = size * zoom * (scale / max(-mv.z, 1.0));
                     gl_Position = projectionMatrix * mv;
                 }
             `,
@@ -3805,7 +3829,14 @@ class ParticleStream {
         // Size that NEW particles will be born at - written into the size
         // attribute when the particle spawns. Existing in-flight particles
         // keep whatever size they were emitted with.
-        this._currentSize = 0.05;
+        this._sizeScale = sizeScale;
+        this._currentSize = 0.05 * sizeScale;
+    }
+
+    // Camera-distance compensation, applied uniformly to all in-flight dots
+    // (unlike per-particle spawn sizes, zooming should resize existing dots).
+    setZoom(z) {
+        this._material.uniforms.zoom.value = z;
     }
 
     setRate(bps) {
@@ -3826,7 +3857,7 @@ class ParticleStream {
         // Stored for use at spawn time only - particles already in flight
         // keep their birth size so a sudden rate change doesn't visually
         // resize dots that have already left the sender.
-        this._currentSize = 0.0375 + (intensity * intensity) * 1.3125;
+        this._currentSize = (0.0375 + (intensity * intensity) * 1.3125) * this._sizeScale;
         // Velocity: 2.5 idle -> 6.5 saturated. Still communicates throughput
         // without slamming between crawl and jet on per-poll rate fluctuations.
         this._velocity = 2.5 + intensity * 4.0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1736,6 +1736,9 @@ export class LanFlowMap {
         const camPos = this.camera.position;
         const devMax = Math.max(1.0, Math.min(DEVICE_ZOOM_MAX, ZOOM_EFFECTIVE_CEIL / this._deviceScale));
         const linkMax = Math.max(1.0, Math.min(LINK_ZOOM_MAX, ZOOM_EFFECTIVE_CEIL / this._linkScale));
+        // Zoom-in floor is relative like the ceiling: large properties thin
+        // their pipes further up close; single-home keeps the designed floor.
+        const linkMin = LINK_ZOOM_MIN * this._linkScale;
         for (const group of this._nodeMeshes.values()) {
             const { core, halo } = group.userData ?? {};
             if (!core) continue;
@@ -1747,7 +1750,7 @@ export class LanFlowMap {
         for (const { pipe, down, up } of this._linkMeshes.values()) {
             if (!pipe) continue;
             const dist = camPos.distanceTo(pipe.position);
-            const z = Math.max(LINK_ZOOM_MIN, Math.min(linkMax, dist / DEVICE_ZOOM_REF_DIST));
+            const z = Math.max(linkMin, Math.min(linkMax, dist / DEVICE_ZOOM_REF_DIST));
             pipe.scale.x = z;
             pipe.scale.z = z;
             down?.setZoom(z);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2901,11 +2901,11 @@ export class LanFlowMap {
             const capDown = link.capacityDownBps, capUp = link.capacityUpBps;
             let capTip = null;
             if (capDown > 0 && capUp > 0) {
-                capTip = `Link speed: ↓ ${formatBps(capDown)} / ↑ ${formatBps(capUp)}`;
+                capTip = `Link speed: ↓ ${formatCapacity(capDown)} / ↑ ${formatCapacity(capUp)}`;
             } else if (capDown > 0 || capUp > 0) {
-                capTip = `Link speed: ${formatBps(capDown > 0 ? capDown : capUp)}`;
+                capTip = `Link speed: ${formatCapacity(capDown > 0 ? capDown : capUp)}`;
             } else if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
-                capTip = `Link speed: ${formatBps(link.capacityBps)}`;
+                capTip = `Link speed: ${formatCapacity(link.capacityBps)}`;
             }
             if (capTip) {
                 el.setAttribute('data-tooltip', capTip);
@@ -4122,6 +4122,12 @@ function formatBps(bps) {
     let v = bps;
     while (v >= 1000 && i < units.length - 1) { v /= 1000; i += 1; }
     return `${v >= 100 ? v.toFixed(0) : v.toFixed(1)} ${units[i]}`;
+}
+
+// Capacity variant: whole numbers drop the trailing .0 ("1 Gbps" not
+// "1.0 Gbps"), real decimals keep it ("2.5 Gbps").
+function formatCapacity(bps) {
+    return formatBps(bps).replace('.0 ', ' ');
 }
 
 function formatAge(ms) {


### PR DESCRIPTION
Makes the 3D LAN Flow Map read correctly on large and multi-building properties, where fixed-size objects and labels used to tower over the shrunken buildings. Adds link speed tooltips, precise device height placement, and fixes a placement round-trip bug. Most of the sizing work is 3D-only; the capacity and WAN changes are server-side and also improve the 2D LAN Topology Flow Map.

## Monitoring - 3D LAN Flow Map

### Object sizing

- **Property-relative object sizes** - Devices, pipes, particle streams, and WAN globes now shrink in proportion to the property's meters-to-scene factor, so they keep a consistent physical size against the buildings instead of dominating large campuses. Single-home maps render exactly as before.
- **Camera-distance compensation** - Devices, pipes, and particles scale up toward a capped ceiling when zoomed out (so they stay visible at property level) and down to a floor when zoomed in (no room-filling routers or hose-sized pipes). Ceilings and floors are relative to property size, so single-home maps stay at their designed size while large campuses keep their zoom headroom.

### Labels

- **Distance-aware sizing and fade** - Device labels shrink as they recede and fade out entirely once they are too far to be legible; throughput pills fade earlier so device identity outlives the rate readouts.
- **Crowd-aware shrink** - Labels in a locally dense cluster (a rack area) shrink proportionally so they do not pile up, easing off when zoomed in where the cluster spreads across the screen.
- **Anchoring and dedup** - Labels anchor just above the rendered top of each device shape rather than a fixed offset, and infrastructure devices no longer render a duplicate sprite label behind their DOM label.

### Link speed tooltips

- **Hover a throughput pill for its link speed** - Shows the link's negotiated capacity on a short delay so it does not fire while panning. Asymmetric links (Wi-Fi client, mesh backhaul, ISP-provisioned WAN) show both directions; whole numbers drop the trailing `.0`. Pills use the standard help cursor, block text selection, and pass the scroll wheel through to the map.

### Pipe and WAN sizing

- **WAN pipe diameter reflects the ISP plan** - WAN pipes size from the provisioned plan speed (the larger of download/upload) instead of the WAN port PHY, so they rank sensibly against LAN pipes. Applies to both the 3D map and the 2D LAN Topology Flow Map.
- **Readable speed contrast on shrunken maps** - The capacity-driven part of pipe girth stays at designed size so speed differences remain visible on large properties.

### Device placement

- **Precise device height** - Repositioning a device in 3D now persists its exact height, not just a mount-type estimate, via a new nullable per-site column. The floor assignment still carries through to the Wi-Fi Optimizer floor plans. Existing placements are unaffected.
- **Steadier reposition nudges** - WASD repositioning steps scale with camera distance and property size for consistent fine control across zoom levels and property sizes.
- **Fixed devices scattering on reload** - The scene reference frame (center, scale, and outlier pruning) is now anchored to access points only. Placing a switch or camera toward a building no longer perturbs the scene scale or trips the outlier guard, which could previously drop a just-placed device to a scatter position far from its building on the next load.
