### PR TITLE
Security Audit: fix false-positive VLAN isolation finding when a narrow block precedes a broad block

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -859,9 +859,13 @@ public class FirewallRuleAnalyzer
     {
         // Use FirewallRuleEvaluator to find the effective rule for this traffic direction
         // Use forNewConnections=true to skip infrastructure rules like "Allow Established/Related"
-        // that only handle return traffic and shouldn't be considered as isolation bypasses
+        // that only handle return traffic and shouldn't be considered as isolation bypasses.
+        // Partial block rules (specific ports/protocols/domains) are skipped, mirroring
+        // CheckAndAddIsolationIssue: traffic outside their scope falls through, so an allow
+        // rule behind a narrow block still takes effect for the remaining traffic.
         var evalResult = FirewallRuleEvaluator.Evaluate(rules,
-            r => HasNetworkPair(r, sourceNet, destNet),
+            r => HasNetworkPair(r, sourceNet, destNet) &&
+                 (!r.ActionType.IsBlockAction() || BlocksAllTraffic(r)),
             forNewConnections: true);
 
         // Only flag if traffic is effectively allowed (allow rule takes effect)
@@ -974,16 +978,21 @@ public class FirewallRuleAnalyzer
 
         // Evaluate firewall rules considering rule ordering (lower index = higher priority)
         // Use forNewConnections=true to skip RESPOND_ONLY allow rules (like "Allow Return Traffic")
-        // since we care about whether NEW connections can be initiated, not established traffic
+        // since we care about whether NEW connections can be initiated, not established traffic.
+        // Block rules restricted to specific ports/protocols/domains are skipped entirely: they
+        // only remove a slice of traffic and the remainder falls through to later rules, so a
+        // broad block behind a narrow one still provides isolation (#1010). Allow rules are
+        // never skipped - an earlier allow genuinely bypasses a later broad block.
         var evalResult = FirewallRuleEvaluator.Evaluate(rules,
-            r => HasNetworkPair(r, sourceNetwork, destNetwork),
+            r => HasNetworkPair(r, sourceNetwork, destNetwork) &&
+                 (!r.ActionType.IsBlockAction() || BlocksAllTraffic(r)),
             forNewConnections: true);
 
         // For isolation, the rule must:
         // 1. Be a block action (checked by IsBlocked)
         // 2. Block NEW connections (checked by IsBlocked via BlocksNewConnections)
-        // 3. Block ALL traffic, not just specific ports/protocols/domains
-        var hasIsolationRule = evalResult.IsBlocked && BlocksAllTraffic(evalResult.EffectiveRule!);
+        // 3. Block ALL traffic, not just specific ports/protocols/domains (guaranteed by the predicate)
+        var hasIsolationRule = evalResult.IsBlocked;
 
         if (evalResult.BlockRuleEclipsed)
         {

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -9014,6 +9014,149 @@ public class FirewallRuleAnalyzerTests
             i.Message.Contains("Invalid"));
     }
 
+    // Issue #1010: a narrow port-specific block preceding a broad all-traffic block for the
+    // same zone pair must not cause a Missing Isolation false positive. The narrow block only
+    // removes a slice of traffic; the remainder falls through to the broad block.
+    [Fact]
+    public void CheckInterVlanIsolation_NarrowBlockBeforeBroadBlock_NoMissingIsolation()
+    {
+        var iotNet = CreateNetwork("IoT", NetworkPurpose.IoT, id: "iot-net",
+            vlanId: 40, firewallZoneId: "zone-iot");
+        var corpNet = CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net",
+            vlanId: 10, firewallZoneId: "zone-internal");
+        var networks = new List<NetworkInfo> { iotNet, corpNet };
+
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "block-dot", Name = "Block IoT zone to Internal zone DoT",
+                Action = "drop", Enabled = true, Index = 40000,
+                Protocol = "tcp", DestinationPort = "853",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            },
+            new FirewallRule
+            {
+                Id = "block-all", Name = "Block IoT zone to Internal zone",
+                Action = "drop", Enabled = true, Index = 40001,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().NotContain(i => i.Type == IssueTypes.MissingIsolation &&
+            i.Message.Contains("IoT") && i.Message.Contains("Corporate"));
+        issues.Should().NotContain(i => i.Type == IssueTypes.IsolationBypassed);
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_NarrowBlockOnly_ReportsMissingIsolation()
+    {
+        // A port-specific block alone does NOT provide isolation - all other traffic passes.
+        var iotNet = CreateNetwork("IoT", NetworkPurpose.IoT, id: "iot-net",
+            vlanId: 40, firewallZoneId: "zone-iot");
+        var corpNet = CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net",
+            vlanId: 10, firewallZoneId: "zone-internal");
+        var networks = new List<NetworkInfo> { iotNet, corpNet };
+
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "block-dot", Name = "Block IoT zone to Internal zone DoT",
+                Action = "drop", Enabled = true, Index = 40000,
+                Protocol = "tcp", DestinationPort = "853",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == IssueTypes.MissingIsolation &&
+            i.Message.Contains("IoT") && i.Message.Contains("Corporate"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_NarrowBlockBeforeBroadAllow_FlagsIsolationBypassed()
+    {
+        // A narrow block in front of a broad allow must not mask the allow - everything
+        // outside the narrow block's scope is still permitted.
+        var iotNet = CreateNetwork("IoT", NetworkPurpose.IoT, id: "iot-net",
+            vlanId: 40, firewallZoneId: "zone-iot");
+        var corpNet = CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net",
+            vlanId: 10, firewallZoneId: "zone-internal");
+        var networks = new List<NetworkInfo> { iotNet, corpNet };
+
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "block-dot", Name = "Block IoT zone to Internal zone DoT",
+                Action = "drop", Enabled = true, Index = 40000,
+                Protocol = "tcp", DestinationPort = "853",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            },
+            new FirewallRule
+            {
+                Id = "allow-all", Name = "Allow IoT zone to Internal zone",
+                Action = "accept", Enabled = true, Index = 40001,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == IssueTypes.IsolationBypassed &&
+            i.Message.Contains("IoT") && i.Message.Contains("Corporate"));
+    }
+
+    [Fact]
+    public void CheckInterVlanIsolation_AllowBeforeBroadBlock_StillFlagsIsolationBypassed()
+    {
+        // An allow rule ahead of the broad block genuinely bypasses isolation and must
+        // still be detected - skipping narrow blocks must not skip allow rules.
+        var iotNet = CreateNetwork("IoT", NetworkPurpose.IoT, id: "iot-net",
+            vlanId: 40, firewallZoneId: "zone-iot");
+        var corpNet = CreateNetwork("Corporate", NetworkPurpose.Corporate, id: "corp-net",
+            vlanId: 10, firewallZoneId: "zone-internal");
+        var networks = new List<NetworkInfo> { iotNet, corpNet };
+
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-ssh", Name = "Allow IoT SSH to Internal",
+                Action = "accept", Enabled = true, Index = 40000,
+                Protocol = "tcp", DestinationPort = "22",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            },
+            new FirewallRule
+            {
+                Id = "block-all", Name = "Block IoT zone to Internal zone",
+                Action = "drop", Enabled = true, Index = 40001,
+                Protocol = "all",
+                SourceMatchingTarget = "ANY", DestinationMatchingTarget = "ANY",
+                SourceZoneId = "zone-iot", DestinationZoneId = "zone-internal"
+            }
+        };
+
+        var issues = _analyzer.CheckInterVlanIsolation(rules, networks);
+
+        issues.Should().Contain(i => i.Type == IssueTypes.IsolationBypassed &&
+            i.Message.Contains("IoT") && i.Message.Contains("Corporate"));
+        issues.Should().NotContain(i => i.Type == IssueTypes.MissingIsolation &&
+            i.Message.Contains("IoT") && i.Message.Contains("Corporate"));
+    }
+
     #endregion
 
     #region Helper Methods


### PR DESCRIPTION
Fixes #1010.

## Security Audit

- **Missing Isolation false positive** - The VLAN isolation evaluator took the first rule matching the source/destination zone pair. A narrow port-specific block (e.g. the reporter's TCP/853 DoT block) ahead of an all-traffic block made it stop at the narrow rule, fail the blocks-all-traffic check, and report that the zone pair has no isolation rule. Partial block rules are now transparent to the evaluation: they only remove a slice of traffic, and the remainder falls through to the later rules, so a broad block behind a narrow one satisfies isolation.
- **Isolation Bypassed check kept consistent** - The same treatment applies when looking for problematic allow rules, so a broad allow sitting behind a narrow block is now correctly flagged instead of being masked by the block. Allow rules are never skipped: an earlier allow ahead of a broad block still bypasses isolation and is still detected.
- **Tests** - Four new tests covering the reported ordering (narrow block then broad block), a narrow block alone (still Missing Isolation), a narrow block ahead of a broad allow (Isolation Bypassed), and an allow ahead of a broad block (still Isolation Bypassed).

Thanks @jimstrang for the detailed repro.
