### PR TITLE
Live View: synced timeline playback, WAN chart seek, loss accuracy, duplex link colour

### DIFF
--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -664,14 +664,16 @@ from(bucket: ""{_bucket}"")
         {
             if (group.Select(r => r.ClientMac).Distinct(StringComparer.OrdinalIgnoreCase).Count() != 1)
                 continue; // multiple clients in the window - trunk/uplink, never label
-            var latest = group.OrderByDescending(r => r.Time).First();
+            // Nearest to the scrub instant, matching the counter selection in
+            // QueryPortStatsAsync (name/IP can change across the window).
+            var nearest = group.OrderBy(r => Math.Abs((r.Time - center).Ticks)).First();
             result.Add(new WiredPortClientPoint
             {
-                DeviceMac = latest.DeviceMac,
-                Port = latest.Port,
-                ClientMac = latest.ClientMac,
-                ClientIp = latest.Ip,
-                ClientName = latest.Name,
+                DeviceMac = nearest.DeviceMac,
+                Port = nearest.Port,
+                ClientMac = nearest.ClientMac,
+                ClientIp = nearest.Ip,
+                ClientName = nearest.Name,
             });
         }
         return result;
@@ -1179,12 +1181,17 @@ from(bucket: ""{_bucket}"")
         if (!IsConfigured) return Array.Empty<PortStatsPoint>();
 
         string rangeClause;
+        var lastClause = "\n  |> last()";
         if (at.HasValue)
         {
-            // Mirror the historic snapshot window used elsewhere on the Live tab so
-            // the table lines up with the map and WAN chart at the same scrub point.
+            // Same fetch window as the historic snapshot used elsewhere on the Live
+            // tab. No last() here: last() would take the newest sample in the window
+            // (up to 30 s AFTER the scrub instant), putting the table ahead of the
+            // map and stat cards, which pick the sample NEAREST the instant. Fetch
+            // every sample and let the coalescing below pick the nearest one.
             var center = at.Value.ToUniversalTime();
             rangeClause = $"range(start: {ToFluxInstant(center.AddSeconds(-90))}, stop: {ToFluxInstant(center.AddSeconds(30))})";
+            lastClause = "";
         }
         else
         {
@@ -1204,8 +1211,7 @@ from(bucket: ""{_bucket}"")
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> {rangeClause}
-  |> filter(fn: (r) => r._measurement == ""interface_counters""){macFilter}
-  |> last()
+  |> filter(fn: (r) => r._measurement == ""interface_counters""){macFilter}{lastClause}
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var raw = new List<PortStatsPoint>();
@@ -1240,13 +1246,18 @@ from(bucket: ""{_bucket}"")
         // written when a rate is computable, so a fresh point may carry oper_status
         // and packet counters while the rates sit on an earlier point. pivot-by-time
         // then splits one interface into several partial rows. Collapse to a single
-        // row per (device, interface), coalescing each field from the most recent
-        // sample that carries it.
+        // row per (device, interface), coalescing each field from the best sample
+        // that carries it: nearest to the scrub instant in historic mode (keeping
+        // the table in lockstep with the map, which picks nearest), most recent
+        // otherwise.
+        var atUtc = at?.ToUniversalTime();
         return raw
             .GroupBy(p => (p.DeviceMac, p.IfName), TupleMacIfComparer)
             .Select(g =>
             {
-                var ordered = g.OrderByDescending(p => p.Time).ToList();
+                var ordered = atUtc.HasValue
+                    ? g.OrderBy(p => Math.Abs((p.Time - atUtc.Value).Ticks)).ToList()
+                    : g.OrderByDescending(p => p.Time).ToList();
                 long? FirstLong(Func<PortStatsPoint, long?> sel) => ordered.Select(sel).FirstOrDefault(v => v.HasValue);
                 double? FirstDouble(Func<PortStatsPoint, double?> sel) => ordered.Select(sel).FirstOrDefault(v => v.HasValue);
                 return new PortStatsPoint

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1689,7 +1689,9 @@ rtt = base
 loss = base
   |> filter(fn: (r) => r._field == ""loss_percent"")
   |> group(columns: [""target_id"", ""target_type""])
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: true)
+  |> fill(usePrevious: true)
+  |> filter(fn: (r) => exists r._value)
   |> group(columns: [""target_type"", ""_time""])
   |> mean()
   |> group(columns: [""_time""])

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3607,7 +3607,7 @@ else
                     "window.__mountWanLiveChart = async function(elId) {" +
                     $"  const m = await import('{VersionedJs("/js/wan-live-chart.js")}');" +
                     "  window.__wanLiveChart = m;" +
-                    "  await m.mount(elId);" +
+                    "  await m.mount(elId, { seekOnClick: true });" +
                     "}");
                 _ = JS.InvokeVoidAsync("__mountWanLiveChart", "monitoring-wan-live-chart");
             }

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -43,45 +43,7 @@ public static class MonitoringChartEndpoints
                 }
             }
 
-            var targets = await liveStats.GetIspTransitTargetsAsync(ct);
-
-            var ispRtts = new List<double>();
-            var ispLosses = new List<double>();
-            var transitRtts = new List<double>();
-            var transitLosses = new List<double>();
-
-            foreach (var t in targets)
-            {
-                var st = liveStats.GetTargetStats(t.TargetId);
-                if (st == null) continue;
-
-                if (t.TargetType == MonitoringTargetType.AccessIsp)
-                {
-                    if (st.RttAvgMs != null) ispRtts.Add(st.RttAvgMs.Value);
-                    ispLosses.Add(st.LossPercent);
-                }
-                else
-                {
-                    if (st.RttAvgMs != null) transitRtts.Add(st.RttAvgMs.Value);
-                    transitLosses.Add(st.LossPercent);
-                }
-            }
-
-            var ispRtt = ispRtts.Count > 0 ? ispRtts.Average() : (double?)null;
-            var ispLoss = ispLosses.Count > 0 ? ispLosses.Average() : 0.0;
-            var transitRtt = transitRtts.Count > 0 ? transitRtts.Average() : (double?)null;
-            var transitLoss = transitLosses.Count > 0 ? transitLosses.Average() : 0.0;
-
-            double? meanRtt = null;
-            if (ispRtt != null && transitRtt != null)
-                meanRtt = (ispRtt.Value + transitRtt.Value) / 2;
-            else meanRtt = ispRtt ?? transitRtt;
-
-            double meanLoss = 0;
-            if (ispRtt != null && transitRtt != null)
-                meanLoss = (ispLoss + transitLoss) / 2;
-            else if (ispRtt != null) meanLoss = ispLoss;
-            else if (transitRtts.Count > 0) meanLoss = transitLoss;
+            var (meanRtt, meanLoss) = await liveStats.GetMeanIspTransitLiveAsync(ct);
 
             return Results.Ok(new
             {

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -101,18 +101,19 @@ public static class MonitoringChartEndpoints
             var wanData = await wanTask;
             var rttData = await rttTask;
 
-            var rttByTime = new Dictionary<long, MonitoringInfluxClient.LatencyPoint>();
-            foreach (var p in rttData)
-            {
-                var bucket = p.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5);
-                rttByTime[bucket] = p;
-            }
+            // As-of merge: each WAN point adopts the newest latency point at or
+            // before its own timestamp. The previous exact-bucket join silently
+            // DROPPED latency points whenever the SNMP tier skipped the matching
+            // 5s window - and SNMP polls get delayed exactly under load, so loss
+            // spikes vanished from the chart precisely when they mattered.
+            var rttSorted = rttData.OrderBy(p => p.Time).ToList();
+            var ri = 0;
             MonitoringInfluxClient.LatencyPoint? lastRtt = null;
 
-            var points = wanData.Select(w =>
+            var points = wanData.OrderBy(w => w.Time).Select(w =>
             {
-                var bucket = w.Time.Ticks / (TimeSpan.TicksPerSecond * 5) * (TimeSpan.TicksPerSecond * 5);
-                if (rttByTime.TryGetValue(bucket, out var rtt)) lastRtt = rtt;
+                while (ri < rttSorted.Count && rttSorted[ri].Time <= w.Time)
+                    lastRtt = rttSorted[ri++];
 
                 return new
                 {
@@ -122,7 +123,7 @@ public static class MonitoringChartEndpoints
                     rttMs = lastRtt?.RttAvgMs,
                     lossPercent = lastRtt?.LossPercent,
                 };
-            });
+            }).ToList();
 
             return Results.Ok(new { points });
         });

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCache.cs
@@ -85,4 +85,5 @@ public record HistoricDataCache(
     IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WifiClients,
     IReadOnlyList<MonitoringInfluxClient.ClientThroughputPoint> WiredClients,
     Dictionary<string, IReadOnlyList<MonitoringInfluxClient.DeviceHealthPoint>> HealthByDevice,
-    Dictionary<MonitoringTargetType, IReadOnlyList<MonitoringInfluxClient.LatencyPoint>> LatencyByTargetType);
+    Dictionary<MonitoringTargetType, IReadOnlyList<MonitoringInfluxClient.LatencyPoint>> LatencyByTargetType,
+    IReadOnlyList<MonitoringInfluxClient.LatencyPoint> MeanIspTransit);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -436,6 +436,12 @@ public class LanFlowMapService
         // Cloud RTT: pick the lowest RTT across all access hop targets for this
         // WAN so the globe shows the nearest ISP infrastructure latency, not a
         // deeper transit hop that happens to be last in the wizard ordering.
+        // WAN globe LOSS is different: it shows the combined ISP+Transit mean the
+        // WAN live chart plots, so the globe and the chart's Loss series always
+        // agree - the lowest-RTT hop's own loss missed drops on the other hops.
+        double? wanChartLoss = null;
+        try { wanChartLoss = (await _liveStats.GetMeanIspTransitLiveAsync(ct)).MeanLossPercent; }
+        catch { }
         foreach (var cloud in snapshot.Clouds)
         {
             double? rtt = cloud.RttAvgMs;
@@ -461,6 +467,8 @@ public class LanFlowMapService
                     loss = bestLoss;
                     success = true;
                 }
+                if (cloud.Kind == LanCloudKind.AccessIsp && wanChartLoss != null)
+                    loss = wanChartLoss;
             }
 
             update.CloudStats[cloud.Id] = new CloudLiveStats
@@ -895,10 +903,19 @@ public class LanFlowMapService
                         .FirstOrDefault();
                 }
                 if (best == null) continue;
+                // WAN globe loss mirrors the WAN chart's Loss series (combined
+                // ISP+Transit mean) at the same instant, matching the live path.
+                double? loss = best.LossPercent;
+                if (cloud.Kind == LanCloudKind.AccessIsp && cached.MeanIspTransit.Count > 0)
+                {
+                    loss = cached.MeanIspTransit
+                        .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                        .First().LossPercent;
+                }
                 update.CloudStats[cloud.Id] = new CloudLiveStats
                 {
                     RttAvgMs = best.RttAvgMs,
-                    LossPercent = best.LossPercent,
+                    LossPercent = loss,
                     Success = best.RttAvgMs.HasValue,
                 };
             }
@@ -2103,7 +2120,17 @@ public class LanFlowMapService
             catch (Exception ex) { _logger.LogDebug(ex, "Historic latency fetch failed for {Type}", targetType); }
         }
 
-        return new HistoricDataCache(from, to, ratesByDevice, wifi, wired, healthByDevice, latencyByType);
+        // Combined ISP+Transit mean - the series the WAN live chart plots. WAN globe
+        // loss reads from this during playback so globe and chart always agree.
+        IReadOnlyList<MonitoringInfluxClient.LatencyPoint> meanIspTransit = Array.Empty<MonitoringInfluxClient.LatencyPoint>();
+        try
+        {
+            var targetIds = (await _liveStats.GetIspTransitTargetsAsync(ct)).Select(t => t.TargetId).ToList();
+            meanIspTransit = await _influx.QueryMeanIspTransitLatencyAsync(from, to, targetIds, ct: ct);
+        }
+        catch (Exception ex) { _logger.LogDebug(ex, "Historic mean ISP/transit latency fetch failed"); }
+
+        return new HistoricDataCache(from, to, ratesByDevice, wifi, wired, healthByDevice, latencyByType, meanIspTransit);
     }
 
     private async Task<LinkLiveRates?> QueryClientThroughputAsync(

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -359,6 +359,59 @@ public class MonitoringLiveStats
         return result;
     }
 
+    /// <summary>
+    /// Combined ISP+Transit live latency as plotted by the WAN live chart: RTT and
+    /// loss averaged per target type, then the mean of the two types. Loss follows
+    /// RTT presence so a type with no reachable targets doesn't drag the average
+    /// to zero. Shared by the live-stats endpoint and the LAN flow map WAN globes
+    /// so both always show the same number.
+    /// </summary>
+    public async Task<(double? MeanRttMs, double MeanLossPercent)> GetMeanIspTransitLiveAsync(
+        CancellationToken ct = default)
+    {
+        var targets = await GetIspTransitTargetsAsync(ct);
+
+        var ispRtts = new List<double>();
+        var ispLosses = new List<double>();
+        var transitRtts = new List<double>();
+        var transitLosses = new List<double>();
+
+        foreach (var t in targets)
+        {
+            var st = GetTargetStats(t.TargetId);
+            if (st == null) continue;
+
+            if (t.TargetType == MonitoringTargetType.AccessIsp)
+            {
+                if (st.RttAvgMs != null) ispRtts.Add(st.RttAvgMs.Value);
+                ispLosses.Add(st.LossPercent);
+            }
+            else
+            {
+                if (st.RttAvgMs != null) transitRtts.Add(st.RttAvgMs.Value);
+                transitLosses.Add(st.LossPercent);
+            }
+        }
+
+        var ispRtt = ispRtts.Count > 0 ? ispRtts.Average() : (double?)null;
+        var ispLoss = ispLosses.Count > 0 ? ispLosses.Average() : 0.0;
+        var transitRtt = transitRtts.Count > 0 ? transitRtts.Average() : (double?)null;
+        var transitLoss = transitLosses.Count > 0 ? transitLosses.Average() : 0.0;
+
+        double? meanRtt;
+        if (ispRtt != null && transitRtt != null)
+            meanRtt = (ispRtt.Value + transitRtt.Value) / 2;
+        else meanRtt = ispRtt ?? transitRtt;
+
+        double meanLoss = 0;
+        if (ispRtt != null && transitRtt != null)
+            meanLoss = (ispLoss + transitLoss) / 2;
+        else if (ispRtt != null) meanLoss = ispLoss;
+        else if (transitRtts.Count > 0) meanLoss = transitLoss;
+
+        return (meanRtt, meanLoss);
+    }
+
     /// <summary>Total fabric ingress/egress across all devices in the cache.
     /// Only devices with non-null fabric data contribute (APs are excluded
     /// because the collection agent never calls RecordFabricSum for them).</summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -361,10 +361,12 @@ public class MonitoringLiveStats
 
     /// <summary>
     /// Combined ISP+Transit live latency as plotted by the WAN live chart: RTT and
-    /// loss averaged per target type, then the mean of the two types. Loss follows
-    /// RTT presence so a type with no reachable targets doesn't drag the average
-    /// to zero. Shared by the live-stats endpoint and the LAN flow map WAN globes
-    /// so both always show the same number.
+    /// loss averaged per target type, then the mean of the two types. Loss is
+    /// combined over the types that have loss samples, independent of RTT presence,
+    /// mirroring the historic series (QueryMeanIspTransitLatencyAsync) - during a
+    /// full outage RTT goes null while loss pegs at 100, and gating loss on RTT
+    /// blanked the chart exactly when loss mattered most. Shared by the live-stats
+    /// endpoint and the LAN flow map WAN globes so both always show the same number.
     /// </summary>
     public async Task<(double? MeanRttMs, double MeanLossPercent)> GetMeanIspTransitLiveAsync(
         CancellationToken ct = default)
@@ -404,10 +406,10 @@ public class MonitoringLiveStats
         else meanRtt = ispRtt ?? transitRtt;
 
         double meanLoss = 0;
-        if (ispRtt != null && transitRtt != null)
+        if (ispLosses.Count > 0 && transitLosses.Count > 0)
             meanLoss = (ispLoss + transitLoss) / 2;
-        else if (ispRtt != null) meanLoss = ispLoss;
-        else if (transitRtts.Count > 0) meanLoss = transitLoss;
+        else if (ispLosses.Count > 0) meanLoss = ispLoss;
+        else if (transitLosses.Count > 0) meanLoss = transitLoss;
 
         return (meanRtt, meanLoss);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -456,8 +456,8 @@ h1:focus {
 }
 .wan-chart-mode-cluster {
     position: absolute;
-    top: 0.35rem;
-    left: 0.5rem;
+    top: 0.5rem;
+    right: 3.5rem;
     z-index: 6;
     display: flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -453,11 +453,16 @@ h1:focus {
     position: relative;
     cursor: crosshair;
 }
-.wan-chart-mode-badge {
+.wan-chart-mode-cluster {
     position: absolute;
     top: 0.35rem;
     left: 0.5rem;
     z-index: 6;
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.wan-chart-mode-cluster .lan-flow-map-mode {
     cursor: pointer;
 }
 .dashboard-grid .lv-panel > .wan-live-chart-card {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -463,6 +463,11 @@ h1:focus {
     align-items: center;
     gap: 0.4rem;
 }
+@media (max-width: 768px) {
+    .wan-chart-mode-cluster {
+        right: 0;
+    }
+}
 .wan-chart-mode-cluster .lan-flow-map-mode {
     cursor: pointer;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -449,6 +449,17 @@ h1:focus {
 .wan-live-chart-card .apexcharts-canvas {
     min-height: 0;
 }
+.wan-chart-seekable {
+    position: relative;
+    cursor: crosshair;
+}
+.wan-chart-mode-badge {
+    position: absolute;
+    top: 0.35rem;
+    left: 0.5rem;
+    z-index: 6;
+    cursor: pointer;
+}
 .dashboard-grid .lv-panel > .wan-live-chart-card {
     margin: -0.5rem;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -442,6 +442,7 @@ h1:focus {
     overflow: visible;
 }
 .wan-live-chart-card > .card-body {
+    position: relative;
     padding: 0 0 0.3rem;
     margin-right: -0.75rem;
     overflow: visible;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -558,6 +558,7 @@ class LanFlowMap2D {
             if(e.key!=='ArrowLeft'&&e.key!=='ArrowRight')return;
             if(inst._keys)inst._keys[e.key.toLowerCase()]=false;
             inst._arrowScrubStart=null;
+            inst._kbScrubTime=null;
         });
         // Forward all interactions to the 3D map
         const fwd=()=>window.__lanFlowMap?.getInstance?.();
@@ -580,7 +581,7 @@ class LanFlowMap2D {
             if(e.key==='Shift'){if(inst._keys)inst._keys.shift=false;return;}
             const key=e.key.toLowerCase();
             if(inst._keys)inst._keys[key]=false;
-            if(e.key==='ArrowLeft'||e.key==='ArrowRight')inst._arrowScrubStart=null;
+            if(e.key==='ArrowLeft'||e.key==='ArrowRight'){inst._arrowScrubStart=null;inst._kbScrubTime=null;}
         });
         sRange.addEventListener('input',(e)=>{
             const inst=fwd();if(inst){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1610,7 +1610,11 @@ class LanFlowMap2D {
             const r=off?null:(this._liveRates[e.lk.portKey]||this._liveRates[e.lk.id]);
             const dn=r?.downstreamBps??0,up=r?.upstreamBps??0;
             const cap=e.lk.capacityBps||1e9;
-            const u=Math.max(dn,up)/cap;
+            // Full-duplex: reserve the top (red) colour for BOTH directions
+            // saturated. Busy direction drives the ramp; the quiet one must also
+            // load up to reach full - a lone saturated direction tops out amber.
+            const dU=Math.min(dn/cap,1),uU=Math.min(up/cap,1);
+            const u=0.75*Math.max(dU,uU)+0.25*Math.min(dU,uU);
             const band=e.lk.band;
             ctx.strokeStyle=pipeClr(Math.min(u,1),band);
             ctx.lineWidth=pipeW(e.lk.capacityBps);

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -241,6 +241,8 @@ export class LanFlowMap {
         };
         this._mode = 'live';      // 'live' | 'historic'
         this._historicAt = null;  // Date when in historic mode
+        this._pendingScrubAt = null; // Date of a scrub not yet flushed to _onScrubberChange
+        this._kbScrubTime = null;    // ms epoch of the continuous keyboard-scrub position
         this._dotnetRef = window.__monitoringRef || null;
         this._playbackSpeed = 1;  // real-time multiplier
         this._playbackAccum = 0;  // fractional slider unit accumulator
@@ -422,7 +424,10 @@ export class LanFlowMap {
         this._onKeyUp = (e) => {
             this._keys[e.key.toLowerCase()] = false;
             if (e.key === 'Shift') this._keys.shift = false;
-            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') this._arrowScrubStart = null;
+            if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+                this._arrowScrubStart = null;
+                this._kbScrubTime = null;
+            }
         };
         document.addEventListener('keydown', this._onKeyDown);
         document.addEventListener('keyup', this._onKeyUp);
@@ -518,6 +523,7 @@ export class LanFlowMap {
         if (this._raf) cancelAnimationFrame(this._raf);
         if (this._pollTimer) clearInterval(this._pollTimer);
         if (this._historicPlaybackTimer) clearInterval(this._historicPlaybackTimer);
+        clearTimeout(this._scrubberInputDebounce);
         if (this._snapshotTimer) clearInterval(this._snapshotTimer);
         if (this._windowTickTimer) clearInterval(this._windowTickTimer);
         if (this._resizeObserver) this._resizeObserver.disconnect();
@@ -1684,8 +1690,12 @@ export class LanFlowMap {
             }
 
             // Left/right arrow: scrub timeline. Throttled to 5 ticks/sec.
-            // Accelerates after holding: 4 → 12 → 35 units/tick over 2 seconds.
-            // Shift multiplies by 9x on top of acceleration.
+            // Accelerates after holding: 4 → 12 → 35 slider-units of time per
+            // tick over 2 seconds. Shift multiplies by 9x on top of acceleration.
+            // Steps a continuous timestamp, not the integer slider value: the
+            // slider window trails now, so requantizing through slider units
+            // would make each step land on a slightly different instant than
+            // the label showed, and the seconds would wander.
             if (this._keys?.['arrowleft'] || this._keys?.['arrowright']) {
                 if (this._historicPlaybackTimer) this._stopHistoricPlayback();
                 const now = performance.now();
@@ -1695,17 +1705,30 @@ export class LanFlowMap {
                     const range = this._panels.scrubberRange;
                     if (range) {
                         const held = now - this._arrowScrubStart;
-                        let step = held > 2000 ? 35 : held > 1000 ? 12 : 4;
-                        if (this._keys.shift) step *= 9;
-                        const dir = this._keys['arrowright'] ? step : -step;
-                        const val = Math.max(0, Math.min(10000, Number(range.value) + dir));
+                        let units = held > 2000 ? 35 : held > 1000 ? 12 : 4;
+                        if (this._keys.shift) units *= 9;
+                        const stepMs = units * (this._scrubSpan / 10000);
+                        const { start, end } = this._scrubWindowBounds();
+                        const base = this._kbScrubTime
+                            ?? this._pendingScrubAt?.getTime()
+                            ?? this._historicAt?.getTime()
+                            ?? this._scrubberValueToTime(Number(range.value)).getTime();
+                        const t = Math.max(start, Math.min(end,
+                            base + (this._keys['arrowright'] ? stepMs : -stepMs)));
+                        this._kbScrubTime = t;
+                        const at = new Date(t);
+                        const val = this._timeToScrubberValue(t);
                         range.value = val;
-                        range.dispatchEvent(new Event('input'));
-                        range.dispatchEvent(new Event('change'));
+                        this._onScrubberInput(val, at);
+                        if (this._mode === 'live' && !this._isLiveValue(val, at)) {
+                            this._enterHistoricScrub();
+                        }
+                        this._queueScrubChange(val, at);
                     }
                 }
             } else {
                 this._arrowScrubStart = null;
+                this._kbScrubTime = null;
             }
 
             // Freeze particle motion while paused (Live or Historic) so the
@@ -2006,17 +2029,23 @@ export class LanFlowMap {
         // Track playback as a continuous timestamp, not integer slider units.
         const TICK_MS = 1000;
         const DATA_REFRESH_TICKS = 1;
-        // Seed from the exact parked instant when known - requantizing through
-        // the slider value can be minutes off on a wide window. But only when
-        // the thumb still agrees with it: a quick scrub right before resuming
-        // may not have flushed through the debounced change handler yet, and
-        // then the thumb position is the user's intent, not the stale instant.
+        // A scrub queued but not yet flushed through the debounced change handler
+        // is the user's freshest intent - resume from that exact instant and drop
+        // the pending flush (the first playback tick loads data anyway, and a
+        // late flush would snap playback back to the pre-play position).
+        clearTimeout(this._scrubberInputDebounce);
+        const pending = this._pendingScrubAt;
+        this._pendingScrubAt = null;
+        // Otherwise seed from the exact parked instant when known - requantizing
+        // through the slider value can be minutes off on a wide window. But only
+        // when the thumb still agrees with it; if not, the thumb position is the
+        // user's intent, not the stale instant.
         const fromValue = this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
         const stepMs = this._scrubSpan / 10000;
-        this._playbackTime =
-            (this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
-                ? this._historicAt : fromValue;
+        this._playbackTime = pending
+            ?? ((this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
+                ? this._historicAt : fromValue);
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;
@@ -2293,54 +2322,22 @@ export class LanFlowMap {
         });
         const range = scrubber.querySelector('.lan-flow-map-scrubber-range');
         this._scrubberInputDebounce = null;
-        range.addEventListener('input', (e) => {
-            const val = Number(e.target.value);
-            this._onScrubberInput(val);
-            if (this._mode === 'live' && !this._isLiveValue(val)) {
-                this._mode = 'historic';
-                this._paused = true;
-                this._syncPlayPauseIcon();
-                this._stopHistoricPlayback();
-                if (this._panels.modeBadge) {
-                    this._panels.modeBadge.textContent = 'Historic';
-                    this._panels.modeBadge.classList.add('is-historic');
-                    this._panels.modeBadge.style.cursor = 'pointer';
-                    this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
-                }
-                this._syncSpeedLabel();
-            }
-            const now = Date.now();
-            const sinceLastFire = now - this._scrubberLastFire;
-            clearTimeout(this._scrubberInputDebounce);
-            if (sinceLastFire >= 500) {
-                this._scrubberLastFire = now;
-                this._onScrubberChange(val);
-            } else {
-                this._scrubberInputDebounce = setTimeout(() => {
-                    this._scrubberLastFire = Date.now();
-                    this._onScrubberChange(val);
-                }, 500 - sinceLastFire);
-            }
-        });
-        this._scrubberThrottleTimer = null;
         this._scrubberLastFire = 0;
-        range.addEventListener('change', (e) => {
+        // Both listeners resolve the slider value to a timestamp AT EVENT TIME and
+        // carry it through the debounce. The window trails now, so re-deriving the
+        // time when the debounced handler fires (up to 500ms later) would load a
+        // different instant than the label showed.
+        const onScrub = (e) => {
             const val = Number(e.target.value);
-            this._onScrubberInput(val);
-            clearTimeout(this._scrubberInputDebounce);
-            const now = Date.now();
-            const elapsed = now - this._scrubberLastFire;
-            clearTimeout(this._scrubberThrottleTimer);
-            if (elapsed >= 1000) {
-                this._scrubberLastFire = now;
-                this._onScrubberChange(val);
-            } else {
-                this._scrubberThrottleTimer = setTimeout(() => {
-                    this._scrubberLastFire = Date.now();
-                    this._onScrubberChange(val);
-                }, 1000 - elapsed);
+            const at = this._scrubberValueToTime(val);
+            this._onScrubberInput(val, at);
+            if (this._mode === 'live' && !this._isLiveValue(val, at)) {
+                this._enterHistoricScrub();
             }
-        });
+            this._queueScrubChange(val, at);
+        };
+        range.addEventListener('input', onScrub);
+        range.addEventListener('change', onScrub);
         range.addEventListener('keydown', (e) => e.preventDefault());
         // User grabbing the thumb implicitly cancels any active historic playback.
         range.addEventListener('pointerdown', () => this._stopHistoricPlayback());
@@ -2608,18 +2605,54 @@ export class LanFlowMap {
     // Timeline scrubber
     // ------------------------------------------------------------------------
 
-    _onScrubberInput(value) {
+    // Flip Live -> Historic on the first scrub interaction: land paused with the
+    // Historic badge up, and kill any running playback.
+    _enterHistoricScrub() {
+        this._mode = 'historic';
+        this._paused = true;
+        this._syncPlayPauseIcon();
+        this._stopHistoricPlayback();
+        if (this._panels.modeBadge) {
+            this._panels.modeBadge.textContent = 'Historic';
+            this._panels.modeBadge.classList.add('is-historic');
+            this._panels.modeBadge.style.cursor = 'pointer';
+            this._panels.modeBadge.setAttribute('data-tooltip', 'Click to return to live');
+        }
+        this._syncSpeedLabel();
+    }
+
+    // Debounced data-load dispatch for scrub interactions (leading fire, then
+    // trailing at 500ms). The exact instant rides along so the eventual
+    // _onScrubberChange loads what the label showed; _pendingScrubAt keeps the
+    // not-yet-flushed instant visible to _startHistoricPlayback, so stepping and
+    // immediately hitting play resumes from the stepped position instead of a
+    // requantized slider value.
+    _queueScrubChange(val, at) {
+        this._pendingScrubAt = at;
+        const now = Date.now();
+        const sinceLastFire = now - this._scrubberLastFire;
+        clearTimeout(this._scrubberInputDebounce);
+        const fire = () => {
+            this._scrubberLastFire = Date.now();
+            this._pendingScrubAt = null;
+            this._onScrubberChange(val, at);
+        };
+        if (sinceLastFire >= 500) fire();
+        else this._scrubberInputDebounce = setTimeout(fire, 500 - sinceLastFire);
+    }
+
+    _onScrubberInput(value, at = null) {
         // Visual-only update while dragging - cheap label refresh.
-        const at = this._scrubberValueToTime(value);
-        const rightLabel = this._isLiveValue(value) ? 'Live' : _fmtDateTime(at);
+        at = at ?? this._scrubberValueToTime(value);
+        const rightLabel = this._isLiveValue(value, at) ? 'Live' : _fmtDateTime(at);
         if (this._panels.scrubberRight) {
             this._panels.scrubberRight.textContent = rightLabel;
         }
         flowData.publishScrubber(value, rightLabel, this._playbackSpeed);
     }
 
-    async _onScrubberChange(value) {
-        if (this._isLiveValue(value)) {
+    async _onScrubberChange(value, at = null) {
+        if (this._isLiveValue(value, at)) {
             // Snap back to live.
             this._stopHistoricPlayback();
             this._mode = 'live';
@@ -2643,7 +2676,7 @@ export class LanFlowMap {
             await this._pollLive();
             return;
         }
-        const at = this._scrubberValueToTime(value);
+        at = at ?? this._scrubberValueToTime(value);
         this._mode = 'historic';
         this._historicAt = at;
         // Redirect any running playback to the new position - otherwise its
@@ -2722,10 +2755,12 @@ export class LanFlowMap {
     // The window trails now, so the right edge of the slider is Live. Near-edge
     // values only count as Live when they are also near now in TIME - on a wide
     // window the last couple of slider steps span many minutes, and a position
-    // parked "10 minutes ago" must not read (or snap) as Live.
-    _isLiveValue(value) {
+    // parked "10 minutes ago" must not read (or snap) as Live. Callers that
+    // already resolved the value to an instant pass it so the check agrees with
+    // the time they are actually working with.
+    _isLiveValue(value, at = null) {
         if (value < 9998) return false;
-        return Date.now() - this._scrubberValueToTime(value).getTime() < 60000;
+        return Date.now() - (at ?? this._scrubberValueToTime(value)).getTime() < 60000;
     }
 
     // Widest selectable span: capped by the primary bucket's 90-day retention and,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2046,6 +2046,12 @@ export class LanFlowMap {
         this._playbackTime = pending
             ?? ((this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
                 ? this._historicAt : fromValue);
+        // Publish the seed position immediately instead of waiting for the first
+        // 1s tick: consumers re-baseline their playhead on a confirmed seek, and
+        // an adopted pending scrub gets its data loaded now rather than a tick late.
+        this._historicAt = this._playbackTime;
+        this._notifyStatCards(this._playbackTime);
+        this._loadHistoric(this._playbackTime);
         let tickCount = 0;
         this._historicPlaybackTimer = setInterval(() => {
             if (this._paused) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -145,6 +145,10 @@ const NET_LABEL_FADE_END_DIST = 102;
 // should outlive the rate readouts.
 const LINK_LABEL_FADE_START_DIST = 62;
 const LINK_LABEL_FADE_END_DIST = 97;
+// WAN throughput labels outlast the LAN pills - there are only one or two of
+// them and WAN utilisation stays interesting from farther back.
+const WAN_LINK_LABEL_FADE_START_DIST = 78;
+const WAN_LINK_LABEL_FADE_END_DIST = 121;
 
 const LINK_KIND = {
     Uplink: 0,
@@ -3197,8 +3201,9 @@ export class LanFlowMap {
             }
             tmp.project(this.camera);
             if (tmp.z > 1) { el.classList.remove('is-visible'); continue; }
-            const fade = 1 - Math.min(1, Math.max(0,
-                (dist - LINK_LABEL_FADE_START_DIST) / (LINK_LABEL_FADE_END_DIST - LINK_LABEL_FADE_START_DIST)));
+            const fadeStart = kind === LINK_KIND.Wan ? WAN_LINK_LABEL_FADE_START_DIST : LINK_LABEL_FADE_START_DIST;
+            const fadeEnd = kind === LINK_KIND.Wan ? WAN_LINK_LABEL_FADE_END_DIST : LINK_LABEL_FADE_END_DIST;
+            const fade = 1 - Math.min(1, Math.max(0, (dist - fadeStart) / (fadeEnd - fadeStart)));
             if (fade <= 0.01) { el.classList.remove('is-visible'); continue; }
             el.style.opacity = fade.toFixed(3);
             const x = (tmp.x * halfW) + halfW;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1372,13 +1372,19 @@ export class LanFlowMap {
             link.down.setRate(r.downstreamBps || 0);
             link.up.setRate(r.upstreamBps || 0);
 
-            // Health: utilization = max(down, up) / capacity. If we don't have capacity,
-            // fall back to a fixed 1 Gbps reference so it still reads.
+            // Health: per-direction utilization against capacity. A link is
+            // full-duplex - each direction carries the full capacity independently
+            // - so a single saturated direction is NOT a saturated link. Reserve
+            // the top (red) color for genuine duplex saturation: the busier
+            // direction drives most of the ramp, but the quieter one must also
+            // load up to reach full. A lone saturated direction tops out in amber.
+            // Without capacity, fall back to a fixed 1 Gbps reference so it reads.
             const capacity = (link.link.capacityBps && link.link.capacityBps > 0)
                 ? link.link.capacityBps
                 : 1_000_000_000;
-            const peak = Math.max(r.downstreamBps || 0, r.upstreamBps || 0);
-            const util = Math.min(peak / capacity, 1.0);
+            const downU = Math.min((r.downstreamBps || 0) / capacity, 1.0);
+            const upU = Math.min((r.upstreamBps || 0) / capacity, 1.0);
+            const util = 0.75 * Math.max(downU, upU) + 0.25 * Math.min(downU, upU);
             this._setPipeHealth(link.pipe, util);
         }
         // Refresh the device-rate text on the floating DOM labels.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2652,13 +2652,10 @@ export class LanFlowMap {
     }
 
     // External seek to an absolute instant (ms epoch) - e.g. a click on the WAN
-    // chart timeline. Mirrors a manual scrub: stops any playback, moves the
-    // timeline to the instant (or snaps to Live at the right edge) and loads it
-    // through the same pipeline as slider/keyboard scrubbing. With autoPlay the
-    // timeline resumes playback from the instant instead of parking paused -
-    // _startHistoricPlayback adopts the instant via _pendingScrubAt and
-    // publishes/loads it immediately.
-    seekTo(ms, { autoPlay = false } = {}) {
+    // chart timeline. Mirrors a manual scrub: stops any playback, parks the
+    // timeline at the instant (or snaps to Live at the right edge) and loads it
+    // through the same debounced pipeline as slider/keyboard scrubbing.
+    seekTo(ms) {
         const range = this._panels.scrubberRange;
         if (!range || !Number.isFinite(ms)) return;
         this._stopHistoricPlayback();
@@ -2668,22 +2665,8 @@ export class LanFlowMap {
         const val = this._timeToScrubberValue(t);
         range.value = val;
         this._onScrubberInput(val, at);
-        if (this._isLiveValue(val, at)) {
-            this._queueScrubChange(val, at);
-            return;
-        }
-        if (this._mode === 'live') this._enterHistoricScrub();
-        if (autoPlay) {
-            this._historicAt = at;
-            this._pendingScrubAt = at;
-            this._paused = false;
-            this._syncPlayPauseIcon();
-            flowData.publishPlayState(false, this._mode);
-            this._notifyPlayState();
-            this._startHistoricPlayback();
-        } else {
-            this._queueScrubChange(val, at);
-        }
+        if (this._mode === 'live' && !this._isLiveValue(val, at)) this._enterHistoricScrub();
+        this._queueScrubChange(val, at);
     }
 
     _onScrubberInput(value, at = null) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2652,10 +2652,13 @@ export class LanFlowMap {
     }
 
     // External seek to an absolute instant (ms epoch) - e.g. a click on the WAN
-    // chart timeline. Mirrors a manual scrub: stops any playback, parks the
-    // timeline at the instant (or snaps to Live at the right edge) and loads it
-    // through the same debounced pipeline as slider/keyboard scrubbing.
-    seekTo(ms) {
+    // chart timeline. Mirrors a manual scrub: stops any playback, moves the
+    // timeline to the instant (or snaps to Live at the right edge) and loads it
+    // through the same pipeline as slider/keyboard scrubbing. With autoPlay the
+    // timeline resumes playback from the instant instead of parking paused -
+    // _startHistoricPlayback adopts the instant via _pendingScrubAt and
+    // publishes/loads it immediately.
+    seekTo(ms, { autoPlay = false } = {}) {
         const range = this._panels.scrubberRange;
         if (!range || !Number.isFinite(ms)) return;
         this._stopHistoricPlayback();
@@ -2665,8 +2668,22 @@ export class LanFlowMap {
         const val = this._timeToScrubberValue(t);
         range.value = val;
         this._onScrubberInput(val, at);
-        if (this._mode === 'live' && !this._isLiveValue(val, at)) this._enterHistoricScrub();
-        this._queueScrubChange(val, at);
+        if (this._isLiveValue(val, at)) {
+            this._queueScrubChange(val, at);
+            return;
+        }
+        if (this._mode === 'live') this._enterHistoricScrub();
+        if (autoPlay) {
+            this._historicAt = at;
+            this._pendingScrubAt = at;
+            this._paused = false;
+            this._syncPlayPauseIcon();
+            flowData.publishPlayState(false, this._mode);
+            this._notifyPlayState();
+            this._startHistoricPlayback();
+        } else {
+            this._queueScrubChange(val, at);
+        }
     }
 
     _onScrubberInput(value, at = null) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -143,8 +143,8 @@ const NET_LABEL_FADE_START_DIST = 66;
 const NET_LABEL_FADE_END_DIST = 102;
 // Throughput pills fade earlier still - when pulling back, device identity
 // should outlive the rate readouts.
-const LINK_LABEL_FADE_START_DIST = 54;
-const LINK_LABEL_FADE_END_DIST = 84;
+const LINK_LABEL_FADE_START_DIST = 62;
+const LINK_LABEL_FADE_END_DIST = 97;
 
 const LINK_KIND = {
     Uplink: 0,

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2651,6 +2651,24 @@ export class LanFlowMap {
         else this._scrubberInputDebounce = setTimeout(fire, 500 - sinceLastFire);
     }
 
+    // External seek to an absolute instant (ms epoch) - e.g. a click on the WAN
+    // chart timeline. Mirrors a manual scrub: stops any playback, parks the
+    // timeline at the instant (or snaps to Live at the right edge) and loads it
+    // through the same debounced pipeline as slider/keyboard scrubbing.
+    seekTo(ms) {
+        const range = this._panels.scrubberRange;
+        if (!range || !Number.isFinite(ms)) return;
+        this._stopHistoricPlayback();
+        const { start, end } = this._scrubWindowBounds();
+        const t = Math.max(start, Math.min(end, ms));
+        const at = new Date(t);
+        const val = this._timeToScrubberValue(t);
+        range.value = val;
+        this._onScrubberInput(val, at);
+        if (this._mode === 'live' && !this._isLiveValue(val, at)) this._enterHistoricScrub();
+        this._queueScrubChange(val, at);
+    }
+
     _onScrubberInput(value, at = null) {
         // Visual-only update while dragging - cheap label refresh.
         at = at ?? this._scrubberValueToTime(value);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -3,6 +3,7 @@
 // /api/monitoring/live-stats for real-time updates.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
+import * as flowData from './lan-flow-data.js?v=5';
 
 const HISTORY_MINUTES = 5;
 // Poll faster than the 5s SNMP fast tier so no sample is missed when the two
@@ -41,17 +42,20 @@ let histRate = 0;
 // stale response after a newer one snaps the playhead backward.
 let seekGen = 0;
 // Click-to-seek (Live View mount only): clicking the chart scrubs the map
-// timeline to the clicked instant; double-clicking toggles play/pause. The
-// single-click seek is delayed so the second click of a double can cancel it -
-// otherwise the click pair would park playback and the toggle could only
-// ever resume, never pause.
+// timeline to the clicked instant.
 let seekOnClick = false;
-let clickSeekTimer = null;
-const CLICK_SEEK_DELAY_MS = 280;
-// Historic mode badge (upper-left). Unlike the map badges it hides in live
-// mode entirely - the chart is live by default and only needs the flag (and
-// the click-back-to-live affordance) while parked or playing back.
+// Historic mode cluster (upper-left): play/pause button + Historic badge
+// (click returns to live). Unlike the map badges it hides in live mode
+// entirely - the chart is live by default and only needs the flag while
+// parked or playing back. Synced from the shared store's playstate events.
+let modeCluster = null;
 let histBadge = null;
+let playBtn = null;
+let unsubFlow = null;
+// Renders forced through the tooltip hold-off until this wall time: a click
+// on the chart (to seek or play) must draw its playhead even though the
+// pointer - and therefore the tooltip - is still over the plot.
+let clickRenderUntil = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -87,30 +91,24 @@ function buildOpts() {
             parentHeightOffset: 0,
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
             events: {
-                // Click-to-seek (delayed so a double-click can cancel it): park
-                // the map timeline - and this chart's playhead, via the normal
-                // seekTime round-trip - at the clicked instant. Live View only -
-                // the mount opts in.
+                // Click-to-seek: park the map timeline - and this chart's
+                // playhead, via the normal seekTime round-trip - at the clicked
+                // instant. Live View only - the mount opts in.
                 click: (event, ctx) => {
                     if (!seekOnClick || !event?.clientX) return;
                     const t = clickToTime(event, ctx);
                     if (t == null) return;
-                    clearTimeout(clickSeekTimer);
-                    clickSeekTimer = setTimeout(() => {
-                        clickSeekTimer = null;
-                        const inst = window.__lanFlowMap?.getInstance?.();
-                        if (!inst?.seekTo) return;
-                        // Instant feedback: freeze live drawing and draw the
-                        // playhead at the clicked instant from the buffer already
-                        // on screen; the seek round-trip then re-renders with the
-                        // proper window.
-                        pause();
-                        histAt = t;
-                        histWall = Date.now();
-                        if (histBadge) histBadge.style.display = '';
-                        renderHistoric(t);
-                        inst.seekTo(t);
-                    }, CLICK_SEEK_DELAY_MS);
+                    const inst = window.__lanFlowMap?.getInstance?.();
+                    if (!inst?.seekTo) return;
+                    // Instant feedback: freeze live drawing and draw the playhead
+                    // at the clicked instant from the buffer already on screen;
+                    // the seek round-trip then re-renders with the proper window.
+                    pause();
+                    histAt = t;
+                    histWall = Date.now();
+                    clickRenderUntil = Date.now() + 1500;
+                    renderHistoric(t);
+                    inst.seekTo(t);
                 },
             },
         },
@@ -394,6 +392,54 @@ async function backfillHistory() {
     updateChart();
 }
 
+// Upper-left mode cluster: play/pause + Historic badge, shown only while the
+// timeline is off the live edge. State comes from the shared store's playstate
+// events (published by the 3D map instance, which owns the timeline).
+function ensureModeUi(el) {
+    if (!seekOnClick) return;
+    if (!modeCluster) {
+        modeCluster = document.createElement('div');
+        modeCluster.className = 'wan-chart-mode-cluster';
+
+        playBtn = document.createElement('button');
+        playBtn.type = 'button';
+        playBtn.className = 'lan-flow-map-scrubber-playpause';
+        playBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            clickRenderUntil = Date.now() + 1500;
+            window.__lanFlowMap?.getInstance?.()?._togglePlayPause?.();
+        });
+        modeCluster.appendChild(playBtn);
+
+        histBadge = document.createElement('div');
+        histBadge.className = 'lan-flow-map-mode is-historic';
+        histBadge.textContent = 'Historic';
+        histBadge.setAttribute('data-tooltip', 'Click to return to live');
+        histBadge.setAttribute('data-tooltip-hover-only', '');
+        histBadge.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window.__lanFlowMap?.getInstance?.()?._returnToLive?.();
+        });
+        modeCluster.appendChild(histBadge);
+    }
+    // Re-append every mount: ApexCharts rebuilds the container's content.
+    el.appendChild(modeCluster);
+    if (!unsubFlow) {
+        unsubFlow = flowData.subscribe((ev) => { if (ev === 'playstate') syncModeUi(); });
+    }
+    syncModeUi();
+}
+
+function syncModeUi() {
+    if (!modeCluster) return;
+    const historic = flowData.getMode() === 'historic';
+    modeCluster.style.display = historic ? '' : 'none';
+    if (!playBtn) return;
+    const paused = flowData.isPaused();
+    playBtn.textContent = paused ? '▶' : '⏸';
+    playBtn.setAttribute('aria-label', paused ? 'Play' : 'Pause');
+}
+
 export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
@@ -406,35 +452,13 @@ export async function mount(containerId, opts) {
     if (!el) return;
     seekOnClick = !!opts?.seekOnClick;
     el.classList.toggle('wan-chart-seekable', seekOnClick);
-    // Double-click toggles play/pause (native listener - ApexCharts has no
-    // dblclick event). Wire once; the container div survives remounts.
-    if (seekOnClick && !el._wanSeekDbl) {
-        el._wanSeekDbl = true;
-        el.addEventListener('dblclick', (e) => {
-            if (!seekOnClick) return;
-            e.preventDefault();
-            clearTimeout(clickSeekTimer);
-            clickSeekTimer = null;
-            window.__lanFlowMap?.getInstance?.()?._togglePlayPause?.();
-        });
-    }
-    if (seekOnClick && !histBadge) {
-        histBadge = document.createElement('div');
-        histBadge.className = 'wan-chart-mode-badge lan-flow-map-mode is-historic';
-        histBadge.textContent = 'Historic';
-        histBadge.style.display = 'none';
-        histBadge.setAttribute('data-tooltip', 'Click to return to live');
-        histBadge.setAttribute('data-tooltip-hover-only', '');
-        histBadge.addEventListener('click', (e) => {
-            e.stopPropagation();
-            window.__lanFlowMap?.getInstance?.()?._returnToLive?.();
-        });
-        el.appendChild(histBadge);
-    }
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();
     if (gen !== mountGen) return;
+    // After render - ApexCharts rebuilds the container's content, so anything
+    // appended before it is wiped.
+    ensureModeUi(el);
 
     await loadHistory();
     if (gen !== mountGen) return;
@@ -473,11 +497,16 @@ export function resume() {
 
 // Render the historic view at a given playhead time from the current buffer.
 // No fetching - callers load data; the interpolation timer reuses it.
-// Deliberately NOT gated on the tooltip being active (unlike live updateChart):
-// a seek or running playback must move the playhead and reload the window even
-// while the user hovers the chart - clicking to seek happens with the tooltip up.
+// Hovering holds redraws (same as live updateChart) so values can be inspected
+// without the chart shifting under the cursor - EXCEPT briefly after a click on
+// the chart, which must draw its playhead even though the pointer (and so the
+// tooltip) is still over the plot.
 function renderHistoric(at) {
     if (!chart || buffer.length === 0) return;
+    if (Date.now() > clickRenderUntil) {
+        const el = document.getElementById(elId);
+        if (el?.classList.contains('apexcharts-tooltip-active')) return;
+    }
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     const maxTime = Math.min(at + halfWindow, Date.now());
     const playhead = {
@@ -531,8 +560,8 @@ export async function seekTime(isoTimestamp) {
     seekGen++;
     if (!isoTimestamp) {
         // Return to live mode - updateChart replaces the annotations with the
-        // plain time grid, dropping the playhead.
-        if (histBadge) histBadge.style.display = 'none';
+        // plain time grid, dropping the playhead. (Mode cluster visibility is
+        // driven by the store's playstate events, not by seeks.)
         stopHistInterpolation();
         if (pollTimer) return; // already live
         const liveGen = seekGen;
@@ -546,7 +575,6 @@ export async function seekTime(isoTimestamp) {
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
-    if (histBadge) histBadge.style.display = '';
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
@@ -605,9 +633,8 @@ export async function seekTime(isoTimestamp) {
 export function unmount() {
     mountGen++;
     stopHistInterpolation();
-    clearTimeout(clickSeekTimer);
-    clickSeekTimer = null;
-    if (histBadge) { histBadge.remove(); histBadge = null; }
+    if (unsubFlow) { unsubFlow(); unsubFlow = null; }
+    if (modeCluster) { modeCluster.remove(); modeCluster = null; histBadge = null; playBtn = null; }
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -37,6 +37,9 @@ let histTimer = null;
 let histAt = 0;
 let histWall = 0;
 let histRate = 0;
+// Seek fetch generation: rapid seeks can resolve out of order, and applying a
+// stale response after a newer one snaps the playhead backward.
+let seekGen = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -445,13 +448,16 @@ function stopHistInterpolation() {
 
 export async function seekTime(isoTimestamp) {
     if (!chart) return;
+    seekGen++;
     if (!isoTimestamp) {
         // Return to live mode - updateChart replaces the annotations with the
         // plain time grid, dropping the playhead.
         stopHistInterpolation();
         if (pollTimer) return; // already live
+        const liveGen = seekGen;
         buffer = [];
         await loadHistory();
+        if (liveGen !== seekGen) return; // seeked again while loading
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
         scrollTimer = setInterval(updateChart, SCROLL_MS);
@@ -462,6 +468,7 @@ export async function seekTime(isoTimestamp) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
+    const gen = seekGen;
     const at = new Date(isoTimestamp).getTime();
     histAt = at;
     histWall = Date.now();
@@ -479,6 +486,7 @@ export async function seekTime(isoTimestamp) {
             { credentials: 'same-origin' });
         if (!resp.ok) return;
         const data = await resp.json();
+        if (gen !== seekGen) return; // a newer seek (or return to live) superseded this one
         buffer = (data.points || []).map(p => ({
             time: new Date(p.time).getTime(),
             download: p.downloadBps,

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -506,6 +506,12 @@ export async function seekTime(isoTimestamp) {
                 if (histRate > 0) { histRate = 0; renderHistoric(histAt); }
                 return;
             }
+            // Playback just started: the last seek (histWall) was the final scrub
+            // position, stamped BEFORE play was pressed. Re-baseline so the idle
+            // gap between scrubbing and pressing play isn't counted as playback
+            // time - extrapolating it made the cursor run ahead and then snap
+            // back when the first real playback seek arrived.
+            if (histRate === 0) histWall = Date.now();
             histRate = rate;
             const elapsed = Date.now() - histWall;
             if (elapsed > 2500) return; // seeks stalled (hidden tab etc) - hold

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -422,8 +422,11 @@ function ensureModeUi(el) {
         });
         modeCluster.appendChild(histBadge);
     }
-    // Re-append every mount: ApexCharts rebuilds the container's content.
-    el.appendChild(modeCluster);
+    // Parent OUTSIDE the chart's mount div: ApexCharts rebuilds that div's
+    // content on render (and can again on option updates), silently removing
+    // any foreign children. The card body wraps the chart tightly, so the
+    // cluster anchors to the same visual spot.
+    (el.closest('.card-body') ?? el).appendChild(modeCluster);
     if (!unsubFlow) {
         unsubFlow = flowData.subscribe((ev) => { if (ev === 'playstate') syncModeUi(); });
     }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -80,12 +80,23 @@ function buildOpts() {
             events: {
                 // Click-to-seek: jump the map timeline (and with it this chart's
                 // playhead, via the normal seekTime round-trip) to the clicked
-                // instant. Live View only - the mount opts in.
+                // instant and resume playback from there. Live View only - the
+                // mount opts in.
                 click: (event, ctx) => {
                     if (!seekOnClick || !event?.clientX) return;
                     const t = clickToTime(event, ctx);
                     if (t == null) return;
-                    window.__lanFlowMap?.getInstance?.()?.seekTo?.(t);
+                    const inst = window.__lanFlowMap?.getInstance?.();
+                    if (!inst?.seekTo) return;
+                    // Instant feedback: freeze live drawing and draw the playhead
+                    // at the clicked instant from the buffer already on screen.
+                    // The map's seek round-trip then re-renders with the proper
+                    // window and playback interpolation takes over.
+                    pause();
+                    histAt = t;
+                    histWall = Date.now();
+                    renderHistoric(t);
+                    inst.seekTo(t, { autoPlay: true });
                 },
             },
         },

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -41,8 +41,14 @@ let histRate = 0;
 // Seek fetch generation: rapid seeks can resolve out of order, and applying a
 // stale response after a newer one snaps the playhead backward.
 let seekGen = 0;
-// Click-to-seek (Live View mount only): clicking the chart scrubs the map
-// timeline to the clicked instant.
+// Touch-primary devices tap the plot to reveal the value tooltip - that's the
+// established paradigm and click-to-seek must not hijack it. Tap-to-seek is
+// desktop-only; the play/pause + Historic cluster (separate tap targets off the
+// plot) still shows, so mobile keeps playback control without breaking tooltips.
+const IS_TOUCH = typeof window !== 'undefined'
+    && window.matchMedia && window.matchMedia('(pointer: coarse)').matches;
+// Click-to-seek (Live View, desktop mount only): clicking the chart scrubs the
+// map timeline to the clicked instant.
 let seekOnClick = false;
 // Historic mode cluster (upper-left): play/pause button + Historic badge
 // (click returns to live). Unlike the map badges it hides in live mode
@@ -95,7 +101,8 @@ function buildOpts() {
                 // playhead, via the normal seekTime round-trip - at the clicked
                 // instant. Live View only - the mount opts in.
                 click: (event, ctx) => {
-                    if (!seekOnClick || !event?.clientX) return;
+                    // Touch: leave the tap for the native tooltip, don't seek.
+                    if (!seekOnClick || IS_TOUCH || !event?.clientX) return;
                     const t = clickToTime(event, ctx);
                     if (t == null) return;
                     const inst = window.__lanFlowMap?.getInstance?.();
@@ -454,7 +461,8 @@ export async function mount(containerId, opts) {
     const el = document.getElementById(containerId);
     if (!el) return;
     seekOnClick = !!opts?.seekOnClick;
-    el.classList.toggle('wan-chart-seekable', seekOnClick);
+    // Crosshair only where tap-to-seek is actually live (desktop).
+    el.classList.toggle('wan-chart-seekable', seekOnClick && !IS_TOUCH);
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -41,8 +41,17 @@ let histRate = 0;
 // stale response after a newer one snaps the playhead backward.
 let seekGen = 0;
 // Click-to-seek (Live View mount only): clicking the chart scrubs the map
-// timeline to the clicked instant.
+// timeline to the clicked instant; double-clicking toggles play/pause. The
+// single-click seek is delayed so the second click of a double can cancel it -
+// otherwise the click pair would park playback and the toggle could only
+// ever resume, never pause.
 let seekOnClick = false;
+let clickSeekTimer = null;
+const CLICK_SEEK_DELAY_MS = 280;
+// Historic mode badge (upper-left). Unlike the map badges it hides in live
+// mode entirely - the chart is live by default and only needs the flag (and
+// the click-back-to-live affordance) while parked or playing back.
+let histBadge = null;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -78,25 +87,30 @@ function buildOpts() {
             parentHeightOffset: 0,
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
             events: {
-                // Click-to-seek: jump the map timeline (and with it this chart's
-                // playhead, via the normal seekTime round-trip) to the clicked
-                // instant and resume playback from there. Live View only - the
-                // mount opts in.
+                // Click-to-seek (delayed so a double-click can cancel it): park
+                // the map timeline - and this chart's playhead, via the normal
+                // seekTime round-trip - at the clicked instant. Live View only -
+                // the mount opts in.
                 click: (event, ctx) => {
                     if (!seekOnClick || !event?.clientX) return;
                     const t = clickToTime(event, ctx);
                     if (t == null) return;
-                    const inst = window.__lanFlowMap?.getInstance?.();
-                    if (!inst?.seekTo) return;
-                    // Instant feedback: freeze live drawing and draw the playhead
-                    // at the clicked instant from the buffer already on screen.
-                    // The map's seek round-trip then re-renders with the proper
-                    // window and playback interpolation takes over.
-                    pause();
-                    histAt = t;
-                    histWall = Date.now();
-                    renderHistoric(t);
-                    inst.seekTo(t, { autoPlay: true });
+                    clearTimeout(clickSeekTimer);
+                    clickSeekTimer = setTimeout(() => {
+                        clickSeekTimer = null;
+                        const inst = window.__lanFlowMap?.getInstance?.();
+                        if (!inst?.seekTo) return;
+                        // Instant feedback: freeze live drawing and draw the
+                        // playhead at the clicked instant from the buffer already
+                        // on screen; the seek round-trip then re-renders with the
+                        // proper window.
+                        pause();
+                        histAt = t;
+                        histWall = Date.now();
+                        if (histBadge) histBadge.style.display = '';
+                        renderHistoric(t);
+                        inst.seekTo(t);
+                    }, CLICK_SEEK_DELAY_MS);
                 },
             },
         },
@@ -391,7 +405,32 @@ export async function mount(containerId, opts) {
     const el = document.getElementById(containerId);
     if (!el) return;
     seekOnClick = !!opts?.seekOnClick;
-    el.style.cursor = seekOnClick ? 'crosshair' : '';
+    el.classList.toggle('wan-chart-seekable', seekOnClick);
+    // Double-click toggles play/pause (native listener - ApexCharts has no
+    // dblclick event). Wire once; the container div survives remounts.
+    if (seekOnClick && !el._wanSeekDbl) {
+        el._wanSeekDbl = true;
+        el.addEventListener('dblclick', (e) => {
+            if (!seekOnClick) return;
+            e.preventDefault();
+            clearTimeout(clickSeekTimer);
+            clickSeekTimer = null;
+            window.__lanFlowMap?.getInstance?.()?._togglePlayPause?.();
+        });
+    }
+    if (seekOnClick && !histBadge) {
+        histBadge = document.createElement('div');
+        histBadge.className = 'wan-chart-mode-badge lan-flow-map-mode is-historic';
+        histBadge.textContent = 'Historic';
+        histBadge.style.display = 'none';
+        histBadge.setAttribute('data-tooltip', 'Click to return to live');
+        histBadge.setAttribute('data-tooltip-hover-only', '');
+        histBadge.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window.__lanFlowMap?.getInstance?.()?._returnToLive?.();
+        });
+        el.appendChild(histBadge);
+    }
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();
@@ -434,10 +473,11 @@ export function resume() {
 
 // Render the historic view at a given playhead time from the current buffer.
 // No fetching - callers load data; the interpolation timer reuses it.
+// Deliberately NOT gated on the tooltip being active (unlike live updateChart):
+// a seek or running playback must move the playhead and reload the window even
+// while the user hovers the chart - clicking to seek happens with the tooltip up.
 function renderHistoric(at) {
     if (!chart || buffer.length === 0) return;
-    const el = document.getElementById(elId);
-    if (el?.classList.contains('apexcharts-tooltip-active')) return;
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     const maxTime = Math.min(at + halfWindow, Date.now());
     const playhead = {
@@ -492,6 +532,7 @@ export async function seekTime(isoTimestamp) {
     if (!isoTimestamp) {
         // Return to live mode - updateChart replaces the annotations with the
         // plain time grid, dropping the playhead.
+        if (histBadge) histBadge.style.display = 'none';
         stopHistInterpolation();
         if (pollTimer) return; // already live
         const liveGen = seekGen;
@@ -505,6 +546,7 @@ export async function seekTime(isoTimestamp) {
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp
+    if (histBadge) histBadge.style.display = '';
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
@@ -563,6 +605,9 @@ export async function seekTime(isoTimestamp) {
 export function unmount() {
     mountGen++;
     stopHistInterpolation();
+    clearTimeout(clickSeekTimer);
+    clickSeekTimer = null;
+    if (histBadge) { histBadge.remove(); histBadge = null; }
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -40,6 +40,9 @@ let histRate = 0;
 // Seek fetch generation: rapid seeks can resolve out of order, and applying a
 // stale response after a newer one snaps the playhead backward.
 let seekGen = 0;
+// Click-to-seek (Live View mount only): clicking the chart scrubs the map
+// timeline to the clicked instant.
+let seekOnClick = false;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -47,6 +50,19 @@ function formatBps(v) {
     if (v >= 1e6) return (v / 1e6).toFixed(1) + ' Mbps';
     if (v >= 1e3) return (v / 1e3).toFixed(0) + ' Kbps';
     return v.toFixed(0) + ' bps';
+}
+
+// Map a click inside the chart to the instant under the cursor. The inner
+// (grid) group's rect avoids translate math; its width is the plotted span.
+function clickToTime(event, ctx) {
+    const g = ctx?.w?.globals;
+    const inner = ctx?.el?.querySelector('.apexcharts-inner');
+    if (!g || !inner || !Number.isFinite(g.minX) || !Number.isFinite(g.maxX)) return null;
+    const rect = inner.getBoundingClientRect();
+    if (!rect.width) return null;
+    const frac = (event.clientX - rect.left) / rect.width;
+    if (frac < 0 || frac > 1) return null;
+    return g.minX + frac * (g.maxX - g.minX);
 }
 
 function buildOpts() {
@@ -61,6 +77,17 @@ function buildOpts() {
             // labels sit close to the card bottom.
             parentHeightOffset: 0,
             animations: { enabled: true, easing: 'smooth', dynamicAnimation: { speed: 800 } },
+            events: {
+                // Click-to-seek: jump the map timeline (and with it this chart's
+                // playhead, via the normal seekTime round-trip) to the clicked
+                // instant. Live View only - the mount opts in.
+                click: (event, ctx) => {
+                    if (!seekOnClick || !event?.clientX) return;
+                    const t = clickToTime(event, ctx);
+                    if (t == null) return;
+                    window.__lanFlowMap?.getInstance?.()?.seekTo?.(t);
+                },
+            },
         },
         series: [
             { name: 'Download', type: 'area', data: [] },
@@ -352,6 +379,8 @@ export async function mount(containerId, opts) {
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
+    seekOnClick = !!opts?.seekOnClick;
+    el.style.cursor = seekOnClick ? 'crosshair' : '';
 
     chart = new ApexCharts(el, buildOpts());
     await chart.render();


### PR DESCRIPTION
Timeline playback across the Live View tab (the 3D/2D map, WAN chart, **Port Statistics** table, and stat cards) now stays locked together while scrubbing, plus fixes for ISP/Transit loss accuracy and a more truthful link load colour.

## Monitoring - Live View

### Timeline scrubbing & playback

- Scrubbing (keyboard and slider) tracks a continuous timestamp instead of the integer slider position, so steps are uniform and every consumer loads the exact instant shown on the label rather than one re-derived against the trailing window.
- Pressing play after scrubbing resumes from the parked instant with no backward jump; the map, **Port Statistics**, and WAN chart cursor stay on the same moment.
- **Port Statistics** selects the sample nearest the scrub instant (was the newest in the window), so the table no longer runs ahead of the map and cards during playback.

### WAN live chart

- Click the chart to scrub the whole Live View timeline to that instant. A **Historic** badge and a play/pause control appear top-right while off the live edge; the badge returns to live.
- On touch devices the tap-for-tooltip behavior is preserved - click-to-seek is desktop-only, while the playback controls still show.

### ISP/Transit loss

- The WAN chart Loss series and the WAN globes on the map now share one combined ISP+Transit loss figure, so they always agree.
- Loss is no longer dropped when a latency sample lands between the chart's sampling windows, or when a probe cycle times out under load - sustained loss now shows for its full duration instead of only a recovering tail.

### Link load color

- Link color under load treats links as full-duplex: the saturated (red) color is reserved for both directions loaded, and a single saturated direction reads as amber. Applies to both the 3D and 2D maps.

### 3D map labels

- Throughput pills fade out slightly farther from the camera, and WAN throughput labels persist farther still.
