### PR TITLE
Monitoring: warn on over-length SNMP Community String and self-heal rotated credentials

### DIFF
--- a/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
@@ -21,6 +21,11 @@ public sealed class SnmpFailureTracker
 
     private readonly ConcurrentDictionary<string, int> _failures = new();
     private readonly ConcurrentDictionary<string, DateTime> _excluded = new();
+    // Devices that have polled successfully at least once this lifecycle. Retained
+    // across Reset() so the fabric-wide-failure heuristic keeps a baseline of "which
+    // devices were known to work" - a device that never spoke SNMP (e.g. a Flex Mini)
+    // must not count toward a credential-rotation signal.
+    private readonly ConcurrentDictionary<string, byte> _healthy = new();
     private readonly int _threshold;
     private readonly TimeSpan _duration;
 
@@ -48,11 +53,41 @@ public sealed class SnmpFailureTracker
         return _excluded.TryAdd(key, DateTime.UtcNow);
     }
 
-    /// <summary>Records a successful poll, resetting the failure counter.</summary>
+    /// <summary>Records a successful poll, resetting the failure counter and marking the device healthy.</summary>
     public void NoteSuccess(string key)
     {
         if (string.IsNullOrEmpty(key)) return;
         _failures.TryRemove(key, out _);
+        _healthy[key] = 1;
+    }
+
+    /// <summary>
+    /// Clears all failure counters and exclusions - used after the SNMP credentials
+    /// change (self-heal), so devices dropped under the old, stale community are retried
+    /// immediately with the new one instead of waiting out their exclusion window. The
+    /// seen-healthy baseline is intentionally retained.
+    /// </summary>
+    public void Reset()
+    {
+        _failures.Clear();
+        _excluded.Clear();
+    }
+
+    /// <summary>Number of devices that have polled successfully at least once this lifecycle.</summary>
+    public int HealthyCount => _healthy.Count;
+
+    /// <summary>
+    /// Number of previously-healthy devices currently excluded from polling (dropped
+    /// after crossing the failure threshold). A high count signals a fabric-wide SNMP
+    /// failure - e.g. the community string was rotated in UniFi - as opposed to a single
+    /// dead device, letting the caller re-pull the config and self-heal.
+    /// </summary>
+    public int ExcludedHealthyCount()
+    {
+        int count = 0;
+        foreach (var key in _healthy.Keys)
+            if (PeekExcluded(key, out _)) count++;
+        return count;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
@@ -77,16 +77,21 @@ public sealed class SnmpFailureTracker
     public int HealthyCount => _healthy.Count;
 
     /// <summary>
-    /// Number of previously-healthy devices currently excluded from polling (dropped
-    /// after crossing the failure threshold). A high count signals a fabric-wide SNMP
-    /// failure - e.g. the community string was rotated in UniFi - as opposed to a single
-    /// dead device, letting the caller re-pull the config and self-heal.
+    /// Number of previously-healthy devices currently failing - either already excluded,
+    /// or with at least <paramref name="minConsecutiveFailures"/> consecutive failures
+    /// pending. A high count signals a fabric-wide SNMP failure (e.g. the community
+    /// string was rotated in UniFi) as opposed to a single dead device, letting the
+    /// caller re-pull the config and self-heal. Keying on the raw failure count rather
+    /// than full exclusion reacts within a couple of poll cycles instead of waiting out
+    /// the 5-failure exclusion threshold - which a device that intermittently answers
+    /// (mid-reprovision) may never reach.
     /// </summary>
-    public int ExcludedHealthyCount()
+    public int FailingHealthyCount(int minConsecutiveFailures = 2)
     {
         int count = 0;
         foreach (var key in _healthy.Keys)
-            if (PeekExcluded(key, out _)) count++;
+            if (PeekExcluded(key, out _) || GetFailureCount(key) >= minConsecutiveFailures)
+                count++;
         return count;
     }
 

--- a/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpFailureTracker.cs
@@ -21,11 +21,6 @@ public sealed class SnmpFailureTracker
 
     private readonly ConcurrentDictionary<string, int> _failures = new();
     private readonly ConcurrentDictionary<string, DateTime> _excluded = new();
-    // Devices that have polled successfully at least once this lifecycle. Retained
-    // across Reset() so the fabric-wide-failure heuristic keeps a baseline of "which
-    // devices were known to work" - a device that never spoke SNMP (e.g. a Flex Mini)
-    // must not count toward a credential-rotation signal.
-    private readonly ConcurrentDictionary<string, byte> _healthy = new();
     private readonly int _threshold;
     private readonly TimeSpan _duration;
 
@@ -53,19 +48,17 @@ public sealed class SnmpFailureTracker
         return _excluded.TryAdd(key, DateTime.UtcNow);
     }
 
-    /// <summary>Records a successful poll, resetting the failure counter and marking the device healthy.</summary>
+    /// <summary>Records a successful poll, resetting the failure counter.</summary>
     public void NoteSuccess(string key)
     {
         if (string.IsNullOrEmpty(key)) return;
         _failures.TryRemove(key, out _);
-        _healthy[key] = 1;
     }
 
     /// <summary>
     /// Clears all failure counters and exclusions - used after the SNMP credentials
     /// change (self-heal), so devices dropped under the old, stale community are retried
-    /// immediately with the new one instead of waiting out their exclusion window. The
-    /// seen-healthy baseline is intentionally retained.
+    /// immediately with the new one instead of waiting out their exclusion window.
     /// </summary>
     public void Reset()
     {
@@ -73,27 +66,15 @@ public sealed class SnmpFailureTracker
         _excluded.Clear();
     }
 
-    /// <summary>Number of devices that have polled successfully at least once this lifecycle.</summary>
-    public int HealthyCount => _healthy.Count;
-
     /// <summary>
-    /// Number of previously-healthy devices currently failing - either already excluded,
-    /// or with at least <paramref name="minConsecutiveFailures"/> consecutive failures
-    /// pending. A high count signals a fabric-wide SNMP failure (e.g. the community
-    /// string was rotated in UniFi) as opposed to a single dead device, letting the
-    /// caller re-pull the config and self-heal. Keying on the raw failure count rather
-    /// than full exclusion reacts within a couple of poll cycles instead of waiting out
-    /// the 5-failure exclusion threshold - which a device that intermittently answers
-    /// (mid-reprovision) may never reach.
+    /// Whether the given key is currently failing: already excluded, or with at least
+    /// <paramref name="minConsecutiveFailures"/> consecutive failures pending. The caller
+    /// counts these across the current SNMP-enabled device list to detect a fabric-wide
+    /// failure (community rotated / SNMP disabled) without needing any prior-success
+    /// baseline - so it fires even on a cold start where the community was already wrong.
     /// </summary>
-    public int FailingHealthyCount(int minConsecutiveFailures = 2)
-    {
-        int count = 0;
-        foreach (var key in _healthy.Keys)
-            if (PeekExcluded(key, out _) || GetFailureCount(key) >= minConsecutiveFailures)
-                count++;
-        return count;
-    }
+    public bool IsFailing(string key, int minConsecutiveFailures = 2) =>
+        PeekExcluded(key, out _) || GetFailureCount(key) >= minConsecutiveFailures;
 
     /// <summary>
     /// Whether the key is currently excluded. An expired exclusion is removed

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -274,6 +274,33 @@ public class SnmpPoller : ISnmpPoller
             var cache = _deviceCache.GetOrAdd(cacheKey, _ => new DevicePollerCache());
             var now = DateTime.UtcNow;
 
+            // Reachability probe FIRST: walk the primary traffic counter before any other
+            // work. When the device stops answering (rotated community, reboot, firewall)
+            // every walk runs its full timeout+retries, so the old order - metadata and
+            // medium-tier walks before the fast counters - burned minutes of timeouts per
+            // device per cycle, exactly when the credential self-heal needed the failure
+            // counted within seconds. A device that answers nothing here aborts the whole
+            // poll after at most two walks.
+            var hcInOctets = await BulkWalkAsync(ip, UniFiOids.IfHCInOctets);
+            bool needFallback = hcInOctets.Count == 0;
+            List<Variable>? inOctets32 = null, outOctets32 = null;
+            List<Variable> hcOutOctets;
+            if (needFallback)
+            {
+                inOctets32 = await BulkWalkAsync(ip, UniFiOids.IfInOctets);
+                if (inOctets32.Count == 0)
+                {
+                    _logger.LogDebug("No traffic counters from {Ip} - unreachable over SNMP, skipping remaining walks this cycle", ip);
+                    return interfaces;
+                }
+                outOctets32 = await BulkWalkAsync(ip, UniFiOids.IfOutOctets);
+                hcOutOctets = new List<Variable>();
+            }
+            else
+            {
+                hcOutOctets = await BulkWalkAsync(ip, UniFiOids.IfHCOutOctets);
+            }
+
             // Slow tier: refresh static interface metadata when cache has expired
             if (cache.Metadata == null ||
                 (now - cache.LastMetadataPoll).TotalSeconds >= _config.SlowPollIntervalSeconds)
@@ -314,18 +341,6 @@ public class SnmpPoller : ISnmpPoller
 
                 cache.LastOperPoll = now;
                 DebugLog($"Medium tier: refreshed oper/error counters for {ip}");
-            }
-
-            // Fast tier: always walk HC traffic counters
-            var hcInOctets = await BulkWalkAsync(ip, UniFiOids.IfHCInOctets);
-            var hcOutOctets = await BulkWalkAsync(ip, UniFiOids.IfHCOutOctets);
-
-            bool needFallback = hcInOctets.Count == 0;
-            List<Variable>? inOctets32 = null, outOctets32 = null;
-            if (needFallback)
-            {
-                inOctets32 = await BulkWalkAsync(ip, UniFiOids.IfInOctets);
-                outOctets32 = await BulkWalkAsync(ip, UniFiOids.IfOutOctets);
             }
 
             // Fast tier: packet counters (unicast, multicast, broadcast)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2317,6 +2317,10 @@ else
             _snmpState = settings.SnmpDetectionState;
             _snmpCommunityTooLong = result.CommunityTooLong;
             _snmpCommunityLength = result.Community?.Length ?? 0;
+            // Fresh console read beats the agent's cached self-heal sighting - otherwise a
+            // fixed community still shows the too-long banner until the agent's next re-pull.
+            _serverCommunityTooLong = result.CommunityTooLong;
+            CollectionAgent.NoteExternalDetection(result.CommunityTooLong);
         }
         else
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -183,7 +183,11 @@ else
                 <div class="banner-content">
                     <span class="banner-icon banner-icon-warning">!</span>
                     <div class="banner-text" style="flex: 1;">
-                        @if (unpolledKeyDevices.Count == 1)
+                        @if (CommunityTooLong)
+                        {
+                            @("SNMP community string is too long - devices reject anything over 20 characters. Shorten it in UniFi.")
+                        }
+                        else if (unpolledKeyDevices.Count == 1)
                         {
                             var d = unpolledKeyDevices[0];
                             @($"{d.Name} {KeyDeviceReason(d)}")
@@ -194,7 +198,10 @@ else
                         }
                     </div>
                     <div class="banner-actions">
-                        <button class="btn btn-sm btn-primary" @onclick="GoToSnmpDevices">Review SNMP devices</button>
+                        @if (!CommunityTooLong)
+                        {
+                            <button class="btn btn-sm btn-primary" @onclick="GoToSnmpDevices">Review SNMP devices</button>
+                        }
                     </div>
                 </div>
             </div>
@@ -1350,11 +1357,14 @@ else
         }
         else
         {
-            @if (_snmpCommunityTooLong)
+            @if (CommunityTooLong)
             {
                 <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
                     <strong>SNMP community string is too long.</strong>
-                    Your community string is @_snmpCommunityLength characters. UniFi switches and most other SNMP devices silently reject a community string longer than 20 characters, so they drop from polling while the gateway (which tolerates it) keeps reporting. Shorten it to 20 characters or fewer in UniFi Network (Settings, search "SNMP Monitoring"), let your devices reprovision, then re-check.
+                    @(_snmpCommunityLength > 0
+                        ? $"Yours is {_snmpCommunityLength} characters; UniFi devices silently reject anything over 20."
+                        : "UniFi devices silently reject anything over 20 characters.")
+                    Shorten it and re-check.
                     <div style="margin-top: 0.75rem;">
                         <button class="btn btn-sm btn-secondary" @onclick="RunDetection" disabled="@_detecting">
                             @if (_detecting) { <span class="spinner-sm"></span> <span>Re-checking...</span> }
@@ -1595,6 +1605,11 @@ else
     private string? _detectionError;
     private bool _snmpCommunityTooLong;
     private int _snmpCommunityLength;
+    // Server-side sighting from the collection agent's self-heal re-pull, refreshed on
+    // the 15s tick - catches a too-long community set while the user sits on Live View,
+    // where page-load detection has already come and gone.
+    private bool _serverCommunityTooLong;
+    private bool CommunityTooLong => _snmpCommunityTooLong || _serverCommunityTooLong;
 
     private bool? _influxReachable;
     private string? _influxError;
@@ -2337,6 +2352,7 @@ else
         try
         {
             _snmpDeviceStatuses = await CollectionAgent.GetSnmpDeviceStatusesAsync();
+            _serverCommunityTooLong = CollectionAgent.CommunityTooLongDetected;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2368,10 +2368,12 @@ else
         {
             _snmpDeviceStatuses = await CollectionAgent.GetSnmpDeviceStatusesAsync();
             var serverTooLong = CollectionAgent.CommunityTooLongDetected;
-            // The server flag flipping on means the community changed under us - re-run
-            // detection so the banner's character count reflects the new value instead of
-            // pairing a stale length with the fresh too-long verdict.
-            if (serverTooLong && !_serverCommunityTooLong && !_detecting)
+            // While the too-long banner is showing (either source), re-run detection each
+            // tick: the count stays accurate, and the banner auto-dismisses as soon as the
+            // console reports a fixed Community String - no manual re-check needed. Also
+            // fires when the server flag first flips on, so a stale local length never
+            // pairs with a fresh too-long verdict.
+            if (!_detecting && ((serverTooLong && !_serverCommunityTooLong) || CommunityTooLong))
                 _ = InvokeAsync(RunDetection);
             _serverCommunityTooLong = serverTooLong;
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1350,6 +1350,20 @@ else
         }
         else
         {
+            @if (_snmpCommunityTooLong)
+            {
+                <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
+                    <strong>SNMP community string is too long.</strong>
+                    Your community string is @_snmpCommunityLength characters. UniFi switches and most other SNMP devices silently reject a community string longer than 20 characters, so they drop from polling while the gateway (which tolerates it) keeps reporting. Shorten it to 20 characters or fewer in UniFi Network (Settings, search "SNMP Monitoring"), let your devices reprovision, then re-check.
+                    <div style="margin-top: 0.75rem;">
+                        <button class="btn btn-sm btn-secondary" @onclick="RunDetection" disabled="@_detecting">
+                            @if (_detecting) { <span class="spinner-sm"></span> <span>Re-checking...</span> }
+                            else { <span>Re-check</span> }
+                        </button>
+                    </div>
+                </div>
+            }
+
             @if (_showV3Recommendation && _snmpState == SnmpDetectionState.EnabledV3Only)
             {
                 <div class="alert alert-info" style="margin-bottom: 1.5rem;">
@@ -1579,6 +1593,8 @@ else
     private bool _detecting;
     private bool _showV3Recommendation = true;
     private string? _detectionError;
+    private bool _snmpCommunityTooLong;
+    private int _snmpCommunityLength;
 
     private bool? _influxReachable;
     private string? _influxError;
@@ -2275,6 +2291,8 @@ else
             await SnmpDetection.SaveDetectionResultAsync(result);
             var settings = await SnmpDetection.GetOrCreateSettingsAsync();
             _snmpState = settings.SnmpDetectionState;
+            _snmpCommunityTooLong = result.CommunityTooLong;
+            _snmpCommunityLength = result.Community?.Length ?? 0;
         }
         else
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -187,7 +187,7 @@ else
                     <div class="banner-text" style="flex: 1;">
                         @if (CommunityTooLong)
                         {
-                            @("SNMP Community String is too long - UniFi devices only reliably support 20 characters. Shorten it in UniFi.")
+                            @("SNMP Community String is too long - UniFi devices only reliably support 20 characters. Shorten it in UniFi Network.")
                         }
                         else if (unpolledKeyDevices.Count == 1)
                         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -185,7 +185,7 @@ else
                     <div class="banner-text" style="flex: 1;">
                         @if (CommunityTooLong)
                         {
-                            @("SNMP community string is too long - devices reject anything over 20 characters. Shorten it in UniFi.")
+                            @("SNMP Community String is too long - devices reject anything over 20 characters. Shorten it in UniFi.")
                         }
                         else if (unpolledKeyDevices.Count == 1)
                         {
@@ -1306,7 +1306,7 @@ else
                             <ol>
                                 <li>Open UniFi Network</li>
                                 <li>Search Settings for <strong>"SNMP Monitoring"</strong></li>
-                                <li>Enable <strong>SNMP v1/v2c</strong> and set a unique community string</li>
+                                <li>Enable <strong>SNMP v1/v2c</strong> and set a unique Community String (20 characters max)</li>
                             </ol>
                             <p>Currently at: Settings → CyberSecure → Traffic Logging → SNMP Monitoring. This menu has moved between UniFi versions - the search term is the reliable way to find it.</p>
 
@@ -1321,7 +1321,7 @@ else
                             <p>Devices without SNMP enabled will not report port-level traffic or health metrics.</p>
 
                             <h4>Recommended configuration</h4>
-                            <p><strong>SNMP v1/v2c</strong> with a unique community string is recommended over v3. SNMPv3's per-packet authentication and encryption adds measurable CPU load to your gateway and fabric devices. The recommended security posture is a <strong>management VLAN</strong> isolating your network devices, not per-packet crypto.</p>
+                            <p><strong>SNMP v1/v2c</strong> with a unique Community String is recommended over v3. SNMPv3's per-packet authentication and encryption adds measurable CPU load to your gateway and fabric devices. The recommended security posture is a <strong>management VLAN</strong> isolating your network devices, not per-packet crypto.</p>
                         </div>
                     </details>
 
@@ -1360,7 +1360,7 @@ else
             @if (CommunityTooLong)
             {
                 <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
-                    <strong>SNMP community string is too long.</strong>
+                    <strong>SNMP Community String is too long.</strong>
                     @(_snmpCommunityLength > 0
                         ? $"Yours is {_snmpCommunityLength} characters; UniFi devices silently reject anything over 20."
                         : "UniFi devices silently reject anything over 20 characters.")

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -187,7 +187,14 @@ else
                     <div class="banner-text" style="flex: 1;">
                         @if (CommunityTooLong)
                         {
-                            @("SNMP Community String is too long - UniFi devices only reliably support 20 characters. Shorten it in UniFi Network.")
+                            @* Keep the gateway-down specifics when both conditions hold - only the
+                               device-table pointer is useless here, not the who's-affected detail. *@
+                            var prefix = unpolledKeyDevices.Count == 1
+                                ? $"{unpolledKeyDevices[0].Name} isn't being polled - the "
+                                : unpolledKeyDevices.Count > 1
+                                    ? $"{unpolledKeyDevices.Count} key devices aren't being polled - the "
+                                    : "The ";
+                            @($"{prefix}SNMP Community String is too long. UniFi devices only reliably support 20 characters; shorten it in UniFi Network.")
                         }
                         else if (unpolledKeyDevices.Count == 1)
                         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1370,7 +1370,9 @@ else
             {
                 <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
                     <strong>SNMP Community String is too long.</strong>
-                    @(_snmpCommunityLength > 0
+                    @* Show the count only when THIS page's detection measured it - the server
+                       flag can flip the banner on while the locally cached length is stale. *@
+                    @(_snmpCommunityTooLong && _snmpCommunityLength > 0
                         ? $"Yours is {_snmpCommunityLength} characters; UniFi devices only reliably support 20."
                         : "UniFi devices only reliably support 20 characters.")
                     Shorten it and re-check.
@@ -2365,7 +2367,13 @@ else
         try
         {
             _snmpDeviceStatuses = await CollectionAgent.GetSnmpDeviceStatusesAsync();
-            _serverCommunityTooLong = CollectionAgent.CommunityTooLongDetected;
+            var serverTooLong = CollectionAgent.CommunityTooLongDetected;
+            // The server flag flipping on means the community changed under us - re-run
+            // detection so the banner's character count reflects the new value instead of
+            // pairing a stale length with the fresh too-long verdict.
+            if (serverTooLong && !_serverCommunityTooLong && !_detecting)
+                _ = InvokeAsync(RunDetection);
+            _serverCommunityTooLong = serverTooLong;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -176,8 +176,10 @@ else
     @* ──────────────── Tab: Live View ──────────────── *@
     @if (_activeTab == "live" && _monitoringReady)
     {
+        @* Too-long community shows even when the gateway is still polling - gateways
+           often tolerate a long Community String while the switches silently drop. *@
         var unpolledKeyDevices = GetUnpolledKeyDevices();
-        if (unpolledKeyDevices.Count > 0)
+        if (unpolledKeyDevices.Count > 0 || CommunityTooLong)
         {
             <div class="alert alert-warning" style="margin-bottom: 1rem;">
                 <div class="banner-content">
@@ -185,7 +187,7 @@ else
                     <div class="banner-text" style="flex: 1;">
                         @if (CommunityTooLong)
                         {
-                            @("SNMP Community String is too long - devices reject anything over 20 characters. Shorten it in UniFi.")
+                            @("SNMP Community String is too long - UniFi devices only reliably support 20 characters. Shorten it in UniFi.")
                         }
                         else if (unpolledKeyDevices.Count == 1)
                         {
@@ -1362,8 +1364,8 @@ else
                 <div class="alert alert-warning" style="margin-bottom: 1.5rem;">
                     <strong>SNMP Community String is too long.</strong>
                     @(_snmpCommunityLength > 0
-                        ? $"Yours is {_snmpCommunityLength} characters; UniFi devices silently reject anything over 20."
-                        : "UniFi devices silently reject anything over 20 characters.")
+                        ? $"Yours is {_snmpCommunityLength} characters; UniFi devices only reliably support 20."
+                        : "UniFi devices only reliably support 20 characters.")
                     Shorten it and re-check.
                     <div style="margin-top: 0.75rem;">
                         <button class="btn btn-sm btn-secondary" @onclick="RunDetection" disabled="@_detecting">

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -442,7 +442,7 @@ public class AgentProbeResultSink
             if (detected.CommunityTooLong)
             {
                 _logger.LogWarning(
-                    "SNMP self-heal (agent site {Slug}): UniFi community string is {Len} chars (> {Max}); switches reject it. Not adopting - shorten it in UniFi Network.",
+                    "SNMP self-heal (agent site {Slug}): UniFi community string is {Len} chars (> {Max}); devices reject it. Not adopting - it must be shortened.",
                     siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
                 return settings;
             }

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -412,9 +412,11 @@ public class AgentProbeResultSink
         string siteSlug, NetworkOptimizerDbContext db, MonitoringSettings? settings, CancellationToken ct)
     {
         if (settings is not { Enabled: true }) return settings;
-        if (settings.SnmpDetectionState != SnmpDetectionState.EnabledV2c
-            && settings.SnmpDetectionState != SnmpDetectionState.EnabledV3Only
-            && settings.SnmpDetectionState != SnmpDetectionState.Working)
+        // Disabled stays in the rotation: if SNMP was turned off in the remote UniFi and we
+        // adopted that, we must keep re-detecting to notice it being turned back ON (the
+        // ConfigDiffers Disabled->Enabled transition). Only NotChecked - detection never
+        // ran for this site - is excluded.
+        if (settings.SnmpDetectionState == SnmpDetectionState.NotChecked)
             return settings;
 
         if (_lastAgentSnmpRedetectAt.TryGetValue(siteSlug, out var last)

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -442,7 +442,7 @@ public class AgentProbeResultSink
             if (detected.CommunityTooLong)
             {
                 _logger.LogWarning(
-                    "SNMP self-heal (agent site {Slug}): UniFi community string is {Len} chars (> {Max}); devices reject it. Not adopting - it must be shortened.",
+                    "SNMP self-heal (agent site {Slug}): UniFi Community String is {Len} chars, over the reliable {Max}-char device max. Not adopting - it must be shortened.",
                     siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
                 return settings;
             }

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -68,6 +68,15 @@ public class AgentProbeResultSink
     // because this sink is a singleton serving every agent site.
     private readonly ConcurrentDictionary<string, LanFabricAggregator> _fabricBySite = new();
 
+    // Agent-site SNMP self-heal. The server doesn't poll SNMP for agent sites (the agent
+    // does and only relays results), so there's no per-device failure signal to react to
+    // like on direct sites. Instead we re-detect the SNMP config from the site's console
+    // (reached through the agent's tunnel) on this throttle inside the periodic config
+    // push, adopting and re-pushing any change - so a community rotated in the remote
+    // UniFi reaches the agent within a couple of minutes instead of never. Keyed by slug.
+    private readonly ConcurrentDictionary<string, DateTime> _lastAgentSnmpRedetectAt = new();
+    private static readonly TimeSpan AgentSnmpRedetectInterval = TimeSpan.FromMinutes(2);
+
     public AgentProbeResultSink(
         SiteDbContextFactory siteDbFactory,
         MonitoringInfluxRegistry influxRegistry,
@@ -281,6 +290,12 @@ public class AgentProbeResultSink
             await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault: false);
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
 
+            // Before building the push, re-detect the SNMP config from the site's console
+            // and adopt any change, so a community/credential rotation in the remote UniFi
+            // propagates to the agent. Throttled internally; returns the (possibly updated)
+            // settings so the config we push below carries the fresh credentials.
+            settings = await MaybeRedetectAgentSnmpAsync(connection.SiteSlug, db, settings, ct);
+
             var config = new SnmpConfig { Enabled = false };
             if (settings is { Enabled: true })
             {
@@ -380,6 +395,76 @@ public class AgentProbeResultSink
         {
             _logger.LogWarning(ex, "Failed to push SNMP config to agent {Id} (site {Slug})",
                 connection.AgentId, connection.SiteSlug);
+        }
+    }
+
+    /// <summary>
+    /// Re-detects the SNMP config from an agent site's console (reached through the
+    /// agent's tunnel) and adopts it if it changed, on a per-site throttle. This is the
+    /// agent-site equivalent of the direct-poll self-heal: because the server never sees
+    /// the agent's per-device SNMP failures, it can't react to them, so instead it
+    /// proactively re-pulls the config every couple of minutes and lets the caller push
+    /// any change. Returns the (possibly updated) settings so the push carries the fresh
+    /// credentials. A too-long community is left alone (re-pulling returns the same value
+    /// the devices already reject; the Setup tab surfaces the length warning).
+    /// </summary>
+    private async Task<MonitoringSettings?> MaybeRedetectAgentSnmpAsync(
+        string siteSlug, NetworkOptimizerDbContext db, MonitoringSettings? settings, CancellationToken ct)
+    {
+        if (settings is not { Enabled: true }) return settings;
+        if (settings.SnmpDetectionState != SnmpDetectionState.EnabledV2c
+            && settings.SnmpDetectionState != SnmpDetectionState.EnabledV3Only
+            && settings.SnmpDetectionState != SnmpDetectionState.Working)
+            return settings;
+
+        if (_lastAgentSnmpRedetectAt.TryGetValue(siteSlug, out var last)
+            && DateTime.UtcNow - last < AgentSnmpRedetectInterval)
+            return settings;
+
+        var siteConnection = _siteConnections.GetFor(siteSlug);
+        if (!siteConnection.IsConnected || siteConnection.Client == null)
+            return settings; // console (via tunnel) not up yet; retry on the next push
+
+        _lastAgentSnmpRedetectAt[siteSlug] = DateTime.UtcNow;
+
+        try
+        {
+            SnmpDetectionResult detected;
+            using (var raw = await siteConnection.Client.GetSettingsRawAsync(ct))
+            {
+                if (raw == null) return settings;
+                detected = SnmpDetectionService.ParseSnmpSettings(raw);
+            }
+            if (!detected.Success) return settings;
+
+            if (detected.CommunityTooLong)
+            {
+                _logger.LogWarning(
+                    "SNMP self-heal (agent site {Slug}): UniFi community string is {Len} chars (> {Max}); switches reject it. Not adopting - shorten it in UniFi Network.",
+                    siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
+                return settings;
+            }
+
+            if (!SnmpDetectionService.ConfigDiffers(settings, detected, _credentialProtection))
+                return settings; // unchanged - nothing to adopt
+
+            var row = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
+            if (row == null) return settings;
+            var before = row.SnmpDetectionState;
+            SnmpDetectionService.ApplyToSettings(row, detected, _credentialProtection);
+            row.LastSnmpDetection = DateTime.UtcNow;
+            row.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+
+            _logger.LogWarning(
+                "SNMP self-heal (agent site {Slug}): adopted updated SNMP config from UniFi ({Before} -> {After}); re-pushing to agent.",
+                siteSlug, before, row.SnmpDetectionState);
+            return row;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "SNMP self-heal re-detect failed for agent site {Slug}", siteSlug);
+            return settings;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -84,6 +84,7 @@ public class AgentProbeResultSink
         SiteConnectionRegistry siteConnections,
         MonitoringAlertRegistry alertRegistry,
         ICredentialProtectionService credentialProtection,
+        MonitoringCollectionRegistry collectionRegistry,
         ILogger<AgentProbeResultSink> logger)
     {
         _siteDbFactory = siteDbFactory;
@@ -92,8 +93,11 @@ public class AgentProbeResultSink
         _siteConnections = siteConnections;
         _alertRegistry = alertRegistry;
         _credentialProtection = credentialProtection;
+        _collectionRegistry = collectionRegistry;
         _logger = logger;
     }
+
+    private readonly MonitoringCollectionRegistry _collectionRegistry;
 
     /// <summary>Called once per connection after the hello exchange, and by the periodic refresh.</summary>
     public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct)
@@ -438,6 +442,11 @@ public class AgentProbeResultSink
                 detected = SnmpDetectionService.ParseSnmpSettings(raw);
             }
             if (!detected.Success) return settings;
+
+            // Mirror the sighting onto the site's collection agent instance - the site's
+            // Monitoring page reads that flag (scoped DI resolves per-site), so a managed
+            // site's banner auto-appears and auto-dismisses just like the default site's.
+            _collectionRegistry.GetFor(siteSlug).NoteExternalDetection(detected.CommunityTooLong);
 
             if (detected.CommunityTooLong)
             {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -71,6 +71,13 @@ public class MonitoringCollectionAgent : BackgroundService
     // "last polled" column and "not yet polled" state on the Setup dashboard.
     private readonly ConcurrentDictionary<string, DateTime> _snmpLastPolled = new();
 
+    // SNMP self-heal throttle. When a batch of previously-healthy devices all drop
+    // from polling (the classic symptom of a community string rotated in UniFi), we
+    // re-pull the SNMP config from the console and adopt it if it changed. Rate-limited
+    // so a genuine outage (reboot, firewall/IPS) can't hammer the console API.
+    private DateTime _lastSnmpSelfHealAt = DateTime.MinValue;
+    private static readonly TimeSpan SnmpSelfHealCooldown = TimeSpan.FromMinutes(5);
+
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
     private DateTime _customOidsLoadedAt = DateTime.MinValue;
@@ -463,6 +470,133 @@ public class MonitoringCollectionAgent : BackgroundService
         // fallbacks. Shared verbatim with the agent-relayed path (AgentProbeResultSink)
         // via LanFabricAggregator so secondary sites compute identical numbers.
         _fabric.WriteAggregates(devices, _liveStats, DateTime.UtcNow);
+
+        // If a batch of previously-healthy devices just dropped from polling, the SNMP
+        // credentials may have been rotated in UniFi. Re-pull and adopt if they changed.
+        await MaybeSelfHealSnmpAsync(settings, ct);
+    }
+
+    /// <summary>
+    /// Self-heals stale SNMP credentials. SNMPv2c gives no distinct "wrong community"
+    /// error - a rotated community is indistinguishable from a timeout - so the trigger
+    /// is behavioural: a batch of devices that were polling fine have all dropped at
+    /// once. When that happens we re-pull the SNMP config from the console API (which
+    /// still answers even when SNMP to the devices is dead, different transport) and
+    /// adopt it only if it actually differs from what we're using. A real outage leaves
+    /// UniFi's config untouched, so same config = no-op. Covers a rotated v2c community,
+    /// changed v3 credentials, and SNMP being disabled entirely. A community longer than
+    /// the device-supported max is left alone - re-pulling returns the same broken value,
+    /// and the Setup tab already surfaces the length warning.
+    /// </summary>
+    private async Task MaybeSelfHealSnmpAsync(MonitoringSettings settings, CancellationToken ct)
+    {
+        if (settings.SnmpDetectionState != SnmpDetectionState.EnabledV2c
+            && settings.SnmpDetectionState != SnmpDetectionState.EnabledV3Only
+            && settings.SnmpDetectionState != SnmpDetectionState.Working)
+            return;
+
+        if (DateTime.UtcNow - _lastSnmpSelfHealAt < SnmpSelfHealCooldown) return;
+
+        // Trigger: at least half of the devices that were known to work (floor of 2)
+        // are now dropped. A single dead device, or one that never spoke SNMP, doesn't
+        // qualify - that's not a credential change.
+        var healthy = _snmpFailures.HealthyCount;
+        if (healthy < 2) return;
+        var dropped = _snmpFailures.ExcludedHealthyCount();
+        var threshold = Math.Max(2, (int)Math.Ceiling(healthy * 0.5));
+        if (dropped < threshold) return;
+
+        _lastSnmpSelfHealAt = DateTime.UtcNow;
+
+        if (_connectionService.Client == null || !_connectionService.IsConnected)
+            return; // can't reach the console to re-pull; retry after the cooldown
+
+        _logger.LogWarning(
+            "SNMP self-heal (site {Site}): {Dropped}/{Healthy} previously-healthy devices dropped from polling. Re-pulling SNMP config from UniFi to check for a credential change.",
+            _siteSlug, dropped, healthy);
+
+        try
+        {
+            SnmpDetectionResult detected;
+            using (var raw = await _connectionService.Client.GetSettingsRawAsync(ct))
+            {
+                if (raw == null) return;
+                detected = SnmpDetectionService.ParseSnmpSettings(raw);
+            }
+            if (!detected.Success) return;
+
+            // A too-long community re-pulls to the same value the devices already reject;
+            // adopting it would change nothing and we'd loop. Leave it for the user.
+            if (detected.CommunityTooLong)
+            {
+                _logger.LogWarning(
+                    "SNMP self-heal (site {Site}): UniFi community string is {Len} chars (> {Max}); switches reject it. Not adopting - shorten it in UniFi Network.",
+                    _siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
+                return;
+            }
+
+            if (!SnmpConfigDiffers(settings, detected))
+            {
+                _logger.LogInformation(
+                    "SNMP self-heal (site {Site}): UniFi SNMP config is unchanged, so the failures are not a credential change (device outage, firewall, or IPS). Leaving polling as-is.",
+                    _siteSlug);
+                return;
+            }
+
+            await using var db = await CreateSiteDbAsync(ct);
+            var row = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
+            if (row == null) return;
+            var before = row.SnmpDetectionState;
+            SnmpDetectionService.ApplyToSettings(row, detected, _credentialProtection);
+            row.LastSnmpDetection = DateTime.UtcNow;
+            row.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+
+            // Clear failure/exclusion state so the dropped devices are retried at once
+            // with the new credentials. The poller rebuilds itself next cycle because
+            // ComputePollerConfigHash keys on the credential fields we just changed.
+            _snmpFailures.Reset();
+
+            _logger.LogWarning(
+                "SNMP self-heal (site {Site}): adopted updated SNMP config from UniFi ({Before} -> {After}). Reset failure tracking; polling resumes with the new credentials.",
+                _siteSlug, before, row.SnmpDetectionState);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "SNMP self-heal (site {Site}): re-pull failed", _siteSlug);
+        }
+    }
+
+    /// <summary>
+    /// Whether the SNMP config just pulled from UniFi differs from what this agent is
+    /// currently polling with (version, community, or v3 credentials), including SNMP
+    /// having been turned off entirely. Decrypts the stored secrets to compare.
+    /// </summary>
+    private bool SnmpConfigDiffers(MonitoringSettings current, SnmpDetectionResult detected)
+    {
+        switch (detected.DetectionState)
+        {
+            case SnmpDetectionState.Disabled:
+                return current.SnmpDetectionState != SnmpDetectionState.Disabled;
+
+            case SnmpDetectionState.EnabledV2c:
+                if (current.SnmpVersion != SnmpVersionSetting.V2c) return true;
+                var storedCommunity = string.IsNullOrEmpty(current.SnmpCommunity)
+                    ? string.Empty
+                    : _credentialProtection.Decrypt(current.SnmpCommunity);
+                return !string.Equals(storedCommunity, detected.Community ?? string.Empty, StringComparison.Ordinal);
+
+            case SnmpDetectionState.EnabledV3Only:
+                if (current.SnmpVersion != SnmpVersionSetting.V3) return true;
+                if (!string.Equals(current.SnmpV3Username, detected.V3Username, StringComparison.Ordinal)) return true;
+                var storedPassword = string.IsNullOrEmpty(current.SnmpV3AuthPassword)
+                    ? string.Empty
+                    : _credentialProtection.Decrypt(current.SnmpV3AuthPassword);
+                return !string.Equals(storedPassword, detected.V3Password ?? string.Empty, StringComparison.Ordinal);
+
+            default:
+                return false;
+        }
     }
 
     // Owns the per-port / per-device byte-rate caches and the topology-boundary

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -84,10 +84,12 @@ public class MonitoringCollectionAgent : BackgroundService
     private static readonly TimeSpan SnmpSelfHealMinInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan SnmpSelfHealIdleBackoff = TimeSpan.FromMinutes(15);
     // When the fast tier first actually polls (console up, poller built). Self-heal
-    // stays quiet for a warm-up window after this so first-cycle jitter can't fire a
-    // needless re-pull before devices have had a fair chance to answer.
+    // stays quiet for a short warm-up after this so first-cycle jitter can't fire a
+    // needless re-pull before devices have had a fair chance to answer. Kept short (a
+    // few poll cycles) so it doesn't slow the genuine cold-start-wrong-community heal -
+    // the 2-consecutive-failure requirement and the diff-gate are the real guards.
     private DateTime _snmpPollingStartedAt = DateTime.MinValue;
-    private static readonly TimeSpan SnmpSelfHealWarmup = TimeSpan.FromSeconds(45);
+    private static readonly TimeSpan SnmpSelfHealWarmup = TimeSpan.FromSeconds(15);
 
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
@@ -248,8 +250,18 @@ public class MonitoringCollectionAgent : BackgroundService
             WifiClientTierCollectAsync,
             TimeSpan.FromSeconds(30),
             stoppingToken);
+        // SNMP credential self-heal on its own short cadence. It must NOT ride the fast
+        // tier's cycle: when every SNMP call is timing out (the exact failure it exists to
+        // detect), a fast cycle stretches to minutes of stacked timeouts and an end-of-cycle
+        // check starves - the self-heal took 4+ minutes to fire. This loop reads the failure
+        // tracker and (rarely, throttled) makes one console API call, so 10s is cheap.
+        var selfHealTask = RunTierAsync("snmp-selfheal",
+            _ => TimeSpan.FromSeconds(10),
+            SnmpSelfHealTierAsync,
+            TimeSpan.FromSeconds(12),
+            stoppingToken);
 
-        await Task.WhenAll(fastTask, mediumTask, slowTask, latencyTask, healthTask, wifiTask);
+        await Task.WhenAll(fastTask, mediumTask, slowTask, latencyTask, healthTask, wifiTask, selfHealTask);
         _logger.LogInformation("Monitoring collection agent stopped (site {Site})", _siteSlug);
     }
 
@@ -484,9 +496,19 @@ public class MonitoringCollectionAgent : BackgroundService
         // fallbacks. Shared verbatim with the agent-relayed path (AgentProbeResultSink)
         // via LanFabricAggregator so secondary sites compute identical numbers.
         _fabric.WriteAggregates(devices, _liveStats, DateTime.UtcNow);
+    }
 
-        // If a majority of SNMP-enabled devices are failing, the SNMP credentials may
-        // have been rotated in UniFi. Re-pull and adopt if they changed.
+    /// <summary>
+    /// The dedicated self-heal tier: evaluates the failure tracker against the current
+    /// device list every tick, independent of the fast tier's cycle time. Uses the same
+    /// cached device list as the pollers (4s TTL), so a tick normally costs a dictionary
+    /// scan and nothing else.
+    /// </summary>
+    private async Task SnmpSelfHealTierAsync(MonitoringSettings settings, CancellationToken ct)
+    {
+        if (AgentCoversCollection()) return;
+        var devices = await GetMonitorableDevicesAsync(ct);
+        if (devices.Count == 0) return;
         await MaybeSelfHealSnmpAsync(devices, settings, ct);
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -83,6 +83,11 @@ public class MonitoringCollectionAgent : BackgroundService
     private int _lastSnmpSelfHealFailingCount;
     private static readonly TimeSpan SnmpSelfHealMinInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan SnmpSelfHealIdleBackoff = TimeSpan.FromMinutes(15);
+    // When the fast tier first actually polls (console up, poller built). Self-heal
+    // stays quiet for a warm-up window after this so first-cycle jitter can't fire a
+    // needless re-pull before devices have had a fair chance to answer.
+    private DateTime _snmpPollingStartedAt = DateTime.MinValue;
+    private static readonly TimeSpan SnmpSelfHealWarmup = TimeSpan.FromSeconds(45);
 
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
@@ -352,6 +357,9 @@ public class MonitoringCollectionAgent : BackgroundService
         var poller = GetOrBuildPoller(settings);
         if (poller == null) return;
 
+        // Mark the first real poll cycle so the self-heal warm-up grace can start.
+        if (_snmpPollingStartedAt == default) _snmpPollingStartedAt = DateTime.UtcNow;
+
         // Configure InfluxDB client (no-op if already configured)
         if (!_influx.IsConfigured)
             await _influx.ReconfigureAsync(ct);
@@ -477,46 +485,60 @@ public class MonitoringCollectionAgent : BackgroundService
         // via LanFabricAggregator so secondary sites compute identical numbers.
         _fabric.WriteAggregates(devices, _liveStats, DateTime.UtcNow);
 
-        // If a batch of previously-healthy devices just dropped from polling, the SNMP
-        // credentials may have been rotated in UniFi. Re-pull and adopt if they changed.
-        await MaybeSelfHealSnmpAsync(settings, ct);
+        // If a majority of SNMP-enabled devices are failing, the SNMP credentials may
+        // have been rotated in UniFi. Re-pull and adopt if they changed.
+        await MaybeSelfHealSnmpAsync(devices, settings, ct);
     }
 
     /// <summary>
     /// Self-heals stale SNMP credentials. SNMPv2c gives no distinct "wrong community"
     /// error - a rotated community is indistinguishable from a timeout - so the trigger
-    /// is behavioural: a batch of devices that were polling fine have all dropped at
-    /// once. When that happens we re-pull the SNMP config from the console API (which
-    /// still answers even when SNMP to the devices is dead, different transport) and
-    /// adopt it only if it actually differs from what we're using. A real outage leaves
-    /// UniFi's config untouched, so same config = no-op. Covers a rotated v2c community,
-    /// changed v3 credentials, and SNMP being disabled entirely. A community longer than
-    /// the device-supported max is left alone - re-pulling returns the same broken value,
+    /// is behavioural: a majority of the SNMP-enabled devices are failing. When that
+    /// happens we re-pull the SNMP config from the console API (which still answers even
+    /// when SNMP to the devices is dead, different transport) and adopt it only if it
+    /// actually differs from what we're using. A real outage leaves UniFi's config
+    /// untouched, so same config = no-op. Covers a rotated v2c community, changed v3
+    /// credentials, and SNMP being disabled entirely. A community longer than the
+    /// device-supported max is left alone - re-pulling returns the same broken value,
     /// and the Setup tab already surfaces the length warning.
     /// </summary>
-    private async Task MaybeSelfHealSnmpAsync(MonitoringSettings settings, CancellationToken ct)
+    private async Task MaybeSelfHealSnmpAsync(
+        IReadOnlyList<UniFiDeviceResponse> devices, MonitoringSettings settings, CancellationToken ct)
     {
         if (settings.SnmpDetectionState != SnmpDetectionState.EnabledV2c
             && settings.SnmpDetectionState != SnmpDetectionState.EnabledV3Only
             && settings.SnmpDetectionState != SnmpDetectionState.Working)
             return;
 
-        // Trigger: the devices that were polling fine have started failing (>= 2
-        // consecutive misses each, so a single dropped packet doesn't count). We don't
-        // wait for a fabric-wide dropout or the 5-failure exclusion - the re-pull is
-        // cheap and diff-gated, so reacting after a couple of failures is the whole
-        // point. A device that never spoke SNMP (Flex Mini) isn't in the healthy set,
-        // so it can't trigger this. A genuine outage leaves the config unchanged and
-        // the re-pull simply no-ops.
-        //
-        // The floor is 2 devices on a normal fabric (one flaky device shouldn't re-pull),
-        // but scales down to 1 for a single-device network - a lone all-in-one (a UDR7 with
-        // no separate switches or APs) must still self-heal off its own failure.
-        var healthy = _snmpFailures.HealthyCount;
-        if (healthy == 0) return;
-        var failing = _snmpFailures.FailingHealthyCount(minConsecutiveFailures: 2);
-        var trigger = Math.Min(2, healthy);
-        if (failing < trigger)
+        // Denominator: the devices UniFi reports as SNMP-enabled (location/contact set).
+        // Basing the trigger on the current device list - NOT a "previously-healthy" set -
+        // is what makes it fire even on a cold start where the community was already wrong
+        // before this process began (nothing ever polled successfully, so a healthy
+        // baseline is permanently empty). This was the bug: a restart during an outage
+        // could never self-heal.
+        var snmpMacs = devices
+            .Where(d => Monitoring.SnmpDeviceRules.HasSnmpEnabled(d))
+            .Select(d => NormalizeMac(d.Mac))
+            .Where(m => m.Length > 0)
+            .ToList();
+        if (snmpMacs.Count == 0) return;
+
+        // Warm-up grace: ignore the first poll cycles after startup, where transient
+        // failures (network/console still settling) shouldn't fire a re-pull. A correct
+        // community answers immediately, so this only delays a genuinely-wrong cold start.
+        if (_snmpPollingStartedAt == default
+            || DateTime.UtcNow - _snmpPollingStartedAt < SnmpSelfHealWarmup)
+            return;
+
+        // Trigger: a majority of SNMP-enabled devices failing (>= 2 consecutive misses
+        // each, so a single dropped packet doesn't count). A majority is a fabric-wide
+        // problem (community rotated / SNMP disabled); a minority is a device problem
+        // (a Flex Mini that can't do SNMP) and must NOT re-pull. On a single-device
+        // network the majority is that one device. The re-pull is cheap and diff-gated,
+        // so a genuine outage just no-ops.
+        var failing = snmpMacs.Count(mac => _snmpFailures.IsFailing(mac, minConsecutiveFailures: 2));
+        var threshold = Math.Max(1, (int)Math.Ceiling(snmpMacs.Count * 0.5));
+        if (failing < threshold)
         {
             // Fabric is healthy again - forget the baseline so the next failure event is
             // treated as fresh and re-pulls promptly instead of waiting out the backoff.
@@ -541,8 +563,8 @@ public class MonitoringCollectionAgent : BackgroundService
         _lastSnmpSelfHealFailingCount = failing;
 
         _logger.LogWarning(
-            "SNMP self-heal (site {Site}): {Failing} previously-healthy device(s) failing SNMP polls. Re-pulling config from UniFi to check for a credential change.",
-            _siteSlug, failing);
+            "SNMP self-heal (site {Site}): {Failing}/{Total} SNMP-enabled devices failing polls. Re-pulling config from UniFi to check for a credential change.",
+            _siteSlug, failing, snmpMacs.Count);
 
         try
         {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -614,7 +614,7 @@ public class MonitoringCollectionAgent : BackgroundService
             if (detected.CommunityTooLong)
             {
                 _logger.LogWarning(
-                    "SNMP self-heal (site {Site}): UniFi community string is {Len} chars (> {Max}); devices reject it. Not adopting - it must be shortened.",
+                    "SNMP self-heal (site {Site}): UniFi Community String is {Len} chars, over the reliable {Max}-char device max. Not adopting - it must be shortened.",
                     _siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
                 return;
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -91,6 +91,15 @@ public class MonitoringCollectionAgent : BackgroundService
     private DateTime _snmpPollingStartedAt = DateTime.MinValue;
     private static readonly TimeSpan SnmpSelfHealWarmup = TimeSpan.FromSeconds(15);
 
+    /// <summary>
+    /// Set when the self-heal re-pull found the console's community string over the
+    /// device-supported max (nothing can be adopted; polling stays down until the user
+    /// shortens it). The Monitoring page reads this on its refresh tick so the Live View
+    /// banner can name the real problem instead of pointing at the SNMP device table.
+    /// Cleared whenever polling is healthy or a usable config is adopted.
+    /// </summary>
+    public bool CommunityTooLongDetected { get; private set; }
+
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
     private DateTime _customOidsLoadedAt = DateTime.MinValue;
@@ -565,6 +574,7 @@ public class MonitoringCollectionAgent : BackgroundService
             // Fabric is healthy again - forget the baseline so the next failure event is
             // treated as fresh and re-pulls promptly instead of waiting out the backoff.
             _lastSnmpSelfHealFailingCount = 0;
+            CommunityTooLongDetected = false;
             return;
         }
 
@@ -597,13 +607,14 @@ public class MonitoringCollectionAgent : BackgroundService
                 detected = SnmpDetectionService.ParseSnmpSettings(raw);
             }
             if (!detected.Success) return;
+            CommunityTooLongDetected = detected.CommunityTooLong;
 
             // A too-long community re-pulls to the same value the devices already reject;
             // adopting it would change nothing and we'd loop. Leave it for the user.
             if (detected.CommunityTooLong)
             {
                 _logger.LogWarning(
-                    "SNMP self-heal (site {Site}): UniFi community string is {Len} chars (> {Max}); switches reject it. Not adopting - shorten it in UniFi Network.",
+                    "SNMP self-heal (site {Site}): UniFi community string is {Len} chars (> {Max}); devices reject it. Not adopting - it must be shortened.",
                     _siteSlug, detected.Community?.Length, SnmpDetectionResult.MaxSupportedCommunityLength);
                 return;
             }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -501,16 +501,22 @@ public class MonitoringCollectionAgent : BackgroundService
             && settings.SnmpDetectionState != SnmpDetectionState.Working)
             return;
 
-        // Trigger: a couple of devices that were polling fine have started failing
-        // (>= 2 consecutive misses each, so a single dropped packet doesn't count). We
-        // don't wait for a fabric-wide dropout or the 5-failure exclusion - the re-pull
-        // is cheap and diff-gated, so reacting after a couple of failures is the whole
+        // Trigger: the devices that were polling fine have started failing (>= 2
+        // consecutive misses each, so a single dropped packet doesn't count). We don't
+        // wait for a fabric-wide dropout or the 5-failure exclusion - the re-pull is
+        // cheap and diff-gated, so reacting after a couple of failures is the whole
         // point. A device that never spoke SNMP (Flex Mini) isn't in the healthy set,
         // so it can't trigger this. A genuine outage leaves the config unchanged and
         // the re-pull simply no-ops.
-        if (_snmpFailures.HealthyCount == 0) return;
+        //
+        // The floor is 2 devices on a normal fabric (one flaky device shouldn't re-pull),
+        // but scales down to 1 for a single-device network - a lone all-in-one (a UDR7 with
+        // no separate switches or APs) must still self-heal off its own failure.
+        var healthy = _snmpFailures.HealthyCount;
+        if (healthy == 0) return;
         var failing = _snmpFailures.FailingHealthyCount(minConsecutiveFailures: 2);
-        if (failing < 2)
+        var trigger = Math.Min(2, healthy);
+        if (failing < trigger)
         {
             // Fabric is healthy again - forget the baseline so the next failure event is
             // treated as fresh and re-pulls promptly instead of waiting out the backoff.
@@ -558,7 +564,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 return;
             }
 
-            if (!SnmpConfigDiffers(settings, detected))
+            if (!SnmpDetectionService.ConfigDiffers(settings, detected, _credentialProtection))
             {
                 _logger.LogInformation(
                     "SNMP self-heal (site {Site}): UniFi SNMP config is unchanged, so the failures are not a credential change (device outage, firewall, or IPS). Leaving polling as-is.",
@@ -587,38 +593,6 @@ public class MonitoringCollectionAgent : BackgroundService
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "SNMP self-heal (site {Site}): re-pull failed", _siteSlug);
-        }
-    }
-
-    /// <summary>
-    /// Whether the SNMP config just pulled from UniFi differs from what this agent is
-    /// currently polling with (version, community, or v3 credentials), including SNMP
-    /// having been turned off entirely. Decrypts the stored secrets to compare.
-    /// </summary>
-    private bool SnmpConfigDiffers(MonitoringSettings current, SnmpDetectionResult detected)
-    {
-        switch (detected.DetectionState)
-        {
-            case SnmpDetectionState.Disabled:
-                return current.SnmpDetectionState != SnmpDetectionState.Disabled;
-
-            case SnmpDetectionState.EnabledV2c:
-                if (current.SnmpVersion != SnmpVersionSetting.V2c) return true;
-                var storedCommunity = string.IsNullOrEmpty(current.SnmpCommunity)
-                    ? string.Empty
-                    : _credentialProtection.Decrypt(current.SnmpCommunity);
-                return !string.Equals(storedCommunity, detected.Community ?? string.Empty, StringComparison.Ordinal);
-
-            case SnmpDetectionState.EnabledV3Only:
-                if (current.SnmpVersion != SnmpVersionSetting.V3) return true;
-                if (!string.Equals(current.SnmpV3Username, detected.V3Username, StringComparison.Ordinal)) return true;
-                var storedPassword = string.IsNullOrEmpty(current.SnmpV3AuthPassword)
-                    ? string.Empty
-                    : _credentialProtection.Decrypt(current.SnmpV3AuthPassword);
-                return !string.Equals(storedPassword, detected.V3Password ?? string.Empty, StringComparison.Ordinal);
-
-            default:
-                return false;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -71,14 +71,14 @@ public class MonitoringCollectionAgent : BackgroundService
     // "last polled" column and "not yet polled" state on the Setup dashboard.
     private readonly ConcurrentDictionary<string, DateTime> _snmpLastPolled = new();
 
-    // SNMP self-heal throttle. As soon as a couple of previously-healthy devices start
-    // failing (the symptom of a community string rotated in UniFi), we re-pull the SNMP
-    // config from the console and adopt it if it changed. The re-pull is one cheap,
-    // diff-gated console call, so we react eagerly. Two guards keep habitually-failing
-    // devices from re-pulling forever: a hard floor between any two re-pulls, and a long
-    // idle backoff once the same devices keep failing (a device problem, not a credential
-    // change). A fresh escalation - more devices failing than last time - bypasses the
-    // backoff so a genuine fabric-wide flip is still caught within a couple of cycles.
+    // SNMP self-heal throttle. When a majority of SNMP-enabled devices are failing (the
+    // symptom of a community string rotated in UniFi), we re-pull the SNMP config from
+    // the console and adopt it if it changed. The re-pull is one cheap, diff-gated
+    // console call, so we react eagerly. Two guards keep habitually-failing devices from
+    // re-pulling forever: a hard floor between any two re-pulls, and a long idle backoff
+    // once the same devices keep failing (a device problem, not a credential change).
+    // Escalation - more devices failing than last time, or a standing too-long-community
+    // verdict - bypasses the backoff so a genuine flip is caught within a couple of cycles.
     private DateTime _lastSnmpSelfHealAt = DateTime.MinValue;
     private int _lastSnmpSelfHealFailingCount;
     private static readonly TimeSpan SnmpSelfHealMinInterval = TimeSpan.FromSeconds(30);

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -71,12 +71,18 @@ public class MonitoringCollectionAgent : BackgroundService
     // "last polled" column and "not yet polled" state on the Setup dashboard.
     private readonly ConcurrentDictionary<string, DateTime> _snmpLastPolled = new();
 
-    // SNMP self-heal throttle. When a batch of previously-healthy devices all drop
-    // from polling (the classic symptom of a community string rotated in UniFi), we
-    // re-pull the SNMP config from the console and adopt it if it changed. Rate-limited
-    // so a genuine outage (reboot, firewall/IPS) can't hammer the console API.
+    // SNMP self-heal throttle. As soon as a couple of previously-healthy devices start
+    // failing (the symptom of a community string rotated in UniFi), we re-pull the SNMP
+    // config from the console and adopt it if it changed. The re-pull is one cheap,
+    // diff-gated console call, so we react eagerly. Two guards keep habitually-failing
+    // devices from re-pulling forever: a hard floor between any two re-pulls, and a long
+    // idle backoff once the same devices keep failing (a device problem, not a credential
+    // change). A fresh escalation - more devices failing than last time - bypasses the
+    // backoff so a genuine fabric-wide flip is still caught within a couple of cycles.
     private DateTime _lastSnmpSelfHealAt = DateTime.MinValue;
-    private static readonly TimeSpan SnmpSelfHealCooldown = TimeSpan.FromMinutes(5);
+    private int _lastSnmpSelfHealFailingCount;
+    private static readonly TimeSpan SnmpSelfHealMinInterval = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan SnmpSelfHealIdleBackoff = TimeSpan.FromMinutes(15);
 
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
@@ -495,25 +501,42 @@ public class MonitoringCollectionAgent : BackgroundService
             && settings.SnmpDetectionState != SnmpDetectionState.Working)
             return;
 
-        if (DateTime.UtcNow - _lastSnmpSelfHealAt < SnmpSelfHealCooldown) return;
+        // Trigger: a couple of devices that were polling fine have started failing
+        // (>= 2 consecutive misses each, so a single dropped packet doesn't count). We
+        // don't wait for a fabric-wide dropout or the 5-failure exclusion - the re-pull
+        // is cheap and diff-gated, so reacting after a couple of failures is the whole
+        // point. A device that never spoke SNMP (Flex Mini) isn't in the healthy set,
+        // so it can't trigger this. A genuine outage leaves the config unchanged and
+        // the re-pull simply no-ops.
+        if (_snmpFailures.HealthyCount == 0) return;
+        var failing = _snmpFailures.FailingHealthyCount(minConsecutiveFailures: 2);
+        if (failing < 2)
+        {
+            // Fabric is healthy again - forget the baseline so the next failure event is
+            // treated as fresh and re-pulls promptly instead of waiting out the backoff.
+            _lastSnmpSelfHealFailingCount = 0;
+            return;
+        }
 
-        // Trigger: at least half of the devices that were known to work (floor of 2)
-        // are now dropped. A single dead device, or one that never spoke SNMP, doesn't
-        // qualify - that's not a credential change.
-        var healthy = _snmpFailures.HealthyCount;
-        if (healthy < 2) return;
-        var dropped = _snmpFailures.ExcludedHealthyCount();
-        var threshold = Math.Max(2, (int)Math.Ceiling(healthy * 0.5));
-        if (dropped < threshold) return;
+        var sinceLast = DateTime.UtcNow - _lastSnmpSelfHealAt;
+        if (sinceLast < SnmpSelfHealMinInterval) return;
 
-        _lastSnmpSelfHealAt = DateTime.UtcNow;
+        // Past the floor: only re-pull again if MORE devices are failing than at our last
+        // check. If it's the same devices still down, we already confirmed the config
+        // didn't change (a device problem, not a credential rotation), so wait out the
+        // idle backoff rather than re-pulling for habitually-failing devices every cycle.
+        bool escalated = failing > _lastSnmpSelfHealFailingCount;
+        if (!escalated && sinceLast < SnmpSelfHealIdleBackoff) return;
 
         if (_connectionService.Client == null || !_connectionService.IsConnected)
-            return; // can't reach the console to re-pull; retry after the cooldown
+            return; // can't reach the console; retry once reconnected (interval not consumed)
+
+        _lastSnmpSelfHealAt = DateTime.UtcNow;
+        _lastSnmpSelfHealFailingCount = failing;
 
         _logger.LogWarning(
-            "SNMP self-heal (site {Site}): {Dropped}/{Healthy} previously-healthy devices dropped from polling. Re-pulling SNMP config from UniFi to check for a credential change.",
-            _siteSlug, dropped, healthy);
+            "SNMP self-heal (site {Site}): {Failing} previously-healthy device(s) failing SNMP polls. Re-pulling config from UniFi to check for a credential change.",
+            _siteSlug, failing);
 
         try
         {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -100,6 +100,14 @@ public class MonitoringCollectionAgent : BackgroundService
     /// </summary>
     public bool CommunityTooLongDetected { get; private set; }
 
+    /// <summary>
+    /// Lets the Setup page's interactive re-check override the cached self-heal sighting
+    /// with its fresher console read. Without this, a user who shortens the community and
+    /// hits Re-check still sees the too-long banner until the agent's next re-pull.
+    /// </summary>
+    public void NoteExternalDetection(bool communityTooLong) =>
+        CommunityTooLongDetected = communityTooLong;
+
     // Custom OID config cache. Refreshed every medium-tier cycle.
     private Dictionary<string, List<CustomOidConfiguration>> _customOidsByDevice = new();
     private DateTime _customOidsLoadedAt = DateTime.MinValue;
@@ -585,7 +593,10 @@ public class MonitoringCollectionAgent : BackgroundService
         // check. If it's the same devices still down, we already confirmed the config
         // didn't change (a device problem, not a credential rotation), so wait out the
         // idle backoff rather than re-pulling for habitually-failing devices every cycle.
-        bool escalated = failing > _lastSnmpSelfHealFailingCount;
+        // Exception: while the last verdict was a too-long community, keep the short
+        // cadence - the user is presumably out shortening it, and the fix must be
+        // adopted ~30s after devices reprovision, not after a 15-minute backoff.
+        bool escalated = failing > _lastSnmpSelfHealFailingCount || CommunityTooLongDetected;
         if (!escalated && sinceLast < SnmpSelfHealIdleBackoff) return;
 
         if (_connectionService.Client == null || !_connectionService.IsConnected)

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -263,6 +263,9 @@ public class SnmpDetectionService
                 return current.SnmpDetectionState != SnmpDetectionState.Disabled;
 
             case SnmpDetectionState.EnabledV2c:
+                // Re-enabled after we adopted Disabled counts as a change even when the
+                // credentials are identical - otherwise the state parks at Disabled forever.
+                if (current.SnmpDetectionState == SnmpDetectionState.Disabled) return true;
                 if (current.SnmpVersion != SnmpVersionSetting.V2c) return true;
                 var storedCommunity = string.IsNullOrEmpty(current.SnmpCommunity)
                     ? string.Empty
@@ -270,6 +273,7 @@ public class SnmpDetectionService
                 return !string.Equals(storedCommunity, detected.Community ?? string.Empty, StringComparison.Ordinal);
 
             case SnmpDetectionState.EnabledV3Only:
+                if (current.SnmpDetectionState == SnmpDetectionState.Disabled) return true;
                 if (current.SnmpVersion != SnmpVersionSetting.V3) return true;
                 if (!string.Equals(current.SnmpV3Username, detected.V3Username, StringComparison.Ordinal)) return true;
                 var storedPassword = string.IsNullOrEmpty(current.SnmpV3AuthPassword)

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -8,11 +8,11 @@ namespace NetworkOptimizer.Web.Services;
 public class SnmpDetectionResult
 {
     /// <summary>
-    /// Longest community string the SNMP agents on UniFi devices actually accept.
-    /// UniFi Network lets you save a longer one at the Console level, but the on-device
-    /// agents (gateways included) silently reject requests carrying a community longer
-    /// than this, so everything drops from polling. Warn the user when the detected
-    /// community exceeds this so they can shorten it.
+    /// Longest community string UniFi devices reliably accept. UniFi Network lets you
+    /// save a longer one at the Console level, but past this length device support gets
+    /// firmware-dependent: switches typically silently reject it and drop from polling,
+    /// while gateways often (not always) tolerate it and keep reporting. Warn the user
+    /// when the detected community exceeds this so they can shorten it.
     /// </summary>
     public const int MaxSupportedCommunityLength = 20;
 
@@ -27,7 +27,8 @@ public class SnmpDetectionResult
 
     /// <summary>
     /// True when SNMP v2c is enabled with a community string longer than
-    /// <see cref="MaxSupportedCommunityLength"/> - devices reject it and all polling fails.
+    /// <see cref="MaxSupportedCommunityLength"/> - switches typically drop from polling
+    /// (the gateway may keep reporting) and nothing heals until it's shortened.
     /// </summary>
     public bool CommunityTooLong =>
         SnmpEnabled && Community is { Length: > MaxSupportedCommunityLength };

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -133,52 +133,16 @@ public class SnmpDetectionService
                 };
             }
 
-            if (!settings.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+            var result = ParseSnmpSettings(settings);
+            if (result.Success)
             {
-                return new SnmpDetectionResult
-                {
-                    Success = false,
-                    ErrorMessage = "Unexpected settings response format"
-                };
-            }
-
-            foreach (var item in data.EnumerateArray())
-            {
-                if (!item.TryGetProperty("key", out var key) || key.GetString() != "snmp")
-                    continue;
-
-                var result = new SnmpDetectionResult { Success = true };
-
-                if (item.TryGetProperty("enabled", out var enabled))
-                    result.SnmpEnabled = enabled.GetBoolean();
-
-                if (item.TryGetProperty("enabledV3", out var enabledV3))
-                    result.SnmpV3Enabled = enabledV3.GetBoolean();
-
-                if (item.TryGetProperty("community", out var community))
-                    result.Community = community.GetString();
-
-                if (item.TryGetProperty("username", out var username))
-                    result.V3Username = username.GetString();
-
-                if (item.TryGetProperty("x_password", out var password))
-                    result.V3Password = password.GetString();
-
                 _logger.LogInformation(
                     "SNMP detection: enabled={Enabled}, v3={V3}, community={HasCommunity}, v3user={HasV3User}",
                     result.SnmpEnabled, result.SnmpV3Enabled,
                     !string.IsNullOrEmpty(result.Community),
                     !string.IsNullOrEmpty(result.V3Username));
-
-                return result;
             }
-
-            return new SnmpDetectionResult
-            {
-                Success = true,
-                SnmpEnabled = false,
-                SnmpV3Enabled = false
-            };
+            return result;
         }
         catch (Exception ex)
         {
@@ -188,6 +152,96 @@ public class SnmpDetectionService
                 Success = false,
                 ErrorMessage = $"Failed to read settings: {ex.Message}"
             };
+        }
+    }
+
+    /// <summary>
+    /// Parses the SNMP section out of a raw UniFi settings response (the document
+    /// returned by <c>GetSettingsRawAsync</c>). Pure and side-effect-free so both the
+    /// interactive detection flow and the collection agent's self-heal can share one
+    /// parser and never drift. Returns Success=false only when the response shape is
+    /// unusable; a well-formed response with SNMP off returns Success=true with the
+    /// enabled flags cleared.
+    /// </summary>
+    public static SnmpDetectionResult ParseSnmpSettings(JsonDocument settings)
+    {
+        if (settings == null
+            || !settings.RootElement.TryGetProperty("data", out var data)
+            || data.ValueKind != JsonValueKind.Array)
+        {
+            return new SnmpDetectionResult
+            {
+                Success = false,
+                ErrorMessage = "Unexpected settings response format"
+            };
+        }
+
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!item.TryGetProperty("key", out var key) || key.GetString() != "snmp")
+                continue;
+
+            var result = new SnmpDetectionResult { Success = true };
+
+            if (item.TryGetProperty("enabled", out var enabled))
+                result.SnmpEnabled = enabled.GetBoolean();
+
+            if (item.TryGetProperty("enabledV3", out var enabledV3))
+                result.SnmpV3Enabled = enabledV3.GetBoolean();
+
+            if (item.TryGetProperty("community", out var community))
+                result.Community = community.GetString();
+
+            if (item.TryGetProperty("username", out var username))
+                result.V3Username = username.GetString();
+
+            if (item.TryGetProperty("x_password", out var password))
+                result.V3Password = password.GetString();
+
+            return result;
+        }
+
+        return new SnmpDetectionResult
+        {
+            Success = true,
+            SnmpEnabled = false,
+            SnmpV3Enabled = false
+        };
+    }
+
+    /// <summary>
+    /// Maps a detection result onto a <see cref="MonitoringSettings"/> entity: version,
+    /// community, and v3 credentials, encrypting secrets via <paramref name="credentialProtection"/>.
+    /// Sets <see cref="MonitoringSettings.SnmpDetectionState"/> but leaves the timestamp
+    /// fields to the caller. Shared by the interactive save path and the collection
+    /// agent's self-heal adopt path so credential handling stays identical.
+    /// </summary>
+    public static void ApplyToSettings(
+        MonitoringSettings settings,
+        SnmpDetectionResult result,
+        ICredentialProtectionService credentialProtection)
+    {
+        settings.SnmpDetectionState = result.DetectionState;
+
+        if (result.DetectionState == SnmpDetectionState.EnabledV2c)
+        {
+            settings.SnmpVersion = SnmpVersionSetting.V2c;
+            settings.SnmpCommunity = credentialProtection.Encrypt(result.Community!);
+            if (!string.IsNullOrEmpty(result.V3Username))
+            {
+                settings.SnmpV3Username = result.V3Username;
+                settings.SnmpV3AuthPassword = !string.IsNullOrEmpty(result.V3Password)
+                    ? credentialProtection.Encrypt(result.V3Password)
+                    : null;
+            }
+        }
+        else if (result.DetectionState == SnmpDetectionState.EnabledV3Only)
+        {
+            settings.SnmpVersion = SnmpVersionSetting.V3;
+            settings.SnmpV3Username = result.V3Username;
+            settings.SnmpV3AuthPassword = !string.IsNullOrEmpty(result.V3Password)
+                ? credentialProtection.Encrypt(result.V3Password)
+                : null;
         }
     }
 
@@ -224,30 +278,8 @@ public class SnmpDetectionService
                 db.MonitoringSettings.Add(settings);
             }
 
-            settings.SnmpDetectionState = result.DetectionState;
+            ApplyToSettings(settings, result, _credentialProtection);
             settings.LastSnmpDetection = DateTime.UtcNow;
-
-            if (result.DetectionState == SnmpDetectionState.EnabledV2c)
-            {
-                settings.SnmpVersion = SnmpVersionSetting.V2c;
-                settings.SnmpCommunity = _credentialProtection.Encrypt(result.Community!);
-                if (!string.IsNullOrEmpty(result.V3Username))
-                {
-                    settings.SnmpV3Username = result.V3Username;
-                    settings.SnmpV3AuthPassword = !string.IsNullOrEmpty(result.V3Password)
-                        ? _credentialProtection.Encrypt(result.V3Password)
-                        : null;
-                }
-            }
-            else if (result.DetectionState == SnmpDetectionState.EnabledV3Only)
-            {
-                settings.SnmpVersion = SnmpVersionSetting.V3;
-                settings.SnmpV3Username = result.V3Username;
-                settings.SnmpV3AuthPassword = !string.IsNullOrEmpty(result.V3Password)
-                    ? _credentialProtection.Encrypt(result.V3Password)
-                    : null;
-            }
-
             settings.UpdatedAt = DateTime.UtcNow;
             await db.SaveChangesAsync(ct);
         }

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -222,6 +222,12 @@ public class SnmpDetectionService
     {
         settings.SnmpDetectionState = result.DetectionState;
 
+        // Never store a too-long community: devices reject it, so adopting it clobbers a
+        // possibly-working credential for nothing. Record the state/timestamps (the UI
+        // warning keys off the detection result, not storage) and keep the old creds so
+        // the fixed community registers as a change when the user shortens it.
+        if (result.CommunityTooLong) return;
+
         if (result.DetectionState == SnmpDetectionState.EnabledV2c)
         {
             settings.SnmpVersion = SnmpVersionSetting.V2c;

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -8,12 +8,11 @@ namespace NetworkOptimizer.Web.Services;
 public class SnmpDetectionResult
 {
     /// <summary>
-    /// Longest community string the SNMP agents on UniFi switches (and other network
-    /// devices) will actually accept. UniFi Network lets you set a longer one at the
-    /// Console level, but the per-device agents silently reject requests carrying a
-    /// community longer than this, so those devices drop from polling while the gateway
-    /// (which tolerates it) keeps reporting. Warn the user when the detected community
-    /// exceeds this so they can shorten it.
+    /// Longest community string the SNMP agents on UniFi devices actually accept.
+    /// UniFi Network lets you save a longer one at the Console level, but the on-device
+    /// agents (gateways included) silently reject requests carrying a community longer
+    /// than this, so everything drops from polling. Warn the user when the detected
+    /// community exceeds this so they can shorten it.
     /// </summary>
     public const int MaxSupportedCommunityLength = 20;
 
@@ -28,8 +27,7 @@ public class SnmpDetectionResult
 
     /// <summary>
     /// True when SNMP v2c is enabled with a community string longer than
-    /// <see cref="MaxSupportedCommunityLength"/> - the most common reason switches fail
-    /// to poll while the gateway succeeds.
+    /// <see cref="MaxSupportedCommunityLength"/> - devices reject it and all polling fails.
     /// </summary>
     public bool CommunityTooLong =>
         SnmpEnabled && Community is { Length: > MaxSupportedCommunityLength };

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -245,6 +245,43 @@ public class SnmpDetectionService
         }
     }
 
+    /// <summary>
+    /// Whether the SNMP config just pulled from the console differs from what a
+    /// <see cref="MonitoringSettings"/> row currently holds (version, community, or v3
+    /// credentials), including SNMP having been turned off entirely. Decrypts the stored
+    /// secrets to compare. Shared by the direct-poll self-heal and the agent-site
+    /// re-detect so both decide "did it actually change?" identically.
+    /// </summary>
+    public static bool ConfigDiffers(
+        MonitoringSettings current,
+        SnmpDetectionResult detected,
+        ICredentialProtectionService credentialProtection)
+    {
+        switch (detected.DetectionState)
+        {
+            case SnmpDetectionState.Disabled:
+                return current.SnmpDetectionState != SnmpDetectionState.Disabled;
+
+            case SnmpDetectionState.EnabledV2c:
+                if (current.SnmpVersion != SnmpVersionSetting.V2c) return true;
+                var storedCommunity = string.IsNullOrEmpty(current.SnmpCommunity)
+                    ? string.Empty
+                    : credentialProtection.Decrypt(current.SnmpCommunity);
+                return !string.Equals(storedCommunity, detected.Community ?? string.Empty, StringComparison.Ordinal);
+
+            case SnmpDetectionState.EnabledV3Only:
+                if (current.SnmpVersion != SnmpVersionSetting.V3) return true;
+                if (!string.Equals(current.SnmpV3Username, detected.V3Username, StringComparison.Ordinal)) return true;
+                var storedPassword = string.IsNullOrEmpty(current.SnmpV3AuthPassword)
+                    ? string.Empty
+                    : credentialProtection.Decrypt(current.SnmpV3AuthPassword);
+                return !string.Equals(storedPassword, detected.V3Password ?? string.Empty, StringComparison.Ordinal);
+
+            default:
+                return false;
+        }
+    }
+
     public async Task<MonitoringSettings> GetOrCreateSettingsAsync(CancellationToken ct = default)
     {
         await _settingsLock.WaitAsync(ct);

--- a/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/SnmpDetectionService.cs
@@ -7,6 +7,16 @@ namespace NetworkOptimizer.Web.Services;
 
 public class SnmpDetectionResult
 {
+    /// <summary>
+    /// Longest community string the SNMP agents on UniFi switches (and other network
+    /// devices) will actually accept. UniFi Network lets you set a longer one at the
+    /// Console level, but the per-device agents silently reject requests carrying a
+    /// community longer than this, so those devices drop from polling while the gateway
+    /// (which tolerates it) keeps reporting. Warn the user when the detected community
+    /// exceeds this so they can shorten it.
+    /// </summary>
+    public const int MaxSupportedCommunityLength = 20;
+
     public bool Success { get; set; }
     public string? ErrorMessage { get; set; }
 
@@ -15,6 +25,14 @@ public class SnmpDetectionResult
     public string? Community { get; set; }
     public string? V3Username { get; set; }
     public string? V3Password { get; set; }
+
+    /// <summary>
+    /// True when SNMP v2c is enabled with a community string longer than
+    /// <see cref="MaxSupportedCommunityLength"/> - the most common reason switches fail
+    /// to poll while the gateway succeeds.
+    /// </summary>
+    public bool CommunityTooLong =>
+        SnmpEnabled && Community is { Length: > MaxSupportedCommunityLength };
 
     public SnmpDetectionState DetectionState
     {

--- a/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
@@ -36,9 +36,9 @@ public class SnmpFailureTrackerTests
     }
 
     [Fact]
-    public void ExcludedHealthyCount_CountsOnlyPreviouslyHealthyDevices()
+    public void FailingHealthyCount_CountsOnlyPreviouslyHealthyDevices()
     {
-        var tracker = new SnmpFailureTracker(failureThreshold: 2);
+        var tracker = new SnmpFailureTracker(failureThreshold: 5);
 
         // A and B polled successfully before; C never did (e.g. a device that
         // does not speak SNMP), so its later failures must not count.
@@ -51,7 +51,12 @@ public class SnmpFailureTrackerTests
             tracker.NoteFailure(device);
         }
 
-        tracker.ExcludedHealthyCount().Should().Be(2, "only A and B were healthy before failing");
+        // Two consecutive failures each - below the exclusion threshold, but the
+        // eager self-heal signal counts them the moment they cross minConsecutiveFailures.
+        tracker.FailingHealthyCount(minConsecutiveFailures: 2)
+            .Should().Be(2, "only A and B were healthy before failing");
+        tracker.FailingHealthyCount(minConsecutiveFailures: 3)
+            .Should().Be(0, "neither has 3 consecutive failures yet");
     }
 
     [Fact]
@@ -70,6 +75,6 @@ public class SnmpFailureTrackerTests
         tracker.IsExcluded(DeviceA, out _).Should().BeFalse("exclusions cleared");
         tracker.GetFailureCount(DeviceA).Should().Be(0, "failure counters cleared");
         tracker.HealthyCount.Should().Be(2, "seen-healthy baseline is retained");
-        tracker.ExcludedHealthyCount().Should().Be(0);
+        tracker.FailingHealthyCount().Should().Be(0);
     }
 }

--- a/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
@@ -23,49 +23,48 @@ public class SnmpFailureTrackerTests
     }
 
     [Fact]
-    public void NoteSuccess_MarksDeviceHealthy()
-    {
-        var tracker = new SnmpFailureTracker();
-
-        tracker.HealthyCount.Should().Be(0);
-        tracker.NoteSuccess(DeviceA);
-        tracker.NoteSuccess(DeviceB);
-        tracker.NoteSuccess(DeviceA); // idempotent per device
-
-        tracker.HealthyCount.Should().Be(2);
-    }
-
-    [Fact]
-    public void FailingHealthyCount_CountsOnlyPreviouslyHealthyDevices()
+    public void IsFailing_TrueAtConsecutiveFailures_NoPriorSuccessNeeded()
     {
         var tracker = new SnmpFailureTracker(failureThreshold: 5);
 
-        // A and B polled successfully before; C never did (e.g. a device that
-        // does not speak SNMP), so its later failures must not count.
-        tracker.NoteSuccess(DeviceA);
-        tracker.NoteSuccess(DeviceB);
-
-        foreach (var device in new[] { DeviceA, DeviceB, DeviceC })
-        {
-            tracker.NoteFailure(device);
-            tracker.NoteFailure(device);
-        }
-
-        // Two consecutive failures each - below the exclusion threshold, but the
-        // eager self-heal signal counts them the moment they cross minConsecutiveFailures.
-        tracker.FailingHealthyCount(minConsecutiveFailures: 2)
-            .Should().Be(2, "only A and B were healthy before failing");
-        tracker.FailingHealthyCount(minConsecutiveFailures: 3)
-            .Should().Be(0, "neither has 3 consecutive failures yet");
+        // A cold-start device that never polled successfully - it must still register as
+        // failing (this is the whole point: a restart during an outage can self-heal).
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 2).Should().BeFalse();
+        tracker.NoteFailure(DeviceA);
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 2).Should().BeFalse("only one failure so far");
+        tracker.NoteFailure(DeviceA);
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 2).Should().BeTrue("two consecutive failures");
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 3).Should().BeFalse("not three yet");
     }
 
     [Fact]
-    public void Reset_ClearsFailuresAndExclusions_RetainsHealthyBaseline()
+    public void IsFailing_TrueWhileExcluded()
     {
         var tracker = new SnmpFailureTracker(failureThreshold: 2);
 
+        tracker.NoteFailure(DeviceA);
+        tracker.NoteFailure(DeviceA); // hits threshold -> excluded
+        tracker.IsFailing(DeviceA).Should().BeTrue("excluded devices count as failing");
+    }
+
+    [Fact]
+    public void NoteSuccess_ClearsFailing()
+    {
+        var tracker = new SnmpFailureTracker(failureThreshold: 5);
+
+        tracker.NoteFailure(DeviceA);
+        tracker.NoteFailure(DeviceA);
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 2).Should().BeTrue();
+
         tracker.NoteSuccess(DeviceA);
-        tracker.NoteSuccess(DeviceB);
+        tracker.IsFailing(DeviceA, minConsecutiveFailures: 2).Should().BeFalse("a success resets the counter");
+    }
+
+    [Fact]
+    public void Reset_ClearsFailuresAndExclusions()
+    {
+        var tracker = new SnmpFailureTracker(failureThreshold: 2);
+
         tracker.NoteFailure(DeviceA);
         tracker.NoteFailure(DeviceA);
         tracker.IsExcluded(DeviceA, out _).Should().BeTrue();
@@ -74,7 +73,6 @@ public class SnmpFailureTrackerTests
 
         tracker.IsExcluded(DeviceA, out _).Should().BeFalse("exclusions cleared");
         tracker.GetFailureCount(DeviceA).Should().Be(0, "failure counters cleared");
-        tracker.HealthyCount.Should().Be(2, "seen-healthy baseline is retained");
-        tracker.FailingHealthyCount().Should().Be(0);
+        tracker.IsFailing(DeviceA).Should().BeFalse();
     }
 }

--- a/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/SnmpFailureTrackerTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Monitoring.Tests;
+
+public class SnmpFailureTrackerTests
+{
+    private const string DeviceA = "aa:bb:cc:dd:ee:01";
+    private const string DeviceB = "aa:bb:cc:dd:ee:02";
+    private const string DeviceC = "aa:bb:cc:dd:ee:03";
+
+    [Fact]
+    public void NoteFailure_CrossesThreshold_ExcludesDevice()
+    {
+        var tracker = new SnmpFailureTracker(failureThreshold: 3);
+
+        tracker.NoteFailure(DeviceA).Should().BeFalse();
+        tracker.NoteFailure(DeviceA).Should().BeFalse();
+        tracker.NoteFailure(DeviceA).Should().BeTrue("the third failure hits the threshold");
+
+        tracker.IsExcluded(DeviceA, out _).Should().BeTrue();
+    }
+
+    [Fact]
+    public void NoteSuccess_MarksDeviceHealthy()
+    {
+        var tracker = new SnmpFailureTracker();
+
+        tracker.HealthyCount.Should().Be(0);
+        tracker.NoteSuccess(DeviceA);
+        tracker.NoteSuccess(DeviceB);
+        tracker.NoteSuccess(DeviceA); // idempotent per device
+
+        tracker.HealthyCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void ExcludedHealthyCount_CountsOnlyPreviouslyHealthyDevices()
+    {
+        var tracker = new SnmpFailureTracker(failureThreshold: 2);
+
+        // A and B polled successfully before; C never did (e.g. a device that
+        // does not speak SNMP), so its later failures must not count.
+        tracker.NoteSuccess(DeviceA);
+        tracker.NoteSuccess(DeviceB);
+
+        foreach (var device in new[] { DeviceA, DeviceB, DeviceC })
+        {
+            tracker.NoteFailure(device);
+            tracker.NoteFailure(device);
+        }
+
+        tracker.ExcludedHealthyCount().Should().Be(2, "only A and B were healthy before failing");
+    }
+
+    [Fact]
+    public void Reset_ClearsFailuresAndExclusions_RetainsHealthyBaseline()
+    {
+        var tracker = new SnmpFailureTracker(failureThreshold: 2);
+
+        tracker.NoteSuccess(DeviceA);
+        tracker.NoteSuccess(DeviceB);
+        tracker.NoteFailure(DeviceA);
+        tracker.NoteFailure(DeviceA);
+        tracker.IsExcluded(DeviceA, out _).Should().BeTrue();
+
+        tracker.Reset();
+
+        tracker.IsExcluded(DeviceA, out _).Should().BeFalse("exclusions cleared");
+        tracker.GetFailureCount(DeviceA).Should().Be(0, "failure counters cleared");
+        tracker.HealthyCount.Should().Be(2, "seen-healthy baseline is retained");
+        tracker.ExcludedHealthyCount().Should().Be(0);
+    }
+}


### PR DESCRIPTION
Fixes #1018.

UniFi Network accepts an SNMP Community String longer than UniFi devices reliably support (20 characters) - switches typically drop from polling while the gateway often keeps reporting, which reads as "no data from any of my switches". And when the Community String was rotated (or fixed), Network Optimizer kept polling with the stale credential until Monitoring was toggled off and on.

## Monitoring

### Setup

- **SNMP Community String length warning** - detection flags a Community String over 20 characters with a banner showing the measured length and a Re-check button; the banner auto-dismisses once the console reports a fixed value. A too-long value is never adopted as the polling credential, so a working credential isn't clobbered by a broken one. (#1018, thanks @vipul128 for the report and testing)
- **How to Enable SNMP** - the guide now notes the 20 character max.

### Live View

- **Key-device banner** - when the Community String is too long, the banner names that as the cause (keeping the gateway-down specifics when both apply) instead of pointing at the SNMP device table. It also appears when switches are dropped but a tolerant gateway still polls, which previously surfaced nothing.

### SNMP credential self-heal

- **Direct sites** - when a majority of SNMP-enabled devices fail two consecutive polls, the server re-pulls the SNMP config from the UniFi Console and adopts it if it actually changed, then resets failure tracking so dropped devices retry immediately. A rotated Community String heals in roughly 30-45 seconds, including after a restart mid-outage. Real outages no-op (config unchanged) and back off; devices that never spoke SNMP can't trigger it.
- **Agent sites** - the server re-detects the SNMP config through the agent tunnel every 2 minutes inside the existing config push, adopting and re-pushing changes. Also picks up SNMP being disabled and later re-enabled.
- **Fail-fast polling** - an unreachable device aborts its poll after the first unanswered counter walk instead of grinding through every OID with timeouts, so failures are counted in seconds instead of minutes.

