### PR TITLE
Technitium DNS: prefer /api/status for provider detection

### DIFF
--- a/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
+++ b/src/NetworkOptimizer.Audit/Dns/ThirdPartyDnsDetector.cs
@@ -994,11 +994,15 @@ public class ThirdPartyDnsDetector
     /// </summary>
     private async Task<bool> TryProbeTechnitiumDnsEndpointAsync(string baseUrl, int timeoutSeconds = 3)
     {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+
+        if (await TryProbeTechnitiumStatusAsync(baseUrl, cts.Token))
+            return true;
+
         try
         {
             _logger.LogDebug("Probing Technitium DNS at {Url}", baseUrl);
 
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
             var response = await _httpClient.GetAsync(baseUrl, cts.Token);
 
             if (!response.IsSuccessStatusCode)
@@ -1020,6 +1024,63 @@ public class ThirdPartyDnsDetector
         catch (Exception ex)
         {
             _logger.LogDebug("Technitium DNS probe to {Url} error: {Type} - {Message}", baseUrl, ex.GetType().Name, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Probe the Technitium status API within the parent endpoint's timeout budget.
+    /// </summary>
+    private async Task<bool> TryProbeTechnitiumStatusAsync(string baseUrl, CancellationToken cancellationToken)
+    {
+        var statusUrl = $"{baseUrl}/api/status";
+
+        try
+        {
+            _logger.LogDebug("Probing Technitium DNS status API at {Url}", statusUrl);
+
+            var response = await _httpClient.GetAsync(statusUrl, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+                return false;
+
+            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            using var document = JsonDocument.Parse(content);
+            var root = document.RootElement;
+
+            if (root.ValueKind != JsonValueKind.Object ||
+                !root.TryGetProperty("status", out var status) ||
+                status.ValueKind != JsonValueKind.String ||
+                !string.Equals(status.GetString(), "ok", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var hasDefaultCredentials = root.TryGetProperty("hasDefaultCredentials", out var defaultCredentials) &&
+                defaultCredentials.ValueKind is JsonValueKind.True or JsonValueKind.False;
+            var hasSsoEnabled = root.TryGetProperty("ssoEnabled", out var ssoEnabled) &&
+                ssoEnabled.ValueKind is JsonValueKind.True or JsonValueKind.False;
+
+            return hasDefaultCredentials && hasSsoEnabled;
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogDebug("Technitium DNS status API probe to {Url} timed out", statusUrl);
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug("Technitium DNS status API probe to {Url} failed: {Message}", statusUrl, ex.Message);
+            return false;
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogDebug("Technitium DNS status API probe to {Url} returned invalid JSON: {Message}", statusUrl, ex.Message);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug("Technitium DNS status API probe to {Url} error: {Type} - {Message}", statusUrl, ex.GetType().Name, ex.Message);
             return false;
         }
     }

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/ThirdPartyDnsDetectorTests.cs
@@ -172,6 +172,93 @@ public class ThirdPartyDnsDetectorTests : IDisposable
     }
 
     [Fact]
+    public async Task DetectThirdPartyDnsAsync_TechnitiumStatusApiDetected_FlagsProviderAsTechnitiumDns()
+    {
+        const string baseUrl = "http://10.10.20.30:5380";
+        var httpClient = CreateRequestAwareMockHttpClient(request =>
+        {
+            if (request.RequestUri?.AbsoluteUri == $"{baseUrl}/api/status")
+            {
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("""{"hasDefaultCredentials":false,"ssoEnabled":true,"server":"technitium.example.local","status":"ok"}""")
+                };
+            }
+
+            return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
+        });
+        var detector = CreateDetector(httpClient);
+
+        var result = await detector.DetectThirdPartyDnsAsync(CreateTechnitiumTestNetworks(), customUrl: baseUrl);
+
+        result.Should().ContainSingle();
+        result[0].IsTechnitiumDns.Should().BeTrue();
+        result[0].DnsProviderName.Should().Be("Technitium DNS");
+    }
+
+    [Theory]
+    [InlineData("{\"status\":\"ok\"}")]
+    [InlineData("{\"status\":\"ok\",\"hasDefaultCredentials\":false}")]
+    [InlineData("{\"status\":\"ok\",\"ssoEnabled\":true}")]
+    [InlineData("{\"status\":\"ok\",\"hasDefaultCredentials\":false,\"ssoEnabled\":\"true\"}")]
+    [InlineData("not-json")]
+    public async Task DetectThirdPartyDnsAsync_NonTechnitiumStatusResponse_NotDetectedAsTechnitiumDns(string statusResponse)
+    {
+        var httpClient = CreateRequestAwareMockHttpClient(request =>
+        {
+            if (request.RequestUri?.AbsolutePath == "/api/status")
+            {
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(statusResponse)
+                };
+            }
+
+            return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
+        });
+        var detector = CreateDetector(httpClient);
+
+        var result = await detector.DetectThirdPartyDnsAsync(CreateTechnitiumTestNetworks(), customUrl: "http://10.10.20.30:5380");
+
+        result.Should().ContainSingle();
+        result[0].IsTechnitiumDns.Should().BeFalse();
+        result[0].DnsProviderName.Should().Be("Third-Party LAN DNS");
+    }
+
+    [Fact]
+    public async Task DetectThirdPartyDnsAsync_TechnitiumStatusUnavailable_FallsBackToHtmlDetection()
+    {
+        const string baseUrl = "http://10.10.20.30:5380";
+        var requestedPaths = new List<string>();
+        var technitiumResponse = @"<html><head><title>Technitium DNS Server</title><script src=""js/common.js""></script></head><body>Technitium</body></html>";
+        var httpClient = CreateRequestAwareMockHttpClient(request =>
+        {
+            requestedPaths.Add(request.RequestUri?.AbsolutePath ?? "");
+
+            if (request.RequestUri?.GetLeftPart(UriPartial.Authority) == baseUrl &&
+                request.RequestUri.AbsolutePath == "/")
+            {
+                return new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(technitiumResponse)
+                };
+            }
+
+            return new HttpResponseMessage { StatusCode = HttpStatusCode.NotFound };
+        });
+        var detector = CreateDetector(httpClient);
+
+        var result = await detector.DetectThirdPartyDnsAsync(CreateTechnitiumTestNetworks(), customUrl: baseUrl);
+
+        requestedPaths.Should().Contain("/api/status");
+        result.Should().ContainSingle();
+        result[0].IsTechnitiumDns.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task DetectThirdPartyDnsAsync_TechnitiumTitleWithoutAssets_NotDetectedAsTechnitiumDns()
     {
         var technitiumLikeResponse = @"<html><head><title>Technitium DNS Server</title></head><body>Technitium</body></html>";
@@ -199,6 +286,23 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         result[0].DnsProviderName.Should().Be("Third-Party LAN DNS");
     }
 
+    private static List<NetworkInfo> CreateTechnitiumTestNetworks()
+    {
+        return
+        [
+            new NetworkInfo
+            {
+                Id = "net1",
+                DhcpEnabled = true,
+                Name = "Trusted",
+                VlanId = 1,
+                Subnet = "10.10.20.0/24",
+                Gateway = "10.10.20.1",
+                DnsServers = ["10.10.20.30"]
+            }
+        ];
+    }
+
     private ThirdPartyDnsDetector CreateDetector(HttpClient? httpClient = null)
     {
         httpClient ??= new HttpClient { Timeout = TimeSpan.FromSeconds(3) };
@@ -219,6 +323,20 @@ public class ThirdPartyDnsDetectorTests : IDisposable
                 StatusCode = statusCode,
                 Content = new StringContent(content)
             });
+
+        return new HttpClient(handlerMock.Object) { Timeout = TimeSpan.FromSeconds(3) };
+    }
+
+    private static HttpClient CreateRequestAwareMockHttpClient(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage request, CancellationToken _) => responseFactory(request));
 
         return new HttpClient(handlerMock.Object) { Timeout = TimeSpan.FromSeconds(3) };
     }
@@ -1457,8 +1575,8 @@ public class ThirdPartyDnsDetectorTests : IDisposable
         // HTTP handler should only be called once per unique IP
         // Pi-hole probe: 3 attempts (port 80, 443, 8080)
         // AdGuard Home probe: 3 attempts (port 80, 443, 3000)
-        // Technitium DNS probe: 4 attempts (port 5380, 53443, 80, 443)
-        callCount.Should().BeLessThanOrEqualTo(10);
+        // Technitium DNS probe: 8 attempts (status API and HTML on ports 5380, 53443, 80, 443)
+        callCount.Should().BeLessThanOrEqualTo(14);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Prefer Technitium DNS Server’s `/api/status` endpoint for provider detection while retaining HTML detection for older releases.

Closes #960.

## Testing

- Added coverage for valid, malformed, and incomplete status responses
- Verified legacy HTML fallback
- All 579 DNS-focused tests pass