### PR TITLE
Agent on gateway: correct the firmware-upgrade persistence docs

### DIFF
--- a/scripts/agent/install-agent-gateway.sh
+++ b/scripts/agent/install-agent-gateway.sh
@@ -31,10 +31,12 @@
 # Re-running the installer upgrades the agent in place: it downloads the latest
 # release, keeps the enrolled key, and restarts the service on the new binary.
 #
-# NOTE: the systemd unit lives on the overlay root, so it does not survive a
-# UniFi OS firmware update. The binary and config under /data do persist. After a
-# firmware update, re-run this installer (it keeps the enrolled key) to reinstate
-# the service.
+# Survives firmware upgrades with no action needed: on UniFi OS the root
+# filesystem is an overlay whose writable upper layer IS the persistent /data
+# partition, so a unit written to /etc/systemd/system physically lands on
+# persistent storage (this is exactly how udm-boot itself survives). The binary,
+# config, and systemd unit all carry across a firmware upgrade untouched. (A
+# factory reset wipes /data and needs a fresh install, like anything else.)
 
 set -euo pipefail
 
@@ -90,7 +92,7 @@ esac
 
 # Memory pre-flight: the agent's real steady-state cost is ~50 MB, but the unit
 # fences it at MemoryHigh=256M, so require that much headroom before installing.
-# Skipped when the service is already running (an update/reinstate - its memory
+# Skipped when the service is already running (an update re-run - its memory
 # is already accounted for in MemAvailable).
 MIN_AVAILABLE_MB=256
 if ! systemctl is-active --quiet "${SERVICE_NAME}.service"; then
@@ -117,8 +119,8 @@ mv -f "${INSTALL_DIR}/NetworkOptimizer.Agent.new" "${INSTALL_DIR}/NetworkOptimiz
 
 CONFIG="${INSTALL_DIR}/agent.json"
 
-# Preserve an already-enrolled config so re-running (to update the binary, or to
-# reinstate the service after a firmware update) never wipes the persisted key.
+# Preserve an already-enrolled config so re-running to update the binary never
+# wipes the persisted key.
 if grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
     echo "Existing enrolled agent config found - keeping it."
 else

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -78,11 +78,15 @@ headroom.
 This path is **monitoring-only**: the LAN speed test stays off, because hosting
 an nginx/iperf3 speed-test server on the router would compete with the data
 plane. For LAN speed testing, run a Docker or bare-metal agent on a separate box
-(and size that box to the LAN speed, per above). Two caveats: the systemd unit
-lives on the overlay, so a UniFi OS firmware update drops it - re-run the
-installer to reinstate it (it keeps the enrolled key; the binary and config
-under `/data` persist) - and putting the agent on the gateway trades away the
-"segment the agent box" isolation described under Security and hardening.
+(and size that box to the LAN speed, per above).
+
+It survives UniFi OS firmware upgrades with nothing to re-run: on UniFi OS the
+root filesystem is an overlay whose writable upper layer is the persistent
+`/data` partition, so the binary, config, and the systemd unit under
+`/etc/systemd/system` all live on persistent storage and carry across a firmware
+upgrade untouched (the same reason udm-boot survives). The one trade-off to weigh
+is isolation: putting the agent on the gateway gives up the "segment the agent
+box" hardening described under Security and hardening.
 
 ## Install
 
@@ -136,8 +140,8 @@ curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main
 ```
 
 It accepts `--insecure`, `--dir PATH`, and `--uninstall` (clean teardown). See
-"Where to run it > On a UniFi gateway" for the footprint and firmware-update
-caveats.
+"Where to run it > On a UniFi gateway" for the footprint, firmware-upgrade
+persistence, and the isolation trade-off.
 
 ### Speed test listener: TLS, plain HTTP, and reverse proxies
 


### PR DESCRIPTION
The gateway installer header and agent README claimed the agent's systemd unit lived on the overlay root and was **dropped by a UniFi OS firmware upgrade**, so users had to re-run the installer to reinstate it after every firmware update.

That's wrong. On UniFi OS the root filesystem is an overlay whose writable upper layer **is** the persistent `/data` partition:

```
/  overlayfs-root  overlay  rw,...,lowerdir=/mnt/.rofs,upperdir=/mnt/.rwfs/data,workdir=/mnt/.rwfs/.workdir
```

So a unit written to `/etc/systemd/system/netopt-agent.service` physically lands on persistent storage - the exact mechanism udm-boot itself relies on to survive (its own unit sits in the same place). The binary, config, and systemd unit all carry across a firmware upgrade untouched; there is nothing to re-run. (A factory reset wipes `/data` and needs a fresh install, like anything else.)

**Docs/comment-only.** The installer's behavior was already correct - the v2.2.0 install already produces a firmware-surviving agent. This just deletes the false caveat from the script header, the agent README ("Where to run it" + Install cross-reference), and a stale config-preserve comment.

## Multi-Site

- **On a UniFi gateway** - the setup docs no longer tell users to re-run the installer after a firmware upgrade; the on-gateway agent persists across upgrades on its own.