### PR TITLE
UniFi Device Bridge support: bridged-device names and throughput on the LAN Flow Map

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
@@ -255,6 +255,36 @@ public class UniFiClientResponse
     /// </summary>
     [JsonPropertyName("roam_count")]
     public int? RoamCount { get; set; }
+
+    /// <summary>
+    /// UniFi ecosystem device metadata surfaced by the console (ucore) for an adopted/bridged
+    /// device that shows up as a client - e.g. a UniFi Protect camera bridged onto the LAN via a
+    /// UniFi Device Bridge, or a UNAS. Carries the friendly device name and product line/model.
+    /// Null for ordinary clients.
+    /// </summary>
+    [JsonPropertyName("unifi_device_info_from_ucore")]
+    public UniFiUcoreDeviceInfo? UnifiDeviceInfoFromUcore { get; set; }
+}
+
+/// <summary>
+/// UniFi ecosystem device info (from the console's ucore) for an adopted/bridged device that
+/// appears as a client - e.g. a UniFi Protect camera on a UniFi Device Bridge. The friendly
+/// <see cref="Name"/> is what UniFi shows for the device; the product fields are kept for
+/// identifying the device line/model.
+/// </summary>
+public class UniFiUcoreDeviceInfo
+{
+    /// <summary>Friendly device name as configured in the owning app, e.g. "[Camera] Driveway".</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>Product line, e.g. "PROTECT", "NETWORK", "UNAS".</summary>
+    [JsonPropertyName("product_line")]
+    public string? ProductLine { get; set; }
+
+    /// <summary>Short product/model name, e.g. "UVC G6 Pro Bullet".</summary>
+    [JsonPropertyName("product_shortname")]
+    public string? ProductShortname { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiClientResponse.cs
@@ -274,7 +274,7 @@ public class UniFiClientResponse
 /// </summary>
 public class UniFiUcoreDeviceInfo
 {
-    /// <summary>Friendly device name as configured in the owning app, e.g. "[Camera] Driveway".</summary>
+    /// <summary>Friendly device name as configured in the owning app, e.g. "[Camera] Front Door".</summary>
     [JsonPropertyName("name")]
     public string? Name { get; set; }
 

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -888,7 +888,7 @@ public class DiscoveredClient
     public string DisplayName { get; set; } = string.Empty;
     /// <summary>
     /// Friendly name of a bridged/adopted UniFi ecosystem device (from the console's ucore),
-    /// e.g. a UniFi Protect camera's "[Camera] Driveway" surfaced through a UniFi Device Bridge.
+    /// e.g. a UniFi Protect camera's "[Camera] Front Door" surfaced through a UniFi Device Bridge.
     /// Empty for ordinary clients. Used as a display-label fallback below the user-set Name.
     /// </summary>
     public string UcoreName { get; set; } = string.Empty;

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -381,6 +381,7 @@ public class UniFiDiscovery
                 Hostname = c.Hostname,
                 Name = c.Name,
                 DisplayName = displayNames.TryGetValue(c.Mac.ToLowerInvariant(), out var dn) ? dn : string.Empty,
+                UcoreName = c.UnifiDeviceInfoFromUcore?.Name ?? string.Empty,
                 IpAddress = ipAddress ?? string.Empty,
                 Network = c.Network,
                 NetworkId = c.NetworkId,
@@ -885,6 +886,12 @@ public class DiscoveredClient
     /// Prefer this over <see cref="Name"/>/<see cref="Hostname"/> for display labels.
     /// </summary>
     public string DisplayName { get; set; } = string.Empty;
+    /// <summary>
+    /// Friendly name of a bridged/adopted UniFi ecosystem device (from the console's ucore),
+    /// e.g. a UniFi Protect camera's "[Camera] Driveway" surfaced through a UniFi Device Bridge.
+    /// Empty for ordinary clients. Used as a display-label fallback below the user-set Name.
+    /// </summary>
+    public string UcoreName { get; set; } = string.Empty;
     public string IpAddress { get; set; } = string.Empty;
     public string Network { get; set; } = string.Empty;
     public string NetworkId { get; set; } = string.Empty;

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -731,6 +731,10 @@ public class AgentProbeResultSink
                     // fast tier's RecordInterfaceAggregate(mac, out, in) convention.
                     liveStats.RecordInterfaceAggregate(mDev.Mac, m.Out, m.In, aggNow);
             fabric.WriteAggregates(console.Devices, liveStats, aggNow);
+            // Persist UDB downlink port_table rates to interface_counters for the historic
+            // resolver - identical to the directly-monitored fast tier (in-memory-only live path,
+            // and a UDB has no SNMP interface series to re-derive from during playback).
+            BridgeInterfaceRecorder.Record(fabric, console.Devices, influx, aggNow);
         }
 
         // Reconcile the InterfaceNameMap (friendly name, negotiated speed, port number,

--- a/src/NetworkOptimizer.Web/Services/BridgeInterfaceRecorder.cs
+++ b/src/NetworkOptimizer.Web/Services/BridgeInterfaceRecorder.cs
@@ -1,0 +1,101 @@
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Persists each UniFi Device Bridge (UDB) downlink port_table rate to the interface_counters
+/// InfluxDB measurement so the LAN Flow Map's HISTORIC resolver can re-derive it.
+///
+/// The live path reads a UDB's rate from <see cref="LanFabricAggregator"/> + MonitoringLiveStats,
+/// which are in-memory only. Every other device's boundary aggregate has a durable
+/// interface_counters series to re-derive from during playback (an SNMP uplink port, or a mesh
+/// AP's vwiresta interface). A UDB's throughput uniquely lives on its own port_table - a
+/// UniFi-API signal that is never SNMP-polled - so without this it has no durable series at all.
+///
+/// One summed "bridge-downlink" series is written per UDB, matching the live WriteAggregates
+/// aggregate. Shared by the directly-monitored fast tier (MonitoringCollectionAgent) and the
+/// agent-relayed path (AgentProbeResultSink) so both site types record identically.
+/// </summary>
+public static class BridgeInterfaceRecorder
+{
+    /// <summary>
+    /// Synthetic interface name for a UDB's summed downlink port_table series in
+    /// interface_counters. The historic MeshBackhaul and WiredClient resolvers match on it.
+    /// </summary>
+    public const string DownlinkIfName = "bridge-downlink";
+
+    /// <summary>
+    /// Writes the downlink port_table rate of every DeviceBridge in <paramref name="devices"/>
+    /// to interface_counters. Call right after <see cref="LanFabricAggregator.WriteAggregates"/>
+    /// (its live sibling), once <see cref="LanFabricAggregator.UpdateUnifiPortRates"/> has run so
+    /// PortRate is populated. No-op until a rate is available (needs a prior byte sample to delta).
+    /// </summary>
+    public static void Record(
+        LanFabricAggregator fabric,
+        IReadOnlyList<UniFiDeviceResponse> devices,
+        MonitoringInfluxClient influx,
+        DateTime now)
+    {
+        if (!influx.IsConfigured) return;
+
+        foreach (var dev in devices)
+        {
+            if (dev.DeviceType != DeviceType.DeviceBridge || dev.PortTable == null) continue;
+
+            var devMac = dev.Mac.ToLowerInvariant().Replace("-", ":");
+            double downBps = 0, upBps = 0;
+            long txBytes = 0, rxBytes = 0;
+            long? speedBps = null;
+            bool anyRate = false;
+
+            foreach (var port in dev.PortTable)
+            {
+                if (port.IsUplink) continue;
+                var rate = fabric.PortRate(devMac, port.PortIdx);
+                if (!rate.HasValue) continue;
+
+                // PortRate tuple: DownBps = RX-derived = bytes FROM the bridged client = upload
+                // (upstream, toward the gateway); UpBps = TX-derived = bytes TO the client =
+                // download (downstream). Persist in interface_counters' convention, where
+                // rateIn = downstream/download and rateOut = upstream/upload, so the historic
+                // resolvers read it with the same (Down = rateIn, Up = rateOut) mapping they use
+                // for a vwiresta or SNMP series.
+                downBps += rate.Value.UpBps;
+                upBps += rate.Value.DownBps;
+                txBytes += port.TxBytes;
+                rxBytes += port.RxBytes;
+                if (port.Speed > 0) speedBps = Math.Max(speedBps ?? 0, (long)port.Speed * 1_000_000L);
+                anyRate = true;
+            }
+
+            if (!anyRate) continue;
+
+            _ = influx.WriteInterfaceCountersAsync(
+                deviceMac: devMac,
+                ifName: DownlinkIfName,
+                portId: null,
+                direction: InterfaceDirection.Unknown,
+                bytesIn: txBytes,   // rateIn = download  -> port TX bytes (toward the client)
+                bytesOut: rxBytes,  // rateOut = upload    -> port RX bytes (from the client)
+                rateInBps: downBps,
+                rateOutBps: upBps,
+                speedBps: speedBps,
+                operStatus: 1,
+                errorsIn: 0,
+                errorsOut: 0,
+                discardsIn: 0,
+                discardsOut: 0,
+                hcCounters: true,
+                ucastPktsIn: null,
+                ucastPktsOut: null,
+                mcastPktsIn: null,
+                mcastPktsOut: null,
+                bcastPktsIn: null,
+                bcastPktsOut: null,
+                timestamp: now);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -953,7 +953,7 @@ public class ClientDashboardService
     private ClientIdentity MapClientToIdentity(UniFiClientResponse client, string? displayName = null)
     {
         // Bridged UniFi ecosystem devices (e.g. a Protect camera on a UniFi Device Bridge) have
-        // no user Name/display_name but expose a friendly ucore name like "[Camera] Driveway".
+        // no user Name/display_name but expose a friendly ucore name like "[Camera] Front Door".
         var ucoreName = client.UnifiDeviceInfoFromUcore?.Name;
         return new ClientIdentity
         {

--- a/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientDashboardService.cs
@@ -101,6 +101,7 @@ public class ClientDashboardService
                     c.BestIp!,
                     displayNames.TryGetValue(c.Mac.ToLowerInvariant(), out var dn) ? dn
                         : !string.IsNullOrWhiteSpace(c.Name) ? c.Name
+                        : c.UnifiDeviceInfoFromUcore?.Name is { Length: > 0 } ucore ? ucore
                         : !string.IsNullOrWhiteSpace(c.Hostname) ? c.Hostname : c.BestIp!,
                     c.IsWired))
                 .OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase)
@@ -951,14 +952,18 @@ public class ClientDashboardService
 
     private ClientIdentity MapClientToIdentity(UniFiClientResponse client, string? displayName = null)
     {
+        // Bridged UniFi ecosystem devices (e.g. a Protect camera on a UniFi Device Bridge) have
+        // no user Name/display_name but expose a friendly ucore name like "[Camera] Driveway".
+        var ucoreName = client.UnifiDeviceInfoFromUcore?.Name;
         return new ClientIdentity
         {
             Mac = client.Mac,
             // Prefer UniFi's system-selected display name (v2 active-clients, e.g. a
-            // fingerprint-derived "Apple TV") over the raw stat/sta name, matching Client
-            // Stats and the offline-identity path so an unnamed device never shows as a MAC.
+            // fingerprint-derived "Apple TV") over the raw stat/sta name, then the ucore device
+            // name, matching Client Stats/the map so an unnamed device never shows as a MAC.
             Name = !string.IsNullOrEmpty(displayName) ? displayName
-                 : !string.IsNullOrEmpty(client.Name) ? client.Name : null,
+                 : !string.IsNullOrEmpty(client.Name) ? client.Name
+                 : !string.IsNullOrEmpty(ucoreName) ? ucoreName : null,
             Hostname = !string.IsNullOrEmpty(client.Hostname) ? client.Hostname : null,
             Ip = client.Ip,
             IsWired = client.IsWired,

--- a/src/NetworkOptimizer.Web/Services/LanFabricAggregator.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFabricAggregator.cs
@@ -224,30 +224,29 @@ public sealed class LanFabricAggregator
             // would produce a one-burst / many-zeroes pattern here).
         }
 
-        // Second pass: mesh-uplinked APs need a custom aggregate because
-        // UniFi's device-level stat.tx_bytes / rx_bytes doesn't reliably
-        // include traffic shuttled across the wireless backhaul - the
-        // AP-fallback above can read low or zero even when the AP is
-        // relaying a lot of traffic for downstream gear and its own
-        // wireless clients. Wired APs don't need this: their parent
-        // switch port already sees every byte (wireless clients included)
-        // because that traffic exits the AP via Ethernet. Mesh APs have
-        // no such port to read, so we synthesize the aggregate from two
-        // contributors:
-        //   (a) downstream UniFi devices (switch or another AP plugged
-        //       into the mesh AP's Ethernet downlink) - their boundary
-        //       aggregates were just written in the first pass.
-        //   (b) wireless clients directly associated to this mesh AP -
-        //       their TX/RX throughput maps onto the backhaul flow.
-        // NetworkPathAnalyzer treats device.Uplink.Type == "wireless" as
-        // the mesh marker; mirror that here for consistency with how the
-        // speed-test path tracer identifies mesh hops.
-        foreach (var meshAp in devices.Where(d =>
-            d.DeviceType == DeviceType.AccessPoint
+        // Second pass: wirelessly-uplinked devices - mesh APs AND single-port bridges
+        // (UDBs) - need a custom aggregate because UniFi's device-level stat.tx_bytes /
+        // rx_bytes doesn't reliably include traffic shuttled across the wireless backhaul,
+        // and there's no parent switch port to read (the first pass found nothing for them).
+        // Wired APs/switches don't need this: their parent port already sees every byte.
+        // We synthesize the aggregate from whichever of these contributors apply:
+        //   (a) downstream UniFi devices (switch or another AP plugged into an Ethernet
+        //       downlink) - their boundary aggregates were just written in the first pass.
+        //   (b) wireless clients directly associated to a mesh AP - their TX/RX throughput
+        //       maps onto the backhaul flow.
+        //   (c) for a UDB, the bridged client is a plain wired client (neither a UniFi child
+        //       nor a wifi client), so its throughput lives on the bridge's OWN downlink
+        //       port_table; read that. Restricted to DeviceBridge so a mesh AP never
+        //       double-counts its downstream, which is already covered by (a).
+        // NetworkPathAnalyzer treats device.Uplink.Type == "wireless" as the mesh marker;
+        // mirror that here for consistency with how the speed-test path tracer identifies
+        // mesh hops.
+        foreach (var dev in devices.Where(d =>
+            (d.DeviceType == DeviceType.AccessPoint || d.DeviceType == DeviceType.DeviceBridge)
             && d.Uplink != null
             && string.Equals(d.Uplink.Type, "wireless", StringComparison.OrdinalIgnoreCase)))
         {
-            var meshMac = NormalizeMac(meshAp.Mac);
+            var devMac = NormalizeMac(dev.Mac);
             double sumIn = 0, sumOut = 0;
             bool anyContribution = false;
 
@@ -255,7 +254,7 @@ public sealed class LanFabricAggregator
             foreach (var child in devices)
             {
                 if (child.Uplink == null || string.IsNullOrEmpty(child.Uplink.UplinkMac)) continue;
-                if (!string.Equals(NormalizeMac(child.Uplink.UplinkMac), meshMac, StringComparison.OrdinalIgnoreCase)) continue;
+                if (!string.Equals(NormalizeMac(child.Uplink.UplinkMac), devMac, StringComparison.OrdinalIgnoreCase)) continue;
                 var stats = liveStats.GetForDevice(child.Mac);
                 if (stats == null || !stats.LastRateUpdate.HasValue) continue;
                 sumIn += stats.RateInBps ?? 0;
@@ -267,7 +266,8 @@ public sealed class LanFabricAggregator
             // is AP -> client (downloads, gateway-relative), Rx is the
             // reverse (uploads). Sum onto the same RateIn / RateOut sides
             // the children write so the totals stay direction-consistent.
-            foreach (var wc in liveStats.GetWifiClientsForAp(meshAp.Mac))
+            // A UDB is not an AP, so this yields nothing for it.
+            foreach (var wc in liveStats.GetWifiClientsForAp(dev.Mac))
             {
                 var rx = wc.RxThroughputBps ?? 0;
                 var tx = wc.TxThroughputBps ?? 0;
@@ -279,17 +279,37 @@ public sealed class LanFabricAggregator
                 }
             }
 
+            // (c) UDB bridged wired client: its bytes live on the bridge's own downlink
+            // port_table. Same direction convention as a parent reading a port toward a
+            // child (port RX = uploads from the client, TX = downloads to it), so add
+            // (DownBps, UpBps) onto the same (sumIn, sumOut) sides as (a)/(b). DeviceBridge
+            // only - a mesh AP's own downstream is already counted in (a).
+            if (dev.DeviceType == DeviceType.DeviceBridge && dev.PortTable != null)
+            {
+                foreach (var port in dev.PortTable)
+                {
+                    if (port.IsUplink) continue;
+                    var portRate = PortRate(devMac, port.PortIdx);
+                    if (portRate.HasValue)
+                    {
+                        sumIn += portRate.Value.DownBps;
+                        sumOut += portRate.Value.UpBps;
+                        anyContribution = true;
+                    }
+                }
+            }
+
             // SNMP first-pass (vwiresta) is the most accurate source. Only
             // overwrite if SNMP didn't get a chance (e.g. AP unreachable via
             // SNMP) - i.e. the live-stats entry has no aggregate yet.
             if (anyContribution)
             {
-                var existing = liveStats.GetForDevice(meshAp.Mac);
+                var existing = liveStats.GetForDevice(dev.Mac);
                 bool snmpAlreadySet = existing?.RateInBps.HasValue == true
                                       || existing?.RateOutBps.HasValue == true;
                 if (!snmpAlreadySet)
                 {
-                    liveStats.RecordInterfaceAggregate(meshAp.Mac, sumIn, sumOut, now);
+                    liveStats.RecordInterfaceAggregate(dev.Mac, sumIn, sumOut, now);
                 }
             }
         }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -150,6 +150,13 @@ public class LanLink
     /// <summary>Stable correlation key for wired throughput chain: device MAC + ifName (spec 3.7).
     /// Also the lookup key for MonitoringLiveStats.GetPortRate per-port live tick refreshes.</summary>
     public string? PortKey { get; set; }
+
+    /// <summary>Server-side only. Set to the parent's device MAC ONLY for a wired-client link whose
+    /// parent is a single-port UniFi Device Bridge (UDB). The live-rate pass sources this leaf's
+    /// rate from the bridge's device aggregate, because the bridged client's own wired byte
+    /// counters are always zero. Null for every other link, so no existing case is affected.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public string? BridgeParentMac { get; set; }
 }
 
 public enum LanCloudKind

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -678,6 +678,14 @@ public class LanFlowMapService
                                         && !p.IfName.Contains('.'))
                                     .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
                                     .FirstOrDefault();
+                                // UDB single-port bridge: no vwiresta interface. Its downlink
+                                // port_table rate is persisted under a synthetic "bridge-downlink"
+                                // series (BridgeInterfaceRecorder), stored in the same rateIn =
+                                // downstream convention, so it maps through the block below.
+                                resolved ??= cPts
+                                    .Where(p => string.Equals(p.IfName, BridgeInterfaceRecorder.DownlinkIfName, StringComparison.OrdinalIgnoreCase))
+                                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                                    .FirstOrDefault();
                             }
                             else
                             {
@@ -746,6 +754,25 @@ public class LanFlowMapService
                             if (closest != null)
                                 rates = MapPortToLinkRates(link, closest.RateInBps ?? 0, closest.RateOutBps ?? 0, closest.Time);
                         }
+                    }
+                    // UDB bridged leaf: the client's own wired counters are always zero, so source
+                    // the rate from the bridge's persisted downlink series (mirrors the live path's
+                    // BridgeParentMac substitution). Set only for DeviceBridge parents, so switch/AP
+                    // clients keep the wired_client fallback below untouched.
+                    if (rates == null && !string.IsNullOrEmpty(link.BridgeParentMac)
+                        && ratesByDevice.TryGetValue(link.BridgeParentMac, out var bpts))
+                    {
+                        var closest = bpts
+                            .Where(p => string.Equals(p.IfName, BridgeInterfaceRecorder.DownlinkIfName, StringComparison.OrdinalIgnoreCase))
+                            .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
+                            .FirstOrDefault();
+                        if (closest != null)
+                            rates = new LinkLiveRates
+                            {
+                                DownstreamBps = closest.RateInBps ?? 0,
+                                UpstreamBps = closest.RateOutBps ?? 0,
+                                AsOf = closest.Time,
+                            };
                     }
                     // Fallback: wired_client from batch pre-fetch
                     if (rates == null)
@@ -2105,6 +2132,9 @@ public class LanFlowMapService
                 var (mac, _) = ParsePortKey(link.PortKey);
                 if (!string.IsNullOrEmpty(mac)) deviceMacs.Add(mac);
             }
+            // A UDB-bridged client leaf sources its historic rate from the bridge's persisted
+            // downlink series, so make sure the bridge's interface rows are fetched.
+            if (!string.IsNullOrEmpty(link.BridgeParentMac)) deviceMacs.Add(link.BridgeParentMac);
         }
 
         var ratesByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.InterfaceRatePoint>>(

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -352,6 +352,24 @@ public class LanFlowMapService
                         }
                     }
                 }
+                // UDB (single-port bridge) leaf: the bridged client's own wired counters are
+                // always zero, so source the rate from the bridge's device aggregate (the same
+                // value shown on the UDB's wireless-uplink link, since it's a single flow).
+                // BridgeParentMac is set only for DeviceBridge parents, so switch/AP clients
+                // never take this path and keep their existing client-counter behavior.
+                if (rates == null && !string.IsNullOrEmpty(link.BridgeParentMac))
+                {
+                    var bridge = _liveStats.GetForDevice(link.BridgeParentMac);
+                    if (bridge != null && bridge.LastRateUpdate.HasValue)
+                    {
+                        rates = new LinkLiveRates
+                        {
+                            DownstreamBps = bridge.RateOutBps ?? 0,
+                            UpstreamBps = bridge.RateInBps ?? 0,
+                            AsOf = bridge.LastRateUpdate.Value,
+                        };
+                    }
+                }
                 // Fallback: UniFi client stats (for switches without SNMP).
                 // TX from the client's perspective = upload = upstream on the link.
                 if (rates == null)
@@ -1382,6 +1400,13 @@ public class LanFlowMapService
                         if (string.IsNullOrEmpty(node.SwitchPortName) && !string.IsNullOrEmpty(port.Name))
                             node.SwitchPortName = port.Name;
                     }
+
+                    // A UDB (single-port bridge) never reports non-zero wired byte counters for the
+                    // client behind it, so tag this leaf to source its live rate from the bridge's
+                    // device aggregate instead. Only DeviceBridge parents are tagged - switch/AP
+                    // clients keep their existing (working) client-counter path untouched.
+                    if (parentDev.DeviceType == DeviceType.DeviceBridge)
+                        link.BridgeParentMac = parentMac;
                 }
             }
             else if (!c.IsWired)
@@ -2035,6 +2060,9 @@ public class LanFlowMapService
     {
         if (!string.IsNullOrWhiteSpace(c.DisplayName)) return c.DisplayName;
         if (!string.IsNullOrWhiteSpace(c.Name)) return c.Name;
+        // Bridged UniFi ecosystem devices (Protect cameras, UNAS) carry no user Name/DisplayName
+        // but expose a friendly ucore name; prefer it over the auto-generated hostname.
+        if (!string.IsNullOrWhiteSpace(c.UcoreName)) return c.UcoreName;
         if (!string.IsNullOrWhiteSpace(c.Hostname)) return c.Hostname;
         return string.IsNullOrEmpty(c.Mac) ? "unknown" : c.Mac;
     }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -833,7 +833,12 @@ public class LanFlowMapService
                     var isGw = node.Kind == LanNodeKind.Gateway;
                     var filtered = isGw
                         ? rates.Where(p => System.Text.RegularExpressions.Regex.IsMatch(p.IfName, @"^eth\d+$"))
-                        : rates;
+                        // Exclude the synthetic UDB bridge-downlink series: it's a single directional
+                        // flow, not a switch fabric, so summing it as ingress/egress makes a bridge
+                        // look asymmetric. Dropping it leaves the bridge with no fabric badge, so it
+                        // falls back to adjacent-link summing (symmetric) - matching the live badge,
+                        // which has no fabric series for a UDB either.
+                        : rates.Where(p => !string.Equals(p.IfName, BridgeInterfaceRecorder.DownlinkIfName, StringComparison.OrdinalIgnoreCase));
                     var closestRates = filtered
                         .GroupBy(p => p.Time)
                         .OrderBy(g => Math.Abs((g.Key - at).TotalMilliseconds))

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -512,7 +512,12 @@ public class MonitoringCollectionAgent : BackgroundService
         // synthesis, and gateway WAN rates, with all the direction conventions and
         // fallbacks. Shared verbatim with the agent-relayed path (AgentProbeResultSink)
         // via LanFabricAggregator so secondary sites compute identical numbers.
-        _fabric.WriteAggregates(devices, _liveStats, DateTime.UtcNow);
+        var aggNow = DateTime.UtcNow;
+        _fabric.WriteAggregates(devices, _liveStats, aggNow);
+        // Persist UDB downlink port_table rates to interface_counters so the historic LAN-flow-map
+        // resolver can re-derive them (the live path above is in-memory only, and a UDB has no
+        // SNMP interface series). Shared verbatim with the agent-relayed path.
+        BridgeInterfaceRecorder.Record(_fabric, devices, _influx, aggNow);
     }
 
     /// <summary>


### PR DESCRIPTION
Adds first-class support for UniFi Device Bridge (UDB) setups - friendly names for bridged UniFi ecosystem devices, and throughput for the bridge and the device behind it.

## Monitoring - Live View

- **Bridged device names on the LAN Flow Map** - A device bridged onto the LAN through a UDB (e.g. a UniFi Protect camera) carries no user-set name and no system display name - only an auto-generated hostname - so it rendered as that raw hostname. It now resolves the friendly name the console keeps for it (`unifi_device_info_from_ucore`), reading as e.g. "[Camera] Front Door", with the bridge itself shown as "[Bridge] ...".

- **UDB throughput on the LAN Flow Map** - A UDB uplinks over Wi-Fi with its bridged client on a single downlink port, and UniFi reports that client's own wired counters as zero - so both the UDB's uplink link and the bridged-client leaf showed no throughput at all. Both now show the real rate, read from the UDB's own port_table and folded into the existing mesh-AP backhaul synthesis (gated to bridges, so switches, their clients, and mesh APs are untouched). It works in live view and in historic timeline playback - the bridge rate is persisted so the scrubber can replay it - for both directly-monitored and agent-relayed sites.

## Client Performance

- **Bridged device names** - The same ucore-name fallback applies to the Client Performance identity and the device picker, so a bridged camera shows its friendly name rather than a MAC.

## Known limitation

If a bridged client is physically moved to a *different* bridge, historic playback attributes its leaf to whichever bridge it is on now (the map overlays past rates on the current topology - the same simplification every link makes today). This is left for the planned historic topology / port-role recording to resolve uniformly rather than special-cased here. The bridge uplink links are unaffected.
