### PR TITLE
ISP Health: involvement-weighted Transit Health, destination-absolved transit jitter, off-path hop guidance

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -321,6 +321,19 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### Upstream path discovery: broaden trace exposure for transit attribution (Setup tab)
+Transit Health involvement weighting and destination->transit jitter absolution both key off which
+monitored internet targets a transit ASN provably carries (trace ancestry). On heavily-peered
+connections the current CDN/DNS targets all peer at the local IX, so they cross no transit and the
+attribution has nothing to work with (both fall back to equal weight / no absolve). Add AWS service
+endpoints (S3 / DynamoDB regional) as extra trace targets - they often ride paid transit where
+CDN/DNS peer directly, so they'd expose the transit path and feed both mechanisms.
+Caveats that make this its own change, not a one-liner:
+- **Not anycast** - resolve + latency-rank to the nearest region instead of a fixed endpoint, else
+  you trace a transcontinental path that misrepresents the transit.
+- **Often no ICMP** - treat them as path-exposure-only (traced but not a pingable monitored target,
+  like the existing transit probes) or add TCP-probe support to the fallback map + injection.
+
 ### Investigation Functions (Network Performance tab)
 The Investigate card currently jumps the latency charts to the most recent **packet-loss** and **loaded-loss** events and steps event-to-event (coalesced, peak-loss minute). Ideas to extend it:
 

--- a/TODO.md
+++ b/TODO.md
@@ -321,18 +321,22 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
-### Upstream path discovery: broaden trace exposure for transit attribution (Setup tab)
+### Upstream path discovery: DynamoDB regional endpoints for transit trace exposure (Setup tab)
 Transit Health involvement weighting and destination->transit jitter absolution both key off which
-monitored internet targets a transit ASN provably carries (trace ancestry). On heavily-peered
-connections the current CDN/DNS targets all peer at the local IX, so they cross no transit and the
-attribution has nothing to work with (both fall back to equal weight / no absolve). Add AWS service
-endpoints (S3 / DynamoDB regional) as extra trace targets - they often ride paid transit where
-CDN/DNS peer directly, so they'd expose the transit path and feed both mechanisms.
-Caveats that make this its own change, not a one-liner:
-- **Not anycast** - resolve + latency-rank to the nearest region instead of a fixed endpoint, else
-  you trace a transcontinental path that misrepresents the transit.
-- **Often no ICMP** - treat them as path-exposure-only (traced but not a pingable monitored target,
-  like the existing transit probes) or add TCP-probe support to the fallback map + injection.
+monitored internet targets a transit ASN provably carries (trace ancestry). The current CDN/DNS
+targets peer at the local IX, so they cross no transit and give the attribution nothing to work with.
+AWS DynamoDB regional endpoints ARE ICMP-pingable and DO ride paid transit, so they're good extra
+trace targets (and can double as monitored targets):
+
+    dynamodb.<region>.amazonaws.com   (nearest region(s) first, e.g. us-west-2, us-west-1, us-east-2, us-east-1)
+
+- **Not anycast** - resolve + latency-rank to the nearest region(s), else you trace a transcontinental
+  path that misrepresents the transit.
+- **Attribution still needs work (observed in testing):** the endpoint pings and the path is NOT
+  peered, but the intermediate transit hops don't answer traceroute (all stars) - so the current
+  ancestry can't tell WHICH transit ASN it crossed. DynamoDB gives a clean AWS target that genuinely
+  transits; surfacing which transit still needs the responding-hop-ASN capture (record every
+  responding hop's ASN, not just monitored-target IPs), and pure-star segments recover nothing.
 
 ### Investigation Functions (Network Performance tab)
 The Investigate card currently jumps the latency charts to the most recent **packet-loss** and **loaded-loss** events and steps event-to-event (coalesced, peak-loss minute). Ideas to extend it:

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2828,8 +2828,9 @@ else
             await _latencyTargetsCard.ExpandAndHighlightAsync(targetId);
     }
 
-    // ISP Health disable hint (off-path, jittery hop): switch to the Setup tab, then highlight the
-    // target once its card mounts (handled in OnAfterRenderAsync via _pendingLatencyJumpId).
+    // ISP Health disable hint (off-path, jittery hop): switch to the Network Performance tab (where
+    // Latency targets lives, same as JumpToLatencyTargetAsync), then highlight the target once its
+    // card mounts (handled in OnAfterRenderAsync via _pendingLatencyJumpId).
     private int? _pendingLatencyJumpId;
 
     private void ReviewIspHopInLatencyTargets(string targetId)
@@ -2837,7 +2838,7 @@ else
         var id = _targets.FirstOrDefault(t => t.TargetId == targetId)?.Id;
         if (id == null) return;
         _pendingLatencyJumpId = id;
-        SetActiveTab("setup");
+        SetActiveTab("performance");
     }
 
     private async Task DismissLanFlakyHintAsync(MonitoringTarget target)
@@ -3528,8 +3529,8 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // Pending jump from the ISP Health disable hint: once the Setup tab's Latency targets card
-        // has mounted, expand + highlight the target, then clear so it fires once.
+        // Pending jump from the ISP Health disable hint: once the Network Performance tab's Latency
+        // targets card has mounted, expand + highlight the target, then clear so it fires once.
         if (_pendingLatencyJumpId is int jumpId && _latencyTargetsCard != null)
         {
             _pendingLatencyJumpId = null;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -369,7 +369,7 @@ else
         {
             @FlakyTargetsBanner
         }
-        <IspHealthPanel />
+        <IspHealthPanel OnReviewTarget="ReviewIspHopInLatencyTargets" />
     }
 
     @* ──────────────── Tab: Network Performance ──────────────── *@
@@ -2828,6 +2828,18 @@ else
             await _latencyTargetsCard.ExpandAndHighlightAsync(targetId);
     }
 
+    // ISP Health disable hint (off-path, jittery hop): switch to the Setup tab, then highlight the
+    // target once its card mounts (handled in OnAfterRenderAsync via _pendingLatencyJumpId).
+    private int? _pendingLatencyJumpId;
+
+    private void ReviewIspHopInLatencyTargets(string targetId)
+    {
+        var id = _targets.FirstOrDefault(t => t.TargetId == targetId)?.Id;
+        if (id == null) return;
+        _pendingLatencyJumpId = id;
+        SetActiveTab("setup");
+    }
+
     private async Task DismissLanFlakyHintAsync(MonitoringTarget target)
     {
         try
@@ -3516,6 +3528,14 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        // Pending jump from the ISP Health disable hint: once the Setup tab's Latency targets card
+        // has mounted, expand + highlight the target, then clear so it fires once.
+        if (_pendingLatencyJumpId is int jumpId && _latencyTargetsCard != null)
+        {
+            _pendingLatencyJumpId = null;
+            await _latencyTargetsCard.ExpandAndHighlightAsync(jumpId);
+        }
+
         // The chart containers only exist while the console is connected - the whole
         // tab region renders behind the connection banner. Without this guard, a page
         // opened during a console outage (agent-backed site waiting for its tunnel,

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1,5 +1,6 @@
 @using NetworkOptimizer.Web.Services.Monitoring.IspHealth
 @using NetworkOptimizer.Storage.Models
+@using System.Globalization
 @implements IDisposable
 @inject IspHealthService IspHealth
 @inject NavigationManager NavigationManager
@@ -420,19 +421,21 @@ else
                                             ? PhysicalLinkInvestigateTooltip(r.PhysicalLinkSelectedKey, r.PhysicalLinkMedium)
                                             : "Jump to the most recent matching loss event on the Network Performance charts";
                                     }
-                                    @if (investigateUrl != null)
-                                    {
-                                        <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
-                                           data-tooltip="@investigateTooltip" data-tooltip-hover-only>@factor.Name</a>
-                                    }
-                                    else
-                                    {
-                                        <span class="isp-factor-name">@factor.Name</span>
-                                    }
-                                    @if (!string.IsNullOrEmpty(factor.InvolvementTooltip))
-                                    {
-                                        <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@factor.InvolvementTooltip">½</span>
-                                    }
+                                    <div class="isp-factor-name-row">
+                                        @if (investigateUrl != null)
+                                        {
+                                            <a class="isp-factor-name isp-factor-link" href="@investigateUrl"
+                                               data-tooltip="@investigateTooltip" data-tooltip-hover-only>@factor.Name</a>
+                                        }
+                                        else
+                                        {
+                                            <span class="isp-factor-name">@factor.Name</span>
+                                        }
+                                        @if (!string.IsNullOrEmpty(factor.InvolvementTooltip))
+                                        {
+                                            @InvolvementPie(factor.Weight, factor.InvolvementTooltip!)
+                                        }
+                                    </div>
                                     @if (!string.IsNullOrEmpty(factor.ValueText))
                                     {
                                         <span class="isp-factor-value">@factor.ValueText</span>
@@ -485,7 +488,13 @@ else
                         <div class="isp-asn-card">
                             <div class="isp-asn-card-header">
                                 <div>
-                                    <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
+                                    <div class="isp-asn-name-row">
+                                        <div class="isp-asn-name">@(string.IsNullOrEmpty(asn.AsnName) ? $"AS{asn.AsnNumber}" : asn.AsnName)</div>
+                                        @if (!string.IsNullOrEmpty(asn.InvolvementTooltip))
+                                        {
+                                            @InvolvementPie(asn.InvolvementWeight ?? 1.0, asn.InvolvementTooltip!)
+                                        }
+                                    </div>
                                     <div class="isp-asn-sub">@(isIspAsn ? "ISP network" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
                                 </div>
                                 <span class="isp-asn-grade @ScoreTextClass(asn.OverallScore)">@(asn.OverallScore?.ToString() ?? "--")</span>
@@ -653,6 +662,34 @@ else
 
 @code {
     private const int NetworkPreviewCount = 5;
+
+    // Arm 4: pie-slice icon showing a transit ASN's internet-host involvement weight (0.25-1.0).
+    private RenderFragment InvolvementPie(double weight, string tooltip) => @<span class="isp-involvement-pie" data-tooltip="@tooltip">
+        <svg viewBox="0 0 16 16" width="13" height="13" aria-hidden="true">
+            <circle cx="8" cy="8" r="6" fill="var(--bg-tertiary)" stroke="var(--text-muted)" stroke-width="1"></circle>
+            @if (weight >= 0.999)
+            {
+                <circle cx="8" cy="8" r="6" fill="var(--primary-color)"></circle>
+            }
+            else
+            {
+                <path d="@PieSlicePath(weight)" fill="var(--primary-color)"></path>
+            }
+        </svg>
+    </span>;
+
+    // SVG path for a pie wedge filled from 12 o'clock clockwise by `fraction` of a full turn, on a
+    // 16x16 viewBox, radius 6. Empty for fraction <= 0; the full-circle case is handled by the caller.
+    private static string PieSlicePath(double fraction)
+    {
+        fraction = Math.Clamp(fraction, 0, 1);
+        if (fraction <= 0) return string.Empty;
+        var theta = 2 * Math.PI * fraction;
+        var ex = 8 + 6 * Math.Sin(theta);
+        var ey = 8 - 6 * Math.Cos(theta);
+        var large = fraction > 0.5 ? 1 : 0;
+        return string.Create(CultureInfo.InvariantCulture, $"M8,8 L8,2 A6,6 0 {large} 1 {ex:0.##},{ey:0.##} Z");
+    }
 
     private IspHealthReport? _report;
     private bool _loading = true;

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -345,11 +345,11 @@ else
                                             @target.Name
                                             @if (target.IsGradedHop)
                                             {
-                                                <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
+                                                <span class="isp-target-badge isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
                                             }
                                             @if (target.SuggestDisable)
                                             {
-                                                <button type="button" class="isp-target-disable-hint"
+                                                <button type="button" class="isp-target-badge isp-target-disable-hint"
                                                         data-tooltip="Not on your traced path but adding jitter - review in Latency targets to disable"
                                                         @onclick="() => OnReviewTarget.InvokeAsync(target.TargetId)">Not on path &#9888;</button>
                                             }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -429,6 +429,10 @@ else
                                     {
                                         <span class="isp-factor-name">@factor.Name</span>
                                     }
+                                    @if (!string.IsNullOrEmpty(factor.InvolvementTooltip))
+                                    {
+                                        <span class="tooltip-icon tooltip-icon-sm" data-tooltip="@factor.InvolvementTooltip">½</span>
+                                    }
                                     @if (!string.IsNullOrEmpty(factor.ValueText))
                                     {
                                         <span class="isp-factor-value">@factor.ValueText</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -347,6 +347,12 @@ else
                                             {
                                                 <span class="isp-target-graded" data-tooltip="The lowest-RTT ISP hop; access-layer idle latency is measured from it">Lowest RTT</span>
                                             }
+                                            @if (target.SuggestDisable)
+                                            {
+                                                <button type="button" class="isp-target-disable-hint"
+                                                        data-tooltip="Not on your traced path but adding jitter - review in Latency targets to disable"
+                                                        @onclick="() => OnReviewTarget.InvokeAsync(target.TargetId)">Not on path &#9888;</button>
+                                            }
                                         </div>
                                         <div class="isp-factor-bar-track">
                                             <div class="isp-factor-bar @BarClass(target.OverallScore)" style="width: @(target.OverallScore ?? 0)%"></div>
@@ -662,6 +668,10 @@ else
 
 @code {
     private const int NetworkPreviewCount = 5;
+
+    // Raised when the user clicks the disable hint on an off-path, jittery ISP hop; the parent jumps
+    // to the Latency targets card so they can pause it. Argument is the hop's TargetId.
+    [Parameter] public EventCallback<string> OnReviewTarget { get; set; }
 
     // Arm 4: pie-slice icon showing a transit ASN's internet-host involvement weight (0.25-1.0).
     private RenderFragment InvolvementPie(double weight, string tooltip) => @<span class="isp-involvement-pie" data-tooltip="@tooltip">

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -133,8 +133,8 @@ public class IspAsnHealth
     /// <summary>Fraction-icon tooltip built from the involvement fields; null when not shown.</summary>
     public string? InvolvementTooltip => !ShowInvolvement || InvolvementWeight is not double w ? null
         : InvolvementReach > 0
-            ? $"Carries {InvolvementReach}/{InvolvementHostTotal} hosts (forward path), {w * 100:0}% weight"
-            : $"Off the forward path; held at {w * 100:0}% (likely the return path from popular services)";
+            ? $"Carries {InvolvementReach} of {InvolvementHostTotal} internet targets (forward path), {w * 100:0}% weight"
+            : $"No internet target's forward path crosses this; held at {w * 100:0}% (likely their return path)";
 
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -133,8 +133,8 @@ public class IspAsnHealth
     /// <summary>Fraction-icon tooltip built from the involvement fields; null when not shown.</summary>
     public string? InvolvementTooltip => !ShowInvolvement || InvolvementWeight is not double w ? null
         : InvolvementReach > 0
-            ? $"Carries {InvolvementReach} of {InvolvementHostTotal} monitored internet host{(InvolvementHostTotal == 1 ? "" : "s")} - weighted at {w * 100:0}% in Transit Health"
-            : $"No monitored internet host is confirmed on this transit's path - weighted at {w * 100:0}% (the minimum)";
+            ? $"Carries {InvolvementReach} of {InvolvementHostTotal} monitored internet host{(InvolvementHostTotal == 1 ? "" : "s")} on the forward path - weighted at {w * 100:0}% in Transit Health"
+            : $"No monitored host's forward path crosses this transit, so it's held at the {w * 100:0}% minimum rather than dropped - it still counts because return traffic from popular services often comes back this way (asymmetric routing, which a forward traceroute can't see).";
 
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -111,6 +111,31 @@ public class IspAsnHealth
     /// <summary>Median RTT beyond the first clean ISP hop. Null for ISP ASNs.</summary>
     public double? ReachDeltaMs { get; init; }
 
+    /// <summary>
+    /// Arm 4 - internet-host involvement, for transit ASNs. Set only when attribution is known
+    /// (hop order + destinations); left false/null for ISP ASNs and unattributable installs.
+    /// </summary>
+    public bool ShowInvolvement { get; set; }
+
+    /// <summary>How many monitored internet destinations are proven to route through this ASN.</summary>
+    public int InvolvementReach { get; set; }
+
+    /// <summary>Total monitored internet destinations (the denominator of the involvement fraction).</summary>
+    public int InvolvementHostTotal { get; set; }
+
+    /// <summary>
+    /// The 0.25-1.0 weight this ASN's own score carries in Transit Health; the remaining (1 - weight)
+    /// blends to a neutral 100, so a transit carrying none of your hosts can't drag the dimension.
+    /// Null when involvement isn't shown.
+    /// </summary>
+    public double? InvolvementWeight { get; set; }
+
+    /// <summary>Fraction-icon tooltip built from the involvement fields; null when not shown.</summary>
+    public string? InvolvementTooltip => !ShowInvolvement || InvolvementWeight is not double w ? null
+        : InvolvementReach > 0
+            ? $"Carries {InvolvementReach} of {InvolvementHostTotal} monitored internet host{(InvolvementHostTotal == 1 ? "" : "s")} - weighted at {w * 100:0}% in Transit Health"
+            : $"No monitored internet host is confirmed on this transit's path - weighted at {w * 100:0}% (the minimum)";
+
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }
     public int? LossScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -53,6 +53,14 @@ public class IspScoreFactor
 
     /// <summary>What was measured and against which expectation.</summary>
     public string? Description { get; init; }
+
+    /// <summary>
+    /// For transit ASNs (Arm 4): the involvement-weight tooltip, e.g. "Carries 6 of 8 monitored
+    /// internet hosts - weighted at 100% in Transit Health". Null when involvement doesn't
+    /// differentiate (no host attributable to any transit, so all fall to equal weight) - the UI
+    /// shows the fraction icon only when this is set.
+    /// </summary>
+    public string? InvolvementTooltip { get; init; }
 }
 
 /// <summary>One of the three top-level score dimensions.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -133,8 +133,8 @@ public class IspAsnHealth
     /// <summary>Fraction-icon tooltip built from the involvement fields; null when not shown.</summary>
     public string? InvolvementTooltip => !ShowInvolvement || InvolvementWeight is not double w ? null
         : InvolvementReach > 0
-            ? $"Carries {InvolvementReach} of {InvolvementHostTotal} monitored internet host{(InvolvementHostTotal == 1 ? "" : "s")} on the forward path - weighted at {w * 100:0}% in Transit Health"
-            : $"No monitored host's forward path crosses this transit, so it's held at the {w * 100:0}% minimum rather than dropped - it still counts because return traffic from popular services often comes back this way (asymmetric routing, which a forward traceroute can't see).";
+            ? $"Carries {InvolvementReach}/{InvolvementHostTotal} hosts (forward path), {w * 100:0}% weight"
+            : $"Off the forward path; held at {w * 100:0}% (likely the return path from popular services)";
 
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -134,7 +134,7 @@ public class IspAsnHealth
     public string? InvolvementTooltip => !ShowInvolvement || InvolvementWeight is not double w ? null
         : InvolvementReach > 0
             ? $"Carries {InvolvementReach} of {InvolvementHostTotal} internet targets (forward path), {w * 100:0}% weight"
-            : $"No internet target's forward path crosses this; held at {w * 100:0}% (likely their return path)";
+            : $"Off the forward path; held at {w * 100:0}% (likely the return path from popular services)";
 
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }
@@ -176,6 +176,18 @@ public class IspTargetHealth
 
     /// <summary>True for the first clean hop, the target the access layer idle latency comes from.</summary>
     public bool IsGradedHop { get; init; }
+
+    /// <summary>
+    /// True when this hop answers pings but appears in no discovery trace (HopNumber 0) - e.g. an
+    /// OLT/CMTS that ICMP-deprioritizes traceroute. Its jitter isn't a forward-path signal.
+    /// </summary>
+    public bool NotOnTracedPath { get; init; }
+
+    /// <summary>
+    /// True when this hop is off the traced path AND its jitter is materially degrading its score -
+    /// a strong "you probably want to stop scoring this" signal that drives the ISP Health disable hint.
+    /// </summary>
+    public bool SuggestDisable { get; init; }
 }
 
 /// <summary>An actionable finding or recommendation surfaced on the ISP Health tab.</summary>
@@ -693,6 +705,12 @@ public class IspHealthInputs
     /// transit (transit is always downstream of the ISP) and stays closed for ISP siblings.
     /// </summary>
     public bool HopOrderKnown { get; init; }
+
+    /// <summary>
+    /// TargetIds of monitored hops that answer pings but appear in no discovery trace (HopNumber 0) -
+    /// used to flag likely-disable ISP hops whose jitter isn't a forward-path signal.
+    /// </summary>
+    public IReadOnlySet<string> NotTracedTargetIds { get; init; } = new HashSet<string>();
 
     /// <summary>
     /// Window-aggregated physical-link metrics for the one source matched to the WAN, or null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -229,7 +229,7 @@ public class IspHealthScorer
             IspAsnDimension = ispAsnDimension,
             TransitAsns = transitAsns,
             IspAsns = ispAsns,
-            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades, _options.RttWinsorPercentile)).ToList(),
+            IspTargets = inputs.IspTargetSeries.Select(s => BuildIspTargetHealth(s, inputs.FirstHopTargetId, ispHopGrades, _options.RttWinsorPercentile, inputs.NotTracedTargetIds)).ToList(),
             CongestionEvents = inputs.CongestionEvents,
             PathShifts = inputs.PathShifts,
             Outages = inputs.Outages,
@@ -1255,7 +1255,13 @@ public class IspHealthScorer
         return result;
     }
 
-    private IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile)
+    /// <summary>
+    /// A hop is suggested for disable when its jitter score is at or below this - i.e. jitter is a
+    /// real deficit, not noise. Combined with "off the traced path" to avoid nagging on clean hops.
+    /// </summary>
+    private const int DisableSuggestMaxJitterScore = 70;
+
+    private IspTargetHealth BuildIspTargetHealth(AsnSeries series, string? firstHopTargetId, List<IspAsnHealth> hopGrades, double winsorPercentile, IReadOnlySet<string> notTracedTargetIds)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
@@ -1265,6 +1271,8 @@ public class IspHealthScorer
         // Jitter comes from the grade (the effective/absolved value the hop is scored on), so
         // the row matches the grade beside it. Fall back to the hop's own raw P95 when ungraded.
         var rawP95 = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null;
+        var isGraded = targetId == firstHopTargetId;
+        var notTraced = notTracedTargetIds.Contains(targetId);
         return new IspTargetHealth
         {
             TargetId = targetId,
@@ -1276,7 +1284,11 @@ public class IspHealthScorer
             LossPct = losses.Count > 0 ? losses.Average() : null,
             OverallScore = grade?.OverallScore,
             ReachDeltaMs = grade?.ReachDeltaMs,
-            IsGradedHop = targetId == firstHopTargetId
+            IsGradedHop = isGraded,
+            NotOnTracedPath = notTraced,
+            // Off the traced path AND its jitter is a real deficit - the "why am I still scoring this?"
+            // candidate. Never the graded nearest hop.
+            SuggestDisable = notTraced && !isGraded && grade?.JitterScore is int js && js <= DisableSuggestMaxJitterScore
         };
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -115,8 +115,13 @@ public class IspHealthScorer
         var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
+        // Attribution is "known" when we have the ancestry to prove routes-through AND destinations
+        // to test against. Then reach == 0 is a TRUE zero (a peered site whose destinations cross no
+        // transit) and floors the ASN at 25% - distinct from "no ancestry at all", where we can't
+        // tell and fall back to equal weight.
+        var transitAttributionKnown = inputs.HopOrderKnown && inputs.DestinationSeries.Count > 0;
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns,
-            transitReachByAsn, transitMaxReach, inputs.DestinationSeries.Count);
+            transitReachByAsn, transitMaxReach, inputs.DestinationSeries.Count, transitAttributionKnown);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
@@ -1293,21 +1298,24 @@ public class IspHealthScorer
     private const double TransitInvolvementFloor = 0.25;
 
     /// <summary>
-    /// Builds a transit-style ASN dimension. When <paramref name="reachByAsn"/> is supplied and at
-    /// least one ASN has an attributable internet host (<paramref name="maxReach"/> &gt; 0), each
-    /// ASN's contribution to the dimension score is weighted by its involvement -
-    /// <see cref="TransitInvolvementFloor"/> + (1 - floor) * reach / maxReach - and a fraction-icon
-    /// tooltip is attached. When nothing is attributable (transit invisible on the destination
-    /// paths), every weight is 1.0, so the score is the plain average and no tooltip is shown.
+    /// Builds a transit-style ASN dimension. When <paramref name="hostAttributionKnown"/> (we have
+    /// the ancestry and destinations to test routes-through), each ASN is weighted by its involvement
+    /// - <see cref="TransitInvolvementFloor"/> + (1 - floor) * reach / maxReach, or the bare floor
+    /// when no ASN carries a host (<paramref name="maxReach"/> == 0, a peered site) - and a
+    /// fraction-icon tooltip is attached. Without attribution (no hop order / no destinations) we
+    /// can't tell, so every weight is 1.0 (plain average) and no tooltip is shown.
     /// </summary>
     private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns,
-        Dictionary<int, int>? reachByAsn = null, int maxReach = 0, int destinationTotal = 0)
+        Dictionary<int, int>? reachByAsn = null, int maxReach = 0, int destinationTotal = 0,
+        bool hostAttributionKnown = false)
     {
-        var differentiate = reachByAsn != null && maxReach > 0;
+        var showInvolvement = reachByAsn != null && hostAttributionKnown;
 
         double Involvement(int asn)
         {
-            if (!differentiate) return 1.0;
+            if (!showInvolvement) return 1.0;
+            // Attribution known but no ASN carries a host (peered site): true-zero involvement, floor.
+            if (maxReach <= 0) return TransitInvolvementFloor;
             var reach = reachByAsn!.TryGetValue(asn, out var rc) ? rc : 0;
             return TransitInvolvementFloor + (1 - TransitInvolvementFloor) * ((double)reach / maxReach);
         }
@@ -1316,7 +1324,7 @@ public class IspHealthScorer
         {
             var reach = reachByAsn != null && reachByAsn.TryGetValue(a.AsnNumber, out var rc) ? rc : 0;
             var involvement = Involvement(a.AsnNumber);
-            var tip = !differentiate ? null
+            var tip = !showInvolvement ? null
                 : reach > 0
                     ? $"Carries {reach} of {destinationTotal} monitored internet host{(destinationTotal == 1 ? "" : "s")} - weighted at {involvement * 100:0}% in Transit Health"
                     : $"No monitored internet host is confirmed on this transit's path - weighted at {involvement * 100:0}% (the minimum)";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -91,7 +91,21 @@ public class IspHealthScorer
         var accessMedianRtt = SeriesStats.Median(
             inputs.FirstHopSeries.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList());
 
-        var transitAsns = inputs.TransitAsnSeries.Select(s => GradeAsn(s, inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs)).ToList();
+        var transitAsns = GradeTransitAsns(inputs.TransitAsnSeries, inputs.DestinationSeries, inputs.HopOrderKnown,
+            inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs);
+
+        // Arm 4: each transit ASN's "internet host involvement" - how many monitored internet
+        // destinations are proven to route through it (routes-through gated on stored ancestry).
+        // Feeds the involvement-weighted Transit dimension below. Zero for every ASN when transit
+        // is traceroute-invisible on the destination paths, in which case the dimension falls back
+        // to an equal-weighted average (the prior behavior).
+        var transitHopIpsByAsn = inputs.TransitAsnSeries
+            .GroupBy(s => s.AsnNumber)
+            .ToDictionary(g => g.Key, g => g.SelectMany(s => s.HopIps).Distinct(StringComparer.OrdinalIgnoreCase).ToList());
+        var transitReachByAsn = transitHopIpsByAsn.ToDictionary(
+            kv => kv.Key,
+            kv => inputs.HopOrderKnown ? inputs.DestinationSeries.Count(d => RoutesThrough(d.AncestorIps, kv.Value)) : 0);
+        var transitMaxReach = transitReachByAsn.Count > 0 ? transitReachByAsn.Values.Max() : 0;
 
         // Every ISP hop is graded; the dimension averages them all. Each hop's jitter is
         // absolved per-hop and routes-through-gated (a transit ASN or deeper ISP hop only
@@ -101,7 +115,8 @@ public class IspHealthScorer
         var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
-        var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
+        var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns,
+            transitReachByAsn, transitMaxReach, inputs.DestinationSeries.Count);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
@@ -1000,6 +1015,70 @@ public class IspHealthScorer
     /// ICMP-deprioritized hop whose forwarded traffic actually reaches the destination cleanly.
     /// Hops are also scored against the intra-ASN reach floor (distance, not a fault).
     /// </summary>
+    /// <summary>
+    /// Grades every transit ASN. Beyond the within-ASN far-cluster absolution baked into each
+    /// series' <see cref="AsnSeries.JitterSourceSamples"/>, a transit ASN's jitter is additionally
+    /// absolved (Arm A) by any monitored destination - or any OTHER transit ASN - proven to route
+    /// through it (routes-through gated on stored ancestry): a clean end-to-end path across the ASN
+    /// is an upper bound on the ASN's true jitter, so an ICMP-deprioritized transit router isn't
+    /// penalized for control-plane noise its forwarded traffic never sees. Strict: with no ancestry
+    /// (hopOrderKnown false) nothing absolves, and a witness only counts where it provably routes
+    /// through the ASN - never on faith. Falls back to the base within-ASN grade when no witness
+    /// applies.
+    /// </summary>
+    private List<IspAsnHealth> GradeTransitAsns(
+        List<AsnSeries> transitSeries,
+        List<AsnSeries> destinationSeries,
+        bool hopOrderKnown,
+        List<CongestionEvent> congestionEvents,
+        double? jitterFloorMs,
+        double? accessBaselineRtt,
+        double? internetMedianDeltaMs)
+    {
+        // Base grade (within-ASN far-cluster absolution only) - the prior behavior. Serves as the
+        // fallback and as each ASN's own jitter when it witnesses another ASN.
+        var baseGrades = transitSeries
+            .Select(s => (Series: s, Grade: GradeAsn(s, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs)))
+            .ToList();
+
+        // Destination end-to-end jitter + each transit ASN's base jitter, keyed by the ancestor IPs
+        // that prove what they route through. Destinations only when ancestry exists (strict).
+        var destWitnesses = hopOrderKnown
+            ? destinationSeries
+                .Select(d => (d.AncestorIps, Jitter: ScoringJitterOf(d.Samples)))
+                .Where(w => w.Jitter.HasValue)
+                .Select(w => (w.AncestorIps, Jitter: w.Jitter!.Value))
+                .ToList()
+            : new List<(List<string> AncestorIps, double Jitter)>();
+        var transitWitnesses = baseGrades
+            .Where(b => b.Grade.P95JitterMs.HasValue)
+            .Select(b => (b.Series.AsnNumber, b.Series.AncestorIps, Jitter: b.Grade.P95JitterMs!.Value))
+            .ToList();
+
+        var grades = new List<IspAsnHealth>();
+        foreach (var (series, baseGrade) in baseGrades)
+        {
+            // The jitter the base grade scored on: near vs this ASN's own farther cluster.
+            var within = EffectiveLower(series.Samples, series.JitterSourceSamples, ScoringJitterOf);
+            var witnesses = destWitnesses
+                .Where(w => hopOrderKnown && RoutesThrough(w.AncestorIps, series.HopIps))
+                .Select(w => w.Jitter)
+                .Concat(transitWitnesses
+                    .Where(w => hopOrderKnown && w.AsnNumber != series.AsnNumber && RoutesThrough(w.AncestorIps, series.HopIps))
+                    .Select(w => w.Jitter))
+                .ToList();
+            if (witnesses.Count == 0)
+            {
+                grades.Add(baseGrade);
+                continue;
+            }
+            var effective = within.HasValue ? Math.Min(within.Value, witnesses.Min()) : witnesses.Min();
+            grades.Add(GradeAsn(series, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs,
+                jitterOverrideMs: effective));
+        }
+        return grades;
+    }
+
     private List<IspAsnHealth> GradeIspHops(
         List<AsnSeries> ispHopSeries,
         List<AsnSeries> transitSeries,
@@ -1206,21 +1285,65 @@ public class IspHealthScorer
         return new IspScoreDimension { Name = name, Score = score, Weight = weight, Factors = factors };
     }
 
-    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns)
+    /// <summary>
+    /// Weight below which a graded transit ASN never falls: the least-involved transit still counts
+    /// at 25% relative to the most-involved (a 4x cap on the spread), so a bad-but-minor transit is
+    /// de-weighted but never escapes accountability. Arm 4.
+    /// </summary>
+    private const double TransitInvolvementFloor = 0.25;
+
+    /// <summary>
+    /// Builds a transit-style ASN dimension. When <paramref name="reachByAsn"/> is supplied and at
+    /// least one ASN has an attributable internet host (<paramref name="maxReach"/> &gt; 0), each
+    /// ASN's contribution to the dimension score is weighted by its involvement -
+    /// <see cref="TransitInvolvementFloor"/> + (1 - floor) * reach / maxReach - and a fraction-icon
+    /// tooltip is attached. When nothing is attributable (transit invisible on the destination
+    /// paths), every weight is 1.0, so the score is the plain average and no tooltip is shown.
+    /// </summary>
+    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns,
+        Dictionary<int, int>? reachByAsn = null, int maxReach = 0, int destinationTotal = 0)
     {
-        var factors = asns.Select(a => new IspScoreFactor
+        var differentiate = reachByAsn != null && maxReach > 0;
+
+        double Involvement(int asn)
         {
-            Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
-            Score = a.OverallScore,
-            Weight = 1.0,
-            ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
-            Description = a.CongestionEventCount > 0
-                ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
-                : null
+            if (!differentiate) return 1.0;
+            var reach = reachByAsn!.TryGetValue(asn, out var rc) ? rc : 0;
+            return TransitInvolvementFloor + (1 - TransitInvolvementFloor) * ((double)reach / maxReach);
+        }
+
+        var factors = asns.Select(a =>
+        {
+            var reach = reachByAsn != null && reachByAsn.TryGetValue(a.AsnNumber, out var rc) ? rc : 0;
+            var involvement = Involvement(a.AsnNumber);
+            var tip = !differentiate ? null
+                : reach > 0
+                    ? $"Carries {reach} of {destinationTotal} monitored internet host{(destinationTotal == 1 ? "" : "s")} - weighted at {involvement * 100:0}% in Transit Health"
+                    : $"No monitored internet host is confirmed on this transit's path - weighted at {involvement * 100:0}% (the minimum)";
+            return new IspScoreFactor
+            {
+                Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
+                Score = a.OverallScore,
+                Weight = involvement,
+                ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
+                Description = a.CongestionEventCount > 0
+                    ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
+                    : null,
+                InvolvementTooltip = tip
+            };
         }).ToList();
 
         var scored = asns.Where(a => a.OverallScore.HasValue).ToList();
-        int? score = scored.Count > 0 ? (int)Math.Round(scored.Average(a => a.OverallScore!.Value)) : null;
+        int? score;
+        if (scored.Count == 0)
+            score = null;
+        else
+        {
+            var wsum = scored.Sum(a => Involvement(a.AsnNumber));
+            score = wsum > 0
+                ? (int)Math.Round(scored.Sum(a => a.OverallScore!.Value * Involvement(a.AsnNumber)) / wsum)
+                : (int)Math.Round(scored.Average(a => a.OverallScore!.Value));
+        }
         return new IspScoreDimension { Name = name, Score = score, Weight = weight, Factors = factors };
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -107,6 +107,24 @@ public class IspHealthScorer
             kv => inputs.HopOrderKnown ? inputs.DestinationSeries.Count(d => RoutesThrough(d.AncestorIps, kv.Value)) : 0);
         var transitMaxReach = transitReachByAsn.Count > 0 ? transitReachByAsn.Values.Max() : 0;
 
+        // Attribution is "known" when we have the ancestry to prove routes-through AND destinations to
+        // test against. Then reach == 0 is a TRUE zero (a peered site whose destinations cross no
+        // transit) and floors the ASN at 25% - distinct from "no ancestry at all", where we can't tell
+        // and leave involvement unset (equal weight). Attach the involvement to each transit ASN so
+        // both Transit Health and the Networks on Your Path card read from one source.
+        var transitAttributionKnown = inputs.HopOrderKnown && inputs.DestinationSeries.Count > 0;
+        foreach (var a in transitAsns)
+        {
+            a.ShowInvolvement = transitAttributionKnown;
+            a.InvolvementHostTotal = inputs.DestinationSeries.Count;
+            a.InvolvementReach = transitReachByAsn.TryGetValue(a.AsnNumber, out var rc) ? rc : 0;
+            a.InvolvementWeight = transitAttributionKnown
+                ? (transitMaxReach > 0
+                    ? TransitInvolvementFloor + (1 - TransitInvolvementFloor) * ((double)a.InvolvementReach / transitMaxReach)
+                    : TransitInvolvementFloor)
+                : null;
+        }
+
         // Every ISP hop is graded; the dimension averages them all. Each hop's jitter is
         // absolved per-hop and routes-through-gated (a transit ASN or deeper ISP hop only
         // absolves a hop it is proven downstream of), so a divergent clean transit can't
@@ -115,13 +133,7 @@ public class IspHealthScorer
         var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
-        // Attribution is "known" when we have the ancestry to prove routes-through AND destinations
-        // to test against. Then reach == 0 is a TRUE zero (a peered site whose destinations cross no
-        // transit) and floors the ASN at 25% - distinct from "no ancestry at all", where we can't
-        // tell and fall back to equal weight.
-        var transitAttributionKnown = inputs.HopOrderKnown && inputs.DestinationSeries.Count > 0;
-        var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns,
-            transitReachByAsn, transitMaxReach, inputs.DestinationSeries.Count, transitAttributionKnown);
+        var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
         var ispAsnDimension = BuildIspDimension(_options.IspAsnWeight, ispHopGrades);
 
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
@@ -1297,59 +1309,48 @@ public class IspHealthScorer
     /// </summary>
     private const double TransitInvolvementFloor = 0.25;
 
+    /// <summary>Neutral baseline the uninvolved fraction of a transit ASN's score blends toward: a
+    /// transit carrying none of your hosts can't hurt Transit Health (it contributes ~100).</summary>
+    private const double TransitNeutralBaseline = 100.0;
+
     /// <summary>
-    /// Builds a transit-style ASN dimension. When <paramref name="hostAttributionKnown"/> (we have
-    /// the ancestry and destinations to test routes-through), each ASN is weighted by its involvement
-    /// - <see cref="TransitInvolvementFloor"/> + (1 - floor) * reach / maxReach, or the bare floor
-    /// when no ASN carries a host (<paramref name="maxReach"/> == 0, a peered site) - and a
-    /// fraction-icon tooltip is attached. Without attribution (no hop order / no destinations) we
-    /// can't tell, so every weight is 1.0 (plain average) and no tooltip is shown.
+    /// Builds a transit-style ASN dimension. Each ASN carries its <see cref="IspAsnHealth.InvolvementWeight"/>
+    /// (0.25-1.0, set upstream from internet-host involvement); its effective contribution is
+    /// weight * own + (1 - weight) * <see cref="TransitNeutralBaseline"/>, and the dimension score is
+    /// the involvement-weighted average of those - so the transit you actually use dominates and a
+    /// side-path transit's problems don't drag the number. When no ASN has involvement set (no
+    /// attribution), it's the plain average and no fraction icon is shown.
     /// </summary>
-    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns,
-        Dictionary<int, int>? reachByAsn = null, int maxReach = 0, int destinationTotal = 0,
-        bool hostAttributionKnown = false)
+    private static IspScoreDimension BuildAsnDimension(string name, double weight, List<IspAsnHealth> asns)
     {
-        var showInvolvement = reachByAsn != null && hostAttributionKnown;
-
-        double Involvement(int asn)
+        var factors = asns.Select(a => new IspScoreFactor
         {
-            if (!showInvolvement) return 1.0;
-            // Attribution known but no ASN carries a host (peered site): true-zero involvement, floor.
-            if (maxReach <= 0) return TransitInvolvementFloor;
-            var reach = reachByAsn!.TryGetValue(asn, out var rc) ? rc : 0;
-            return TransitInvolvementFloor + (1 - TransitInvolvementFloor) * ((double)reach / maxReach);
-        }
-
-        var factors = asns.Select(a =>
-        {
-            var reach = reachByAsn != null && reachByAsn.TryGetValue(a.AsnNumber, out var rc) ? rc : 0;
-            var involvement = Involvement(a.AsnNumber);
-            var tip = !showInvolvement ? null
-                : reach > 0
-                    ? $"Carries {reach} of {destinationTotal} monitored internet host{(destinationTotal == 1 ? "" : "s")} - weighted at {involvement * 100:0}% in Transit Health"
-                    : $"No monitored internet host is confirmed on this transit's path - weighted at {involvement * 100:0}% (the minimum)";
-            return new IspScoreFactor
-            {
-                Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
-                Score = a.OverallScore,
-                Weight = involvement,
-                ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
-                Description = a.CongestionEventCount > 0
-                    ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
-                    : null,
-                InvolvementTooltip = tip
-            };
+            Name = string.IsNullOrEmpty(a.AsnName) ? $"AS{a.AsnNumber}" : a.AsnName,
+            Score = a.OverallScore,
+            Weight = a.InvolvementWeight ?? 1.0,
+            ValueText = a.MeanRttMs.HasValue ? FormatMsCoarse(a.MeanRttMs.Value) : null,
+            Description = a.CongestionEventCount > 0
+                ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
+                : null,
+            InvolvementTooltip = a.InvolvementTooltip
         }).ToList();
 
         var scored = asns.Where(a => a.OverallScore.HasValue).ToList();
         int? score;
         if (scored.Count == 0)
             score = null;
+        else if (scored.All(a => a.InvolvementWeight is null))
+            score = (int)Math.Round(scored.Average(a => a.OverallScore!.Value));
         else
         {
-            var wsum = scored.Sum(a => Involvement(a.AsnNumber));
+            var wsum = scored.Sum(a => a.InvolvementWeight ?? 1.0);
             score = wsum > 0
-                ? (int)Math.Round(scored.Sum(a => a.OverallScore!.Value * Involvement(a.AsnNumber)) / wsum)
+                ? (int)Math.Round(scored.Sum(a =>
+                {
+                    var w = a.InvolvementWeight ?? 1.0;
+                    var effective = w * a.OverallScore!.Value + (1 - w) * TransitNeutralBaseline;
+                    return w * effective;
+                }) / wsum)
                 : (int)Math.Round(scored.Average(a => a.OverallScore!.Value));
         }
         return new IspScoreDimension { Name = name, Score = score, Weight = weight, Factors = factors };

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1042,6 +1042,11 @@ public class IspHealthService
             SmartQueuesEnabled = smartQueuesEnabled,
             AdaptiveSqmEnabled = adaptiveSqmEnabled,
             HopOrderKnown = hopOrderKnown,
+            // Hops with a discovery row but HopNumber 0 answered pings yet never landed in a trace
+            // (OLT/CMTS ICMP-deprioritization); only meaningful once we have trace data at all.
+            NotTracedTargetIds = hopOrderKnown
+                ? hopNumberByTargetId.Where(kv => kv.Value == 0).Select(kv => kv.Key).ToHashSet(StringComparer.OrdinalIgnoreCase)
+                : new HashSet<string>(StringComparer.OrdinalIgnoreCase),
             LoadExclusionWindows = loadExclusions,
             PhysicalLink = physical.Input
         };

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1317,8 +1317,9 @@ public class UpstreamTracerService
     /// flipped in either direction: an existing enabled row keeps covering its
     /// cluster (no second pick is added beside it), and an existing disabled row is
     /// never re-enabled - a disabled row can be a flaky-target verdict, not just an
-    /// old default. ASNs with no gate-clearing hop end up with nothing enabled, which
-    /// is what lets the downstream witness/fallback injection step in.
+    /// old default. An ASN with no gate-clearing hop ends up with nothing enabled here;
+    /// that is fine, because a curated transit ASN (e.g. Level 3) still gets its anycast
+    /// witness attached downstream regardless (InjectTransitWitnessesAsync).
     /// </summary>
     internal static void ApplyTransitClumpSelection(IEnumerable<TransitAsnCandidate> candidates)
     {
@@ -1367,8 +1368,8 @@ public class UpstreamTracerService
 
     // Reachability gate: a candidate must answer enough pings in a short rapid burst (200 ms
     // spacing) to be auto-selected, so flaky, ICMP-deprioritized routers don't get monitored - and
-    // so the Level 3 transit witness (4.2.2.2) is injected exactly when no real AS3356 router clears
-    // the gate. We always send 3; the required successes depend on the connection's access medium
+    // so a curated transit witness (e.g. Level 3 4.2.2.2) must itself clear the gate before it is
+    // attached. We always send 3; the required successes depend on the connection's access medium
     // (Item B): air-interface mediums (WISP, cellular) and the unconfigured Unknown case allow one
     // dropped reply (2/3); stable wired/fiber/LEO mediums demand 3/3.
     private const int ReachabilityPingCount = 3;
@@ -1432,12 +1433,12 @@ public class UpstreamTracerService
         // With verified RTTs in hand, refine the provisional per-clump picks: enable
         // the lowest-RTT hop that cleared the gate in each of an ASN's clumps (near
         // ingress + far egress), instead of blindly keeping the lowest hop number.
-        // Runs before witness injection so an ASN that ends up with a selection
-        // doesn't also get a witness.
         ApplyTransitClumpSelection(State.TransitAsns);
 
-        // Item A: if Level 3 (AS3356) is on the path but no AS3356 router cleared the gate, inject
-        // 4.2.2.2 as a transit witness so ISP Health still has Lumen transit data.
+        // Item A: whenever a curated transit ASN (e.g. Level 3 / AS3356) is near-transit, attach its
+        // anycast witness (4.2.2.2) as a transit target - alongside any real routers, not only as a
+        // fallback - so ISP Health always has a stable Lumen transit anchor even when the real hops
+        // vary POP-to-POP across runs or start deprioritizing ICMP.
         await InjectTransitWitnessesAsync(minSuccesses, ct);
 
         // If the access ASN is one we have curated endpoints for and none of its first-mile
@@ -1450,9 +1451,12 @@ public class UpstreamTracerService
     }
 
     // Item A: anycast DNS witnesses for transit ASNs whose routers commonly ICMP-deprioritize or
-    // hide behind L2-transparent infra. Used only when the ASN is on the path but no router clears
-    // the reachability gate. The endpoint is anycast (nearest edge), hence the "transit witness"
-    // label. Extend this table to add witnesses for other transit ASNs (e.g. AS7018 AT&T).
+    // hide behind L2-transparent infra. Attached whenever the ASN is genuinely near-transit - not
+    // only as a fallback - so the tier always has a stable anchor even when real routers respond
+    // (they vary POP-to-POP across runs and can start dropping ICMP). The endpoint is anycast
+    // (nearest edge), hence the "transit witness" label; it hits a more distant POP than the closest
+    // real hop, which is why the real hops are kept, never replaced. Extend this table to add
+    // witnesses for other transit ASNs (e.g. AS7018 AT&T).
     private static readonly (int Asn, string Address, string Name, string Label)[] TransitWitnesses =
     {
         (3356, "4.2.2.2", "Level 3", "Level 3 DNS (transit witness)")
@@ -1598,8 +1602,10 @@ public class UpstreamTracerService
             if (!_nearTransitAsns.Contains(asn)) continue;
             // And not when this tier-1 only ever sits above another tier-1 (core peering).
             if (_excludedTier1Asns.Contains(asn)) continue;
-            // Skip if any real router in this ASN already cleared the gate, or the witness exists.
-            if (State.TransitAsns.Any(t => t.AsnNumber == asn && t.Enabled && !t.Unreachable)) continue;
+            // Skip only if this witness address is already a candidate this run. A real router in the
+            // same ASN no longer suppresses the witness - the anycast anchor is attached alongside it
+            // (the real hops are usually a closer POP, so both are kept). Same-address dedup on write
+            // (UpsertTransitTargetAsync) folds this into any hand-added row at the same address.
             if (State.TransitAsns.Any(t => string.Equals(t.HopAddress, address, StringComparison.OrdinalIgnoreCase))) continue;
 
             // The witness must itself clear the gate before we enable it.
@@ -1624,8 +1630,8 @@ public class UpstreamTracerService
                 VerifiedRttMs = result.RttAvgMs,
                 Enabled = true
             });
-            _logger.LogInformation("Injected transit witness {Address} (AS{Asn} {Name}) - no reachable {Name} router",
-                address, asn, name, name);
+            _logger.LogInformation("Attached transit witness {Address} (AS{Asn} {Name}) - near-transit anchor",
+                address, asn, name);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1632,6 +1632,16 @@ public class UpstreamTracerService
             });
             _logger.LogInformation("Attached transit witness {Address} (AS{Asn} {Name}) - near-transit anchor",
                 address, asn, name);
+
+            // Trace the witness so PersistHopOrderAsync records the real transit hops that precede
+            // it as its ancestry. Without this the anycast endpoint is ping-only, lands in
+            // UpstreamDiscoveries with no ancestors, and fails FarClusterRoutesThroughNear - so ISP
+            // Health can never use the witness's clean end-to-end jitter to absolve a jittery near
+            // hop it routes through. The proof is honest: ancestry comes from 4.2.2.2's actual path,
+            // so an absolve only happens when that path genuinely traverses the monitored hop; if
+            // the anycast lands on a different Level 3 POP there is no overlap and no absolve.
+            var (_, witnessTrace) = await TraceOneAsync(new TraceEndpoint(name, address), ProbeMode.Icmp, ct);
+            _lastTraces.Add(witnessTrace);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16750,6 +16750,29 @@ a.isp-health-hero-speed:hover {
     color: var(--text-primary);
 }
 
+.isp-factor-name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    min-width: 0;
+}
+
+.isp-asn-name-row {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+}
+
+.isp-involvement-pie {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.isp-involvement-pie svg {
+    display: block;
+}
+
 .isp-factor-value {
     font-size: 0.75rem;
     color: var(--text-secondary);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17294,29 +17294,26 @@ a.isp-outage-ack:hover {
     margin-top: 0.45rem;
 }
 
-.isp-target-graded {
-    margin-left: 0.35rem;
+.isp-target-badge {
+    margin-left: 0.5rem;
     padding: 0.05rem 0.4rem;
     border-radius: 4px;
-    background: rgba(5, 80, 181, 0.25);
-    color: var(--primary-hover);
     font-size: 0.62rem;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
+    vertical-align: middle;
+}
+
+.isp-target-graded {
+    background: rgba(5, 80, 181, 0.25);
+    color: var(--primary-hover);
 }
 
 .isp-target-disable-hint {
-    margin-left: 0.35rem;
-    padding: 0.05rem 0.4rem;
     border: none;
-    border-radius: 4px;
     background: rgba(231, 150, 19, 0.2);
     color: var(--warning-color);
-    font-size: 0.62rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
     cursor: pointer;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17306,6 +17306,24 @@ a.isp-outage-ack:hover {
     letter-spacing: 0.04em;
 }
 
+.isp-target-disable-hint {
+    margin-left: 0.35rem;
+    padding: 0.05rem 0.4rem;
+    border: none;
+    border-radius: 4px;
+    background: rgba(231, 150, 19, 0.2);
+    color: var(--warning-color);
+    font-size: 0.62rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+}
+
+.isp-target-disable-hint:hover {
+    background: rgba(231, 150, 19, 0.32);
+}
+
 .isp-target-stat {
     display: flex;
     flex-direction: column;

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1106,6 +1106,35 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Transit_asns_with_no_attributable_hosts_are_floored_and_labeled()
+    {
+        // A fully-peered site: destinations reach the internet directly, so their (complete) ancestry
+        // crosses no transit and every transit ASN carries zero monitored hosts. With attribution
+        // available (hop order + destinations), that is a TRUE zero - each transit is floored at 25%
+        // and labeled, not left at the equal-weight "unknown" fallback. Arm 4.
+        List<AsnSeries> Transits() => new()
+        {
+            new AsnSeries { AsnNumber = 64500, AsnName = "TransitA", TargetIds = { "ta" },
+                Samples = TestSeries.Flat(TestSeries.Start, Day, 10, 0.5), HopIps = { "20.0.0.1" } },
+            new AsnSeries { AsnNumber = 64600, AsnName = "TransitB", TargetIds = { "tb" },
+                Samples = TestSeries.Flat(TestSeries.Start, Day, 12, 0.5), HopIps = { "21.0.0.1" } }
+        };
+        var peeredDest = new AsnSeries
+        {
+            AsnNumber = 64512, AsnName = "Destination", TargetIds = { "dest" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 8, 0.4), HopIps = { "30.0.0.1" },
+            AncestorIps = { "9.9.9.9" } // routes through neither transit (peered)
+        };
+
+        var dim = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: Transits(), destinations: new List<AsnSeries> { peeredDest }, hopOrderKnown: true), Gpon)
+            .TransitDimension;
+
+        dim.Factors.Should().OnlyContain(f => f.InvolvementTooltip != null && f.InvolvementTooltip.Contains("25%"),
+            "complete ancestry showing zero transit involvement floors and labels every transit ASN");
+    }
+
+    [Fact]
     public void Without_hop_order_a_transit_asn_is_graded_on_its_near_cluster()
     {
         // Backward compat: installs that have not re-run discovery have no stored hop

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1099,7 +1099,7 @@ public class IspHealthScorerTests
 
         weighted.Score.Should().BeGreaterThan(equal.Score!.Value,
             "down-weighting the jittery, host-less transit lifts the dimension toward the clean, host-carrying one");
-        weighted.Factors.Single(f => f.Name == "CleanTransit").InvolvementTooltip.Should().Contain("weighted at 100%");
+        weighted.Factors.Single(f => f.Name == "CleanTransit").InvolvementTooltip.Should().Contain("100% weight");
         weighted.Factors.Single(f => f.Name == "JitteryTransit").InvolvementTooltip.Should().Contain("25%");
         equal.Factors.Should().OnlyContain(f => f.InvolvementTooltip == null,
             "with no attributable host there is no involvement to differentiate");

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1010,6 +1010,102 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void A_clean_destination_absolves_a_transit_asn_it_routes_through()
+    {
+        // A transit ASN shows high self-jitter (ICMP deprioritization) with no farther cluster of
+        // its own to disprove it. A monitored destination reached THROUGH the ASN (its hop is in the
+        // destination's ancestor set) is clean end-to-end - a hard upper bound on the ASN's true
+        // jitter - so it absolves the transit ASN. Arm A. Divergent ancestry = no absolve (strict).
+        AsnSeries Transit() => new()
+        {
+            AsnNumber = 64500,
+            AsnName = "TransitOne",
+            TargetIds = { "transit-jittery" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 10, 4.0),
+            HopIps = { "20.0.0.1" }
+        };
+        var cleanDest = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4),
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "20.0.0.1" } // reached through the transit ASN's hop
+        };
+        var divergentDest = new AsnSeries
+        {
+            AsnNumber = 64512,
+            AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4),
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "10.9.9.9" } // a different hop - does not route through our transit
+        };
+
+        var absolved = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { Transit() },
+                destinations: new List<AsnSeries> { cleanDest }, hopOrderKnown: true), Gpon).TransitAsns.Single();
+        var notAbsolved = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: new List<AsnSeries> { Transit() },
+                destinations: new List<AsnSeries> { divergentDest }, hopOrderKnown: true), Gpon).TransitAsns.Single();
+
+        absolved.JitterScore.Should().BeGreaterThan(notAbsolved.JitterScore!.Value,
+            "a clean destination routing through the transit ASN proves its jitter is an ICMP artifact");
+        absolved.JitterAssimilated.Should().BeTrue("the clean destination pulled the jitter down");
+    }
+
+    [Fact]
+    public void Transit_health_weights_asns_by_internet_host_involvement()
+    {
+        // Two transit ASNs, one clean and one jittery. The jittery one carries NO monitored internet
+        // host, so involvement weighting drops it to the 25% floor and the dimension leans on the
+        // clean, host-carrying ASN - scoring higher than the plain average an install with no
+        // attribution would get. Arm 4. The destination routes only through the clean ASN, so Arm A
+        // can't rescue the jittery one's jitter (isolating the weighting effect).
+        List<AsnSeries> Transits() => new()
+        {
+            new AsnSeries
+            {
+                AsnNumber = 64500, AsnName = "CleanTransit",
+                TargetIds = { "transit-clean" },
+                Samples = TestSeries.Flat(TestSeries.Start, Day, 10, 0.4),
+                HopIps = { "20.0.0.1" }
+            },
+            new AsnSeries
+            {
+                AsnNumber = 64600, AsnName = "JitteryTransit",
+                TargetIds = { "transit-jittery" },
+                Samples = TestSeries.Flat(TestSeries.Start, Day, 12, 4.0),
+                HopIps = { "21.0.0.1" }
+            }
+        };
+        var dest = new AsnSeries
+        {
+            AsnNumber = 64512, AsnName = "Destination",
+            TargetIds = { "dest-clean" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 13, 0.4),
+            HopIps = { "30.0.0.1" },
+            AncestorIps = { "20.0.0.1" } // routes through the clean transit only
+        };
+
+        var weighted = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: Transits(), destinations: new List<AsnSeries> { dest }, hopOrderKnown: true), Gpon)
+            .TransitDimension;
+        // Baseline: no attribution, so both ASNs weigh equally - the plain average, no tooltips.
+        var equal = new IspHealthScorer(Options).Score(
+            BuildInputs(transit: Transits(), hopOrderKnown: true), Gpon)
+            .TransitDimension;
+
+        weighted.Score.Should().BeGreaterThan(equal.Score!.Value,
+            "down-weighting the jittery, host-less transit lifts the dimension toward the clean, host-carrying one");
+        weighted.Factors.Single(f => f.Name == "CleanTransit").InvolvementTooltip.Should().Contain("weighted at 100%");
+        weighted.Factors.Single(f => f.Name == "JitteryTransit").InvolvementTooltip.Should().Contain("25%");
+        equal.Factors.Should().OnlyContain(f => f.InvolvementTooltip == null,
+            "with no attributable host there is no involvement to differentiate");
+    }
+
+    [Fact]
     public void Without_hop_order_a_transit_asn_is_graded_on_its_near_cluster()
     {
         // Backward compat: installs that have not re-run discovery have no stored hop

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -40,7 +40,8 @@ public class IspHealthScorerTests
         bool lineIdle = false,
         bool hopOrderKnown = false,
         List<OutageEvent>? outages = null,
-        TimeSpan? scoreWindow = null)
+        TimeSpan? scoreWindow = null,
+        HashSet<string>? notTracedTargetIds = null)
     {
         // lineIdle: a near-zero, flat WAN with no load bursts (~0% average load), for
         // exercising the load-calibrated packet-loss ceiling at the idle end.
@@ -82,6 +83,7 @@ public class IspHealthScorerTests
             CongestionEvents = congestion ?? new List<CongestionEvent>(),
             SmartQueuesEnabled = smartQueuesEnabled,
             HopOrderKnown = hopOrderKnown,
+            NotTracedTargetIds = notTracedTargetIds ?? new HashSet<string>(),
             Outages = outages ?? new List<OutageEvent>()
         };
     }
@@ -1103,6 +1105,34 @@ public class IspHealthScorerTests
         weighted.Factors.Single(f => f.Name == "JitteryTransit").InvolvementTooltip.Should().Contain("25%");
         equal.Factors.Should().OnlyContain(f => f.InvolvementTooltip == null,
             "with no attributable host there is no involvement to differentiate");
+    }
+
+    [Fact]
+    public void Off_path_jittery_isp_hop_is_flagged_for_disable()
+    {
+        // A hop that answers pings but appears on no trace (an OLT that ICMP-deprioritizes traceroute)
+        // with high jitter is flagged SuggestDisable. The graded on-path hop never is.
+        var graded = new AsnSeries
+        {
+            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-near" }, RoleTargetIds = { "isp-near" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 2.0, 0.3), HopIps = { "10.0.0.1" }
+        };
+        var offPathJittery = new AsnSeries
+        {
+            AsnNumber = 64496, AsnName = "ISP", TargetIds = { "isp-olt" }, RoleTargetIds = { "isp-olt" },
+            Samples = TestSeries.Flat(TestSeries.Start, Day, 4.0, 6.0), HopIps = { "10.0.0.9" }
+        };
+        var hops = new List<AsnSeries> { graded, offPathJittery };
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: hops, ispTargets: hops, firstHopTargetId: "isp-near",
+                hopOrderKnown: true, notTracedTargetIds: new HashSet<string> { "isp-olt" }), Gpon);
+
+        var olt = report.IspTargets.Single(t => t.TargetId == "isp-olt");
+        olt.NotOnTracedPath.Should().BeTrue();
+        olt.SuggestDisable.Should().BeTrue("off the traced path and dragging its score with jitter");
+        report.IspTargets.Single(t => t.TargetId == "isp-near").SuggestDisable.Should().BeFalse(
+            "the graded on-path hop is never suggested for disable");
     }
 
     [Fact]


### PR DESCRIPTION
Makes Transit Health reflect the transit you actually use, gives transit jitter the same clean-path absolution the ISP tier already had, and helps you spot ISP hops that are dragging your score without being on your path.

## Monitoring

### ISP Health - Transit Health

- **Destination-absolved transit jitter** - a transit ASN's jitter is now discounted by any monitored internet target (or a deeper transit ASN) proven to route through it, the same clean-end-to-end upper bound the ISP tier already used. An ICMP-deprioritized transit router no longer gets penalized for control-plane noise its forwarded traffic never sees. Strict: only where stored ancestry proves the path, never on faith.
- **Involvement-weighted score** - each transit ASN now counts toward Transit Health in proportion to how much of your internet actually rides it (the share of monitored internet targets whose path crosses it). The transit you use dominates; a side-path or backup transit's problems are blended toward neutral so they can't drag the number, but a graded ASN never drops below a 25% floor. On a fully-peered connection, where no monitored target crosses transit, this reads as low involvement rather than pulling the score down.
- **Involvement pie icon** - Transit factors and the **Networks on Your Path** cards show a small pie filled to the ASN's involvement weight, with a tooltip stating how many internet targets ride it on the forward path and its resulting weight (and, when none do, that it's held at the floor because it's likely the return path from popular services - asymmetric routing a forward traceroute can't see).

### ISP Health - ISP Network

- **Off-path hop disable hint** - an ISP hop that answers pings but appears on no discovery trace (e.g. an OLT/CMTS that deprioritizes traceroute) and whose jitter is degrading its score now shows a "Not on path" hint. It links straight to **Latency targets** (on Network Performance) and highlights the hop so you can pause it instead of letting phantom jitter skew ISP Network.

### Setup - Upstream path discovery

- **Level 3 transit witness always attached** - when Level 3 (or another curated transit) is genuinely near-transit, its stable anycast witness is now attached alongside any real routers, not only as a fallback when none answer. This keeps a consistent Lumen transit anchor across runs even as the real hops shift POP-to-POP or start dropping ICMP; the closer real hops are kept, never replaced.
- **Witness carries ancestry** - the witness is now traced during discovery so the real transit hops preceding it are recorded as its ancestry, which is what lets its clean end-to-end jitter absolve a jittery near hop it provably routes through.
