### PR TITLE
Nokia ONT: disable handler cookies (root cause) + raw-socket curl replay fallback

### DIFF
--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Globalization;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -23,14 +24,20 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 ///      -> {"CurrentPonPw","VendorID","VersionID","SerialNum","Mac","ActiveSwVer",
 ///          "StandbySwVer","RxOptPwr"}
 ///
-/// getUpdateinfo authorization differs by firmware, so two flows are tried and the winner is
-/// cached per config (see <see cref="AuthFlow"/>). <see cref="AuthFlow.Direct"/> calls
-/// getUpdateinfo with just the session cookie straight after login - the minimal request the one
-/// firmware confirmed working (@Liosnel's) accepts, kept untouched. <see cref="AuthFlow.PageWalk"/>
-/// handles a T-Fiber/Metronet CLEI variant that forces a PON-password page after login and gates
-/// getUpdateinfo behind walking through it: GET /ponpasswd.html, POST /GponForm/ponpasswd_GetConfig,
-/// GET /moreinfo.html, each carrying the session cookie and the browser's Referer/Origin/
-/// X-Requested-With headers, then getUpdateinfo with those headers too.
+/// Some firmware (a T-Fiber/Metronet CLEI variant) accepts this sequence from curl and from a
+/// browser but answers 401 -> /login.html when HttpClient sends the logically identical
+/// requests. The rejection is about wire framing, not auth logic: HttpClient omits User-Agent
+/// and Accept, appends "; charset=utf-8" to the Content-Type, emits content headers after the
+/// request headers (curl puts Content-Length before Content-Type) and adds Connection: close.
+/// None of that framing can be fully controlled through HttpClient, so two flows are tried and
+/// the winner is cached per config (see <see cref="AuthFlow"/>). <see cref="AuthFlow.Direct"/>
+/// is the plain HttpClient sequence exactly as shipped in v2.1.1/v2.2.0 - the one firmware
+/// confirmed working (@Liosnel's) accepts it, so its bytes are kept untouched.
+/// <see cref="AuthFlow.CurlReplay"/> writes the raw HTTP requests of the curl script proven on
+/// the picky firmware over a plain TCP socket, byte-for-byte (same headers, order and casing;
+/// fresh connection per request like separate curl invocations), including the forced
+/// PON-password page walk that firmware presents: GET /login.html, login, GET /ponpasswd.html,
+/// POST /GponForm/ponpasswd_GetConfig, GET /moreinfo.html, then getUpdateinfo.
 ///
 /// The device exposes no TX power, temperature, or explicit link state; the receive
 /// optical power (RxOptPwr, dBm) is the one health metric it reports. Login credentials
@@ -54,24 +61,26 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
 
     /// <summary>
-    /// How a given firmware authorizes the getUpdateinfo call. Determined on first contact and
+    /// How a given firmware's getUpdateinfo is reached. Determined on first contact and
     /// cached per config in <see cref="_flowCache"/>; re-detected after a process restart.
     /// </summary>
     private enum AuthFlow
     {
-        /// <summary>getUpdateinfo with just the cookie, straight after login (@Liosnel's firmware).</summary>
+        /// <summary>Plain HttpClient login + cookie-only getUpdateinfo, byte-identical to the
+        /// shipped v2.1.1/v2.2.0 requests (@Liosnel's firmware accepts these).</summary>
         Direct,
 
-        /// <summary>Walk the forced PON-password pages before getUpdateinfo (T-Fiber/Metronet CLEI variant).</summary>
-        PageWalk,
+        /// <summary>Raw-socket byte-for-byte replay of the curl script the picky
+        /// (T-Fiber/Metronet CLEI) firmware is proven to accept.</summary>
+        CurlReplay,
     }
 
     private readonly ILogger<NokiaXs010xOntProvider> _logger;
 
     /// <summary>
-    /// Remembers the getUpdateinfo <see cref="AuthFlow"/> that last succeeded per
-    /// OntConfiguration.Id so later polls go straight to it instead of re-probing the wrong flow
-    /// (and, for the page walk, its extra requests) every interval. Re-detected after a restart.
+    /// Remembers the <see cref="AuthFlow"/> that last succeeded per OntConfiguration.Id so
+    /// later polls go straight to it instead of re-probing the wrong flow (and, for the curl
+    /// replay, its extra requests) every interval. Re-detected after a restart.
     /// </summary>
     private readonly ConcurrentDictionary<int, AuthFlow> _flowCache = new();
 
@@ -144,11 +153,11 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
     /// <summary>
     /// Reads getUpdateinfo trying the resolved <see cref="AuthFlow"/> order, returning the first
-    /// result that carries an RX reading and caching the flow that produced it. Each flow gets its
-    /// own fresh login so a probe of the wrong flow (e.g. a Direct getUpdateinfo that 401s on the
-    /// CLEI variant, which forces a PON-password session state) can't poison the next flow's
-    /// session. Returns the last built stats (which may lack RX) if a flow logged in but returned
-    /// no data, or null if every login failed.
+    /// result that carries an RX reading and caching the flow that produced it. Each flow does its
+    /// own login so a probe of the wrong flow (e.g. a Direct getUpdateinfo that 401s on the CLEI
+    /// variant, which forces a PON-password session state) can't poison the next flow's session.
+    /// Returns the last built stats (which may lack RX) if a flow logged in but returned no data,
+    /// or null if every login failed.
     /// </summary>
     private async Task<OntStats?> FetchStatsAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
@@ -156,13 +165,21 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         OntStats? last = null;
         foreach (var flow in ResolveFlows(context))
         {
-            var cookieId = await LoginAsync(client, baseUrl, context, ct);
-            if (cookieId is null)
-                continue;
+            string? infoJson;
+            if (flow == AuthFlow.CurlReplay)
+            {
+                infoJson = await GetUpdateInfoViaCurlReplayAsync(baseUrl, context, ct);
+            }
+            else
+            {
+                var cookieId = await LoginAsync(client, baseUrl, context, ct);
+                infoJson = cookieId is null
+                    ? null
+                    : await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, ct);
+            }
 
-            var infoJson = flow == AuthFlow.PageWalk
-                ? await GetUpdateInfoViaWalkAsync(client, baseUrl, cookieId, context.Name, ct)
-                : await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, MoreInfoPagePath, browserHeaders: false, ct);
+            if (infoJson is null)
+                continue;
 
             var stats = new OntStats
             {
@@ -188,25 +205,25 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     /// <summary>
     /// The getUpdateinfo flows to try, in order: the one cached for this config first (so a
     /// known-good firmware never re-probes), then the other as a fallback in case the cache is
-    /// empty or the firmware behavior changed. Uncached configs try Direct first - it's one
-    /// request and the only flow confirmed working on real hardware (@Liosnel's), so only a
-    /// variant that needs the walk pays for the extra probe, once, until it's cached.
+    /// empty or the firmware behavior changed. Uncached configs try Direct first - it's two
+    /// requests and the only flow confirmed working on real hardware (@Liosnel's), so only a
+    /// variant that needs the replay pays for the extra probe, once, until it's cached.
     /// </summary>
     private IReadOnlyList<AuthFlow> ResolveFlows(OntPollContext context)
     {
         if (context.Id > 0 && _flowCache.TryGetValue(context.Id, out var cached))
-            return cached == AuthFlow.PageWalk
-                ? new[] { AuthFlow.PageWalk, AuthFlow.Direct }
-                : new[] { AuthFlow.Direct, AuthFlow.PageWalk };
+            return cached == AuthFlow.CurlReplay
+                ? new[] { AuthFlow.CurlReplay, AuthFlow.Direct }
+                : new[] { AuthFlow.Direct, AuthFlow.CurlReplay };
 
-        return new[] { AuthFlow.Direct, AuthFlow.PageWalk };
+        return new[] { AuthFlow.Direct, AuthFlow.CurlReplay };
     }
 
     /// <summary>
     /// Runs the three-step GponForm login and returns the session cookie id, or null if
     /// authentication fails. The cookie is delivered inside the LoginForm JSON body (the
     /// page's script clears the Set-Cookie header), so it is threaded back manually as a
-    /// Cookie header on later requests rather than via a CookieContainer.
+    /// Cookie header on the data request rather than via a CookieContainer.
     /// </summary>
     private async Task<string?> LoginAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
@@ -216,8 +233,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         string configJson;
         int configStatus;
-        using (var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{LoginConfigPath}", "token=token", baseUrl, LoginPagePath, cookieId: null, browserHeaders: true))
-        using (var response = await client.SendAsync(request, ct))
+        using (var content = new StringContent("token=token", Encoding.UTF8, FormContentType))
+        using (var response = await client.PostAsync($"{baseUrl}{LoginConfigPath}", content, ct))
         {
             configStatus = (int)response.StatusCode;
             configJson = await response.Content.ReadAsStringAsync(ct);
@@ -235,8 +252,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         string loginJson;
         int loginStatus;
         string? setCookie;
-        using (var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{LoginPath}", body, baseUrl, LoginPagePath, cookieId: null, browserHeaders: true))
-        using (var response = await client.SendAsync(request, ct))
+        using (var content = new StringContent(body, Encoding.UTF8, FormContentType))
+        using (var response = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct))
         {
             loginStatus = (int)response.StatusCode;
             loginJson = await response.Content.ReadAsStringAsync(ct);
@@ -254,32 +271,14 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         return cookieId;
     }
 
-    /// <summary>
-    /// Walks the forced PON-password pages (GET /ponpasswd.html, POST ponpasswd_GetConfig,
-    /// GET /moreinfo.html) so firmware that gates the data call behind them advances the session,
-    /// then reads getUpdateinfo. The session cookie and browser headers ride every step. Walk
-    /// responses are discarded; a step that 404s on firmware without the page is harmless (that
-    /// firmware just uses the Direct flow instead).
-    /// </summary>
-    private async Task<string> GetUpdateInfoViaWalkAsync(
+    private async Task<string> GetUpdateInfoAsync(
         HttpClient client, string baseUrl, string cookieId, string deviceName, CancellationToken ct)
     {
-        await WalkStepAsync(client, BuildRequest(HttpMethod.Get, $"{baseUrl}{PonPasswdPagePath}", null, baseUrl, LoginPagePath, cookieId, browserHeaders: true), ct);
-        await WalkStepAsync(client, BuildRequest(HttpMethod.Post, $"{baseUrl}{PonPasswdConfigPath}", "token=token", baseUrl, PonPasswdPagePath, cookieId, browserHeaders: true), ct);
-        await WalkStepAsync(client, BuildRequest(HttpMethod.Get, $"{baseUrl}{MoreInfoPagePath}", null, baseUrl, PonPasswdPagePath, cookieId, browserHeaders: true), ct);
-        return await GetUpdateInfoAsync(client, baseUrl, cookieId, deviceName, PonPasswdPagePath, browserHeaders: true, ct);
-    }
-
-    private static async Task WalkStepAsync(HttpClient client, HttpRequestMessage request, CancellationToken ct)
-    {
-        using (request)
-        using (await client.SendAsync(request, ct)) { }
-    }
-
-    private async Task<string> GetUpdateInfoAsync(
-        HttpClient client, string baseUrl, string cookieId, string deviceName, string refererPath, bool browserHeaders, CancellationToken ct)
-    {
-        using var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{UpdateInfoPath}", "token=token", baseUrl, refererPath, cookieId, browserHeaders);
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{UpdateInfoPath}")
+        {
+            Content = new StringContent("token=token", Encoding.UTF8, FormContentType),
+        };
+        request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
 
         using var response = await client.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);
@@ -289,37 +288,262 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Builds a GponForm request. The session cookie is attached whenever one is supplied. When
-    /// <paramref name="browserHeaders"/> is set the request also mirrors the device page's XHR
-    /// traffic - a browser User-Agent, a Referer of the page the call is made from and, for the
-    /// POSTs, Origin and X-Requested-With: XMLHttpRequest - which the T-Fiber/Metronet CLEI variant
-    /// needs. The Direct getUpdateinfo passes false to stay the bare cookie-only request that
-    /// shipped in v2.1.1/v2.2.0 (the one confirmed working, on @Liosnel's box). Pass
-    /// <paramref name="formBody"/> null for a GET (a page navigation).
+    /// Replays the tester-proven curl sequence over raw sockets: GET /login.html, the two login
+    /// POSTs, the PON-password page walk, then getUpdateinfo, every request framed byte-for-byte
+    /// like curl's. Walk-page failures are ignored (firmware without the forced page just 404s
+    /// them); returns the getUpdateinfo body, or null when login fails or the device is
+    /// unreachable.
     /// </summary>
-    private static HttpRequestMessage BuildRequest(
-        HttpMethod method, string url, string? formBody, string baseUrl, string refererPath, string? cookieId, bool browserHeaders)
+    private async Task<string?> GetUpdateInfoViaCurlReplayAsync(
+        string baseUrl, OntPollContext context, CancellationToken ct)
     {
-        var request = new HttpRequestMessage(method, url);
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
 
-        if (formBody is not null)
-            request.Content = new StringContent(formBody, Encoding.UTF8, FormContentType);
+        await SendCurlRequestAsync(baseUrl, context, LoginPagePath, cookieId: null, refererPath: null, formBody: null, ct);
 
-        if (browserHeaders)
+        var config = await SendCurlRequestAsync(baseUrl, context, LoginConfigPath, cookieId: null, LoginPagePath, "token=token", ct);
+        if (config is null)
+            return null;
+
+        var (nonce, saltval) = ParseLoginConfig(config.Value.Body);
+        if (string.IsNullOrEmpty(nonce))
         {
-            request.Headers.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
-            request.Headers.TryAddWithoutValidation("Referer", $"{baseUrl}{refererPath}");
-            if (formBody is not null)
-            {
-                request.Headers.TryAddWithoutValidation("Origin", baseUrl);
-                request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
-            }
+            _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: curl-replay Login_GetConfig HTTP {Status} returned no nonce, body={Body}",
+                context.Name, config.Value.Status, Preview(config.Value.Body));
+            return null;
         }
 
-        if (!string.IsNullOrEmpty(cookieId))
-            request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
+        var cmt = ComputeCmt(username, saltval ?? "", password);
+        var loginBody = $"cmt={cmt}&nonce={Uri.EscapeDataString(nonce)}";
+        var login = await SendCurlRequestAsync(baseUrl, context, LoginPath, cookieId: null, LoginPagePath, loginBody, ct);
+        if (login is null)
+            return null;
 
-        return request;
+        var cookieId = ParseCookieId(login.Value.Body);
+        _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: curl-replay LoginForm HTTP {Status}, gotCookie={HasCookie}, body={Body}",
+            context.Name, login.Value.Status, cookieId != null, Preview(login.Value.Body));
+        if (cookieId is null)
+            return null;
+
+        await SendCurlRequestAsync(baseUrl, context, PonPasswdPagePath, cookieId, LoginPagePath, formBody: null, ct);
+        await SendCurlRequestAsync(baseUrl, context, PonPasswdConfigPath, cookieId, PonPasswdPagePath, "token=token", ct);
+        await SendCurlRequestAsync(baseUrl, context, MoreInfoPagePath, cookieId, PonPasswdPagePath, formBody: null, ct);
+
+        var info = await SendCurlRequestAsync(baseUrl, context, UpdateInfoPath, cookieId, MoreInfoPagePath, "token=token", ct);
+        if (info is null)
+            return null;
+
+        _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: curl-replay getUpdateinfo HTTP {Status}, body={Body}",
+            context.Name, info.Value.Status, Preview(info.Value.Body));
+        return info.Value.Body;
+    }
+
+    /// <summary>
+    /// Sends one curl-framed request on its own TCP connection (each curl invocation in the
+    /// reference script is a separate process and connection) and reads the response until the
+    /// device closes the connection or the body is provably complete. Returns null on network
+    /// errors or timeout so the caller can treat the step as failed without aborting the poll.
+    /// </summary>
+    private async Task<(int Status, string Body)?> SendCurlRequestAsync(
+        string baseUrl, OntPollContext context, string path, string? cookieId, string? refererPath,
+        string? formBody, CancellationToken ct)
+    {
+        var requestBytes = BuildCurlRequest(baseUrl, path, cookieId, refererPath, formBody);
+        var port = context.Port > 0 ? context.Port : 80;
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(TimeoutSeconds));
+        var token = timeoutCts.Token;
+
+        try
+        {
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(context.Host, port, token);
+            var stream = tcp.GetStream();
+            await stream.WriteAsync(requestBytes, token);
+
+            using var memory = new MemoryStream();
+            var buffer = new byte[8192];
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer, token);
+                if (read == 0)
+                    break;
+                memory.Write(buffer, 0, read);
+                if (IsRawResponseComplete(new ReadOnlySpan<byte>(memory.GetBuffer(), 0, (int)memory.Length)))
+                    break;
+            }
+
+            return ParseRawHttpResponse(memory.ToArray());
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: curl-replay request to {Path} timed out", context.Name, path);
+            return null;
+        }
+        catch (Exception ex) when (ex is IOException or SocketException)
+        {
+            _logger.LogDebug(ex, "Nokia XS-010X-Q ONT {Name}: curl-replay request to {Path} failed", context.Name, path);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Builds one request of the curl replay, byte-for-byte as curl frames it (captured against a
+    /// local listener from the tester's script): request line, Host, User-Agent, Accept: */*,
+    /// then Cookie, then Referer, and for POSTs Origin, X-Requested-With, Content-Length before
+    /// Content-Type with no charset suffix. No Connection header (curl relies on HTTP/1.1
+    /// keep-alive; the device closes the connection itself). A null <paramref name="formBody"/>
+    /// makes it a GET page navigation, which carries none of the POST-only headers.
+    /// </summary>
+    internal static byte[] BuildCurlRequest(
+        string baseUrl, string path, string? cookieId, string? refererPath, string? formBody)
+    {
+        var host = baseUrl["http://".Length..];
+        var builder = new StringBuilder()
+            .Append(formBody is null ? "GET " : "POST ").Append(path).Append(" HTTP/1.1\r\n")
+            .Append("Host: ").Append(host).Append("\r\n")
+            .Append("User-Agent: ").Append(BrowserUserAgent).Append("\r\n")
+            .Append("Accept: */*\r\n");
+
+        if (cookieId is not null)
+            builder.Append("Cookie: sessionid=").Append(cookieId).Append("\r\n");
+
+        if (refererPath is not null)
+            builder.Append("Referer: ").Append(baseUrl).Append(refererPath).Append("\r\n");
+
+        if (formBody is not null)
+        {
+            builder.Append("Origin: ").Append(baseUrl).Append("\r\n")
+                .Append("X-Requested-With: XMLHttpRequest\r\n")
+                .Append("Content-Length: ").Append(Encoding.ASCII.GetByteCount(formBody).ToString(CultureInfo.InvariantCulture)).Append("\r\n")
+                .Append("Content-Type: ").Append(FormContentType).Append("\r\n");
+        }
+
+        builder.Append("\r\n");
+        if (formBody is not null)
+            builder.Append(formBody);
+
+        return Encoding.ASCII.GetBytes(builder.ToString());
+    }
+
+    /// <summary>
+    /// Whether a raw HTTP response buffered so far is provably complete: headers received and the
+    /// chunked body's terminating zero chunk seen, or the declared Content-Length satisfied. A
+    /// response with neither framing can only be completed by the device closing the connection,
+    /// so it reports false and the reader waits for EOF. The device answers GponForm calls with
+    /// Transfer-Encoding: chunked and Connection: close, making this an early-out; the EOF path
+    /// is the safety net.
+    /// </summary>
+    internal static bool IsRawResponseComplete(ReadOnlySpan<byte> data)
+    {
+        var headerEnd = data.IndexOf("\r\n\r\n"u8);
+        if (headerEnd < 0)
+            return false;
+
+        var headers = Encoding.ASCII.GetString(data[..headerEnd]);
+        var body = data[(headerEnd + 4)..];
+
+        if (headers.Contains("Transfer-Encoding: chunked", StringComparison.OrdinalIgnoreCase))
+            return TryDecodeChunked(body, out _);
+
+        var contentLength = ParseContentLength(headers);
+        return contentLength is not null && body.Length >= contentLength.Value;
+    }
+
+    /// <summary>
+    /// Splits a raw HTTP/1.1 response into status code and decoded body text, de-chunking when
+    /// the device uses Transfer-Encoding: chunked (it does, on every GponForm response) and
+    /// otherwise honoring Content-Length or taking everything after the headers. Best-effort on
+    /// truncated input: whatever body bytes arrived are returned.
+    /// </summary>
+    internal static (int StatusCode, string Body) ParseRawHttpResponse(byte[] raw)
+    {
+        var data = raw.AsSpan();
+        var headerEnd = data.IndexOf("\r\n\r\n"u8);
+        if (headerEnd < 0)
+            return (0, "");
+
+        var headers = Encoding.ASCII.GetString(data[..headerEnd]);
+        var body = data[(headerEnd + 4)..];
+
+        var statusCode = 0;
+        var statusLine = headers.Split("\r\n", 2)[0].Split(' ');
+        if (statusLine.Length >= 2)
+            int.TryParse(statusLine[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out statusCode);
+
+        if (headers.Contains("Transfer-Encoding: chunked", StringComparison.OrdinalIgnoreCase))
+        {
+            TryDecodeChunked(body, out var decoded);
+            return (statusCode, Encoding.UTF8.GetString(decoded));
+        }
+
+        var contentLength = ParseContentLength(headers);
+        if (contentLength is not null && body.Length > contentLength.Value)
+            body = body[..contentLength.Value];
+
+        return (statusCode, Encoding.UTF8.GetString(body));
+    }
+
+    /// <summary>
+    /// Walks a chunked transfer-coded body, collecting the chunk payloads received so far into
+    /// <paramref name="decoded"/>. Returns true only when the terminating zero-size chunk has
+    /// arrived; on truncated or malformed input it returns false with the chunks recovered up to
+    /// that point.
+    /// </summary>
+    private static bool TryDecodeChunked(ReadOnlySpan<byte> body, out byte[] decoded)
+    {
+        using var output = new MemoryStream();
+        var pos = 0;
+        while (true)
+        {
+            var lineEnd = body[pos..].IndexOf("\r\n"u8);
+            if (lineEnd < 0)
+                break;
+
+            var sizeText = Encoding.ASCII.GetString(body.Slice(pos, lineEnd));
+            var semicolon = sizeText.IndexOf(';');
+            if (semicolon >= 0)
+                sizeText = sizeText[..semicolon];
+
+            if (!int.TryParse(sizeText.Trim(), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var size) || size < 0)
+                break;
+
+            pos += lineEnd + 2;
+            if (size == 0)
+            {
+                decoded = output.ToArray();
+                return true;
+            }
+
+            if (pos + size > body.Length)
+            {
+                output.Write(body[pos..]);
+                break;
+            }
+
+            output.Write(body.Slice(pos, size));
+            pos += size + 2;
+            if (pos > body.Length)
+                break;
+        }
+
+        decoded = output.ToArray();
+        return false;
+    }
+
+    /// <summary>Reads the Content-Length header value out of a raw response's header block.</summary>
+    private static int? ParseContentLength(string headers)
+    {
+        foreach (var line in headers.Split("\r\n"))
+        {
+            if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(line["Content-Length:".Length..].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var length))
+                return length;
+        }
+
+        return null;
     }
 
     /// <summary>Trims a raw device response for diagnostic logging.</summary>

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -143,21 +143,23 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Logs in once, then reads getUpdateinfo trying the resolved <see cref="AuthFlow"/> order,
-    /// returning the first result that carries an RX reading and caching the flow that produced
-    /// it. Returns the last built stats (which may lack RX) if a flow logged in but returned no
-    /// data, or null if login itself failed.
+    /// Reads getUpdateinfo trying the resolved <see cref="AuthFlow"/> order, returning the first
+    /// result that carries an RX reading and caching the flow that produced it. Each flow gets its
+    /// own fresh login so a probe of the wrong flow (e.g. a Direct getUpdateinfo that 401s on the
+    /// CLEI variant, which forces a PON-password session state) can't poison the next flow's
+    /// session. Returns the last built stats (which may lack RX) if a flow logged in but returned
+    /// no data, or null if every login failed.
     /// </summary>
     private async Task<OntStats?> FetchStatsAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
     {
-        var cookieId = await LoginAsync(client, baseUrl, context, ct);
-        if (cookieId is null)
-            return null;
-
         OntStats? last = null;
         foreach (var flow in ResolveFlows(context))
         {
+            var cookieId = await LoginAsync(client, baseUrl, context, ct);
+            if (cookieId is null)
+                continue;
+
             var infoJson = flow == AuthFlow.PageWalk
                 ? await GetUpdateInfoViaWalkAsync(client, baseUrl, cookieId, context.Name, ct)
                 : await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, MoreInfoPagePath, browserHeaders: false, ct);
@@ -289,10 +291,11 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     /// <summary>
     /// Builds a GponForm request. The session cookie is attached whenever one is supplied. When
     /// <paramref name="browserHeaders"/> is set the request also mirrors the device page's XHR
-    /// traffic - a Referer of the page the call is made from and, for the POSTs, Origin and
-    /// X-Requested-With: XMLHttpRequest - which the T-Fiber/Metronet CLEI variant needs. The
-    /// Direct getUpdateinfo passes false to stay the bare cookie-only request the one confirmed
-    /// firmware accepts. Pass <paramref name="formBody"/> null for a GET (a page navigation).
+    /// traffic - a browser User-Agent, a Referer of the page the call is made from and, for the
+    /// POSTs, Origin and X-Requested-With: XMLHttpRequest - which the T-Fiber/Metronet CLEI variant
+    /// needs. The Direct getUpdateinfo passes false to stay the bare cookie-only request that
+    /// shipped in v2.1.1/v2.2.0 (the one confirmed working, on @Liosnel's box). Pass
+    /// <paramref name="formBody"/> null for a GET (a page navigation).
     /// </summary>
     private static HttpRequestMessage BuildRequest(
         HttpMethod method, string url, string? formBody, string baseUrl, string refererPath, string? cookieId, bool browserHeaders)
@@ -304,6 +307,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         if (browserHeaders)
         {
+            request.Headers.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
             request.Headers.TryAddWithoutValidation("Referer", $"{baseUrl}{refererPath}");
             if (formBody is not null)
             {
@@ -431,8 +435,6 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         // boxes can tie the login session to the connection, so keep-alive reuse across the
         // login -> getUpdateinfo steps can return an empty/unauthenticated response.
         client.DefaultRequestHeaders.ConnectionClose = true;
-        // A browser User-Agent - the picky CLEI variant appears to sniff it; harmless elsewhere.
-        client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
         return client;
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -18,17 +19,18 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 ///   1. POST /GponForm/Login_GetConfig (token=token) -> {"nonce":..,"saltval":..}
 ///   2. cmt = sha256(username + saltval + password), lowercase hex
 ///   3. POST /GponForm/LoginForm (cmt=..&nonce=..) -> {"login_result":..,"cookieid":..}
-///   4. POST /GponForm/getUpdateinfo (token=token) with the browser's Origin,
-///      Referer: &lt;base&gt;/moreinfo.html and X-Requested-With: XMLHttpRequest headers,
-///      plus Cookie: sessionid=&lt;cookieid&gt;
+///   4. POST /GponForm/getUpdateinfo (token=token) with Cookie: sessionid=&lt;cookieid&gt;
 ///      -> {"CurrentPonPw","VendorID","VersionID","SerialNum","Mac","ActiveSwVer",
 ///          "StandbySwVer","RxOptPwr"}
 ///
-/// The getUpdateinfo authorization differs by firmware: the unit this was first built from
-/// (per a HAR) accepted the sessionid cookie, while a T-Fiber/Metronet CLEI variant instead
-/// gates on the Referer being /moreinfo.html and 401s to /login.html without it (its browser
-/// sends no cookie at all). Sending both the cookie and the browser headers satisfies both,
-/// so no per-firmware branching is needed.
+/// getUpdateinfo authorization differs by firmware, so two flows are tried and the winner is
+/// cached per config (see <see cref="AuthFlow"/>). <see cref="AuthFlow.Direct"/> calls
+/// getUpdateinfo with just the session cookie straight after login - the minimal request the one
+/// firmware confirmed working (@Liosnel's) accepts, kept untouched. <see cref="AuthFlow.PageWalk"/>
+/// handles a T-Fiber/Metronet CLEI variant that forces a PON-password page after login and gates
+/// getUpdateinfo behind walking through it: GET /ponpasswd.html, POST /GponForm/ponpasswd_GetConfig,
+/// GET /moreinfo.html, each carrying the session cookie and the browser's Referer/Origin/
+/// X-Requested-With headers, then getUpdateinfo with those headers too.
 ///
 /// The device exposes no TX power, temperature, or explicit link state; the receive
 /// optical power (RxOptPwr, dBm) is the one health metric it reports. Login credentials
@@ -43,11 +45,35 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     private const string LoginConfigPath = "/GponForm/Login_GetConfig";
     private const string LoginPath = "/GponForm/LoginForm";
     private const string UpdateInfoPath = "/GponForm/getUpdateinfo";
+    private const string PonPasswdConfigPath = "/GponForm/ponpasswd_GetConfig";
     private const string FormContentType = "application/x-www-form-urlencoded";
     private const string LoginPagePath = "/login.html";
+    private const string PonPasswdPagePath = "/ponpasswd.html";
     private const string MoreInfoPagePath = "/moreinfo.html";
+    private const string BrowserUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+
+    /// <summary>
+    /// How a given firmware authorizes the getUpdateinfo call. Determined on first contact and
+    /// cached per config in <see cref="_flowCache"/>; re-detected after a process restart.
+    /// </summary>
+    private enum AuthFlow
+    {
+        /// <summary>getUpdateinfo with just the cookie, straight after login (@Liosnel's firmware).</summary>
+        Direct,
+
+        /// <summary>Walk the forced PON-password pages before getUpdateinfo (T-Fiber/Metronet CLEI variant).</summary>
+        PageWalk,
+    }
 
     private readonly ILogger<NokiaXs010xOntProvider> _logger;
+
+    /// <summary>
+    /// Remembers the getUpdateinfo <see cref="AuthFlow"/> that last succeeded per
+    /// OntConfiguration.Id so later polls go straight to it instead of re-probing the wrong flow
+    /// (and, for the page walk, its extra requests) every interval. Re-detected after a restart.
+    /// </summary>
+    private readonly ConcurrentDictionary<int, AuthFlow> _flowCache = new();
 
     public NokiaXs010xOntProvider(ILogger<NokiaXs010xOntProvider> logger)
     {
@@ -66,38 +92,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         {
             using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
-
-            OntStats? stats = null;
-            const int maxAttempts = 3;
-            for (var attempt = 1; attempt <= maxAttempts; attempt++)
-            {
-                var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
-                if (cookieId is not null)
-                {
-                    var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
-                    stats = new OntStats
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        DeviceHost = context.ConfiguredHost ?? context.Host,
-                        DeviceName = context.Name,
-                        DeviceModel = "Nokia XS-010X-Q",
-                    };
-                    ApplyUpdateInfo(infoJson, stats);
-                    if (stats.RxPowerDbm is not null)
-                        break;
-                }
-
-                // The device sometimes returns an unauthenticated/empty response when the login
-                // and data request race on the same client - the browser flow and the working
-                // curl script both hit fresh connections with pauses between steps. A fresh login
-                // on a fresh connection (ConnectionClose in CreateClient) usually settles it.
-                if (attempt < maxAttempts)
-                {
-                    _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: no RX power on attempt {Attempt}/{Max}, retrying",
-                        context.Name, attempt, maxAttempts);
-                    await Task.Delay(TimeSpan.FromMilliseconds(600), cancellationToken);
-                }
-            }
+            var stats = await FetchStatsAsync(client, baseUrl, context, cancellationToken);
 
             if (stats is null)
             {
@@ -131,15 +126,10 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         {
             using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
+            var stats = await FetchStatsAsync(client, baseUrl, context, cancellationToken);
 
-            var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
-            if (cookieId is null)
+            if (stats is null)
                 return (false, "Login failed - check username/password (default is admin/1234)");
-
-            var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
-
-            var stats = new OntStats();
-            ApplyUpdateInfo(infoJson, stats);
 
             if (stats.RxPowerDbm is null)
                 return (false, "Logged in but response did not contain the expected RxOptPwr field");
@@ -153,10 +143,68 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     }
 
     /// <summary>
+    /// Logs in once, then reads getUpdateinfo trying the resolved <see cref="AuthFlow"/> order,
+    /// returning the first result that carries an RX reading and caching the flow that produced
+    /// it. Returns the last built stats (which may lack RX) if a flow logged in but returned no
+    /// data, or null if login itself failed.
+    /// </summary>
+    private async Task<OntStats?> FetchStatsAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        var cookieId = await LoginAsync(client, baseUrl, context, ct);
+        if (cookieId is null)
+            return null;
+
+        OntStats? last = null;
+        foreach (var flow in ResolveFlows(context))
+        {
+            var infoJson = flow == AuthFlow.PageWalk
+                ? await GetUpdateInfoViaWalkAsync(client, baseUrl, cookieId, context.Name, ct)
+                : await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, MoreInfoPagePath, browserHeaders: false, ct);
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
+                DeviceName = context.Name,
+                DeviceModel = "Nokia XS-010X-Q",
+            };
+            ApplyUpdateInfo(infoJson, stats);
+            if (stats.RxPowerDbm is not null)
+            {
+                if (context.Id > 0)
+                    _flowCache[context.Id] = flow;
+                return stats;
+            }
+
+            last = stats;
+        }
+
+        return last;
+    }
+
+    /// <summary>
+    /// The getUpdateinfo flows to try, in order: the one cached for this config first (so a
+    /// known-good firmware never re-probes), then the other as a fallback in case the cache is
+    /// empty or the firmware behavior changed. Uncached configs try Direct first - it's one
+    /// request and the only flow confirmed working on real hardware (@Liosnel's), so only a
+    /// variant that needs the walk pays for the extra probe, once, until it's cached.
+    /// </summary>
+    private IReadOnlyList<AuthFlow> ResolveFlows(OntPollContext context)
+    {
+        if (context.Id > 0 && _flowCache.TryGetValue(context.Id, out var cached))
+            return cached == AuthFlow.PageWalk
+                ? new[] { AuthFlow.PageWalk, AuthFlow.Direct }
+                : new[] { AuthFlow.Direct, AuthFlow.PageWalk };
+
+        return new[] { AuthFlow.Direct, AuthFlow.PageWalk };
+    }
+
+    /// <summary>
     /// Runs the three-step GponForm login and returns the session cookie id, or null if
     /// authentication fails. The cookie is delivered inside the LoginForm JSON body (the
     /// page's script clears the Set-Cookie header), so it is threaded back manually as a
-    /// Cookie header on the data request rather than via a CookieContainer.
+    /// Cookie header on later requests rather than via a CookieContainer.
     /// </summary>
     private async Task<string?> LoginAsync(
         HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
@@ -166,7 +214,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         string configJson;
         int configStatus;
-        using (var request = BuildFormPost($"{baseUrl}{LoginConfigPath}", "token=token", baseUrl, LoginPagePath))
+        using (var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{LoginConfigPath}", "token=token", baseUrl, LoginPagePath, cookieId: null, browserHeaders: true))
         using (var response = await client.SendAsync(request, ct))
         {
             configStatus = (int)response.StatusCode;
@@ -185,7 +233,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         string loginJson;
         int loginStatus;
         string? setCookie;
-        using (var request = BuildFormPost($"{baseUrl}{LoginPath}", body, baseUrl, LoginPagePath))
+        using (var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{LoginPath}", body, baseUrl, LoginPagePath, cookieId: null, browserHeaders: true))
         using (var response = await client.SendAsync(request, ct))
         {
             loginStatus = (int)response.StatusCode;
@@ -204,11 +252,32 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         return cookieId;
     }
 
-    private async Task<string> GetUpdateInfoAsync(
+    /// <summary>
+    /// Walks the forced PON-password pages (GET /ponpasswd.html, POST ponpasswd_GetConfig,
+    /// GET /moreinfo.html) so firmware that gates the data call behind them advances the session,
+    /// then reads getUpdateinfo. The session cookie and browser headers ride every step. Walk
+    /// responses are discarded; a step that 404s on firmware without the page is harmless (that
+    /// firmware just uses the Direct flow instead).
+    /// </summary>
+    private async Task<string> GetUpdateInfoViaWalkAsync(
         HttpClient client, string baseUrl, string cookieId, string deviceName, CancellationToken ct)
     {
-        using var request = BuildFormPost($"{baseUrl}{UpdateInfoPath}", "token=token", baseUrl, MoreInfoPagePath);
-        request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
+        await WalkStepAsync(client, BuildRequest(HttpMethod.Get, $"{baseUrl}{PonPasswdPagePath}", null, baseUrl, LoginPagePath, cookieId, browserHeaders: true), ct);
+        await WalkStepAsync(client, BuildRequest(HttpMethod.Post, $"{baseUrl}{PonPasswdConfigPath}", "token=token", baseUrl, PonPasswdPagePath, cookieId, browserHeaders: true), ct);
+        await WalkStepAsync(client, BuildRequest(HttpMethod.Get, $"{baseUrl}{MoreInfoPagePath}", null, baseUrl, PonPasswdPagePath, cookieId, browserHeaders: true), ct);
+        return await GetUpdateInfoAsync(client, baseUrl, cookieId, deviceName, PonPasswdPagePath, browserHeaders: true, ct);
+    }
+
+    private static async Task WalkStepAsync(HttpClient client, HttpRequestMessage request, CancellationToken ct)
+    {
+        using (request)
+        using (await client.SendAsync(request, ct)) { }
+    }
+
+    private async Task<string> GetUpdateInfoAsync(
+        HttpClient client, string baseUrl, string cookieId, string deviceName, string refererPath, bool browserHeaders, CancellationToken ct)
+    {
+        using var request = BuildRequest(HttpMethod.Post, $"{baseUrl}{UpdateInfoPath}", "token=token", baseUrl, refererPath, cookieId, browserHeaders);
 
         using var response = await client.SendAsync(request, ct);
         var body = await response.Content.ReadAsStringAsync(ct);
@@ -218,20 +287,34 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     }
 
     /// <summary>
-    /// Builds a form POST that mirrors the device page's XHR: the Origin, a Referer of the page
-    /// the call is made from, and X-Requested-With: XMLHttpRequest. A T-Fiber/Metronet CLEI
-    /// XS-010X-Q gates getUpdateinfo on the Referer (and 401s to /login.html without it); the
-    /// firmware this was first built from ignored these headers, so sending them is safe for both.
+    /// Builds a GponForm request. The session cookie is attached whenever one is supplied. When
+    /// <paramref name="browserHeaders"/> is set the request also mirrors the device page's XHR
+    /// traffic - a Referer of the page the call is made from and, for the POSTs, Origin and
+    /// X-Requested-With: XMLHttpRequest - which the T-Fiber/Metronet CLEI variant needs. The
+    /// Direct getUpdateinfo passes false to stay the bare cookie-only request the one confirmed
+    /// firmware accepts. Pass <paramref name="formBody"/> null for a GET (a page navigation).
     /// </summary>
-    private static HttpRequestMessage BuildFormPost(string url, string body, string baseUrl, string refererPath)
+    private static HttpRequestMessage BuildRequest(
+        HttpMethod method, string url, string? formBody, string baseUrl, string refererPath, string? cookieId, bool browserHeaders)
     {
-        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        var request = new HttpRequestMessage(method, url);
+
+        if (formBody is not null)
+            request.Content = new StringContent(formBody, Encoding.UTF8, FormContentType);
+
+        if (browserHeaders)
         {
-            Content = new StringContent(body, Encoding.UTF8, FormContentType),
-        };
-        request.Headers.TryAddWithoutValidation("Origin", baseUrl);
-        request.Headers.TryAddWithoutValidation("Referer", $"{baseUrl}{refererPath}");
-        request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
+            request.Headers.TryAddWithoutValidation("Referer", $"{baseUrl}{refererPath}");
+            if (formBody is not null)
+            {
+                request.Headers.TryAddWithoutValidation("Origin", baseUrl);
+                request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
+            }
+        }
+
+        if (!string.IsNullOrEmpty(cookieId))
+            request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
+
         return request;
     }
 
@@ -348,6 +431,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         // boxes can tie the login session to the connection, so keep-alive reuse across the
         // login -> getUpdateinfo steps can return an empty/unauthenticated response.
         client.DefaultRequestHeaders.ConnectionClose = true;
+        // A browser User-Agent - the picky CLEI variant appears to sniff it; harmless elsewhere.
+        client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", BrowserUserAgent);
         return client;
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -24,20 +24,26 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 ///      -> {"CurrentPonPw","VendorID","VersionID","SerialNum","Mac","ActiveSwVer",
 ///          "StandbySwVer","RxOptPwr"}
 ///
-/// Some firmware (a T-Fiber/Metronet CLEI variant) accepts this sequence from curl and from a
-/// browser but answers 401 -> /login.html when HttpClient sends the logically identical
-/// requests. The rejection is about wire framing, not auth logic: HttpClient omits User-Agent
-/// and Accept, appends "; charset=utf-8" to the Content-Type, emits content headers after the
-/// request headers (curl puts Content-Length before Content-Type) and adds Connection: close.
-/// None of that framing can be fully controlled through HttpClient, so two flows are tried and
-/// the winner is cached per config (see <see cref="AuthFlow"/>). <see cref="AuthFlow.Direct"/>
-/// is the plain HttpClient sequence exactly as shipped in v2.1.1/v2.2.0 - the one firmware
-/// confirmed working (@Liosnel's) accepts it, so its bytes are kept untouched.
-/// <see cref="AuthFlow.CurlReplay"/> writes the raw HTTP requests of the curl script proven on
-/// the picky firmware over a plain TCP socket, byte-for-byte (same headers, order and casing;
-/// fresh connection per request like separate curl invocations), including the forced
-/// PON-password page walk that firmware presents: GET /login.html, login, GET /ponpasswd.html,
-/// POST /GponForm/ponpasswd_GetConfig, GET /moreinfo.html, then getUpdateinfo.
+/// Some firmware accepts this sequence from curl and from a browser but answered 401 ->
+/// /login.html when HttpClient sent the logically identical requests. Root cause (found by
+/// @jakerobb on #929): those units answer the login calls with a malformed
+/// "Set-Cookie: Path=/; HttpOnly" header carrying no name=value pair. A cookie-enabled handler
+/// parses "Path=/" as a literal cookie, and once the CookieContainer holds anything for the
+/// host it silently replaces the hand-set "Cookie: sessionid=..." header - so the device never
+/// saw the session id. curl and raw sockets have no cookie engine and browsers discard the
+/// malformed header, which is why every other client worked. <see cref="CreateClient"/>
+/// therefore disables handler cookies so the hand-set header goes out untouched.
+///
+/// Firmware behavior demonstrably varies across units, so two flows are kept and the winner is
+/// cached per config (see <see cref="AuthFlow"/>). <see cref="AuthFlow.Direct"/> is the plain
+/// HttpClient sequence as shipped in v2.1.1/v2.2.0 (confirmed working on @Liosnel's unit) plus
+/// the cookie fix, which only changes the wire when a device emits Set-Cookie on login.
+/// <see cref="AuthFlow.CurlReplay"/> is defense in depth: it writes the raw HTTP requests of
+/// the tester-proven curl script over a plain TCP socket, byte-for-byte (same headers, order
+/// and casing; fresh connection per request like separate curl invocations), including the
+/// forced PON-password page walk some firmware presents: GET /login.html, login,
+/// GET /ponpasswd.html, POST /GponForm/ponpasswd_GetConfig, GET /moreinfo.html, then
+/// getUpdateinfo. It is immune to any handler-level rewriting by construction.
 ///
 /// The device exposes no TX power, temperature, or explicit link state; the receive
 /// optical power (RxOptPwr, dBm) is the one health metric it reports. Login credentials
@@ -66,12 +72,12 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     /// </summary>
     private enum AuthFlow
     {
-        /// <summary>Plain HttpClient login + cookie-only getUpdateinfo, byte-identical to the
-        /// shipped v2.1.1/v2.2.0 requests (@Liosnel's firmware accepts these).</summary>
+        /// <summary>Plain HttpClient login + cookie-only getUpdateinfo (handler cookies off so
+        /// the hand-set session header survives malformed device Set-Cookie headers).</summary>
         Direct,
 
-        /// <summary>Raw-socket byte-for-byte replay of the curl script the picky
-        /// (T-Fiber/Metronet CLEI) firmware is proven to accept.</summary>
+        /// <summary>Raw-socket byte-for-byte replay of the tester-proven curl script, immune to
+        /// handler-level rewriting by construction.</summary>
         CurlReplay,
     }
 
@@ -654,7 +660,14 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
     internal static HttpClient CreateClient()
     {
-        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        // Handler cookies must stay off (thanks @jakerobb, #929): some firmware answers the
+        // login calls with a malformed "Set-Cookie: Path=/; HttpOnly" header, which a default
+        // CookieContainer parses as a literal cookie and then silently substitutes for the
+        // hand-set "Cookie: sessionid=..." header, so the device never sees the session id.
+        // The real session cookie arrives in the LoginForm JSON body, not in Set-Cookie, so
+        // nothing legitimate is lost by disabling the cookie engine.
+        var handler = new HttpClientHandler { UseCookies = false };
+        var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
         // Mirror the working curl flow: a fresh TCP connection per request. These GponForm
         // boxes can tie the login session to the connection, so keep-alive reuse across the
         // login -> getUpdateinfo steps can return an empty/unauthenticated response.

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -54,40 +54,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         try
         {
-            using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
-
-            OntStats? stats = null;
-            const int maxAttempts = 3;
-            for (var attempt = 1; attempt <= maxAttempts; attempt++)
-            {
-                var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
-                if (cookieId is not null)
-                {
-                    var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
-                    stats = new OntStats
-                    {
-                        Timestamp = DateTime.UtcNow,
-                        DeviceHost = context.ConfiguredHost ?? context.Host,
-                        DeviceName = context.Name,
-                        DeviceModel = "Nokia XS-010X-Q",
-                    };
-                    ApplyUpdateInfo(infoJson, stats);
-                    if (stats.RxPowerDbm is not null)
-                        break;
-                }
-
-                // The device sometimes returns an unauthenticated/empty response when the login
-                // and data request race on the same client - the browser flow and the working
-                // curl script both hit fresh connections with pauses between steps. A fresh login
-                // on a fresh connection (ConnectionClose in CreateClient) usually settles it.
-                if (attempt < maxAttempts)
-                {
-                    _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: no RX power on attempt {Attempt}/{Max}, retrying",
-                        context.Name, attempt, maxAttempts);
-                    await Task.Delay(TimeSpan.FromMilliseconds(600), cancellationToken);
-                }
-            }
+            var stats = await PollWithFallbackAsync(baseUrl, context, cancellationToken);
 
             if (stats is null)
             {
@@ -119,17 +87,11 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         try
         {
-            using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
+            var stats = await PollWithFallbackAsync(baseUrl, context, cancellationToken);
 
-            var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
-            if (cookieId is null)
+            if (stats is null)
                 return (false, "Login failed - check username/password (default is admin/1234)");
-
-            var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
-
-            var stats = new OntStats();
-            ApplyUpdateInfo(infoJson, stats);
 
             if (stats.RxPowerDbm is null)
                 return (false, "Logged in but response did not contain the expected RxOptPwr field");
@@ -140,6 +102,79 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         {
             return (false, $"Connection failed: {ex.Message}");
         }
+    }
+
+    /// <summary>
+    /// Runs the login + getUpdateinfo sequence, trying two connection strategies in turn.
+    /// The provider was built from a single community-captured flow that uses a fresh TCP
+    /// connection per request (<see cref="CreateClient"/> with ConnectionClose), which works
+    /// on some XS-010X-Q firmware but not others: variants that bind the auth session to the
+    /// login TCP connection reject the cookie on the separate getUpdateinfo socket with a
+    /// 401 -> /login.html redirect. When the fresh-connection path yields no RX reading, we
+    /// retry over a single shared keep-alive connection so login and data ride the same
+    /// socket. Returns the first result carrying an RX reading, otherwise the last non-null
+    /// (logged-in-but-no-data) result, or null when every attempt failed to log in.
+    /// </summary>
+    private async Task<OntStats?> PollWithFallbackAsync(
+        string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        using (var freshClient = CreateClient(keepAlive: false))
+        {
+            var stats = await PollOnceAsync(freshClient, baseUrl, context, ct);
+            if (stats?.RxPowerDbm is not null)
+                return stats;
+
+            _logger.LogDebug(
+                "Nokia XS-010X-Q ONT {Name}: no RX power over fresh connections, retrying on a single keep-alive connection",
+                context.Name);
+
+            using (var keepAliveClient = CreateClient(keepAlive: true))
+            {
+                var keepAliveStats = await PollOnceAsync(keepAliveClient, baseUrl, context, ct);
+                return keepAliveStats ?? stats;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Runs up to three login + getUpdateinfo attempts on a single client, returning as soon
+    /// as an RX reading is obtained. Retries cover the device occasionally returning an
+    /// unauthenticated/empty response when the login and data request race on the same client.
+    /// Returns the built stats (which may lack an RX reading if login succeeded but the data
+    /// call did not), or null if login never succeeded.
+    /// </summary>
+    private async Task<OntStats?> PollOnceAsync(
+        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
+    {
+        OntStats? stats = null;
+        const int maxAttempts = 3;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            var cookieId = await LoginAsync(client, baseUrl, context, ct);
+            if (cookieId is not null)
+            {
+                var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, ct);
+                stats = new OntStats
+                {
+                    Timestamp = DateTime.UtcNow,
+                    DeviceHost = context.ConfiguredHost ?? context.Host,
+                    DeviceName = context.Name,
+                    DeviceModel = "Nokia XS-010X-Q",
+                };
+                ApplyUpdateInfo(infoJson, stats);
+                if (stats.RxPowerDbm is not null)
+                    break;
+            }
+
+            if (attempt < maxAttempts)
+            {
+                _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: no RX power on attempt {Attempt}/{Max}, retrying",
+                    context.Name, attempt, maxAttempts);
+                await Task.Delay(TimeSpan.FromMilliseconds(600), ct);
+            }
+        }
+
+        return stats;
     }
 
     /// <summary>
@@ -174,16 +209,23 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         string loginJson;
         int loginStatus;
+        string? setCookie;
         using (var content = new StringContent(body, Encoding.UTF8, FormContentType))
         using (var response = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct))
         {
             loginStatus = (int)response.StatusCode;
             loginJson = await response.Content.ReadAsStringAsync(ct);
+            // Diagnostic: the reference flow delivers the cookie in the JSON body and clears the
+            // Set-Cookie header, but some firmware may instead set a real (differently named)
+            // cookie via header. Log it so a non-working unit's logs reveal which path it uses.
+            setCookie = response.Headers.TryGetValues("Set-Cookie", out var cookieValues)
+                ? string.Join(" | ", cookieValues)
+                : null;
         }
 
         var cookieId = ParseCookieId(loginJson);
-        _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: LoginForm HTTP {Status}, gotCookie={HasCookie}, body={Body}",
-            context.Name, loginStatus, cookieId != null, Preview(loginJson));
+        _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: LoginForm HTTP {Status}, gotCookie={HasCookie}, setCookie={SetCookie}, body={Body}",
+            context.Name, loginStatus, cookieId != null, setCookie ?? "(none)", Preview(loginJson));
         return cookieId;
     }
 
@@ -309,8 +351,21 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     private static double? ParseDouble(string? text) =>
         double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
 
-    internal static HttpClient CreateClient()
+    internal static HttpClient CreateClient(bool keepAlive = false)
     {
+        if (keepAlive)
+        {
+            // Fallback strategy: pin every request to a single shared connection. Firmware that
+            // binds the auth session to the login TCP connection needs login and getUpdateinfo
+            // to ride the same socket, otherwise the cookie is rejected (401 -> /login.html).
+            // MaxConnectionsPerServer=1 forces the sequential requests through one connection.
+            var handler = new SocketsHttpHandler { MaxConnectionsPerServer = 1 };
+            return new HttpClient(handler, disposeHandler: true)
+            {
+                Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            };
+        }
+
         var client = new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
         // Mirror the working curl flow: a fresh TCP connection per request. These GponForm
         // boxes can tie the login session to the connection, so keep-alive reuse across the

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -18,9 +18,17 @@ namespace NetworkOptimizer.Web.Services.OntProviders;
 ///   1. POST /GponForm/Login_GetConfig (token=token) -> {"nonce":..,"saltval":..}
 ///   2. cmt = sha256(username + saltval + password), lowercase hex
 ///   3. POST /GponForm/LoginForm (cmt=..&nonce=..) -> {"login_result":..,"cookieid":..}
-///   4. POST /GponForm/getUpdateinfo (token=token) with Cookie: sessionid=&lt;cookieid&gt;
+///   4. POST /GponForm/getUpdateinfo (token=token) with the browser's Origin,
+///      Referer: &lt;base&gt;/moreinfo.html and X-Requested-With: XMLHttpRequest headers,
+///      plus Cookie: sessionid=&lt;cookieid&gt;
 ///      -> {"CurrentPonPw","VendorID","VersionID","SerialNum","Mac","ActiveSwVer",
 ///          "StandbySwVer","RxOptPwr"}
+///
+/// The getUpdateinfo authorization differs by firmware: the unit this was first built from
+/// (per a HAR) accepted the sessionid cookie, while a T-Fiber/Metronet CLEI variant instead
+/// gates on the Referer being /moreinfo.html and 401s to /login.html without it (its browser
+/// sends no cookie at all). Sending both the cookie and the browser headers satisfies both,
+/// so no per-firmware branching is needed.
 ///
 /// The device exposes no TX power, temperature, or explicit link state; the receive
 /// optical power (RxOptPwr, dBm) is the one health metric it reports. Login credentials
@@ -36,6 +44,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     private const string LoginPath = "/GponForm/LoginForm";
     private const string UpdateInfoPath = "/GponForm/getUpdateinfo";
     private const string FormContentType = "application/x-www-form-urlencoded";
+    private const string LoginPagePath = "/login.html";
+    private const string MoreInfoPagePath = "/moreinfo.html";
 
     private readonly ILogger<NokiaXs010xOntProvider> _logger;
 
@@ -54,8 +64,40 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         try
         {
+            using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
-            var stats = await PollWithFallbackAsync(baseUrl, context, cancellationToken);
+
+            OntStats? stats = null;
+            const int maxAttempts = 3;
+            for (var attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
+                if (cookieId is not null)
+                {
+                    var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
+                    stats = new OntStats
+                    {
+                        Timestamp = DateTime.UtcNow,
+                        DeviceHost = context.ConfiguredHost ?? context.Host,
+                        DeviceName = context.Name,
+                        DeviceModel = "Nokia XS-010X-Q",
+                    };
+                    ApplyUpdateInfo(infoJson, stats);
+                    if (stats.RxPowerDbm is not null)
+                        break;
+                }
+
+                // The device sometimes returns an unauthenticated/empty response when the login
+                // and data request race on the same client - the browser flow and the working
+                // curl script both hit fresh connections with pauses between steps. A fresh login
+                // on a fresh connection (ConnectionClose in CreateClient) usually settles it.
+                if (attempt < maxAttempts)
+                {
+                    _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: no RX power on attempt {Attempt}/{Max}, retrying",
+                        context.Name, attempt, maxAttempts);
+                    await Task.Delay(TimeSpan.FromMilliseconds(600), cancellationToken);
+                }
+            }
 
             if (stats is null)
             {
@@ -87,11 +129,17 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         try
         {
+            using var client = CreateClient();
             var baseUrl = BuildBaseUrl(context);
-            var stats = await PollWithFallbackAsync(baseUrl, context, cancellationToken);
 
-            if (stats is null)
+            var cookieId = await LoginAsync(client, baseUrl, context, cancellationToken);
+            if (cookieId is null)
                 return (false, "Login failed - check username/password (default is admin/1234)");
+
+            var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, cancellationToken);
+
+            var stats = new OntStats();
+            ApplyUpdateInfo(infoJson, stats);
 
             if (stats.RxPowerDbm is null)
                 return (false, "Logged in but response did not contain the expected RxOptPwr field");
@@ -102,79 +150,6 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         {
             return (false, $"Connection failed: {ex.Message}");
         }
-    }
-
-    /// <summary>
-    /// Runs the login + getUpdateinfo sequence, trying two connection strategies in turn.
-    /// The provider was built from a single community-captured flow that uses a fresh TCP
-    /// connection per request (<see cref="CreateClient"/> with ConnectionClose), which works
-    /// on some XS-010X-Q firmware but not others: variants that bind the auth session to the
-    /// login TCP connection reject the cookie on the separate getUpdateinfo socket with a
-    /// 401 -> /login.html redirect. When the fresh-connection path yields no RX reading, we
-    /// retry over a single shared keep-alive connection so login and data ride the same
-    /// socket. Returns the first result carrying an RX reading, otherwise the last non-null
-    /// (logged-in-but-no-data) result, or null when every attempt failed to log in.
-    /// </summary>
-    private async Task<OntStats?> PollWithFallbackAsync(
-        string baseUrl, OntPollContext context, CancellationToken ct)
-    {
-        using (var freshClient = CreateClient(keepAlive: false))
-        {
-            var stats = await PollOnceAsync(freshClient, baseUrl, context, ct);
-            if (stats?.RxPowerDbm is not null)
-                return stats;
-
-            _logger.LogDebug(
-                "Nokia XS-010X-Q ONT {Name}: no RX power over fresh connections, retrying on a single keep-alive connection",
-                context.Name);
-
-            using (var keepAliveClient = CreateClient(keepAlive: true))
-            {
-                var keepAliveStats = await PollOnceAsync(keepAliveClient, baseUrl, context, ct);
-                return keepAliveStats ?? stats;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Runs up to three login + getUpdateinfo attempts on a single client, returning as soon
-    /// as an RX reading is obtained. Retries cover the device occasionally returning an
-    /// unauthenticated/empty response when the login and data request race on the same client.
-    /// Returns the built stats (which may lack an RX reading if login succeeded but the data
-    /// call did not), or null if login never succeeded.
-    /// </summary>
-    private async Task<OntStats?> PollOnceAsync(
-        HttpClient client, string baseUrl, OntPollContext context, CancellationToken ct)
-    {
-        OntStats? stats = null;
-        const int maxAttempts = 3;
-        for (var attempt = 1; attempt <= maxAttempts; attempt++)
-        {
-            var cookieId = await LoginAsync(client, baseUrl, context, ct);
-            if (cookieId is not null)
-            {
-                var infoJson = await GetUpdateInfoAsync(client, baseUrl, cookieId, context.Name, ct);
-                stats = new OntStats
-                {
-                    Timestamp = DateTime.UtcNow,
-                    DeviceHost = context.ConfiguredHost ?? context.Host,
-                    DeviceName = context.Name,
-                    DeviceModel = "Nokia XS-010X-Q",
-                };
-                ApplyUpdateInfo(infoJson, stats);
-                if (stats.RxPowerDbm is not null)
-                    break;
-            }
-
-            if (attempt < maxAttempts)
-            {
-                _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: no RX power on attempt {Attempt}/{Max}, retrying",
-                    context.Name, attempt, maxAttempts);
-                await Task.Delay(TimeSpan.FromMilliseconds(600), ct);
-            }
-        }
-
-        return stats;
     }
 
     /// <summary>
@@ -191,8 +166,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
 
         string configJson;
         int configStatus;
-        using (var content = new StringContent("token=token", Encoding.UTF8, FormContentType))
-        using (var response = await client.PostAsync($"{baseUrl}{LoginConfigPath}", content, ct))
+        using (var request = BuildFormPost($"{baseUrl}{LoginConfigPath}", "token=token", baseUrl, LoginPagePath))
+        using (var response = await client.SendAsync(request, ct))
         {
             configStatus = (int)response.StatusCode;
             configJson = await response.Content.ReadAsStringAsync(ct);
@@ -210,14 +185,14 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         string loginJson;
         int loginStatus;
         string? setCookie;
-        using (var content = new StringContent(body, Encoding.UTF8, FormContentType))
-        using (var response = await client.PostAsync($"{baseUrl}{LoginPath}", content, ct))
+        using (var request = BuildFormPost($"{baseUrl}{LoginPath}", body, baseUrl, LoginPagePath))
+        using (var response = await client.SendAsync(request, ct))
         {
             loginStatus = (int)response.StatusCode;
             loginJson = await response.Content.ReadAsStringAsync(ct);
             // Diagnostic: the reference flow delivers the cookie in the JSON body and clears the
-            // Set-Cookie header, but some firmware may instead set a real (differently named)
-            // cookie via header. Log it so a non-working unit's logs reveal which path it uses.
+            // Set-Cookie header, but some firmware may set a real (differently named) cookie via
+            // header. Log it so a non-working unit's logs reveal which path it uses.
             setCookie = response.Headers.TryGetValues("Set-Cookie", out var cookieValues)
                 ? string.Join(" | ", cookieValues)
                 : null;
@@ -232,10 +207,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     private async Task<string> GetUpdateInfoAsync(
         HttpClient client, string baseUrl, string cookieId, string deviceName, CancellationToken ct)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Post, $"{baseUrl}{UpdateInfoPath}")
-        {
-            Content = new StringContent("token=token", Encoding.UTF8, FormContentType),
-        };
+        using var request = BuildFormPost($"{baseUrl}{UpdateInfoPath}", "token=token", baseUrl, MoreInfoPagePath);
         request.Headers.TryAddWithoutValidation("Cookie", $"sessionid={cookieId}");
 
         using var response = await client.SendAsync(request, ct);
@@ -243,6 +215,24 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         _logger.LogDebug("Nokia XS-010X-Q ONT {Name}: getUpdateinfo HTTP {Status}, body={Body}",
             deviceName, (int)response.StatusCode, Preview(body));
         return body;
+    }
+
+    /// <summary>
+    /// Builds a form POST that mirrors the device page's XHR: the Origin, a Referer of the page
+    /// the call is made from, and X-Requested-With: XMLHttpRequest. A T-Fiber/Metronet CLEI
+    /// XS-010X-Q gates getUpdateinfo on the Referer (and 401s to /login.html without it); the
+    /// firmware this was first built from ignored these headers, so sending them is safe for both.
+    /// </summary>
+    private static HttpRequestMessage BuildFormPost(string url, string body, string baseUrl, string refererPath)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(body, Encoding.UTF8, FormContentType),
+        };
+        request.Headers.TryAddWithoutValidation("Origin", baseUrl);
+        request.Headers.TryAddWithoutValidation("Referer", $"{baseUrl}{refererPath}");
+        request.Headers.TryAddWithoutValidation("X-Requested-With", "XMLHttpRequest");
+        return request;
     }
 
     /// <summary>Trims a raw device response for diagnostic logging.</summary>
@@ -351,21 +341,8 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     private static double? ParseDouble(string? text) =>
         double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) ? val : null;
 
-    internal static HttpClient CreateClient(bool keepAlive = false)
+    internal static HttpClient CreateClient()
     {
-        if (keepAlive)
-        {
-            // Fallback strategy: pin every request to a single shared connection. Firmware that
-            // binds the auth session to the login TCP connection needs login and getUpdateinfo
-            // to ride the same socket, otherwise the cookie is rejected (401 -> /login.html).
-            // MaxConnectionsPerServer=1 forces the sequential requests through one connection.
-            var handler = new SocketsHttpHandler { MaxConnectionsPerServer = 1 };
-            return new HttpClient(handler, disposeHandler: true)
-            {
-                Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
-            };
-        }
-
         var client = new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
         // Mirror the working curl flow: a fresh TCP connection per request. These GponForm
         // boxes can tie the login session to the connection, so keep-alive reuse across the

--- a/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
@@ -279,10 +279,39 @@ public class NokiaXs010xOntProviderTests
         server.RejectedUserAgentlessUpdateInfo.Should().BeTrue("the Direct flow should have probed first and been 401'd");
     }
 
+    [Fact]
+    public async Task PollAsync_MalformedSetCookieFirmware_DirectFlowStillAuthenticates()
+    {
+        // Simulates the root cause @jakerobb isolated on #929: the firmware answers the login
+        // calls with a malformed "Set-Cookie: Path=/; HttpOnly" header (no name=value). With a
+        // cookie-enabled handler the CookieContainer swallows it and substitutes garbage for the
+        // hand-set sessionid header; with UseCookies off the Direct flow must succeed as-is,
+        // without ever falling back to the curl replay.
+        await using var server = new PickyGponFormServer(requireUserAgent: false, emitMalformedSetCookie: true);
+        var provider = new NokiaXs010xOntProvider(NullLogger<NokiaXs010xOntProvider>.Instance);
+        var context = new OntPollContext
+        {
+            Id = 2,
+            Name = "TestOnt",
+            Host = "127.0.0.1",
+            Port = server.Port,
+            Username = "admin",
+            Password = "1234",
+        };
+
+        var stats = await provider.PollAsync(context);
+
+        stats.Should().NotBeNull();
+        stats!.RxPowerDbm.Should().BeApproximately(-13.3, 0.0001);
+        server.SawWalkPage.Should().BeFalse("Direct should authenticate without the curl-replay fallback");
+    }
+
     /// <summary>
-    /// Minimal GponForm device double that mimics the picky CLEI firmware: serves the login
-    /// handshake to anyone, but 401s getUpdateinfo when the request has no User-Agent header or
-    /// the wrong session cookie. One request per connection, Connection: close, like the device.
+    /// Minimal GponForm device double that mimics the picky firmware variants: serves the login
+    /// handshake to anyone, but 401s getUpdateinfo when the session cookie is wrong (or, when
+    /// <c>requireUserAgent</c> is set, when the request has no User-Agent header), and can emit
+    /// the malformed Set-Cookie header the real units send on login responses. One request per
+    /// connection, Connection: close, like the device.
     /// </summary>
     private sealed class PickyGponFormServer : IAsyncDisposable
     {
@@ -293,13 +322,19 @@ public class NokiaXs010xOntProviderTests
         private readonly TcpListener _listener;
         private readonly CancellationTokenSource _cts = new();
         private readonly Task _acceptLoop;
+        private readonly bool _requireUserAgent;
+        private readonly bool _emitMalformedSetCookie;
 
         public int Port { get; }
 
         public bool RejectedUserAgentlessUpdateInfo { get; private set; }
 
-        public PickyGponFormServer()
+        public bool SawWalkPage { get; private set; }
+
+        public PickyGponFormServer(bool requireUserAgent = true, bool emitMalformedSetCookie = false)
         {
+            _requireUserAgent = requireUserAgent;
+            _emitMalformedSetCookie = emitMalformedSetCookie;
             _listener = new TcpListener(IPAddress.Loopback, 0);
             _listener.Start();
             Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
@@ -348,21 +383,29 @@ public class NokiaXs010xOntProviderTests
             var hasSession = lines.Any(l =>
                 l.StartsWith("Cookie:", StringComparison.OrdinalIgnoreCase) && l.Contains($"sessionid={CookieId}"));
 
+            if (target == "/ponpasswd.html")
+                SawWalkPage = true;
+
             var status = "200 OK";
+            var setCookie = "";
             string responseBody;
             switch (target)
             {
                 case "/GponForm/Login_GetConfig":
                     responseBody = $$"""{"XError":0,"nonce":"{{Nonce}}","saltval":"{{Salt}}"}""";
+                    if (_emitMalformedSetCookie)
+                        setCookie = "Set-Cookie: Path=/; HttpOnly\r\n";
                     break;
                 case "/GponForm/LoginForm":
                     var expectedCmt = NokiaXs010xOntProvider.ComputeCmt("admin", Salt, "1234");
                     responseBody = body.Contains($"cmt={expectedCmt}") && body.Contains($"nonce={Nonce}")
                         ? $$"""{"login_result":"success","cookieid":"{{CookieId}}"}"""
                         : """{"login_result":"error"}""";
+                    if (_emitMalformedSetCookie)
+                        setCookie = "Set-Cookie: Path=/; HttpOnly\r\n";
                     break;
                 case "/GponForm/getUpdateinfo":
-                    if (hasUserAgent && hasSession)
+                    if ((hasUserAgent || !_requireUserAgent) && hasSession)
                     {
                         responseBody = FullUpdateInfoJson;
                     }
@@ -380,7 +423,7 @@ public class NokiaXs010xOntProviderTests
             }
 
             var response =
-                $"HTTP/1.1 {status}\r\nContent-Type: text/html\r\n" +
+                $"HTTP/1.1 {status}\r\nContent-Type: text/html\r\n{setCookie}" +
                 $"Content-Length: {Encoding.ASCII.GetByteCount(responseBody)}\r\nConnection: close\r\n\r\n" +
                 responseBody;
             await stream.WriteAsync(Encoding.ASCII.GetBytes(response), _cts.Token);

--- a/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
@@ -1,5 +1,10 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Web.Services.OntProviders;
 using Xunit;
 
@@ -93,6 +98,313 @@ public class NokiaXs010xOntProviderTests
 
         nonce.Should().BeNull();
         salt.Should().BeNull();
+    }
+
+    // The exact User-Agent the tester-proven curl script sends (also the provider's constant).
+    private const string CurlScriptUserAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36";
+
+    [Fact]
+    public void BuildCurlRequest_GetUpdateinfo_MatchesCapturedCurlFraming()
+    {
+        // Byte-for-byte template captured by replaying the tester's working curl script against
+        // a local listener: Host, User-Agent, Accept, Cookie, Referer, Origin, X-Requested-With,
+        // then Content-Length BEFORE Content-Type with no charset suffix, and no Connection header.
+        var expected =
+            "POST /GponForm/getUpdateinfo HTTP/1.1\r\n" +
+            "Host: 192.0.2.1\r\n" +
+            $"User-Agent: {CurlScriptUserAgent}\r\n" +
+            "Accept: */*\r\n" +
+            "Cookie: sessionid=deadbeefcafe0123\r\n" +
+            "Referer: http://192.0.2.1/moreinfo.html\r\n" +
+            "Origin: http://192.0.2.1\r\n" +
+            "X-Requested-With: XMLHttpRequest\r\n" +
+            "Content-Length: 11\r\n" +
+            "Content-Type: application/x-www-form-urlencoded\r\n" +
+            "\r\n" +
+            "token=token";
+
+        var bytes = NokiaXs010xOntProvider.BuildCurlRequest(
+            "http://192.0.2.1", "/GponForm/getUpdateinfo", "deadbeefcafe0123", "/moreinfo.html", "token=token");
+
+        System.Text.Encoding.ASCII.GetString(bytes).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildCurlRequest_LoginConfigWithoutCookie_OmitsCookieHeader()
+    {
+        var expected =
+            "POST /GponForm/Login_GetConfig HTTP/1.1\r\n" +
+            "Host: 192.0.2.1:8080\r\n" +
+            $"User-Agent: {CurlScriptUserAgent}\r\n" +
+            "Accept: */*\r\n" +
+            "Referer: http://192.0.2.1:8080/login.html\r\n" +
+            "Origin: http://192.0.2.1:8080\r\n" +
+            "X-Requested-With: XMLHttpRequest\r\n" +
+            "Content-Length: 11\r\n" +
+            "Content-Type: application/x-www-form-urlencoded\r\n" +
+            "\r\n" +
+            "token=token";
+
+        var bytes = NokiaXs010xOntProvider.BuildCurlRequest(
+            "http://192.0.2.1:8080", "/GponForm/Login_GetConfig", cookieId: null, "/login.html", "token=token");
+
+        System.Text.Encoding.ASCII.GetString(bytes).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildCurlRequest_PageGet_CarriesOnlyCookieAndReferer()
+    {
+        var expected =
+            "GET /ponpasswd.html HTTP/1.1\r\n" +
+            "Host: 192.0.2.1\r\n" +
+            $"User-Agent: {CurlScriptUserAgent}\r\n" +
+            "Accept: */*\r\n" +
+            "Cookie: sessionid=deadbeefcafe0123\r\n" +
+            "Referer: http://192.0.2.1/login.html\r\n" +
+            "\r\n";
+
+        var bytes = NokiaXs010xOntProvider.BuildCurlRequest(
+            "http://192.0.2.1", "/ponpasswd.html", "deadbeefcafe0123", "/login.html", formBody: null);
+
+        System.Text.Encoding.ASCII.GetString(bytes).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BuildCurlRequest_InitialLoginPageGet_HasNoCookieOrReferer()
+    {
+        var expected =
+            "GET /login.html HTTP/1.1\r\n" +
+            "Host: 192.0.2.1\r\n" +
+            $"User-Agent: {CurlScriptUserAgent}\r\n" +
+            "Accept: */*\r\n" +
+            "\r\n";
+
+        var bytes = NokiaXs010xOntProvider.BuildCurlRequest(
+            "http://192.0.2.1", "/login.html", cookieId: null, refererPath: null, formBody: null);
+
+        System.Text.Encoding.ASCII.GetString(bytes).Should().Be(expected);
+    }
+
+    // The device answers every GponForm call with Transfer-Encoding: chunked + Connection: close
+    // (seen in both testers' HARs), so the raw reader has to de-chunk.
+    private const string ChunkedDeviceResponse =
+        "HTTP/1.1 200 OK\r\nServer: nginx\r\nContent-Type: text/html\r\n" +
+        "Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n" +
+        "8\r\n{\"RxOptP\r\nc\r\nwr\":\"-13.3\"}\r\n0\r\n\r\n";
+
+    [Fact]
+    public void ParseRawHttpResponse_ChunkedBody_DecodesStatusAndBody()
+    {
+        var (status, body) = NokiaXs010xOntProvider.ParseRawHttpResponse(
+            System.Text.Encoding.ASCII.GetBytes(ChunkedDeviceResponse));
+
+        status.Should().Be(200);
+        body.Should().Be("""{"RxOptPwr":"-13.3"}""");
+    }
+
+    [Fact]
+    public void ParseRawHttpResponse_ContentLengthBody_TrimsToDeclaredLength()
+    {
+        var raw = System.Text.Encoding.ASCII.GetBytes(
+            "HTTP/1.1 401 Unauthorized\r\nContent-Length: 5\r\n\r\nhelloEXTRA");
+
+        var (status, body) = NokiaXs010xOntProvider.ParseRawHttpResponse(raw);
+
+        status.Should().Be(401);
+        body.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ParseRawHttpResponse_TruncatedChunkedBody_ReturnsBytesReceivedSoFar()
+    {
+        var raw = System.Text.Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n{\"RxOptP");
+
+        var (status, body) = NokiaXs010xOntProvider.ParseRawHttpResponse(raw);
+
+        status.Should().Be(200);
+        body.Should().Be("{\"RxOptP");
+    }
+
+    [Fact]
+    public void IsRawResponseComplete_ChunkedWithTerminator_IsComplete()
+    {
+        NokiaXs010xOntProvider.IsRawResponseComplete(
+            System.Text.Encoding.ASCII.GetBytes(ChunkedDeviceResponse)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRawResponseComplete_ChunkedWithoutTerminator_IsIncomplete()
+    {
+        var raw = System.Text.Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n8\r\n{\"RxOptP\r\n");
+
+        NokiaXs010xOntProvider.IsRawResponseComplete(raw).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRawResponseComplete_NoLengthFraming_WaitsForConnectionClose()
+    {
+        var raw = System.Text.Encoding.ASCII.GetBytes(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\nbody");
+
+        NokiaXs010xOntProvider.IsRawResponseComplete(raw).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task PollAsync_UserAgentGatedFirmware_FallsBackToCurlReplay()
+    {
+        // Simulates the picky firmware: login works for any client, but getUpdateinfo 401s
+        // unless the request carries a User-Agent (the trait every proven-working client - curl
+        // and browsers - shares and the shipped HttpClient request lacks). The Direct flow must
+        // probe first and fail, then the raw-socket curl replay must complete the walk and read.
+        await using var server = new PickyGponFormServer();
+        var provider = new NokiaXs010xOntProvider(NullLogger<NokiaXs010xOntProvider>.Instance);
+        var context = new OntPollContext
+        {
+            Id = 1,
+            Name = "TestOnt",
+            Host = "127.0.0.1",
+            Port = server.Port,
+            Username = "admin",
+            Password = "1234",
+        };
+
+        var stats = await provider.PollAsync(context);
+
+        stats.Should().NotBeNull();
+        stats!.RxPowerDbm.Should().BeApproximately(-13.3, 0.0001);
+        stats.VendorSn.Should().Be("ALCLaabbccdd");
+        server.RejectedUserAgentlessUpdateInfo.Should().BeTrue("the Direct flow should have probed first and been 401'd");
+    }
+
+    /// <summary>
+    /// Minimal GponForm device double that mimics the picky CLEI firmware: serves the login
+    /// handshake to anyone, but 401s getUpdateinfo when the request has no User-Agent header or
+    /// the wrong session cookie. One request per connection, Connection: close, like the device.
+    /// </summary>
+    private sealed class PickyGponFormServer : IAsyncDisposable
+    {
+        private const string Nonce = "AbCdEfGhIjKlMnOpQrStUvWxYz012345";
+        private const string Salt = "ea";
+        private const string CookieId = "deadbeefcafe0123";
+
+        private readonly TcpListener _listener;
+        private readonly CancellationTokenSource _cts = new();
+        private readonly Task _acceptLoop;
+
+        public int Port { get; }
+
+        public bool RejectedUserAgentlessUpdateInfo { get; private set; }
+
+        public PickyGponFormServer()
+        {
+            _listener = new TcpListener(IPAddress.Loopback, 0);
+            _listener.Start();
+            Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+            _acceptLoop = AcceptLoopAsync();
+        }
+
+        private async Task AcceptLoopAsync()
+        {
+            try
+            {
+                while (!_cts.IsCancellationRequested)
+                {
+                    using var client = await _listener.AcceptTcpClientAsync(_cts.Token);
+                    await HandleAsync(client);
+                }
+            }
+            catch (OperationCanceledException) { }
+            catch (SocketException) { }
+        }
+
+        private async Task HandleAsync(TcpClient client)
+        {
+            var stream = client.GetStream();
+            var buffer = new byte[16384];
+            var received = new MemoryStream();
+            string request;
+            int headerEnd;
+            while (true)
+            {
+                var read = await stream.ReadAsync(buffer, _cts.Token);
+                if (read == 0)
+                    return;
+                received.Write(buffer, 0, read);
+                request = Encoding.ASCII.GetString(received.ToArray());
+                headerEnd = request.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+                if (headerEnd < 0)
+                    continue;
+                if (request.Length >= headerEnd + 4 + GetContentLength(request[..headerEnd]))
+                    break;
+            }
+
+            var lines = request[..headerEnd].Split("\r\n");
+            var target = lines[0].Split(' ')[1];
+            var body = request[(headerEnd + 4)..];
+            var hasUserAgent = lines.Any(l => l.StartsWith("User-Agent:", StringComparison.OrdinalIgnoreCase));
+            var hasSession = lines.Any(l =>
+                l.StartsWith("Cookie:", StringComparison.OrdinalIgnoreCase) && l.Contains($"sessionid={CookieId}"));
+
+            var status = "200 OK";
+            string responseBody;
+            switch (target)
+            {
+                case "/GponForm/Login_GetConfig":
+                    responseBody = $$"""{"XError":0,"nonce":"{{Nonce}}","saltval":"{{Salt}}"}""";
+                    break;
+                case "/GponForm/LoginForm":
+                    var expectedCmt = NokiaXs010xOntProvider.ComputeCmt("admin", Salt, "1234");
+                    responseBody = body.Contains($"cmt={expectedCmt}") && body.Contains($"nonce={Nonce}")
+                        ? $$"""{"login_result":"success","cookieid":"{{CookieId}}"}"""
+                        : """{"login_result":"error"}""";
+                    break;
+                case "/GponForm/getUpdateinfo":
+                    if (hasUserAgent && hasSession)
+                    {
+                        responseBody = FullUpdateInfoJson;
+                    }
+                    else
+                    {
+                        if (!hasUserAgent)
+                            RejectedUserAgentlessUpdateInfo = true;
+                        status = "401 Unauthorized";
+                        responseBody = "<html>login</html>";
+                    }
+                    break;
+                default:
+                    responseBody = "<html></html>";
+                    break;
+            }
+
+            var response =
+                $"HTTP/1.1 {status}\r\nContent-Type: text/html\r\n" +
+                $"Content-Length: {Encoding.ASCII.GetByteCount(responseBody)}\r\nConnection: close\r\n\r\n" +
+                responseBody;
+            await stream.WriteAsync(Encoding.ASCII.GetBytes(response), _cts.Token);
+        }
+
+        private static int GetContentLength(string headers)
+        {
+            foreach (var line in headers.Split("\r\n"))
+            {
+                if (line.StartsWith("Content-Length:", StringComparison.OrdinalIgnoreCase) &&
+                    int.TryParse(line["Content-Length:".Length..].Trim(), out var length))
+                    return length;
+            }
+
+            return 0;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            _listener.Stop();
+            try { await _acceptLoop; } catch { }
+            _cts.Dispose();
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Monitoring - ONT Stats

Adds support for Nokia XS-010X-Q ONTs whose firmware rejected our HTTP requests, without regressing the one variant that already worked (#929).

### Root cause (thanks @jakerobb)

The picky firmware answers the login calls with a malformed `Set-Cookie: Path=/; HttpOnly` header - no name=value pair. A default `HttpClientHandler`'s `CookieContainer` parses `Path=/` as a literal cookie, and once the container holds anything for the host, .NET silently substitutes it for the hand-set `Cookie: sessionid=...` header. The device never saw the session id and answered 401 -> `/login.html`. That's why every other client worked: curl and raw sockets have no cookie engine, and browsers discard the malformed header. @jakerobb isolated this and verified `UseCookies = false` on his unit (confirmed locally: a default container turns that header into a literal `Cookie: Path=/` on the next request). The firmware that always worked (@Liosnel's) presumably doesn't emit the header - an empty container passes the hand-set header through untouched, which is why it never hit this.

### The fix

Two flows, tried in order and cached per config (`ConcurrentDictionary` keyed by `OntConfiguration.Id`, re-detected after restart - `NetgearCmProvider._attemptCache` idiom):

- **Direct** - the plain `HttpClient` login + cookie-only `getUpdateinfo` as shipped in v2.1.1/v2.2.0, now with `UseCookies = false` (@jakerobb's fix) so the sessionid header survives the malformed Set-Cookie. This only changes the wire when a device emits Set-Cookie on login, so @Liosnel's proven path is effectively untouched. The real session cookie arrives in the LoginForm JSON body, so nothing legitimate is lost by disabling the cookie engine. Tried first, verified working on @jakerobb's unit (his local build of the same change).
- **CurlReplay** - defense in depth for any firmware pickiness we haven't met yet. Writes the raw HTTP requests of the tester-proven curl script over a plain `TcpClient`, byte-for-byte (headers, order, casing; fresh connection per request), including the forced PON-password page walk: `GET /login.html` -> login -> `GET /ponpasswd.html` -> `POST ponpasswd_GetConfig` -> `GET /moreinfo.html` -> `getUpdateinfo`. Immune to handler-level rewriting by construction; verified working on @jakerobb's unit via the `2.2.1-nokia-ont4` image. Same raw-socket technique as `ArrisSurfboardHnapProvider`'s malformed-header fallback (minus TLS; this device is plain HTTP). Handles the device's chunked, `Connection: close` responses.

Each flow does its own fresh login so a failed probe can't poison the other flow's session.

### Testing

- `dotnet build` - 0 warnings; Nokia provider tests 21/21.
- Raw request framing asserted byte-for-byte against captured curl output (header order, no charset suffix, `Content-Length` placement).
- Two integration tests against a loopback "picky firmware" double: one emits the malformed `Set-Cookie: Path=/; HttpOnly` on login and proves Direct authenticates without falling back; one gates `getUpdateinfo` on a User-Agent and proves the Direct probe fails then CurlReplay completes the walk and reads RxOptPwr.
- Field-verified by @jakerobb on his XS-010X-Q: both the `2.2.1-nokia-ont4` image (CurlReplay) and his local `UseCookies = false` build (Direct) return stats. Awaiting @LossyDragon.

Leave #929 open pending @LossyDragon's confirmation.
