### PR TITLE
ONT Device Monitoring: Network Optimizer Custom (HTTP JSON) provider with SFP module attachment

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -321,6 +321,20 @@ The following were implemented in the WiFi Optimizer feature:
 
 ## Monitoring
 
+### PON supplemental counters: wrap-aware deltas (SFP Stats)
+The augmented PON provider's frame/allocation counters (GEM tx/rx, LAN frames, allocations) are 32-bit
+on the ONT and wrap (~4.29B unsigned, or ~2.15B if signed). Every path handles the wrap **safely**
+today - the chart delta guard (`cur >= prev ? cur - prev : null`), the alert spike check
+(`if (delta < 0) delta = 0`), and ISP Health's positive-increment total all treat a wrap like a
+counter reset. The only cost is a single dropped data point on the frame charts at each wrap, which on
+a busy link can be ~hourly for the high-rate counters.
+
+Follow-up (low priority): reconstruct the true delta across a wrap instead of gapping it. Use
+`sfp_uptime_s` to distinguish a wrap (uptime kept climbing) from a real reset/reboot (uptime dropped),
+then add the modular span. Blocker: we'd have to know the counter width (2^31 vs 2^32) per field, and a
+wrong guess produces a garbage spike - so the safe null-gap stays the default until the widths are
+confirmed. Not worth it for a rare one-point gap; revisit if the frame charts read as too sparse.
+
 ### Upstream path discovery: DynamoDB regional endpoints for transit trace exposure (Setup tab)
 Transit Health involvement weighting and destination->transit jitter absolution both key off which
 monitored internet targets a transit ASN provably carries (trace ancestry). The current CDN/DNS

--- a/docs/features/netopt-custom-pon-contract.md
+++ b/docs/features/netopt-custom-pon-contract.md
@@ -1,0 +1,156 @@
+# Network Optimizer Custom PON Stats - JSON Contract v1
+
+The **Network Optimizer Custom (HTTP JSON)** ONT provider polls a plain HTTP
+endpoint that returns PON-layer statistics as JSON. The contract is
+vendor-neutral (field semantics follow ITU-T G.984.x / G.9807.1 terminology), so
+anyone can implement it for their ONT hardware - a GPON/XGS-PON SFP stick, a
+full ONT, or a small relay script on the gateway that gathers stats from the
+device and serves them.
+
+Configure it under Settings - ONT Device Monitoring with provider
+"Network Optimizer Custom (HTTP JSON)". Two modes:
+
+- **Standalone**: polled like any other ONT provider; PON state and FEC/BIP
+  counters flow to the ONT Stats tab and ONT alerts.
+- **Attached to a monitored SFP module** (the "Attach to SFP Module" setting):
+  polled on the gateway SFP collection cycle instead, with the full metric set
+  merged into that module's `sfp` measurement and charted on the SFP Stats tab.
+  Use this when the ONT *is* the SFP module in your gateway, so its DDM optics
+  readings and its PON internals form one time series.
+
+## Endpoint semantics
+
+- `GET http://<host>:<port>/` (any path is ignored by the reference
+  implementation; the provider requests `/`). Default port: **10012**.
+- Response: `Content-Type: application/json`, UTF-8, a single JSON object.
+- No authentication. Serve it on a management/LAN interface only.
+- The provider allows up to **15 seconds** per request and never issues
+  concurrent requests, so an implementation may gather stats on demand (e.g. an
+  SSH round-trip into an SFP stick) and may be a one-shot listener loop.
+- Stats should be gathered fresh per request (or cached only briefly).
+
+### Failure shape
+
+When the implementation cannot reach the underlying device, return HTTP 200
+with an error object instead of stats:
+
+```json
+{
+  "error": "sfp_unreachable",
+  "message": "Could not reach SFP at 169.254.1.1:30007"
+}
+```
+
+A non-empty `error` marks the poll failed; `message` is a human-readable
+detail shown in the UI. Any transport failure (refused, timeout, non-JSON) is
+treated the same way.
+
+## Payload
+
+Every section and every field is **optional** - serve what the hardware
+exposes; absent values are simply not recorded. All counters are **cumulative
+since ONT boot** (Network Optimizer derives per-interval deltas and uses
+`sfp_uptime_s` to recognize counter resets). Numbers may be JSON numbers or
+numeric strings; 64-bit counters are expected.
+
+```json
+{
+  "lan": {
+    "mode": 15,             // host-side PHY mode (raw device enum, informational)
+    "link_status": 5,       // host (module-to-gateway) link state, raw enum
+    "phy_duplex": 1         // raw enum, informational
+  },
+  "lan_counters": {         // host-link MAC counters (module <-> gateway)
+    "tx_frames": 671630919,
+    "rx_frames": 850075595,
+    "tx_drop_events": 0,
+    "rx_fcs_err": 0,        // FCS/checksum errors - host-link signal integrity
+    "buffer_overflow": 0
+  },
+  "ploam": {
+    "curr_state": 5,        // ITU-T activation state, numeric: 1-7 = O1-O7 (5 = O5 Operation)
+    "previous_state": 4,    // state before the last transition
+    "elapsed_msec": 12345   // ms in the current state (uint32 on many devices; wraps ~49.7 days)
+  },
+  "gtc_status": {
+    "ds_state": 3,          // downstream GTC sync state (raw enum; 3 = sync)
+    "onu_id": 49,           // ONU ID assigned by the OLT; changes on re-ranging
+    "ds_fec_enable": 0,     // OLT profile: downstream FEC on/off (0/1)
+    "us_fec_enable": 0,     // OLT profile: upstream FEC on/off (0/1)
+    "onu_response_time": 34992  // raw ranging response time / equalization delay
+  },
+  "gtc_counters": {
+    "bip": 0,                     // BIP parity errors (0 on a healthy link)
+    "hec_error_corr": 0,          // GTC header errors, corrected
+    "hec_error_uncorr": 1,        // GTC header errors, uncorrectable
+    "bwmap_error_corr": 0,        // upstream bandwidth-map errors, corrected
+    "bwmap_error_uncorr": 0,      // upstream bandwidth-map errors, uncorrectable
+    "fec_error_corr": 0,          // corrected FEC bit errors (informational)
+    "fec_words_corr": 0,          // corrected FEC codewords (early warning)
+    "fec_words_uncorr": 0,        // UNCORRECTABLE FEC codewords - the data-loss signal
+    "fec_words_total": 0,
+    "fec_seconds": 0,
+    "tx_gem_frames_total": 848555332,       // (X)GEM frames sent upstream
+    "tx_gem_bytes_total": 1774937051,       // (often 32-bit; unreliable at line rate)
+    "tx_gem_idle_frames_total": 1076427353, // idle frames = granted-but-unused upstream capacity
+    "rx_gem_frames_total": 682156109,
+    "rx_gem_bytes_total": 0,
+    "rx_gem_frames_dropped": 1,
+    "omci_drop": 0,
+    "drop": 1,
+    "rx_oversized_frames": 0,
+    "allocations_total": 1629046208,        // upstream grants received from the OLT
+    "allocations_lost": 20                  // missed grants - scheduling/resync indicator
+  },
+  "gpe_pon": {              // PON-side bridge port counters (packet engine)
+    "ibp_good": 670798566,  "ibp_discard": 0,   // ingress good/discarded
+    "ebp_good": 848843235,  "ebp_discard": 0,   // egress good/discarded
+    "learning_discard": 0                       // MAC-learning-limit discards
+  },
+  "gpe_lan": {              // host-side bridge port, same fields as gpe_pon
+    "ibp_good": 848843244,  "ibp_discard": 0,
+    "ebp_good": 670798569,  "ebp_discard": 0,
+    "learning_discard": 0
+  },
+  "sfp_uptime_s": 358825    // seconds since the ONT module booted (counter-reset anchor)
+}
+```
+
+## What Network Optimizer records
+
+Not every field is stored. The curated set, and how the standard concepts map
+onto Network Optimizer's existing schema:
+
+| Contract field | Stored as | Notes |
+|---|---|---|
+| `ploam.curr_state` | `pon_link_status` | same encoding as the ont measurement: `initial`, `standby`, `serial_number`, `ranging`, `operation`, `popup`, `emergency_stop` |
+| `ploam.previous_state` | `pon_link_status_prev` | same encoding |
+| `ploam.elapsed_msec` | `ploam_elapsed_ms` | |
+| `gtc_status.ds_state` | `gtc_ds_state` | |
+| `gtc_status.onu_id` | `onu_id` | |
+| `gtc_status.ds_fec_enable` / `us_fec_enable` | `ds_fec_enabled` / `us_fec_enabled` | |
+| `gtc_status.onu_response_time` | `onu_response_time` | |
+| `gtc_counters.bip` | `bip_errors` | standard field |
+| `gtc_counters.fec_words_uncorr` | `fec_errors` | standard field: uncorrectable codewords |
+| `gtc_counters.fec_words_corr` | `fec_corrected_words` | |
+| `gtc_counters.hec_error_corr` / `uncorr` | `hec_corrected` / `hec_uncorrected` | |
+| `gtc_counters.bwmap_error_corr` / `uncorr` | `bwmap_corrected` / `bwmap_uncorrected` | |
+| `gtc_counters.tx_gem_frames_total` etc. | `gem_tx_frames`, `gem_tx_idle_frames`, `gem_rx_frames`, `gem_rx_dropped` | |
+| `gtc_counters.allocations_total` / `lost` | `alloc_total` / `alloc_lost` | |
+| `gpe_pon` / `gpe_lan` discards | `gpe_{pon,lan}_{ingress,egress,learning}_discard` | good-frame counters are not stored |
+| `lan.link_status` | `lan_link_status` | |
+| `lan_counters.*` | `lan_tx_frames`, `lan_rx_frames`, `lan_tx_drop_events`, `lan_rx_fcs_err`, `lan_buffer_overflow` | |
+| `sfp_uptime_s` | `sfp_uptime_s` | |
+
+Not recorded: `lan.mode`, `lan.phy_duplex` (static config), GEM byte counters
+(32-bit wrap), `drop` / `omci_drop` / `rx_oversized_frames`,
+`fec_error_corr` / `fec_words_total` / `fec_seconds`, and the `gpe_*` good-frame
+counters (redundant with `lan_counters` and GEM frame counters).
+
+## Reference implementation
+
+The first serving-side implementation is a pair of shell scripts on a UniFi
+gateway that SSH into a Lantiq-based GPON SFP stick, run the vendor `onu` CLI
+(`ploamsg`, `gtcsg`, `gtctcg`, `gpebptcg`, `lanpsg`, `lantcg`), and serve the
+JSON via a one-shot netcat accept loop on port 10012. Any equivalent works -
+the provider only sees the HTTP contract above.

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -368,6 +368,28 @@ public static class DefaultAlertRules
         },
         new AlertRule
         {
+            // Uncorrected bit errors; always-on signal, and the primary error alert on a
+            // link running with payload FEC disabled. Only ONTs whose provider reports BIP trip it.
+            Name = "ONT: BIP Error Spike",
+            IsEnabled = false,
+            EventTypePattern = "ont.bip_errors",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
+            // Uncorrectable framing-header errors; the live codeword-error signal when payload
+            // FEC is disabled. Only augmented SFP-ONT polling reports HEC, so it stays inert otherwise.
+            Name = "ONT: HEC Error Spike",
+            IsEnabled = false,
+            EventTypePattern = "ont.hec_errors",
+            Source = "ont",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes
+        },
+        new AlertRule
+        {
             // Only ONTs whose provider reports a temperature can trip this; the rest never fire it.
             Name = "ONT: Temperature High",
             IsEnabled = false,

--- a/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
+++ b/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
@@ -1,0 +1,117 @@
+namespace NetworkOptimizer.Core.Models;
+
+/// <summary>
+/// Supplemental PON-layer statistics for an SFP ONT module, fetched from a
+/// "Network Optimizer Custom (HTTP JSON)" stats endpoint and merged into the
+/// module's sfp measurement during the gateway SFP poll. All counters are
+/// cumulative since ONT boot; <see cref="SfpUptimeS"/> detects counter resets.
+/// PLOAM states are pre-encoded with the same stable strings the ont
+/// measurement's pon_link_status field uses (PonLinkStateExtensions.ToInfluxValue).
+/// </summary>
+public class PonSupplementalStats
+{
+    /// <summary>Raw ITU-T PLOAM state number (1-7 = O1-O7) for alert evaluation.</summary>
+    public long? PloamStateRaw { get; set; }
+
+    /// <summary>Current PLOAM state, encoded like the ont measurement's pon_link_status ("operation", "popup", ...).</summary>
+    public string? PonLinkStatus { get; set; }
+
+    /// <summary>Previous PLOAM state, same encoding as <see cref="PonLinkStatus"/>.</summary>
+    public string? PonLinkStatusPrev { get; set; }
+
+    /// <summary>Milliseconds spent in the current PLOAM state. uint32 on-device; wraps at ~49.7 days.</summary>
+    public long? PloamElapsedMs { get; set; }
+
+    /// <summary>Downstream GTC synchronization state (raw device enum).</summary>
+    public long? GtcDsState { get; set; }
+
+    /// <summary>ONU ID assigned by the OLT; changes on re-ranging.</summary>
+    public long? OnuId { get; set; }
+
+    /// <summary>Whether downstream FEC is enabled by the OLT profile (0/1).</summary>
+    public long? DsFecEnabled { get; set; }
+
+    /// <summary>Whether upstream FEC is enabled by the OLT profile (0/1).</summary>
+    public long? UsFecEnabled { get; set; }
+
+    /// <summary>Raw ranging response time reported by the device; changes on re-ranging.</summary>
+    public long? OnuResponseTime { get; set; }
+
+    /// <summary>BIP (bit-interleaved parity) errors. Cumulative; 0 on a healthy link.</summary>
+    public long? BipErrors { get; set; }
+
+    /// <summary>Uncorrectable FEC codewords - the data-loss signal, matching the ont measurement's fec_errors.</summary>
+    public long? FecErrors { get; set; }
+
+    /// <summary>Corrected FEC codewords - benign, early-warning counterpart to <see cref="FecErrors"/>.</summary>
+    public long? FecCorrectedWords { get; set; }
+
+    /// <summary>GTC header errors, corrected.</summary>
+    public long? HecCorrected { get; set; }
+
+    /// <summary>GTC header errors, uncorrectable.</summary>
+    public long? HecUncorrected { get; set; }
+
+    /// <summary>Upstream bandwidth-map errors, corrected.</summary>
+    public long? BwmapCorrected { get; set; }
+
+    /// <summary>Upstream bandwidth-map errors, uncorrectable.</summary>
+    public long? BwmapUncorrected { get; set; }
+
+    /// <summary>GEM frames transmitted upstream (data).</summary>
+    public long? GemTxFrames { get; set; }
+
+    /// <summary>Idle GEM frames transmitted upstream - granted capacity that went unused.</summary>
+    public long? GemTxIdleFrames { get; set; }
+
+    /// <summary>GEM frames received downstream.</summary>
+    public long? GemRxFrames { get; set; }
+
+    /// <summary>GEM frames dropped at reassembly.</summary>
+    public long? GemRxDropped { get; set; }
+
+    /// <summary>Upstream bandwidth allocations (grants) received from the OLT.</summary>
+    public long? AllocTotal { get; set; }
+
+    /// <summary>Upstream allocations lost - missed grants; scheduling/resync indicator.</summary>
+    public long? AllocLost { get; set; }
+
+    /// <summary>PON-side bridge port: ingress frames discarded.</summary>
+    public long? GpePonIngressDiscard { get; set; }
+
+    /// <summary>PON-side bridge port: egress frames discarded.</summary>
+    public long? GpePonEgressDiscard { get; set; }
+
+    /// <summary>PON-side bridge port: frames discarded by MAC learning limits.</summary>
+    public long? GpePonLearningDiscard { get; set; }
+
+    /// <summary>Host-side bridge port: ingress frames discarded.</summary>
+    public long? GpeLanIngressDiscard { get; set; }
+
+    /// <summary>Host-side bridge port: egress frames discarded.</summary>
+    public long? GpeLanEgressDiscard { get; set; }
+
+    /// <summary>Host-side bridge port: frames discarded by MAC learning limits.</summary>
+    public long? GpeLanLearningDiscard { get; set; }
+
+    /// <summary>Host (module-to-gateway) link PHY status, raw device enum.</summary>
+    public long? LanLinkStatus { get; set; }
+
+    /// <summary>Frames transmitted on the host link.</summary>
+    public long? LanTxFrames { get; set; }
+
+    /// <summary>Frames received on the host link.</summary>
+    public long? LanRxFrames { get; set; }
+
+    /// <summary>Transmit drop events on the host link.</summary>
+    public long? LanTxDropEvents { get; set; }
+
+    /// <summary>FCS (checksum) errors received on the host link - signal-integrity indicator.</summary>
+    public long? LanRxFcsErrors { get; set; }
+
+    /// <summary>Buffer overflows on the host link.</summary>
+    public long? LanBufferOverflow { get; set; }
+
+    /// <summary>Seconds since the ONT module booted. Anchors counter-reset detection.</summary>
+    public long? SfpUptimeS { get; set; }
+}

--- a/src/NetworkOptimizer.Monitoring/Providers/ISfpSupplementalOntProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/ISfpSupplementalOntProvider.cs
@@ -1,0 +1,22 @@
+using NetworkOptimizer.Core.Models;
+
+namespace NetworkOptimizer.Monitoring.Providers;
+
+/// <summary>
+/// An ONT provider that can supplement a gateway-slot SFP ONT module with
+/// PON-layer statistics. Configurations attached to a monitored SFP module
+/// (OntConfiguration.AttachedSfpId) are polled on the gateway SFP collection
+/// cycle via <see cref="PollSupplementalAsync"/> and their metrics merged into
+/// that module's sfp measurement, instead of being polled standalone.
+/// </summary>
+public interface ISfpSupplementalOntProvider : IOntProvider
+{
+    /// <summary>
+    /// Poll the endpoint and return PON-layer supplemental stats.
+    /// Implementations should log internally and return null on transport
+    /// or parsing failure; throwing is reserved for programming errors.
+    /// </summary>
+    Task<PonSupplementalStats?> PollSupplementalAsync(
+        OntPollContext context,
+        CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260719120000_AddOntAttachedSfpId.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260719120000_AddOntAttachedSfpId.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719120000_AddOntAttachedSfpId")]
+    partial class AddOntAttachedSfpId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260719120000_AddOntAttachedSfpId.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260719120000_AddOntAttachedSfpId.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <summary>
+/// Adds OntConfigurations.AttachedSfpId: when set, the ONT config supplements the
+/// monitored SFP module with that MonitoredSfp.Id - polled on the gateway SFP
+/// collection cycle and merged into that module's sfp measurement instead of
+/// being polled standalone. Nullable - existing rows stay standalone.
+/// </summary>
+public partial class AddOntAttachedSfpId : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(
+            name: "AttachedSfpId",
+            table: "OntConfigurations",
+            type: "INTEGER",
+            nullable: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "AttachedSfpId",
+            table: "OntConfigurations");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/OntConfiguration.cs
+++ b/src/NetworkOptimizer.Storage/Models/OntConfiguration.cs
@@ -45,6 +45,15 @@ public class OntConfiguration
     [MaxLength(500)]
     public string? PrivateKeyPath { get; set; }
 
+    /// <summary>
+    /// When set, this ONT supplements the monitored SFP module with that
+    /// MonitoredSfp.Id: it is polled on the gateway SFP collection cycle (the
+    /// standalone poll loop and PollingIntervalSeconds are bypassed) and its
+    /// PON-layer metrics merge into that module's sfp measurement. Requires a
+    /// provider implementing ISfpSupplementalOntProvider. Null = standalone ONT.
+    /// </summary>
+    public int? AttachedSfpId { get; set; }
+
     /// <summary>Whether this ONT is enabled for polling</summary>
     public bool Enabled { get; set; } = true;
 

--- a/src/NetworkOptimizer.Storage/Repositories/OntRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/OntRepository.cs
@@ -84,6 +84,7 @@ public class OntRepository : IOntRepository
                     existing.Username = config.Username;
                     existing.Password = config.Password;
                     existing.PrivateKeyPath = config.PrivateKeyPath;
+                    existing.AttachedSfpId = config.AttachedSfpId;
                     existing.Enabled = config.Enabled;
                     existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
                     existing.LastPolled = config.LastPolled;

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -5,6 +5,7 @@ using InfluxDB.Client.Writes;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Storage.Models;
 
 namespace NetworkOptimizer.Storage.Services;
@@ -755,6 +756,64 @@ from(bucket: ""{_longtermBucket}"")
         if (temperatureC.HasValue) point = point.Field("temperature_c", temperatureC.Value);
         if (voltageV.HasValue) point = point.Field("voltage_v", voltageV.Value);
         if (sfpLinkSpeedMbps.HasValue) point = point.Field("sfp_link_speed_mbps", sfpLinkSpeedMbps.Value);
+
+        Enqueue(point, longterm: true);
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Write supplemental PON-layer stats onto the sfp measurement, merging with the
+    /// DDM point CollectSfpForDevice writes for the same module and timestamp (same
+    /// series + timestamp = field union in InfluxDB). pon_link_status / fec_errors /
+    /// bip_errors reuse the ont measurement's field names and encodings so display
+    /// and alert logic can treat SFP-slot and standalone ONTs uniformly.
+    /// </summary>
+    public Task WriteSfpPonAsync(
+        string deviceMac,
+        string portName,
+        PonSupplementalStats stats,
+        DateTime timestamp)
+    {
+        if (!IsConfigured) return Task.CompletedTask;
+        var point = PointData.Measurement("sfp")
+            .Tag("device_mac", NormalizeMac(deviceMac))
+            .Tag("port_name", portName)
+            .Timestamp(timestamp.ToUniversalTime(), WritePrecision.Ns);
+
+        if (!string.IsNullOrEmpty(stats.PonLinkStatus)) point = point.Field("pon_link_status", stats.PonLinkStatus);
+        if (!string.IsNullOrEmpty(stats.PonLinkStatusPrev)) point = point.Field("pon_link_status_prev", stats.PonLinkStatusPrev);
+        if (stats.PloamElapsedMs.HasValue) point = point.Field("ploam_elapsed_ms", stats.PloamElapsedMs.Value);
+        if (stats.GtcDsState.HasValue) point = point.Field("gtc_ds_state", stats.GtcDsState.Value);
+        if (stats.OnuId.HasValue) point = point.Field("onu_id", stats.OnuId.Value);
+        if (stats.DsFecEnabled.HasValue) point = point.Field("ds_fec_enabled", stats.DsFecEnabled.Value);
+        if (stats.UsFecEnabled.HasValue) point = point.Field("us_fec_enabled", stats.UsFecEnabled.Value);
+        if (stats.OnuResponseTime.HasValue) point = point.Field("onu_response_time", stats.OnuResponseTime.Value);
+        if (stats.BipErrors.HasValue) point = point.Field("bip_errors", stats.BipErrors.Value);
+        if (stats.FecErrors.HasValue) point = point.Field("fec_errors", stats.FecErrors.Value);
+        if (stats.FecCorrectedWords.HasValue) point = point.Field("fec_corrected_words", stats.FecCorrectedWords.Value);
+        if (stats.HecCorrected.HasValue) point = point.Field("hec_corrected", stats.HecCorrected.Value);
+        if (stats.HecUncorrected.HasValue) point = point.Field("hec_uncorrected", stats.HecUncorrected.Value);
+        if (stats.BwmapCorrected.HasValue) point = point.Field("bwmap_corrected", stats.BwmapCorrected.Value);
+        if (stats.BwmapUncorrected.HasValue) point = point.Field("bwmap_uncorrected", stats.BwmapUncorrected.Value);
+        if (stats.GemTxFrames.HasValue) point = point.Field("gem_tx_frames", stats.GemTxFrames.Value);
+        if (stats.GemTxIdleFrames.HasValue) point = point.Field("gem_tx_idle_frames", stats.GemTxIdleFrames.Value);
+        if (stats.GemRxFrames.HasValue) point = point.Field("gem_rx_frames", stats.GemRxFrames.Value);
+        if (stats.GemRxDropped.HasValue) point = point.Field("gem_rx_dropped", stats.GemRxDropped.Value);
+        if (stats.AllocTotal.HasValue) point = point.Field("alloc_total", stats.AllocTotal.Value);
+        if (stats.AllocLost.HasValue) point = point.Field("alloc_lost", stats.AllocLost.Value);
+        if (stats.GpePonIngressDiscard.HasValue) point = point.Field("gpe_pon_ingress_discard", stats.GpePonIngressDiscard.Value);
+        if (stats.GpePonEgressDiscard.HasValue) point = point.Field("gpe_pon_egress_discard", stats.GpePonEgressDiscard.Value);
+        if (stats.GpePonLearningDiscard.HasValue) point = point.Field("gpe_pon_learning_discard", stats.GpePonLearningDiscard.Value);
+        if (stats.GpeLanIngressDiscard.HasValue) point = point.Field("gpe_lan_ingress_discard", stats.GpeLanIngressDiscard.Value);
+        if (stats.GpeLanEgressDiscard.HasValue) point = point.Field("gpe_lan_egress_discard", stats.GpeLanEgressDiscard.Value);
+        if (stats.GpeLanLearningDiscard.HasValue) point = point.Field("gpe_lan_learning_discard", stats.GpeLanLearningDiscard.Value);
+        if (stats.LanLinkStatus.HasValue) point = point.Field("lan_link_status", stats.LanLinkStatus.Value);
+        if (stats.LanTxFrames.HasValue) point = point.Field("lan_tx_frames", stats.LanTxFrames.Value);
+        if (stats.LanRxFrames.HasValue) point = point.Field("lan_rx_frames", stats.LanRxFrames.Value);
+        if (stats.LanTxDropEvents.HasValue) point = point.Field("lan_tx_drop_events", stats.LanTxDropEvents.Value);
+        if (stats.LanRxFcsErrors.HasValue) point = point.Field("lan_rx_fcs_err", stats.LanRxFcsErrors.Value);
+        if (stats.LanBufferOverflow.HasValue) point = point.Field("lan_buffer_overflow", stats.LanBufferOverflow.Value);
+        if (stats.SfpUptimeS.HasValue) point = point.Field("sfp_uptime_s", stats.SfpUptimeS.Value);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;
@@ -1798,6 +1857,107 @@ from(bucket: ""{_longtermBucket}"")
                 TxPowerDbm = AsDoubleOrNull(record.GetValueByKey("tx_power_dbm")),
                 TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
                 VoltageV = AsDoubleOrNull(record.GetValueByKey("voltage_v"))
+            });
+        }
+        return results;
+    }
+
+    /// <summary>One point of supplemental PON-layer stats on the sfp measurement (attached ONT config).
+    /// Counters are cumulative; callers derive per-interval deltas.</summary>
+    public class SfpPonPoint
+    {
+        public DateTime Time { get; set; }
+        public string? PonLinkStatus { get; set; }
+        public string? PonLinkStatusPrev { get; set; }
+        public long? OnuId { get; set; }
+        public long? DsFecEnabled { get; set; }
+        public long? UsFecEnabled { get; set; }
+        public long? OnuResponseTime { get; set; }
+        public long? SfpUptimeS { get; set; }
+        public long? BipErrors { get; set; }
+        public long? FecErrors { get; set; }
+        public long? FecCorrectedWords { get; set; }
+        public long? HecUncorrected { get; set; }
+        public long? GemTxFrames { get; set; }
+        public long? GemTxIdleFrames { get; set; }
+        public long? GemRxFrames { get; set; }
+        public long? GemRxDropped { get; set; }
+        public long? AllocLost { get; set; }
+        public long? LanRxFcsErrors { get; set; }
+        public long? LanTxDropEvents { get; set; }
+        public long? LanBufferOverflow { get; set; }
+    }
+
+    /// <summary>
+    /// Supplemental PON-layer time-series for a set of (device_mac, port_name) pairs.
+    /// Only modules with an attached ONT config have these fields; others return no rows.
+    /// Aggregates with fn: last (counters are cumulative - mean would distort deltas).
+    /// </summary>
+    public async Task<Dictionary<string, List<SfpPonPoint>>> QuerySfpPonByModulesAsync(
+        IReadOnlyList<(string DeviceMac, string PortName)> modules,
+        DateTime from,
+        DateTime to,
+        TimeSpan? aggregateWindow = null,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) await ReconfigureAsync(ct);
+        if (!IsConfigured || modules.Count == 0) return new Dictionary<string, List<SfpPonPoint>>();
+        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+
+        var macFilter = string.Join(" or ", modules.Select(m =>
+            $@"(r.device_mac == ""{NormalizeMac(m.DeviceMac)}"" and r.port_name == ""{SanitizeFluxString(m.PortName)}"")"));
+
+        var fields = new[]
+        {
+            "pon_link_status", "pon_link_status_prev", "onu_id", "ds_fec_enabled", "us_fec_enabled",
+            "onu_response_time", "sfp_uptime_s", "bip_errors", "fec_errors", "fec_corrected_words",
+            "hec_uncorrected", "gem_tx_frames", "gem_tx_idle_frames", "gem_rx_frames", "gem_rx_dropped",
+            "alloc_lost", "lan_rx_fcs_err", "lan_tx_drop_events", "lan_buffer_overflow",
+        };
+        var fieldFilter = string.Join(" or ", fields.Select(f => $@"r._field == ""{f}"""));
+
+        var flux = $@"
+from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""sfp"")
+  |> filter(fn: (r) => {macFilter})
+  |> filter(fn: (r) => {fieldFilter})
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new Dictionary<string, List<SfpPonPoint>>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var mac = record.GetValueByKey("device_mac") as string ?? "";
+            var port = record.GetValueByKey("port_name") as string ?? "";
+            var key = $"{mac}:{port}";
+            if (!results.TryGetValue(key, out var list))
+            {
+                list = new List<SfpPonPoint>();
+                results[key] = list;
+            }
+            list.Add(new SfpPonPoint
+            {
+                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+                PonLinkStatus = record.GetValueByKey("pon_link_status") as string,
+                PonLinkStatusPrev = record.GetValueByKey("pon_link_status_prev") as string,
+                OnuId = AsLongOrNull(record.GetValueByKey("onu_id")),
+                DsFecEnabled = AsLongOrNull(record.GetValueByKey("ds_fec_enabled")),
+                UsFecEnabled = AsLongOrNull(record.GetValueByKey("us_fec_enabled")),
+                OnuResponseTime = AsLongOrNull(record.GetValueByKey("onu_response_time")),
+                SfpUptimeS = AsLongOrNull(record.GetValueByKey("sfp_uptime_s")),
+                BipErrors = AsLongOrNull(record.GetValueByKey("bip_errors")),
+                FecErrors = AsLongOrNull(record.GetValueByKey("fec_errors")),
+                FecCorrectedWords = AsLongOrNull(record.GetValueByKey("fec_corrected_words")),
+                HecUncorrected = AsLongOrNull(record.GetValueByKey("hec_uncorrected")),
+                GemTxFrames = AsLongOrNull(record.GetValueByKey("gem_tx_frames")),
+                GemTxIdleFrames = AsLongOrNull(record.GetValueByKey("gem_tx_idle_frames")),
+                GemRxFrames = AsLongOrNull(record.GetValueByKey("gem_rx_frames")),
+                GemRxDropped = AsLongOrNull(record.GetValueByKey("gem_rx_dropped")),
+                AllocLost = AsLongOrNull(record.GetValueByKey("alloc_lost")),
+                LanRxFcsErrors = AsLongOrNull(record.GetValueByKey("lan_rx_fcs_err")),
+                LanTxDropEvents = AsLongOrNull(record.GetValueByKey("lan_tx_drop_events")),
+                LanBufferOverflow = AsLongOrNull(record.GetValueByKey("lan_buffer_overflow")),
             });
         }
         return results;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -717,6 +717,23 @@ else
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="sfp-temp-chart"></div>
                 </div>
+                <!-- Supplemental PON-layer charts: shown only when a module has an attached
+                     Network Optimizer Custom ONT config feeding PON stats. -->
+                <div class="sfp-pon-section" style="display: none;">
+                    <div class="chart-card" style="margin-top: 1rem;">
+                        <div class="chart-header"><h3 class="chart-title">PON Errors (per interval)</h3></div>
+                        <div class="sfp-pon-errors-chart"></div>
+                    </div>
+                    <div class="chart-card" style="margin-top: 1rem;">
+                        <div class="chart-header"><h3 class="chart-title">GEM Frames (per interval)</h3></div>
+                        <div class="sfp-pon-gem-chart"></div>
+                    </div>
+                    <div class="chart-card" style="margin-top: 1rem;">
+                        <div class="chart-header"><h3 class="chart-title">Host Link Errors (per interval)</h3></div>
+                        <div class="sfp-pon-host-chart"></div>
+                    </div>
+                    <div class="sfp-pon-details"></div>
+                </div>
                 <div class="sfp-stats-table"></div>
             </div>
         </div>
@@ -1016,6 +1033,13 @@ else
                 <div class="chart-card" style="margin-top: 1rem;">
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="ont-temp-chart"></div>
+                </div>
+                <!-- Shown only when at least one ONT reports FEC/BIP counters. -->
+                <div class="ont-errors-section" style="display: none;">
+                    <div class="chart-card" style="margin-top: 1rem;">
+                        <div class="chart-header"><h3 class="chart-title">FEC / BIP Errors (per interval)</h3></div>
+                        <div class="ont-errors-chart"></div>
+                    </div>
                 </div>
                 <div class="ont-stats-table"></div>
             </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -725,12 +725,12 @@ else
                         <div class="sfp-pon-errors-chart"></div>
                     </div>
                     <div class="chart-card" style="margin-top: 1rem;">
-                        <div class="chart-header"><h3 class="chart-title">GEM Frames (per interval)</h3></div>
-                        <div class="sfp-pon-gem-chart"></div>
-                    </div>
-                    <div class="chart-card" style="margin-top: 1rem;">
                         <div class="chart-header"><h3 class="chart-title">Host Link Errors (per interval)</h3></div>
                         <div class="sfp-pon-host-chart"></div>
+                    </div>
+                    <div class="chart-card" style="margin-top: 1rem;">
+                        <div class="chart-header"><h3 class="chart-title">GEM Frames (per interval)</h3></div>
+                        <div class="sfp-pon-gem-chart"></div>
                     </div>
                     <div class="sfp-pon-details"></div>
                 </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1939,7 +1939,7 @@ else
 
         var cmConfigs = await CmMonitorService.GetConfigsAsync();
         _cmHasDevices = cmConfigs.Count > 0;
-        var ontConfigs = await OntMonitorService.GetConfigsAsync();
+        var ontConfigs = await OntMonitorService.GetStandaloneConfigsAsync();
         _ontHasDevices = ontConfigs.Count > 0;
         var cellConfigs = await CellularModemService.GetModemsAsync();
         _cellularHasDevices = cellConfigs.Count > 0;

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1565,10 +1565,32 @@
                                 <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
                                 <option value="telekom-modem2">Telekom Glasfaser-Modem 2 (HTTP)</option>
                                 <option value="nokia-xs010x-q">Nokia XS-010X-Q (HTTP)</option>
+                                <option value="netopt-custom">Network Optimizer Custom (HTTP JSON)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
                     </div>
+
+                    @if (_editingOnt.Provider == "netopt-custom")
+                    {
+                        <div class="form-row">
+                            <div class="form-group" style="flex: 2;">
+                                <label class="form-label">Attach to SFP Module</label>
+                                <select class="form-control" @bind="_editingOnt.AttachedSfpId">
+                                    <option value="">None (standalone)</option>
+                                    @foreach (var sfp in _attachableSfps)
+                                    {
+                                        <option value="@sfp.Id">@AttachableSfpLabel(sfp)</option>
+                                    }
+                                </select>
+                                <small class="form-help">
+                                    Attached ONTs are polled with the gateway SFP cycle and their PON stats merge into
+                                    the selected module's SFP Stats series; the polling interval below is ignored.
+                                    Standalone ONTs show on ONT Stats instead.
+                                </small>
+                            </div>
+                        </div>
+                    }
 
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
@@ -3956,6 +3978,7 @@
 
     // External ONT Monitoring
     private List<OntConfiguration> _ontConfigs = new();
+    private List<MonitoredSfp> _attachableSfps = new();
     private OntConfiguration _editingOnt = new() { Provider = "att-gateway", Port = 80, PollingIntervalSeconds = 300, Enabled = true };
     private bool _ontFormVisible;
     private bool _savingOnt;
@@ -5709,6 +5732,17 @@
         try
         {
             _ontConfigs = await OntMonitorService.GetConfigsAsync();
+
+            // Attachment choices for the Network Optimizer Custom provider: the
+            // site's ONT-monitored SFP modules.
+            await using (var sfpDb = SiteDb.CreateForSite(SiteContext.Slug, SiteContext.IsDefault))
+            {
+                _attachableSfps = await sfpDb.MonitoredSfps.AsNoTracking()
+                    .Where(s => s.IsMonitoredOnt)
+                    .OrderBy(s => s.DeviceMac).ThenBy(s => s.PortName)
+                    .ToListAsync();
+            }
+
             if (_ontConfigs.Any(o => !string.IsNullOrEmpty(o.LastError)))
                 _ontStatus = "Error";
             else if (_ontConfigs.Any(o => o.Enabled))
@@ -5826,6 +5860,7 @@
             Username = config.Username,
             Password = config.Password,
             PrivateKeyPath = config.PrivateKeyPath,
+            AttachedSfpId = config.AttachedSfpId,
             PollingIntervalSeconds = config.PollingIntervalSeconds,
             Enabled = config.Enabled,
             LastPolled = config.LastPolled,
@@ -5846,12 +5881,17 @@
         var provider = e.Value?.ToString() ?? "att-gateway";
         _editingOnt.Provider = provider;
         _editingOnt.Port = GetOntProviderDefaultPort(provider);
+        // SFP attachment is only meaningful for providers that support it; clear a
+        // stale association so it can't linger invisibly after a provider switch.
+        if (provider != "netopt-custom")
+            _editingOnt.AttachedSfpId = null;
     }
 
     private static int GetOntProviderDefaultPort(string provider) => provider switch
     {
         "8311" => 443,
         "quantum-q1000k" => 443,
+        "netopt-custom" => 10012,
         _ => 80,
     };
 
@@ -5863,9 +5903,19 @@
         "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "telekom-modem2" => "Telekom Glasfaser-Modem 2 (HTTP)",
         "nokia-xs010x-q" => "Nokia XS-010X-Q (HTTP)",
+        "netopt-custom" => "Network Optimizer Custom (HTTP JSON)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };
+
+    private static string AttachableSfpLabel(MonitoredSfp sfp)
+    {
+        var name = !string.IsNullOrEmpty(sfp.FriendlyName)
+            ? sfp.FriendlyName
+            : $"{sfp.SfpVendor} {sfp.SfpPart}".Trim();
+        if (string.IsNullOrWhiteSpace(name)) name = sfp.DeviceMac;
+        return $"{name} - port {sfp.PortName}";
+    }
 
     // --- Starlink Monitoring ---
 

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -378,7 +378,7 @@ else
             _fabricTargets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.TargetType == MonitoringTargetType.Fabric)
                 .ToListAsync();
-            _externalOnts = await ExternalOntService.GetConfigsAsync();
+            _externalOnts = await ExternalOntService.GetStandaloneConfigsAsync();
             if (_currentIndex >= TotalCount) _currentIndex = 0;
             RefreshExternalStats();
 

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -301,25 +301,11 @@ else
                         @(stats?.TemperatureC.HasValue == true ? $"{stats.TemperatureC.Value:0.0#} °C" : "-")
                     </span>
                 </div>
-                @if (stats?.BipErrors.HasValue == true)
+                @if (stats?.BipErrors.HasValue == true || stats?.FecErrors.HasValue == true || stats?.GemRxDropped.HasValue == true)
                 {
                     <div class="metric-row">
-                        <span class="metric-label">BIP:</span>
-                        <span class="metric-value">@stats.BipErrors.Value.ToString("N0")</span>
-                    </div>
-                }
-                @if (stats?.FecErrors.HasValue == true)
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">FEC:</span>
-                        <span class="metric-value">@stats.FecErrors.Value.ToString("N0")</span>
-                    </div>
-                }
-                @if (stats?.GemRxDropped.HasValue == true)
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Drops:</span>
-                        <span class="metric-value">@stats.GemRxDropped.Value.ToString("N0")</span>
+                        <span class="metric-label" data-tooltip="BIP / FEC / dropped GEM frames (cumulative)">BIP/FEC/Drops:</span>
+                        <span class="metric-value">@FmtCount(stats?.BipErrors) / @FmtCount(stats?.FecErrors) / @FmtCount(stats?.GemRxDropped)</span>
                     </div>
                 }
             </div>
@@ -540,6 +526,8 @@ else
     private static string FormatLinkSpeed(int mbps) => mbps >= 1000
         ? $"{mbps / 1000.0:0.##} Gbps"
         : $"{mbps} Mbps";
+
+    private static string FmtCount(long? v) => v.HasValue ? v.Value.ToString("N0") : "-";
 
     public string? CurrentModuleKey
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -224,6 +224,16 @@ else
         </div>
     </div>
 
+    var sfpPonState = PonLinkStateExtensions.ParsePonLinkState(stats?.PonLinkStatus);
+    // FEC disabled on the OLT profile => FEC counters stay 0; HEC is the live signal.
+    var fecOff = stats?.FecEnabled == false;
+    var midErr = fecOff ? stats?.HecUncorrected : stats?.FecErrors;
+    var midErrLabel = fecOff ? "HEC" : "FEC";
+    var midErrTip = fecOff ? "uncorrectable HEC header errors (payload FEC disabled)" : "uncorrectable FEC codewords";
+    var hasErrCounts = stats?.BipErrors.HasValue == true || midErr.HasValue || stats?.GemRxDropped.HasValue == true;
+    // Supplemental PON data present: move SFP Voltage to the Stats column to keep the
+    // two columns even (Connection gains PON Status + error counts).
+    var hasPonSupplement = sfpPonState != PonLinkState.Unknown || hasErrCounts;
     <div class="cellular-metrics" style="margin-top: 0.75rem;">
         <div class="metric-box">
             <div class="metric-header">Connection</div>
@@ -240,6 +250,13 @@ else
                     <span class="metric-label">Link Type:</span>
                     <span class="metric-value @(current.IsActiveEthernet ? "ont-ae-value" : "")">@LinkTypeLabel(current)</span>
                 </div>
+                @if (sfpPonState != PonLinkState.Unknown)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">PON Status:</span>
+                        <span class="metric-value">@sfpPonState.ToDisplayString()</span>
+                    </div>
+                }
                 @if (current.LinkSpeedMbps.HasValue)
                 {
                     <div class="metric-row">
@@ -258,18 +275,20 @@ else
                         </span>
                     </div>
                 }
-                <div class="metric-row">
-                    <span class="metric-label">SFP Voltage:</span>
-                    <span class="metric-value">
-                        @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
-                    </span>
-                </div>
-                @{ var sfpPonState = PonLinkStateExtensions.ParsePonLinkState(stats?.PonLinkStatus); }
-                @if (sfpPonState != PonLinkState.Unknown)
+                @if (hasErrCounts)
                 {
                     <div class="metric-row">
-                        <span class="metric-label">PON Status:</span>
-                        <span class="metric-value">@sfpPonState.ToDisplayString()</span>
+                        <span class="metric-label" data-tooltip="@($"BIP / {midErrTip} / dropped GEM frames (cumulative)")">@($"BIP/{midErrLabel}/Drops:")</span>
+                        <span class="metric-value">@FmtCount(stats?.BipErrors) / @FmtCount(midErr) / @FmtCount(stats?.GemRxDropped)</span>
+                    </div>
+                }
+                @if (!hasPonSupplement)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">SFP Voltage:</span>
+                        <span class="metric-value">
+                            @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
+                        </span>
                     </div>
                 }
             </div>
@@ -301,11 +320,13 @@ else
                         @(stats?.TemperatureC.HasValue == true ? $"{stats.TemperatureC.Value:0.0#} °C" : "-")
                     </span>
                 </div>
-                @if (stats?.BipErrors.HasValue == true || stats?.FecErrors.HasValue == true || stats?.GemRxDropped.HasValue == true)
+                @if (hasPonSupplement)
                 {
                     <div class="metric-row">
-                        <span class="metric-label" data-tooltip="BIP / FEC / dropped GEM frames (cumulative)">BIP/FEC/Drops:</span>
-                        <span class="metric-value">@FmtCount(stats?.BipErrors) / @FmtCount(stats?.FecErrors) / @FmtCount(stats?.GemRxDropped)</span>
+                        <span class="metric-label">SFP Voltage:</span>
+                        <span class="metric-value">
+                            @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
+                        </span>
                     </div>
                 }
             </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -264,6 +264,14 @@ else
                         @(stats?.VoltageV.HasValue == true ? $"{stats.VoltageV.Value:0.0#} V" : "-")
                     </span>
                 </div>
+                @{ var sfpPonState = PonLinkStateExtensions.ParsePonLinkState(stats?.PonLinkStatus); }
+                @if (sfpPonState != PonLinkState.Unknown)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">PON Status:</span>
+                        <span class="metric-value">@sfpPonState.ToDisplayString()</span>
+                    </div>
+                }
             </div>
         </div>
         <div class="metric-box">
@@ -293,6 +301,27 @@ else
                         @(stats?.TemperatureC.HasValue == true ? $"{stats.TemperatureC.Value:0.0#} °C" : "-")
                     </span>
                 </div>
+                @if (stats?.BipErrors.HasValue == true)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">BIP:</span>
+                        <span class="metric-value">@stats.BipErrors.Value.ToString("N0")</span>
+                    </div>
+                }
+                @if (stats?.FecErrors.HasValue == true)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">FEC:</span>
+                        <span class="metric-value">@stats.FecErrors.Value.ToString("N0")</span>
+                    </div>
+                }
+                @if (stats?.GemRxDropped.HasValue == true)
+                {
+                    <div class="metric-row">
+                        <span class="metric-label">Drops:</span>
+                        <span class="metric-value">@stats.GemRxDropped.Value.ToString("N0")</span>
+                    </div>
+                }
             </div>
         </div>
     </div>

--- a/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
@@ -35,7 +35,9 @@ public static class OntChartEndpoints
 
             var data = await influx.QueryOntAsync(queryFrom, queryTo, ontId, ct: ct);
 
-            var configs = await ontService.GetConfigsAsync();
+            // Standalone configs only: an attached config writes to the sfp
+            // measurement, not ont, and must never appear as a standalone ONT series.
+            var configs = await ontService.GetStandaloneConfigsAsync();
             var nameMap = configs.ToDictionary(c => c.Id.ToString(), c => c.Name);
 
             // Only surface ONTs that still have a config. Deleting an ONT config

--- a/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
@@ -47,11 +47,15 @@ public static class OntChartEndpoints
             {
                 var name = nameMap[kvp.Key];
 
-                return new
+                // FEC/BIP counters are cumulative; the chart wants per-interval deltas
+                // (CM Stats style). A negative step is a device counter reset - null
+                // (a gap), not a bogus spike.
+                var pts = kvp.Value.OrderBy(p => p.Time).ToList();
+                var items = new List<object>(pts.Count);
+                MonitoringInfluxClient.OntPoint? prev = null;
+                foreach (var p in pts)
                 {
-                    id = kvp.Key,
-                    label = name,
-                    data = kvp.Value.Select(p => new
+                    items.Add(new
                     {
                         time = p.Time.ToString("o"),
                         rx = p.RxPowerDbm,
@@ -59,11 +63,24 @@ public static class OntChartEndpoints
                         temp = p.TemperatureC,
                         voltage = p.VoltageV,
                         bias = p.BiasMa,
-                    })
+                        fec = Delta(p.FecErrors, prev?.FecErrors),
+                        bip = Delta(p.BipErrors, prev?.BipErrors),
+                    });
+                    prev = p;
+                }
+
+                return new
+                {
+                    id = kvp.Key,
+                    label = name,
+                    data = items,
                 };
             });
 
             return Results.Ok(new { devices = result });
         });
     }
+
+    private static long? Delta(long? cur, long? prev) =>
+        cur is long c && prev is long p && c >= p ? c - p : null;
 }

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -42,6 +42,8 @@ public static class SfpChartEndpoints
 
             var modules = sfps.Select(s => (s.DeviceMac, s.PortName)).ToList();
             var data = await influx.QuerySfpByModulesAsync(modules, queryFrom, queryTo, ct: ct);
+            // Supplemental PON-layer series (attached ONT configs); empty for modules without one.
+            var ponData = await influx.QuerySfpPonByModulesAsync(modules, queryFrom, queryTo, ct: ct);
 
             var targets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.TargetType == MonitoringTargetType.Fabric)
@@ -76,11 +78,59 @@ public static class SfpChartEndpoints
                         tx = p.TxPowerDbm,
                         temp = p.TemperatureC,
                         voltage = p.VoltageV
-                    })
+                    }),
+                    pon = BuildPonSeries(ponData.TryGetValue(key, out var ponPts) ? ponPts : null)
                 };
             });
 
             return Results.Ok(new { modules = result });
         });
+    }
+
+    /// <summary>
+    /// Project supplemental PON points into the chart payload, converting cumulative
+    /// counters to per-interval deltas (CM Stats style - cumulative lines are unreadable).
+    /// A negative step means the ONT rebooted and reset its counters; that interval's
+    /// delta is null (a gap) rather than a bogus spike. Null when the module has no
+    /// supplemental data, so the UI can hide the PON section entirely.
+    /// </summary>
+    private static List<object>? BuildPonSeries(List<MonitoringInfluxClient.SfpPonPoint>? points)
+    {
+        if (points is not { Count: > 0 }) return null;
+
+        static long? Delta(long? cur, long? prev) =>
+            cur is long c && prev is long p && c >= p ? c - p : null;
+
+        var ordered = points.OrderBy(p => p.Time).ToList();
+        var items = new List<object>(ordered.Count);
+        MonitoringInfluxClient.SfpPonPoint? prev = null;
+        foreach (var p in ordered)
+        {
+            items.Add(new
+            {
+                time = p.Time.ToString("o"),
+                state = p.PonLinkStatus,
+                statePrev = p.PonLinkStatusPrev,
+                onuId = p.OnuId,
+                dsFec = p.DsFecEnabled,
+                usFec = p.UsFecEnabled,
+                respTime = p.OnuResponseTime,
+                uptime = p.SfpUptimeS,
+                bip = Delta(p.BipErrors, prev?.BipErrors),
+                fec = Delta(p.FecErrors, prev?.FecErrors),
+                fecCorr = Delta(p.FecCorrectedWords, prev?.FecCorrectedWords),
+                hec = Delta(p.HecUncorrected, prev?.HecUncorrected),
+                gemTx = Delta(p.GemTxFrames, prev?.GemTxFrames),
+                gemTxIdle = Delta(p.GemTxIdleFrames, prev?.GemTxIdleFrames),
+                gemRx = Delta(p.GemRxFrames, prev?.GemRxFrames),
+                gemDrop = Delta(p.GemRxDropped, prev?.GemRxDropped),
+                allocLost = Delta(p.AllocLost, prev?.AllocLost),
+                lanFcs = Delta(p.LanRxFcsErrors, prev?.LanRxFcsErrors),
+                lanDrop = Delta(p.LanTxDropEvents, prev?.LanTxDropEvents),
+                lanOvfl = Delta(p.LanBufferOverflow, prev?.LanBufferOverflow),
+            });
+            prev = p;
+        }
+        return items;
     }
 }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -356,6 +356,7 @@ builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<IOntProvider, TelekomModem2OntProvider>();
 builder.Services.AddSingleton<IOntProvider, NokiaXs010xOntProvider>();
+builder.Services.AddSingleton<IOntProvider, NetOptCustomPonOntProvider>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).Ont);
 

--- a/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertRuleAutoEnable.cs
@@ -40,6 +40,36 @@ public static class AlertRuleAutoEnable
     }
 
     /// <summary>
+    /// Enables specific disabled rules (by EventTypePattern) when a capability first
+    /// becomes available - e.g. attaching augmented PON polling to an SFP ONT unlocks the
+    /// BIP/HEC error alerts. Skips if any of those patterns is already enabled, so it never
+    /// re-enables a rule the user turned off. Complements the startup
+    /// <see cref="EnableFreshlySeeded"/> path by acting immediately on the triggering save.
+    /// </summary>
+    public static async Task EnablePatternsAsync(IServiceScope scope, IReadOnlyCollection<string> patterns, ILogger logger)
+    {
+        try
+        {
+            var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+
+            var rules = (await db.AlertRules.ToListAsync())
+                .Where(r => patterns.Contains(r.EventTypePattern))
+                .ToList();
+            if (rules.Count == 0 || rules.Any(r => r.IsEnabled)) return;
+
+            foreach (var rule in rules) rule.IsEnabled = true;
+            await db.SaveChangesAsync();
+
+            logger.LogInformation("Auto-enabled {Count} alert rules for patterns [{Patterns}]",
+                rules.Count, string.Join(", ", patterns));
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to auto-enable pattern rules");
+        }
+    }
+
+    /// <summary>
     /// Enables rules that were JUST seeded (their EventTypePattern is in
     /// <paramref name="seededPatterns"/>) for a source whose monitoring is already configured
     /// on this database. Unlike <see cref="EnableBySourceAsync"/> this only touches the

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -139,7 +139,9 @@ public class PhysicalLinkResolver
     private async Task<List<Cand>> PonCandidatesAsync(NetworkOptimizerDbContext db, CancellationToken ct)
     {
         var sfps = await SfpCandidatesAsync(db, SfpCategory.Pon, PhysicalMedium.Pon, ct);
-        var onts = (await db.OntConfigurations.AsNoTracking().Where(o => o.Enabled).ToListAsync(ct))
+        // Attached configs represent the SFP module's PON layer (handled by the SFP
+        // candidate above), not a standalone ONT hop - exclude them here.
+        var onts = (await db.OntConfigurations.AsNoTracking().Where(o => o.Enabled && o.AttachedSfpId == null).ToListAsync(ct))
             .Where(o => IsFresh(o.LastPolled, o.PollingIntervalSeconds))
             .Select(o => new Cand($"ont:{o.Id}", o.Name, PhysicalMedium.Pon, o.Id, null, null));
         return sfps.Concat(onts).ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -18,7 +18,8 @@ public class OntAlertEvaluator
     private const double RxPowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
     private const double TempHysteresisC = PonThresholds.TempHysteresisC;
     private const long FecErrorDeltaThreshold = PonThresholds.PonFecErrorSpikePerPoll;
-    private const long BipErrorDeltaThreshold = PonThresholds.PonBipErrorSpikePerPoll;
+    private const long BipErrorStrictThreshold = PonThresholds.PonBipErrorSpikePerPoll;
+    private const long BipErrorRelaxedThreshold = PonThresholds.PonBipErrorSpikeFecOnPerPoll;
     private const long HecErrorDeltaThreshold = PonThresholds.PonHecErrorSpikePerPoll;
 
     private readonly IAlertEventBus _eventBus;
@@ -66,7 +67,7 @@ public class OntAlertEvaluator
         // BIP is always-on regardless of FEC, so it's evaluated whenever reported.
         if (bipErrors.HasValue)
         {
-            await CheckBipErrors(state, ontId, ontName, bipErrors.Value, ct);
+            await CheckBipErrors(state, ontId, ontName, bipErrors.Value, fecEnabled, ct);
         }
 
         // The uncorrectable-codeword signal adapts to whether payload FEC is running:
@@ -202,10 +203,16 @@ public class OntAlertEvaluator
             v => state.PreviousFecErrors = v, ct);
 
     private ValueTask CheckBipErrors(
-        OntAlertState state, int ontId, string ontName, long bipErrors, CancellationToken ct) =>
-        CheckErrorSpike(ontId, ontName, bipErrors, state.PreviousBipErrors, BipErrorDeltaThreshold,
+        OntAlertState state, int ontId, string ontName, long bipErrors, bool? fecEnabled, CancellationToken ct)
+    {
+        // BIP is uncorrected data loss only when payload FEC is off; with FEC on (or unknown,
+        // the standalone-ONT default) it counts pre-FEC line errors FEC corrects, so relax the
+        // threshold to avoid flagging a healthy FEC-enabled link at its normal operating point.
+        var threshold = fecEnabled == false ? BipErrorStrictThreshold : BipErrorRelaxedThreshold;
+        return CheckErrorSpike(ontId, ontName, bipErrors, state.PreviousBipErrors, threshold,
             "ont.bip_errors", "BIP error", "BIP errors", "bip", "bip_delta",
             v => state.PreviousBipErrors = v, ct);
+    }
 
     private ValueTask CheckHecErrors(
         OntAlertState state, int ontId, string ontName, long hecErrors, CancellationToken ct) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -21,6 +21,7 @@ public class OntAlertEvaluator
     private const long BipErrorStrictThreshold = PonThresholds.PonBipErrorSpikePerPoll;
     private const long BipErrorRelaxedThreshold = PonThresholds.PonBipErrorSpikeFecOnPerPoll;
     private const long HecErrorDeltaThreshold = PonThresholds.PonHecErrorSpikePerPoll;
+    private const string DefaultSourceUrl = "/monitoring?tab=ont";
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<OntAlertEvaluator> _logger;
@@ -53,9 +54,13 @@ public class OntAlertEvaluator
         long? bipErrors = null,
         long? hecErrors = null,
         bool? fecEnabled = null,
+        string? sourceUrl = null,
         CancellationToken ct = default)
     {
         var state = _states.GetOrAdd(ontId, _ => new OntAlertState());
+        // Where a raised alert links to. Attached SFP ONTs surface on SFP Stats, standalone
+        // ONTs on ONT Stats; the caller passes the deep link to the triggering module.
+        state.SourceUrl = string.IsNullOrEmpty(sourceUrl) ? DefaultSourceUrl : sourceUrl;
 
         if (rxPowerDbm.HasValue)
         {
@@ -109,7 +114,7 @@ public class OntAlertEvaluator
                 DeviceName = ontName,
                 MetricValue = rxPower,
                 ThresholdValue = rxPowerLowDbm,
-                SourceUrl = "/monitoring?tab=ont",
+                SourceUrl = state.SourceUrl,
                 Tags = ["ont", "rx_power"],
                 Context = new Dictionary<string, string>
                 {
@@ -148,7 +153,7 @@ public class OntAlertEvaluator
                 DeviceName = ontName,
                 MetricValue = tempC,
                 ThresholdValue = tempHighC,
-                SourceUrl = "/monitoring?tab=ont",
+                SourceUrl = state.SourceUrl,
                 Tags = ["ont", "temperature"],
                 Context = new Dictionary<string, string>
                 {
@@ -181,7 +186,7 @@ public class OntAlertEvaluator
                 Title = $"{ontName} PON link down{_siteSuffix}",
                 Message = $"ONT {ontName} PON link is down (state: {ponLinkStatus}).",
                 DeviceName = ontName,
-                SourceUrl = "/monitoring?tab=ont",
+                SourceUrl = state.SourceUrl,
                 Tags = ["ont", "pon_link"],
                 Context = new Dictionary<string, string>
                 {
@@ -200,7 +205,7 @@ public class OntAlertEvaluator
         OntAlertState state, int ontId, string ontName, long fecErrors, CancellationToken ct) =>
         CheckErrorSpike(ontId, ontName, fecErrors, state.PreviousFecErrors, FecErrorDeltaThreshold,
             "ont.fec_errors", "FEC error", "FEC errors", "fec", "fec_delta",
-            v => state.PreviousFecErrors = v, ct);
+            v => state.PreviousFecErrors = v, state.SourceUrl, ct);
 
     private ValueTask CheckBipErrors(
         OntAlertState state, int ontId, string ontName, long bipErrors, bool? fecEnabled, CancellationToken ct)
@@ -211,14 +216,14 @@ public class OntAlertEvaluator
         var threshold = fecEnabled == false ? BipErrorStrictThreshold : BipErrorRelaxedThreshold;
         return CheckErrorSpike(ontId, ontName, bipErrors, state.PreviousBipErrors, threshold,
             "ont.bip_errors", "BIP error", "BIP errors", "bip", "bip_delta",
-            v => state.PreviousBipErrors = v, ct);
+            v => state.PreviousBipErrors = v, state.SourceUrl, ct);
     }
 
     private ValueTask CheckHecErrors(
         OntAlertState state, int ontId, string ontName, long hecErrors, CancellationToken ct) =>
         CheckErrorSpike(ontId, ontName, hecErrors, state.PreviousHecErrors, HecErrorDeltaThreshold,
             "ont.hec_errors", "HEC error", "HEC errors", "hec", "hec_delta",
-            v => state.PreviousHecErrors = v, ct);
+            v => state.PreviousHecErrors = v, state.SourceUrl, ct);
 
     /// <summary>
     /// Shared per-poll error-counter spike check. Fires when the increase since the last
@@ -228,7 +233,7 @@ public class OntAlertEvaluator
     private async ValueTask CheckErrorSpike(
         int ontId, string ontName, long current, long? previous, long threshold,
         string eventType, string spikeLabel, string countLabel, string metricTag, string deltaKey,
-        Action<long> setPrevious, CancellationToken ct)
+        Action<long> setPrevious, string sourceUrl, CancellationToken ct)
     {
         if (previous.HasValue)
         {
@@ -249,7 +254,7 @@ public class OntAlertEvaluator
                     DeviceName = ontName,
                     MetricValue = delta,
                     ThresholdValue = threshold,
-                    SourceUrl = "/monitoring?tab=ont",
+                    SourceUrl = sourceUrl,
                     Tags = ["ont", metricTag],
                     Context = new Dictionary<string, string>
                     {
@@ -272,5 +277,6 @@ public class OntAlertEvaluator
         public long? PreviousFecErrors;
         public long? PreviousBipErrors;
         public long? PreviousHecErrors;
+        public string SourceUrl = DefaultSourceUrl;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -18,6 +18,8 @@ public class OntAlertEvaluator
     private const double RxPowerHysteresisDbm = PonThresholds.PowerHysteresisDbm;
     private const double TempHysteresisC = PonThresholds.TempHysteresisC;
     private const long FecErrorDeltaThreshold = PonThresholds.PonFecErrorSpikePerPoll;
+    private const long BipErrorDeltaThreshold = PonThresholds.PonBipErrorSpikePerPoll;
+    private const long HecErrorDeltaThreshold = PonThresholds.PonHecErrorSpikePerPoll;
 
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<OntAlertEvaluator> _logger;
@@ -47,6 +49,9 @@ public class OntAlertEvaluator
         double? temperatureC = null,
         double rxPowerLowDbm = PonThresholds.PonRxPowerLowDbm,
         double tempHighC = PonThresholds.PonTempHighC,
+        long? bipErrors = null,
+        long? hecErrors = null,
+        bool? fecEnabled = null,
         CancellationToken ct = default)
     {
         var state = _states.GetOrAdd(ontId, _ => new OntAlertState());
@@ -58,7 +63,22 @@ public class OntAlertEvaluator
 
         await CheckPonLink(state, ontId, ontName, ponLinkStatus, ct);
 
-        if (fecErrors.HasValue)
+        // BIP is always-on regardless of FEC, so it's evaluated whenever reported.
+        if (bipErrors.HasValue)
+        {
+            await CheckBipErrors(state, ontId, ontName, bipErrors.Value, ct);
+        }
+
+        // The uncorrectable-codeword signal adapts to whether payload FEC is running:
+        // FEC codewords when it's enabled (or unknown - the standalone-ONT default),
+        // HEC header errors when it's explicitly disabled and FEC counters stay flat.
+        // Mirrors the SFP ONT card's adaptive FEC/HEC display.
+        if (fecEnabled == false)
+        {
+            if (hecErrors.HasValue)
+                await CheckHecErrors(state, ontId, ontName, hecErrors.Value, ct);
+        }
+        else if (fecErrors.HasValue)
         {
             await CheckFecErrors(state, ontId, ontName, fecErrors.Value, ct);
         }
@@ -175,41 +195,66 @@ public class OntAlertEvaluator
         }
     }
 
-    private async ValueTask CheckFecErrors(
-        OntAlertState state, int ontId, string ontName, long fecErrors, CancellationToken ct)
+    private ValueTask CheckFecErrors(
+        OntAlertState state, int ontId, string ontName, long fecErrors, CancellationToken ct) =>
+        CheckErrorSpike(ontId, ontName, fecErrors, state.PreviousFecErrors, FecErrorDeltaThreshold,
+            "ont.fec_errors", "FEC error", "FEC errors", "fec", "fec_delta",
+            v => state.PreviousFecErrors = v, ct);
+
+    private ValueTask CheckBipErrors(
+        OntAlertState state, int ontId, string ontName, long bipErrors, CancellationToken ct) =>
+        CheckErrorSpike(ontId, ontName, bipErrors, state.PreviousBipErrors, BipErrorDeltaThreshold,
+            "ont.bip_errors", "BIP error", "BIP errors", "bip", "bip_delta",
+            v => state.PreviousBipErrors = v, ct);
+
+    private ValueTask CheckHecErrors(
+        OntAlertState state, int ontId, string ontName, long hecErrors, CancellationToken ct) =>
+        CheckErrorSpike(ontId, ontName, hecErrors, state.PreviousHecErrors, HecErrorDeltaThreshold,
+            "ont.hec_errors", "HEC error", "HEC errors", "hec", "hec_delta",
+            v => state.PreviousHecErrors = v, ct);
+
+    /// <summary>
+    /// Shared per-poll error-counter spike check. Fires when the increase since the last
+    /// poll exceeds the threshold; a negative step (ONT counter reset) counts as zero, so
+    /// a reboot never fakes a spike. The first reading only establishes the baseline.
+    /// </summary>
+    private async ValueTask CheckErrorSpike(
+        int ontId, string ontName, long current, long? previous, long threshold,
+        string eventType, string spikeLabel, string countLabel, string metricTag, string deltaKey,
+        Action<long> setPrevious, CancellationToken ct)
     {
-        if (state.PreviousFecErrors.HasValue)
+        if (previous.HasValue)
         {
-            var delta = fecErrors - state.PreviousFecErrors.Value;
+            var delta = current - previous.Value;
             if (delta < 0) delta = 0; // counter reset
 
-            if (delta > FecErrorDeltaThreshold)
+            if (delta > threshold)
             {
-                _logger.LogDebug("ONT {Name} FEC error spike: {Delta} errors since last poll", ontName, delta);
+                _logger.LogDebug("ONT {Name} {Label} spike: {Delta} since last poll", ontName, spikeLabel, delta);
 
                 await _eventBus.PublishAsync(new AlertEvent
                 {
-                    EventType = "ont.fec_errors",
+                    EventType = eventType,
                     Source = "ont",
                     Severity = AlertSeverity.Warning,
-                    Title = $"{ontName} FEC error spike{_siteSuffix}",
-                    Message = $"ONT {ontName} had {delta:N0} FEC errors since last poll (threshold: {FecErrorDeltaThreshold:N0}).",
+                    Title = $"{ontName} {spikeLabel} spike{_siteSuffix}",
+                    Message = $"ONT {ontName} had {delta:N0} {countLabel} since last poll (threshold: {threshold:N0}).",
                     DeviceName = ontName,
                     MetricValue = delta,
-                    ThresholdValue = FecErrorDeltaThreshold,
+                    ThresholdValue = threshold,
                     SourceUrl = "/monitoring?tab=ont",
-                    Tags = ["ont", "fec"],
+                    Tags = ["ont", metricTag],
                     Context = new Dictionary<string, string>
                     {
                         ["ont_id"] = ontId.ToString(),
-                        ["metric"] = "fec_errors",
-                        ["fec_delta"] = delta.ToString()
+                        ["metric"] = $"{metricTag}_errors",
+                        [deltaKey] = delta.ToString()
                     }
                 }, ct);
             }
         }
 
-        state.PreviousFecErrors = fecErrors;
+        setPrevious(current);
     }
 
     private class OntAlertState
@@ -218,5 +263,7 @@ public class OntAlertEvaluator
         public bool PonLinkDown;
         public bool TempBreached;
         public long? PreviousFecErrors;
+        public long? PreviousBipErrors;
+        public long? PreviousHecErrors;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -31,13 +31,19 @@ public static class PonThresholds
     /// <summary>Per-poll FEC corrected-error spike threshold. Corrected errors are benign in small
     /// numbers (the FEC is doing its job); a sustained rate above this corroborates a marginal optic.</summary>
     public const long PonFecErrorSpikePerPoll = 1000;
-    /// <summary>Per-poll BIP (bit-interleaved-parity) error threshold. BIP errors are uncorrected bit
-    /// errors, so this is stricter than the FEC corrected-error threshold.</summary>
-    public const long PonBipErrorSpikePerPoll = 100;
+    /// <summary>Per-poll BIP threshold on a link running with payload FEC DISABLED, where every BIP is
+    /// uncorrected bit corruption. A healthy link reads 0, so this is deliberately strict - low tens of
+    /// uncorrected bit errors per 5-minute poll is a real fault.</summary>
+    public const long PonBipErrorSpikePerPoll = 25;
+    /// <summary>Per-poll BIP threshold on a FEC-ENABLED (or unknown) link. There BIP counts pre-FEC line
+    /// errors that FEC silently corrects, so a link at the normal ITU operating point reads hundreds/poll
+    /// while data is perfect; only a gross rate (matching the FEC codeword line) is worth flagging.</summary>
+    public const long PonBipErrorSpikeFecOnPerPoll = 1000;
     /// <summary>Per-poll uncorrectable-HEC (header error control) threshold. HEC guards the GEM/GTC
-    /// framing headers and is always active regardless of payload FEC, so it's the live error signal
-    /// on a link running with FEC disabled. Uncorrected like BIP, so it shares BIP's stricter threshold.</summary>
-    public const long PonHecErrorSpikePerPoll = 100;
+    /// framing headers and is always active regardless of payload FEC, so it's the live error signal on a
+    /// FEC-disabled link. Uncorrectable header errors drop frames, and a healthy link reads ~0, so this is
+    /// strict.</summary>
+    public const long PonHecErrorSpikePerPoll = 10;
 
     // --- ONT error-count health for ISP Health (absolute count over the window, per-day). ---
     // A healthy PON link has a negligible BIP / uncorrectable-FEC count: 0 is ideal, a few per day

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PonThresholds.cs
@@ -34,6 +34,10 @@ public static class PonThresholds
     /// <summary>Per-poll BIP (bit-interleaved-parity) error threshold. BIP errors are uncorrected bit
     /// errors, so this is stricter than the FEC corrected-error threshold.</summary>
     public const long PonBipErrorSpikePerPoll = 100;
+    /// <summary>Per-poll uncorrectable-HEC (header error control) threshold. HEC guards the GEM/GTC
+    /// framing headers and is always active regardless of payload FEC, so it's the live error signal
+    /// on a link running with FEC disabled. Uncorrected like BIP, so it shares BIP's stricter threshold.</summary>
+    public const long PonHecErrorSpikePerPoll = 100;
 
     // --- ONT error-count health for ISP Health (absolute count over the window, per-day). ---
     // A healthy PON link has a negligible BIP / uncorrectable-FEC count: 0 is ideal, a few per day

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2215,8 +2215,12 @@ public class MonitoringCollectionAgent : BackgroundService
                 _ = _influx.WriteSfpPonAsync(mac, portName, ponStats, timestamp);
                 // Mirror the key PON values into live stats so the SFP ONT card can show
                 // PON status and absolute error counters without a DB roundtrip.
+                bool? fecEnabled = ponStats.DsFecEnabled.HasValue || ponStats.UsFecEnabled.HasValue
+                    ? ponStats.DsFecEnabled == 1 || ponStats.UsFecEnabled == 1
+                    : null;
                 _liveStats.RecordSfpPon(mac, portName, ponStats.PonLinkStatus,
-                    ponStats.BipErrors, ponStats.FecErrors, ponStats.GemRxDropped, timestamp);
+                    ponStats.BipErrors, ponStats.FecErrors, ponStats.HecUncorrected, fecEnabled,
+                    ponStats.GemRxDropped, timestamp);
             }
 
             // Mirror the values into the live-stats cache so the dashboard SFP card can

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2152,7 +2152,12 @@ public class MonitoringCollectionAgent : BackgroundService
 
                     // Alert evaluation runs in its own try/catch so an alert failure is
                     // logged but never marks the (successful) poll as errored - matching
-                    // the SFP/device-health evaluator call sites.
+                    // the SFP/device-health evaluator call sites. FEC is only meaningful
+                    // when the OLT profile enables it; when disabled the evaluator falls
+                    // back to HEC, so pass the enable state.
+                    bool? fecEnabled = stats.DsFecEnabled.HasValue || stats.UsFecEnabled.HasValue
+                        ? stats.DsFecEnabled == 1 || stats.UsFecEnabled == 1
+                        : null;
                     try
                     {
                         await _ontAlertEvaluator.EvaluateAsync(
@@ -2161,7 +2166,11 @@ public class MonitoringCollectionAgent : BackgroundService
                             NetOptCustomPonOntProvider.ToPonLinkState(stats.PloamStateRaw),
                             stats.FecErrors,
                             temperatureC: null,
-                            thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC, ct);
+                            thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC,
+                            bipErrors: stats.BipErrors,
+                            hecErrors: stats.HecUncorrected,
+                            fecEnabled: fecEnabled,
+                            ct);
                     }
                     catch (Exception ex)
                     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2213,6 +2213,10 @@ public class MonitoringCollectionAgent : BackgroundService
             if (ponSupplemental.TryGetValue((mac, portName), out var ponStats))
             {
                 _ = _influx.WriteSfpPonAsync(mac, portName, ponStats, timestamp);
+                // Mirror the key PON values into live stats so the SFP ONT card can show
+                // PON status and absolute error counters without a DB roundtrip.
+                _liveStats.RecordSfpPon(mac, portName, ponStats.PonLinkStatus,
+                    ponStats.BipErrors, ponStats.FecErrors, ponStats.GemRxDropped, timestamp);
             }
 
             // Mirror the values into the live-stats cache so the dashboard SFP card can

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2,13 +2,16 @@ using System.Collections.Concurrent;
 using System.Net;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Monitoring;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Probes;
+using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -50,6 +53,9 @@ public class MonitoringCollectionAgent : BackgroundService
     private readonly NetworkOptimizer.Web.Services.Monitoring.MonitoringAlertEvaluator _alertEvaluator;
     private readonly NetworkOptimizer.Web.Services.Monitoring.SfpAlertEvaluator _sfpAlertEvaluator;
     private readonly NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator _deviceHealthAlertEvaluator;
+    private readonly NetworkOptimizer.Web.Services.Monitoring.OntAlertEvaluator _ontAlertEvaluator;
+    private readonly Dictionary<string, ISfpSupplementalOntProvider> _supplementalOntProviders;
+    private readonly SiteTunnelRouting _tunnelRouting;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<MonitoringCollectionAgent> _logger;
     private readonly Licensing.LicenseStateService _licenseState;
@@ -125,6 +131,8 @@ public class MonitoringCollectionAgent : BackgroundService
         LocalProbeExecutor localProbe,
         MonitoringAlertRegistry alertRegistry,
         Licensing.LicenseStateService licenseState,
+        IEnumerable<IOntProvider> ontProviders,
+        SiteTunnelRouting tunnelRouting,
         ILoggerFactory loggerFactory,
         ILogger<MonitoringCollectionAgent> logger,
         string siteSlug = SiteManagementService.DefaultSiteSlug)
@@ -144,6 +152,11 @@ public class MonitoringCollectionAgent : BackgroundService
         _alertEvaluator = evaluators.Targets;
         _sfpAlertEvaluator = evaluators.Sfp;
         _deviceHealthAlertEvaluator = evaluators.DeviceHealth;
+        _ontAlertEvaluator = evaluators.Ont;
+        _supplementalOntProviders = ontProviders
+            .OfType<ISfpSupplementalOntProvider>()
+            .ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
+        _tunnelRouting = tunnelRouting;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
@@ -889,12 +902,17 @@ public class MonitoringCollectionAgent : BackgroundService
         var existingSfps = await db.MonitoredSfps.ToDictionaryAsync(
             s => (s.DeviceMac, s.PortName), s => s, ct);
 
+        // Supplemental PON stats: poll ONT configs attached to a monitored SFP module
+        // (Network Optimizer Custom endpoints) so their PON-layer metrics can merge into
+        // the sfp measurement alongside the DDM values below.
+        var ponSupplemental = await CollectPonSupplementalAsync(db, existingSfps, settings, ct);
+
         // SFP collection (spec 5.9): write DDM values to the sfp measurement for every port
         // where UniFi reports sfp_found, and reconcile the MonitoredSfps relational row.
         var nowSfp = DateTime.UtcNow;
         foreach (var device in devices)
         {
-            CollectSfpForDevice(device, db, existingSfps, nowSfp);
+            CollectSfpForDevice(device, db, existingSfps, ponSupplemental, nowSfp);
         }
 
         // SFP threshold evaluation: check DDM values against alert thresholds
@@ -2064,10 +2082,103 @@ public class MonitoringCollectionAgent : BackgroundService
             _logger.LogDebug("Seeded {Count} SFP live entries from InfluxDB (site {Site})", seeded, _siteSlug);
     }
 
+    /// <summary>
+    /// Poll every enabled ONT configuration attached to a monitored SFP module and
+    /// return the supplemental PON stats keyed by that module's (DeviceMac, PortName),
+    /// for merging into the sfp measurement. Attached configs bypass the standalone
+    /// OntMonitorService loop, so their LastPolled/LastError status is stamped here
+    /// (persisted by the slow tier's SaveChanges) and ONT alerts (PON link state, FEC)
+    /// are evaluated here too - DDM alerts stay with the SFP evaluator.
+    /// </summary>
+    private async Task<Dictionary<(string DeviceMac, string PortName), PonSupplementalStats>> CollectPonSupplementalAsync(
+        NetworkOptimizerDbContext db,
+        Dictionary<(string DeviceMac, string PortName), MonitoredSfp> sfps,
+        MonitoringSettings settings,
+        CancellationToken ct)
+    {
+        var result = new Dictionary<(string, string), PonSupplementalStats>();
+        List<OntConfiguration> attached;
+        try
+        {
+            attached = await db.OntConfigurations
+                .Where(o => o.Enabled && o.AttachedSfpId != null)
+                .ToListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Attached ONT config load failed (site {Site})", _siteSlug);
+            return result;
+        }
+        if (attached.Count == 0) return result;
+
+        var sfpById = sfps.Values.Where(s => s.Id > 0).ToDictionary(s => s.Id);
+        var thresholds = NetworkOptimizer.Web.Services.Monitoring.SfpDdmThresholds.FromSettings(settings);
+
+        foreach (var config in attached)
+        {
+            if (!sfpById.TryGetValue(config.AttachedSfpId!.Value, out var sfp))
+            {
+                config.LastError = "Attached SFP module no longer exists";
+                config.UpdatedAt = DateTime.UtcNow;
+                continue;
+            }
+            if (!_supplementalOntProviders.TryGetValue(config.Provider, out var provider))
+            {
+                config.LastError = $"Provider '{config.Provider}' does not support SFP module attachment";
+                config.UpdatedAt = DateTime.UtcNow;
+                continue;
+            }
+
+            try
+            {
+                // Same tunnel-proxy routing the standalone ONT poll path uses, so
+                // attached endpoints on agent sites are reached through the relay.
+                var (host, port) = await _tunnelRouting.RouteAsync(_siteSlug, config.Host, config.Port);
+                var context = new OntPollContext
+                {
+                    Id = config.Id,
+                    Name = config.Name,
+                    Host = host,
+                    ConfiguredHost = config.Host,
+                    Port = port,
+                };
+
+                var stats = await provider.PollSupplementalAsync(context, ct);
+                if (stats != null)
+                {
+                    result[(sfp.DeviceMac, sfp.PortName)] = stats;
+                    config.LastPolled = DateTime.UtcNow;
+                    config.LastError = null;
+
+                    _ = _ontAlertEvaluator.EvaluateAsync(
+                        config.Id, config.Name,
+                        rxPowerDbm: null,
+                        NetOptCustomPonOntProvider.ToPonLinkState(stats.PloamStateRaw),
+                        stats.FecErrors,
+                        temperatureC: null,
+                        thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC, ct);
+                }
+                else
+                {
+                    config.LastError = "Poll returned no data";
+                }
+                config.UpdatedAt = DateTime.UtcNow;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Supplemental PON poll failed for {Name} (site {Site})", config.Name, _siteSlug);
+                config.LastError = ex.Message;
+                config.UpdatedAt = DateTime.UtcNow;
+            }
+        }
+        return result;
+    }
+
     private void CollectSfpForDevice(
         UniFiDeviceResponse device,
         NetworkOptimizerDbContext db,
         Dictionary<(string DeviceMac, string PortName), MonitoredSfp> existing,
+        IReadOnlyDictionary<(string DeviceMac, string PortName), PonSupplementalStats> ponSupplemental,
         DateTime timestamp)
     {
         if (device.PortTable == null || device.PortTable.Count == 0) return;
@@ -2096,6 +2207,13 @@ public class MonitoringCollectionAgent : BackgroundService
                 voltageV: port.SfpVoltage,
                 sfpLinkSpeedMbps: port.Speed > 0 ? port.Speed : null,
                 timestamp: timestamp);
+
+            // Supplemental PON-layer stats from an attached ONT config merge onto the
+            // same series and timestamp (field union with the DDM point above).
+            if (ponSupplemental.TryGetValue((mac, portName), out var ponStats))
+            {
+                _ = _influx.WriteSfpPonAsync(mac, portName, ponStats, timestamp);
+            }
 
             // Mirror the values into the live-stats cache so the dashboard SFP card can
             // render without a DB roundtrip on every refresh.

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2158,6 +2158,8 @@ public class MonitoringCollectionAgent : BackgroundService
                     bool? fecEnabled = stats.DsFecEnabled.HasValue || stats.UsFecEnabled.HasValue
                         ? stats.DsFecEnabled == 1 || stats.UsFecEnabled == 1
                         : null;
+                    // Attached ONTs surface on SFP Stats, so link the alert to that module.
+                    var sfpUrl = $"/monitoring?tab=sfp&sfp={sfp.DeviceMac.Replace("-", ":").ToLowerInvariant()}:{sfp.PortName}";
                     try
                     {
                         await _ontAlertEvaluator.EvaluateAsync(
@@ -2170,7 +2172,8 @@ public class MonitoringCollectionAgent : BackgroundService
                             bipErrors: stats.BipErrors,
                             hecErrors: stats.HecUncorrected,
                             fecEnabled: fecEnabled,
-                            ct);
+                            sourceUrl: sfpUrl,
+                            ct: ct);
                     }
                     catch (Exception ex)
                     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2150,13 +2150,23 @@ public class MonitoringCollectionAgent : BackgroundService
                     config.LastPolled = DateTime.UtcNow;
                     config.LastError = null;
 
-                    _ = _ontAlertEvaluator.EvaluateAsync(
-                        config.Id, config.Name,
-                        rxPowerDbm: null,
-                        NetOptCustomPonOntProvider.ToPonLinkState(stats.PloamStateRaw),
-                        stats.FecErrors,
-                        temperatureC: null,
-                        thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC, ct);
+                    // Alert evaluation runs in its own try/catch so an alert failure is
+                    // logged but never marks the (successful) poll as errored - matching
+                    // the SFP/device-health evaluator call sites.
+                    try
+                    {
+                        await _ontAlertEvaluator.EvaluateAsync(
+                            config.Id, config.Name,
+                            rxPowerDbm: null,
+                            NetOptCustomPonOntProvider.ToPonLinkState(stats.PloamStateRaw),
+                            stats.FecErrors,
+                            temperatureC: null,
+                            thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC, ct);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "PON alert evaluation failed for {Name}", config.Name);
+                    }
                 }
                 else
                 {

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -489,10 +489,12 @@ public class MonitoringLiveStats
     /// supplement poll doesn't blank the prior good values.
     /// </summary>
     public void RecordSfpPon(string deviceMac, string portName, string? ponLinkStatus,
-        long? bipErrors, long? fecErrors, long? gemRxDropped, DateTime timestamp)
+        long? bipErrors, long? fecErrors, long? hecUncorrected, bool? fecEnabled,
+        long? gemRxDropped, DateTime timestamp)
     {
         if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(portName)) return;
-        if (string.IsNullOrEmpty(ponLinkStatus) && !bipErrors.HasValue && !fecErrors.HasValue && !gemRxDropped.HasValue)
+        if (string.IsNullOrEmpty(ponLinkStatus) && !bipErrors.HasValue && !fecErrors.HasValue
+            && !hecUncorrected.HasValue && !gemRxDropped.HasValue)
             return;
 
         var key = (Normalize(deviceMac), portName);
@@ -503,6 +505,8 @@ public class MonitoringLiveStats
                 PonLinkStatus = ponLinkStatus,
                 BipErrors = bipErrors,
                 FecErrors = fecErrors,
+                HecUncorrected = hecUncorrected,
+                FecEnabled = fecEnabled,
                 GemRxDropped = gemRxDropped,
                 LastUpdate = timestamp
             },
@@ -511,6 +515,8 @@ public class MonitoringLiveStats
                 PonLinkStatus = ponLinkStatus ?? prior.PonLinkStatus,
                 BipErrors = bipErrors ?? prior.BipErrors,
                 FecErrors = fecErrors ?? prior.FecErrors,
+                HecUncorrected = hecUncorrected ?? prior.HecUncorrected,
+                FecEnabled = fecEnabled ?? prior.FecEnabled,
                 GemRxDropped = gemRxDropped ?? prior.GemRxDropped,
             });
     }
@@ -719,6 +725,12 @@ public record SfpLiveStats
     public long? BipErrors { get; init; }
     /// <summary>Absolute (cumulative) uncorrectable FEC codewords from the PON supplement.</summary>
     public long? FecErrors { get; init; }
+    /// <summary>Absolute (cumulative) uncorrectable HEC header errors - the always-on
+    /// framing-layer error signal, meaningful even when payload FEC is disabled.</summary>
+    public long? HecUncorrected { get; init; }
+    /// <summary>Whether payload FEC is enabled per the OLT profile. Null = unknown. When
+    /// false, the FEC counters stay 0 and HEC is the live error signal to show instead.</summary>
+    public bool? FecEnabled { get; init; }
     /// <summary>Absolute (cumulative) dropped GEM frames from the PON supplement.</summary>
     public long? GemRxDropped { get; init; }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -469,8 +469,9 @@ public class MonitoringLiveStats
             },
             // Merge: each field keeps the new value when present, otherwise preserves
             // the prior value. One null reading on a single sensor (e.g. bias) no
-            // longer wipes the others.
-            (_, prior) => new SfpLiveStats
+            // longer wipes the others. PON supplement fields (set by RecordSfpPon) are
+            // always carried through - this DDM path never touches them.
+            (_, prior) => prior with
             {
                 RxPowerDbm = rxDbm ?? prior.RxPowerDbm,
                 TxPowerDbm = txDbm ?? prior.TxPowerDbm,
@@ -478,6 +479,39 @@ public class MonitoringLiveStats
                 TemperatureC = tempC ?? prior.TemperatureC,
                 VoltageV = voltageV ?? prior.VoltageV,
                 LastUpdate = timestamp
+            });
+    }
+
+    /// <summary>
+    /// Record the latest PON-layer supplement (from an attached ONT provider) onto the
+    /// module's live SFP entry, preserving the DDM readings. Absolute counters; the card
+    /// shows them as-is. Skips the write when nothing usable came back so a failed
+    /// supplement poll doesn't blank the prior good values.
+    /// </summary>
+    public void RecordSfpPon(string deviceMac, string portName, string? ponLinkStatus,
+        long? bipErrors, long? fecErrors, long? gemRxDropped, DateTime timestamp)
+    {
+        if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(portName)) return;
+        if (string.IsNullOrEmpty(ponLinkStatus) && !bipErrors.HasValue && !fecErrors.HasValue && !gemRxDropped.HasValue)
+            return;
+
+        var key = (Normalize(deviceMac), portName);
+        _sfpStats.AddOrUpdate(
+            key,
+            _ => new SfpLiveStats
+            {
+                PonLinkStatus = ponLinkStatus,
+                BipErrors = bipErrors,
+                FecErrors = fecErrors,
+                GemRxDropped = gemRxDropped,
+                LastUpdate = timestamp
+            },
+            (_, prior) => prior with
+            {
+                PonLinkStatus = ponLinkStatus ?? prior.PonLinkStatus,
+                BipErrors = bipErrors ?? prior.BipErrors,
+                FecErrors = fecErrors ?? prior.FecErrors,
+                GemRxDropped = gemRxDropped ?? prior.GemRxDropped,
             });
     }
 
@@ -677,6 +711,16 @@ public record SfpLiveStats
     public double? TemperatureC { get; init; }
     public double? VoltageV { get; init; }
     public DateTime LastUpdate { get; init; }
+
+    /// <summary>PON activation state, influx-encoded (e.g. "operation"), from an attached
+    /// supplemental ONT provider. Null when the module has no PON supplement.</summary>
+    public string? PonLinkStatus { get; init; }
+    /// <summary>Absolute (cumulative) BIP error count from the PON supplement.</summary>
+    public long? BipErrors { get; init; }
+    /// <summary>Absolute (cumulative) uncorrectable FEC codewords from the PON supplement.</summary>
+    public long? FecErrors { get; init; }
+    /// <summary>Absolute (cumulative) dropped GEM frames from the PON supplement.</summary>
+    public long? GemRxDropped { get; init; }
 }
 
 public record PortLiveRate

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -165,7 +165,16 @@ public class OntMonitorService : IDisposable
 
         if (isNew)
             await AlertRuleAutoEnable.EnableBySourceAsync(scope, "ont", _logger);
+
+        // Attaching augmented PON polling to an SFP ONT unlocks the BIP/HEC error alerts -
+        // enable them immediately (any save that lands an attachment, new or edited), so an
+        // existing-ONT user doesn't have to wait for the next startup's freshly-seeded pass.
+        if (config.AttachedSfpId.HasValue)
+            await AlertRuleAutoEnable.EnablePatternsAsync(scope, AugmentedOntAlertPatterns, _logger);
     }
+
+    /// <summary>PON error alerts unlocked by augmented (SFP-attached) ONT polling.</summary>
+    private static readonly string[] AugmentedOntAlertPatterns = { "ont.bip_errors", "ont.hec_errors" };
 
     /// <summary>
     /// Delete an ONT configuration and remove cached stats.
@@ -279,10 +288,13 @@ public class OntMonitorService : IDisposable
                 // Fire-and-forget write to InfluxDB
                 WriteToInflux(config, stats);
 
+                // Standalone ONT providers report BIP where available but not HEC or the
+                // FEC-enable state, so FEC stays the codeword-error signal (fecEnabled null).
                 _ = _alertEvaluator.EvaluateAsync(
                     config.Id, config.Name,
                     stats.RxPowerDbm, stats.PonLinkStatus, stats.FecErrors,
-                    stats.TemperatureC, thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC);
+                    stats.TemperatureC, thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC,
+                    bipErrors: stats.BipErrors);
 
                 _logger.LogDebug("ONT {Name} polled successfully: Rx={Rx} dBm", config.Name, stats.RxPowerDbm);
                 return stats;

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -209,6 +209,12 @@ public class OntMonitorService : IDisposable
 
             foreach (var config in configs)
             {
+                // Configs attached to a monitored SFP module are polled by that
+                // site's gateway SFP collection cycle (MonitoringCollectionAgent),
+                // which merges their PON stats into the module's sfp measurement.
+                if (config.AttachedSfpId.HasValue)
+                    continue;
+
                 if (!forceAll && config.LastPolled.HasValue)
                 {
                     var elapsed = DateTime.UtcNow - config.LastPolled.Value;

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -95,13 +95,26 @@ public class OntMonitorService : IDisposable
     }
 
     /// <summary>
-    /// Get all ONT configurations (for UI and chart endpoints).
+    /// Get all ONT configurations, including those attached to an SFP module
+    /// (for the Settings management list).
     /// </summary>
     public async Task<List<OntConfiguration>> GetConfigsAsync()
     {
         using var scope = CreateSiteScope();
         var repository = scope.ServiceProvider.GetRequiredService<IOntRepository>();
         return await repository.GetOntConfigurationsAsync();
+    }
+
+    /// <summary>
+    /// Standalone ONT configurations only - excludes configs attached to an SFP
+    /// module, which surface as PON data on that module (SFP Stats), not as their
+    /// own ONT device. Drives the ONT Stats tab, the Dashboard ONT card, and the
+    /// ONT chart endpoint so an attached config never appears as a standalone ONT.
+    /// </summary>
+    public async Task<List<OntConfiguration>> GetStandaloneConfigsAsync()
+    {
+        var configs = await GetConfigsAsync();
+        return configs.Where(c => c.AttachedSfpId == null).ToList();
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -294,7 +294,8 @@ public class OntMonitorService : IDisposable
                     config.Id, config.Name,
                     stats.RxPowerDbm, stats.PonLinkStatus, stats.FecErrors,
                     stats.TemperatureC, thresholds.PonRxPowerLowDbm, thresholds.PonTempHighC,
-                    bipErrors: stats.BipErrors);
+                    bipErrors: stats.BipErrors,
+                    sourceUrl: $"/monitoring?tab=ont&ont={config.Id}");
 
                 _logger.LogDebug("ONT {Name} polled successfully: Rx={Rx} dBm", config.Name, stats.RxPowerDbm);
                 return stats;

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
@@ -27,10 +28,12 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
 
     /// <summary>
     /// Reference endpoints are one-shot listeners (a netcat accept loop) that serve a
-    /// single connection at a time and re-gather stats per request, so requests must
-    /// never overlap. Serialized per provider instance (singleton).
+    /// single connection at a time and re-gather stats per request, so requests to the
+    /// same endpoint must never overlap. Gated per (host, port) so distinct endpoints -
+    /// different devices, different sites - still poll in parallel (this is a shared
+    /// singleton across all sites).
     /// </summary>
-    private readonly SemaphoreSlim _requestGate = new(1, 1);
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _requestGates = new();
 
     private const int DefaultPort = 10012;
 
@@ -110,7 +113,8 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
         var port = context.Port > 0 ? context.Port : DefaultPort;
         var url = $"http://{context.Host}:{port}/";
 
-        await _requestGate.WaitAsync(cancellationToken);
+        var gate = _requestGates.GetOrAdd($"{context.Host}:{port}", _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken);
         try
         {
             // Generous timeout: reference implementations gather stats on demand
@@ -145,7 +149,7 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
         }
         finally
         {
-            _requestGate.Release();
+            gate.Release();
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -1,0 +1,415 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Core.Models;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// Provider for the "Network Optimizer Custom" PON stats JSON contract
+/// (docs/features/netopt-custom-pon-contract.md): a plain HTTP endpoint, typically
+/// served from the gateway or the ONT itself, returning ITU-T PON-layer stats
+/// (PLOAM state, GTC status/counters, GEM/allocation counters, bridge-port
+/// discards, host-link counters) as JSON. Anyone can implement the contract for
+/// their ONT hardware; the first implementation gathers Lantiq `onu` CLI output
+/// from a GPON SFP stick.
+///
+/// Usable standalone like any ONT provider (PON state and error counters flow to
+/// the ont measurement), but designed to be attached to a monitored SFP module
+/// (ISfpSupplementalOntProvider), where its metrics merge into that module's sfp
+/// measurement on the gateway SFP poll cycle.
+/// </summary>
+public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
+{
+    private readonly ILogger<NetOptCustomPonOntProvider> _logger;
+
+    /// <summary>
+    /// Reference endpoints are one-shot listeners (a netcat accept loop) that serve a
+    /// single connection at a time and re-gather stats per request, so requests must
+    /// never overlap. Serialized per provider instance (singleton).
+    /// </summary>
+    private readonly SemaphoreSlim _requestGate = new(1, 1);
+
+    private const int DefaultPort = 10012;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        NumberHandling = JsonNumberHandling.AllowReadingFromString,
+    };
+
+    public NetOptCustomPonOntProvider(ILogger<NetOptCustomPonOntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public string ProviderKey => "netopt-custom";
+    public string DisplayName => "Network Optimizer Custom (HTTP JSON)";
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        var payload = await FetchPayloadAsync(context, cancellationToken);
+        if (payload == null) return null;
+        var stats = MapToOntStats(payload);
+        stats.DeviceHost = context.ConfiguredHost ?? context.Host;
+        stats.DeviceName = context.Name;
+        return stats;
+    }
+
+    public async Task<PonSupplementalStats?> PollSupplementalAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        var payload = await FetchPayloadAsync(context, cancellationToken);
+        return payload == null ? null : MapToSupplemental(payload);
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var payload = await FetchPayloadAsync(context, cancellationToken, throwOnError: true);
+            if (payload == null)
+                return (false, "Endpoint returned no parseable stats");
+
+            var state = ToPonLinkState(payload.Ploam?.CurrState);
+            var detail = state != PonLinkState.Unknown
+                ? $"PLOAM {state.ToDisplayString()}"
+                : "no PLOAM section";
+            if (payload.GtcStatus?.OnuId != null)
+                detail += $", ONU ID {payload.GtcStatus.OnuId}";
+            if (payload.SfpUptimeS != null)
+            {
+                var up = TimeSpan.FromSeconds(payload.SfpUptimeS.Value);
+                detail += $", up {(int)up.TotalDays}d {up.Hours}h {up.Minutes}m";
+            }
+            return (true, $"Connected - {detail}");
+        }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+        catch (TaskCanceledException)
+        {
+            return (false, "Connection timed out");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Unexpected error: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Fetch and parse the endpoint. Returns null on failure (logged at Debug)
+    /// unless <paramref name="throwOnError"/> (the Test button wants the message).
+    /// </summary>
+    private async Task<NetOptCustomPonPayload?> FetchPayloadAsync(
+        OntPollContext context, CancellationToken cancellationToken, bool throwOnError = false)
+    {
+        var port = context.Port > 0 ? context.Port : DefaultPort;
+        var url = $"http://{context.Host}:{port}/";
+
+        await _requestGate.WaitAsync(cancellationToken);
+        try
+        {
+            // Generous timeout: reference implementations gather stats on demand
+            // (e.g. an SSH round-trip into the SFP stick) before responding.
+            using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(15) };
+            var json = await client.GetStringAsync(url, cancellationToken);
+
+            var payload = ParsePayload(json);
+            if (payload == null)
+            {
+                _logger.LogDebug("PON stats endpoint {Host} returned unparseable payload", context.ConfiguredHost ?? context.Host);
+                if (throwOnError) throw new InvalidOperationException("Response was not valid PON stats JSON");
+                return null;
+            }
+
+            if (!string.IsNullOrEmpty(payload.Error))
+            {
+                _logger.LogDebug("PON stats endpoint {Host} reported error: {Error} - {Message}",
+                    context.ConfiguredHost ?? context.Host, payload.Error, payload.Message);
+                if (throwOnError)
+                    throw new InvalidOperationException(
+                        string.IsNullOrEmpty(payload.Message) ? payload.Error : $"{payload.Error}: {payload.Message}");
+                return null;
+            }
+
+            return payload;
+        }
+        catch (Exception ex) when (!throwOnError)
+        {
+            _logger.LogDebug(ex, "PON stats poll failed for {Host}", context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+        finally
+        {
+            _requestGate.Release();
+        }
+    }
+
+    internal static NetOptCustomPonPayload? ParsePayload(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<NetOptCustomPonPayload>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Map the contract payload onto the shared PON supplemental DTO. Standard
+    /// concepts keep their standard encodings: PLOAM states use the same strings
+    /// as the ont measurement's pon_link_status; fec_errors is uncorrectable
+    /// codewords; bip_errors is the raw BIP counter.
+    /// </summary>
+    internal static PonSupplementalStats MapToSupplemental(NetOptCustomPonPayload p) => new()
+    {
+        PloamStateRaw = p.Ploam?.CurrState,
+        PonLinkStatus = EncodePloamState(p.Ploam?.CurrState),
+        PonLinkStatusPrev = EncodePloamState(p.Ploam?.PreviousState),
+        PloamElapsedMs = p.Ploam?.ElapsedMsec,
+        GtcDsState = p.GtcStatus?.DsState,
+        OnuId = p.GtcStatus?.OnuId,
+        DsFecEnabled = p.GtcStatus?.DsFecEnable,
+        UsFecEnabled = p.GtcStatus?.UsFecEnable,
+        OnuResponseTime = p.GtcStatus?.OnuResponseTime,
+        BipErrors = p.GtcCounters?.Bip,
+        FecErrors = p.GtcCounters?.FecWordsUncorr,
+        FecCorrectedWords = p.GtcCounters?.FecWordsCorr,
+        HecCorrected = p.GtcCounters?.HecErrorCorr,
+        HecUncorrected = p.GtcCounters?.HecErrorUncorr,
+        BwmapCorrected = p.GtcCounters?.BwmapErrorCorr,
+        BwmapUncorrected = p.GtcCounters?.BwmapErrorUncorr,
+        GemTxFrames = p.GtcCounters?.TxGemFramesTotal,
+        GemTxIdleFrames = p.GtcCounters?.TxGemIdleFramesTotal,
+        GemRxFrames = p.GtcCounters?.RxGemFramesTotal,
+        GemRxDropped = p.GtcCounters?.RxGemFramesDropped,
+        AllocTotal = p.GtcCounters?.AllocationsTotal,
+        AllocLost = p.GtcCounters?.AllocationsLost,
+        GpePonIngressDiscard = p.GpePon?.IbpDiscard,
+        GpePonEgressDiscard = p.GpePon?.EbpDiscard,
+        GpePonLearningDiscard = p.GpePon?.LearningDiscard,
+        GpeLanIngressDiscard = p.GpeLan?.IbpDiscard,
+        GpeLanEgressDiscard = p.GpeLan?.EbpDiscard,
+        GpeLanLearningDiscard = p.GpeLan?.LearningDiscard,
+        LanLinkStatus = p.Lan?.LinkStatus,
+        LanTxFrames = p.LanCounters?.TxFrames,
+        LanRxFrames = p.LanCounters?.RxFrames,
+        LanTxDropEvents = p.LanCounters?.TxDropEvents,
+        LanRxFcsErrors = p.LanCounters?.RxFcsErr,
+        LanBufferOverflow = p.LanCounters?.BufferOverflow,
+        SfpUptimeS = p.SfpUptimeS,
+    };
+
+    /// <summary>
+    /// Standalone mapping: the standard OntStats fields this contract can serve.
+    /// DDM optics readings are absent by design - in the SFP-module scenario the
+    /// gateway's DDM poll owns those.
+    /// </summary>
+    internal static OntStats MapToOntStats(NetOptCustomPonPayload p) => new()
+    {
+        Timestamp = DateTime.UtcNow,
+        PonLinkStatus = ToPonLinkState(p.Ploam?.CurrState),
+        FecErrors = p.GtcCounters?.FecWordsUncorr,
+        BipErrors = p.GtcCounters?.Bip,
+    };
+
+    /// <summary>Raw PLOAM state number (1-7 = O1-O7) to the shared enum.</summary>
+    internal static PonLinkState ToPonLinkState(long? state) =>
+        state is >= 1 and <= 7 ? (PonLinkState)(int)state.Value : PonLinkState.Unknown;
+
+    private static string? EncodePloamState(long? state) =>
+        state == null ? null : ToPonLinkState(state).ToInfluxValue();
+}
+
+/// <summary>
+/// The "Network Optimizer Custom" PON stats JSON contract, v1. Every section is
+/// optional - implementations serve what their hardware exposes, and absent
+/// sections are simply not recorded. Counters are cumulative since ONT boot.
+/// See docs/features/netopt-custom-pon-contract.md for field semantics.
+/// </summary>
+public class NetOptCustomPonPayload
+{
+    /// <summary>Machine-readable failure code (e.g. "sfp_unreachable"). Non-null means the poll failed.</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; set; }
+
+    /// <summary>Human-readable failure detail accompanying <see cref="Error"/>.</summary>
+    [JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    [JsonPropertyName("lan")]
+    public LanSection? Lan { get; set; }
+
+    [JsonPropertyName("lan_counters")]
+    public LanCountersSection? LanCounters { get; set; }
+
+    [JsonPropertyName("ploam")]
+    public PloamSection? Ploam { get; set; }
+
+    [JsonPropertyName("gtc_status")]
+    public GtcStatusSection? GtcStatus { get; set; }
+
+    [JsonPropertyName("gtc_counters")]
+    public GtcCountersSection? GtcCounters { get; set; }
+
+    [JsonPropertyName("gpe_pon")]
+    public GpeBridgePortSection? GpePon { get; set; }
+
+    [JsonPropertyName("gpe_lan")]
+    public GpeBridgePortSection? GpeLan { get; set; }
+
+    /// <summary>Seconds since the ONT module booted.</summary>
+    [JsonPropertyName("sfp_uptime_s")]
+    public long? SfpUptimeS { get; set; }
+
+    public class LanSection
+    {
+        [JsonPropertyName("mode")]
+        public long? Mode { get; set; }
+
+        [JsonPropertyName("link_status")]
+        public long? LinkStatus { get; set; }
+
+        [JsonPropertyName("phy_duplex")]
+        public long? PhyDuplex { get; set; }
+    }
+
+    public class LanCountersSection
+    {
+        [JsonPropertyName("tx_frames")]
+        public long? TxFrames { get; set; }
+
+        [JsonPropertyName("rx_frames")]
+        public long? RxFrames { get; set; }
+
+        [JsonPropertyName("tx_drop_events")]
+        public long? TxDropEvents { get; set; }
+
+        [JsonPropertyName("rx_fcs_err")]
+        public long? RxFcsErr { get; set; }
+
+        [JsonPropertyName("buffer_overflow")]
+        public long? BufferOverflow { get; set; }
+    }
+
+    public class PloamSection
+    {
+        /// <summary>Current ITU-T activation state, numeric: 1-7 = O1-O7.</summary>
+        [JsonPropertyName("curr_state")]
+        public long? CurrState { get; set; }
+
+        [JsonPropertyName("previous_state")]
+        public long? PreviousState { get; set; }
+
+        [JsonPropertyName("elapsed_msec")]
+        public long? ElapsedMsec { get; set; }
+    }
+
+    public class GtcStatusSection
+    {
+        [JsonPropertyName("ds_state")]
+        public long? DsState { get; set; }
+
+        [JsonPropertyName("onu_id")]
+        public long? OnuId { get; set; }
+
+        [JsonPropertyName("ds_fec_enable")]
+        public long? DsFecEnable { get; set; }
+
+        [JsonPropertyName("us_fec_enable")]
+        public long? UsFecEnable { get; set; }
+
+        [JsonPropertyName("onu_response_time")]
+        public long? OnuResponseTime { get; set; }
+    }
+
+    public class GtcCountersSection
+    {
+        [JsonPropertyName("bip")]
+        public long? Bip { get; set; }
+
+        [JsonPropertyName("hec_error_corr")]
+        public long? HecErrorCorr { get; set; }
+
+        [JsonPropertyName("hec_error_uncorr")]
+        public long? HecErrorUncorr { get; set; }
+
+        [JsonPropertyName("bwmap_error_corr")]
+        public long? BwmapErrorCorr { get; set; }
+
+        [JsonPropertyName("bwmap_error_uncorr")]
+        public long? BwmapErrorUncorr { get; set; }
+
+        [JsonPropertyName("fec_error_corr")]
+        public long? FecErrorCorr { get; set; }
+
+        [JsonPropertyName("fec_words_corr")]
+        public long? FecWordsCorr { get; set; }
+
+        [JsonPropertyName("fec_words_uncorr")]
+        public long? FecWordsUncorr { get; set; }
+
+        [JsonPropertyName("fec_words_total")]
+        public long? FecWordsTotal { get; set; }
+
+        [JsonPropertyName("fec_seconds")]
+        public long? FecSeconds { get; set; }
+
+        [JsonPropertyName("tx_gem_frames_total")]
+        public long? TxGemFramesTotal { get; set; }
+
+        [JsonPropertyName("tx_gem_bytes_total")]
+        public long? TxGemBytesTotal { get; set; }
+
+        [JsonPropertyName("tx_gem_idle_frames_total")]
+        public long? TxGemIdleFramesTotal { get; set; }
+
+        [JsonPropertyName("rx_gem_frames_total")]
+        public long? RxGemFramesTotal { get; set; }
+
+        [JsonPropertyName("rx_gem_bytes_total")]
+        public long? RxGemBytesTotal { get; set; }
+
+        [JsonPropertyName("rx_gem_frames_dropped")]
+        public long? RxGemFramesDropped { get; set; }
+
+        [JsonPropertyName("omci_drop")]
+        public long? OmciDrop { get; set; }
+
+        [JsonPropertyName("drop")]
+        public long? Drop { get; set; }
+
+        [JsonPropertyName("rx_oversized_frames")]
+        public long? RxOversizedFrames { get; set; }
+
+        [JsonPropertyName("allocations_total")]
+        public long? AllocationsTotal { get; set; }
+
+        [JsonPropertyName("allocations_lost")]
+        public long? AllocationsLost { get; set; }
+    }
+
+    public class GpeBridgePortSection
+    {
+        [JsonPropertyName("ibp_good")]
+        public long? IbpGood { get; set; }
+
+        [JsonPropertyName("ibp_discard")]
+        public long? IbpDiscard { get; set; }
+
+        [JsonPropertyName("ebp_good")]
+        public long? EbpGood { get; set; }
+
+        [JsonPropertyName("ebp_discard")]
+        public long? EbpDiscard { get; set; }
+
+        [JsonPropertyName("learning_discard")]
+        public long? LearningDiscard { get; set; }
+    }
+}

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17283,6 +17283,11 @@ a.isp-outage-ack:hover {
 }
 
 .isp-hop-name {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: 0.5rem;
+    row-gap: 0.25rem;
     font-size: 0.85rem;
     font-weight: 500;
     color: var(--text-primary);
@@ -17295,14 +17300,19 @@ a.isp-outage-ack:hover {
 }
 
 .isp-target-badge {
-    margin-left: 0.5rem;
-    padding: 0.05rem 0.4rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 0.15rem 0.4rem;
+    border: 0;
     border-radius: 4px;
+    font-family: inherit;
     font-size: 0.62rem;
     font-weight: 600;
+    line-height: 1;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    vertical-align: middle;
 }
 
 .isp-target-graded {

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -13,6 +13,9 @@ const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*8
 
 let powerChart = null;
 let tempChart = null;
+// FEC/BIP error-delta chart; its section stays hidden unless some ONT reports the counters.
+let errorsChart = null;
+let errorsSeriesByDevice = {};
 let pollTimer = null;
 let currentRangeHours = 24;
 let windowOffset = 0;
@@ -148,6 +151,10 @@ function updateVisibility() {
                 if (vis) tempChart.showSeries(m.label);
                 else tempChart.hideSeries(m.label);
             }
+            const es = errorsSeriesByDevice[m.id];
+            if (errorsChart && es) {
+                es.forEach(n => vis ? errorsChart.showSeries(n) : errorsChart.hideSeries(n));
+            }
         } catch (_) {}
     });
 }
@@ -193,6 +200,7 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tempSeries, false);
+    updateErrorsChart(data);
 
     updateVisibility();
     lastData = data;
@@ -205,6 +213,34 @@ async function loadAndUpdate() {
 
 const fmtDbm = v => v != null ? v.toFixed(2) : '-';
 const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+const fmtCount = v => v == null ? '' : v >= 1e6 ? (v / 1e6).toFixed(1) + 'M' : v >= 1e3 ? (v / 1e3).toFixed(1) + 'k' : String(Math.round(v));
+
+function updateErrorsChart(data) {
+    const container = document.getElementById(containerId);
+    const section = container?.querySelector('.ont-errors-section');
+    if (!section || !errorsChart) return;
+    const withErrors = (data.devices || []).filter(d =>
+        (d.data || []).some(p => p.fec != null || p.bip != null));
+    if (!withErrors.length) {
+        section.style.display = 'none';
+        errorsSeriesByDevice = {};
+        return;
+    }
+    section.style.display = '';
+
+    errorsSeriesByDevice = {};
+    const series = [];
+    withErrors.forEach(d => {
+        const pts = d.data || [];
+        const s = [
+            { name: `${d.label} FEC`, data: pts.filter(p => p.fec != null).map(p => ({ x: new Date(p.time).getTime(), y: p.fec })) },
+            { name: `${d.label} BIP`, data: pts.filter(p => p.bip != null).map(p => ({ x: new Date(p.time).getTime(), y: p.bip })) },
+        ];
+        errorsSeriesByDevice[d.id] = s.map(x => x.name);
+        series.push(...s);
+    });
+    errorsChart.updateSeries(series, false);
+}
 
 function renderStatsTable(container, showAll) {
     const el = container.querySelector('.ont-stats-table');
@@ -379,6 +415,7 @@ export async function mount(elId) {
 
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
+    if (errorsChart) { errorsChart.destroy(); errorsChart = null; }
 
     powerChart = new ApexCharts(powerEl, {
         ...baseOpts(220, 'dBm', v => v != null ? v.toFixed(1) + ' dBm' : '', {
@@ -392,6 +429,15 @@ export async function mount(elId) {
 
     await powerChart.render();
     await tempChart.render();
+
+    const errorsEl = container.querySelector('.ont-errors-chart');
+    if (errorsEl) {
+        errorsChart = new ApexCharts(errorsEl, {
+            ...baseOpts(160, 'errors', fmtCount),
+            series: [], colors: PALETTE,
+        });
+        await errorsChart.render();
+    }
 
     container.querySelectorAll('[data-range]').forEach(btn => {
         btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));
@@ -465,9 +511,11 @@ export function unmount() {
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
+    if (errorsChart) { errorsChart.destroy(); errorsChart = null; }
     containerId = null;
     deviceMeta = [];
     visibility = {};
+    errorsSeriesByDevice = {};
     lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -200,7 +200,7 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tempSeries, false);
-    updateErrorsChart(data);
+    await updateErrorsChart(data);
 
     updateVisibility();
     lastData = data;
@@ -215,10 +215,21 @@ const fmtDbm = v => v != null ? v.toFixed(2) : '-';
 const fmtTemp = v => v != null ? v.toFixed(1) : '-';
 const fmtCount = v => v == null ? '' : v >= 1e6 ? (v / 1e6).toFixed(1) + 'M' : v >= 1e3 ? (v / 1e3).toFixed(1) + 'k' : String(Math.round(v));
 
-function updateErrorsChart(data) {
+// Create the errors chart on first use, so ONTs that never report FEC/BIP don't
+// pay for an instance they'd never see.
+async function ensureErrorsChartMounted() {
+    if (errorsChart) return;
+    const container = document.getElementById(containerId);
+    const errorsEl = container?.querySelector('.ont-errors-chart');
+    if (!errorsEl) return;
+    errorsChart = new ApexCharts(errorsEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    await errorsChart.render();
+}
+
+async function updateErrorsChart(data) {
     const container = document.getElementById(containerId);
     const section = container?.querySelector('.ont-errors-section');
-    if (!section || !errorsChart) return;
+    if (!section) return;
     const withErrors = (data.devices || []).filter(d =>
         (d.data || []).some(p => p.fec != null || p.bip != null));
     if (!withErrors.length) {
@@ -226,6 +237,8 @@ function updateErrorsChart(data) {
         errorsSeriesByDevice = {};
         return;
     }
+    await ensureErrorsChartMounted();
+    if (!errorsChart) return;
     section.style.display = '';
 
     errorsSeriesByDevice = {};
@@ -430,14 +443,8 @@ export async function mount(elId) {
     await powerChart.render();
     await tempChart.render();
 
-    const errorsEl = container.querySelector('.ont-errors-chart');
-    if (errorsEl) {
-        errorsChart = new ApexCharts(errorsEl, {
-            ...baseOpts(160, 'errors', fmtCount),
-            series: [], colors: PALETTE,
-        });
-        await errorsChart.render();
-    }
+    // The FEC/BIP errors chart is mounted lazily (ensureErrorsChartMounted) only when
+    // an ONT actually reports those counters - ONTs without them never create it.
 
     container.querySelectorAll('[data-range]').forEach(btn => {
         btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -200,7 +200,8 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tempSeries, false);
-    await updateErrorsChart(data);
+    // Never let an errors-chart failure abort the rest of the refresh (badges, stats table).
+    try { await updateErrorsChart(data); } catch (_) {}
 
     updateVisibility();
     lastData = data;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -13,6 +13,12 @@ const RANGE_MS = { 0: 15*60000, 1: 3600000, 6: 6*3600000, 24: 86400000, 168: 7*8
 
 let powerChart = null;
 let tempChart = null;
+// Supplemental PON-layer charts (attached Network Optimizer Custom ONT configs);
+// the whole section stays hidden unless some module has PON data.
+let ponErrChart = null;
+let ponGemChart = null;
+let ponHostChart = null;
+let ponSeriesByModule = {};
 let pollTimer = null;
 let currentRangeHours = 24;
 let windowOffset = 0;
@@ -147,6 +153,13 @@ function updateVisibility() {
             if (vis) tempChart.showSeries(m.label);
             else tempChart.hideSeries(m.label);
         }
+        const ps = ponSeriesByModule[m.id];
+        if (ps) {
+            [[ponErrChart, ps.err], [ponGemChart, ps.gem], [ponHostChart, ps.host]].forEach(([chart, names]) => {
+                if (!chart || !names) return;
+                names.forEach(n => vis ? chart.showSeries(n) : chart.hideSeries(n));
+            });
+        }
     });
 }
 
@@ -186,6 +199,7 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tSeries, false);
+    updatePonCharts(data);
 
     updateVisibility();
     lastData = data;
@@ -198,6 +212,93 @@ async function loadAndUpdate() {
 
 const fmtDbm = v => v != null ? v.toFixed(2) : '-';
 const fmtTemp = v => v != null ? v.toFixed(1) : '-';
+const fmtCount = v => v == null ? '' : v >= 1e6 ? (v / 1e6).toFixed(1) + 'M' : v >= 1e3 ? (v / 1e3).toFixed(1) + 'k' : String(Math.round(v));
+
+// Same encoding PonLinkStateExtensions.ToInfluxValue uses for pon_link_status.
+const PLOAM_LABELS = {
+    initial: 'Initializing (O1)', standby: 'Standby (O2)', serial_number: 'Authenticating (O3)',
+    ranging: 'Ranging (O4)', operation: 'Connected (O5)', popup: 'Signal Lost (O6)',
+    emergency_stop: 'Disabled (O7)',
+};
+
+function ponPoints(pts, key) {
+    return pts.filter(p => p[key] != null).map(p => ({ x: new Date(p.time).getTime(), y: p[key] }));
+}
+
+function updatePonCharts(data) {
+    const container = document.getElementById(containerId);
+    const section = container?.querySelector('.sfp-pon-section');
+    if (!section) return;
+    const withPon = (data.modules || []).filter(m => m.pon?.length);
+    if (!withPon.length || !ponErrChart) {
+        section.style.display = 'none';
+        ponSeriesByModule = {};
+        return;
+    }
+    section.style.display = '';
+
+    ponSeriesByModule = {};
+    const errSeries = [], gemSeries = [], hostSeries = [];
+    withPon.forEach(m => {
+        const pts = m.pon;
+        // Prefix series with the module label only when several modules share the
+        // charts - the usual case is a single supplemented module.
+        const prefix = withPon.length > 1 ? `${m.label} ` : '';
+        const err = [
+            { name: `${prefix}BIP`, data: ponPoints(pts, 'bip') },
+            { name: `${prefix}FEC`, data: ponPoints(pts, 'fec') },
+            { name: `${prefix}FEC corrected`, data: ponPoints(pts, 'fecCorr') },
+            { name: `${prefix}HEC`, data: ponPoints(pts, 'hec') },
+            { name: `${prefix}GEM drops`, data: ponPoints(pts, 'gemDrop') },
+            { name: `${prefix}Allocs lost`, data: ponPoints(pts, 'allocLost') },
+        ];
+        const gem = [
+            { name: `${prefix}RX frames`, data: ponPoints(pts, 'gemRx') },
+            { name: `${prefix}TX frames`, data: ponPoints(pts, 'gemTx') },
+            { name: `${prefix}TX idle`, data: ponPoints(pts, 'gemTxIdle') },
+        ];
+        const host = [
+            { name: `${prefix}FCS errors`, data: ponPoints(pts, 'lanFcs') },
+            { name: `${prefix}TX drops`, data: ponPoints(pts, 'lanDrop') },
+            { name: `${prefix}Buffer overflows`, data: ponPoints(pts, 'lanOvfl') },
+        ];
+        ponSeriesByModule[m.id] = {
+            err: err.map(s => s.name), gem: gem.map(s => s.name), host: host.map(s => s.name),
+        };
+        errSeries.push(...err);
+        gemSeries.push(...gem);
+        hostSeries.push(...host);
+    });
+
+    ponErrChart.updateSeries(errSeries, false);
+    ponGemChart.updateSeries(gemSeries, false);
+    ponHostChart.updateSeries(hostSeries, false);
+    renderPonDetails(container, withPon);
+}
+
+function renderPonDetails(container, withPon) {
+    const el = container.querySelector('.sfp-pon-details');
+    if (!el) return;
+    const fmtUp = s => s == null ? '-'
+        : `${Math.floor(s / 86400)}d ${Math.floor(s % 86400 / 3600)}h ${Math.floor(s % 3600 / 60)}m`;
+    const rows = withPon.map(m => {
+        const last = [...m.pon].reverse().find(p => p.state != null) || m.pon[m.pon.length - 1];
+        const state = PLOAM_LABELS[last.state] || last.state || '-';
+        const fec = last.dsFec == null && last.usFec == null ? '-'
+            : `${last.dsFec ? 'on' : 'off'} / ${last.usFec ? 'on' : 'off'}`;
+        return `<tr>
+            <td>${escapeHtml(m.label)}</td>
+            <td>${escapeHtml(state)}</td>
+            <td>${last.onuId ?? '-'}</td>
+            <td>${fec}</td>
+            <td>${last.respTime ?? '-'}</td>
+            <td>${fmtUp(last.uptime)}</td>
+        </tr>`;
+    }).join('');
+    el.innerHTML = `<div class="table-responsive"><table class="data-table">
+        <thead><tr><th>Module</th><th>PLOAM State</th><th>ONU ID</th><th>FEC DS / US</th><th>Response Time</th><th>ONT Uptime</th></tr></thead>
+        <tbody>${rows}</tbody></table></div>`;
+}
 
 function renderStatsTable(container, showAll) {
     const el = container.querySelector('.sfp-stats-table');
@@ -363,6 +464,9 @@ export async function mount(elId) {
 
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
+    if (ponErrChart) { ponErrChart.destroy(); ponErrChart = null; }
+    if (ponGemChart) { ponGemChart.destroy(); ponGemChart = null; }
+    if (ponHostChart) { ponHostChart.destroy(); ponHostChart = null; }
 
     powerChart = new ApexCharts(powerEl, {
         ...baseOpts(200, 'dBm', v => v != null ? v.toFixed(1) + ' dBm' : '', {
@@ -376,6 +480,24 @@ export async function mount(elId) {
 
     await powerChart.render();
     await tempChart.render();
+
+    const ponErrEl = container.querySelector('.sfp-pon-errors-chart');
+    const ponGemEl = container.querySelector('.sfp-pon-gem-chart');
+    const ponHostEl = container.querySelector('.sfp-pon-host-chart');
+    if (ponErrEl && ponGemEl && ponHostEl) {
+        ponErrChart = new ApexCharts(ponErrEl, {
+            ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE,
+        });
+        ponGemChart = new ApexCharts(ponGemEl, {
+            ...baseOpts(160, 'frames', fmtCount), series: [], colors: PALETTE,
+        });
+        ponHostChart = new ApexCharts(ponHostEl, {
+            ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE,
+        });
+        await ponErrChart.render();
+        await ponGemChart.render();
+        await ponHostChart.render();
+    }
 
     container.querySelectorAll('[data-range]').forEach(btn => {
         btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));
@@ -469,9 +591,13 @@ export function unmount() {
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
+    if (ponErrChart) { ponErrChart.destroy(); ponErrChart = null; }
+    if (ponGemChart) { ponGemChart.destroy(); ponGemChart = null; }
+    if (ponHostChart) { ponHostChart.destroy(); ponHostChart = null; }
     containerId = null;
     moduleMeta = [];
     visibility = {};
+    ponSeriesByModule = {};
     lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -241,7 +241,8 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tSeries, false);
-    await updatePonCharts(data);
+    // Never let a PON chart failure abort the rest of the refresh (badges, stats table).
+    try { await updatePonCharts(data); } catch (_) {}
 
     updateVisibility();
     lastData = data;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -18,7 +18,6 @@ let tempChart = null;
 let ponErrChart = null;
 let ponGemChart = null;
 let ponHostChart = null;
-let ponSeriesByModule = {};
 // Modules that currently have PON data, whether visible or not. The PON section and
 // its detail table are shown only for the ones selected in the filter.
 let ponCapableModules = [];
@@ -156,26 +155,54 @@ function updateVisibility() {
             if (vis) tempChart.showSeries(m.label);
             else tempChart.hideSeries(m.label);
         }
-        const ps = ponSeriesByModule[m.id];
-        if (ps) {
-            [[ponErrChart, ps.err], [ponGemChart, ps.gem], [ponHostChart, ps.host]].forEach(([chart, names]) => {
-                if (!chart || !names) return;
-                names.forEach(n => vis ? chart.showSeries(n) : chart.hideSeries(n));
-            });
-        }
     });
-    syncPonSectionVisibility();
+    // Fire-and-forget: rebuilds the PON charts/section for the selected modules. Kept
+    // off the synchronous path so a chart error can never break chip re-rendering.
+    refreshPonSection();
 }
 
-// Show the PON section (charts + detail table) only while at least one PON-capable
-// module is selected in the filter; the table lists just those selected modules.
-function syncPonSectionVisibility() {
+// Rebuild the PON section (charts + detail table) for the currently-selected PON
+// modules, or hide it when none are selected. The section is shown BEFORE the charts
+// are mounted/updated so ApexCharts sizes them correctly - a chart first rendered in a
+// display:none container stays zero-size until its next update.
+async function refreshPonSection() {
     const container = document.getElementById(containerId);
     const section = container?.querySelector('.sfp-pon-section');
     if (!section) return;
     const visiblePon = ponCapableModules.filter(m => visibility[m.id] !== false);
-    section.style.display = visiblePon.length ? '' : 'none';
-    renderPonDetails(container, visiblePon);
+    if (!visiblePon.length) { section.style.display = 'none'; return; }
+    section.style.display = '';
+    await ensurePonChartsMounted();
+    if (!ponErrChart) return;
+    try {
+        const multi = visiblePon.length > 1;
+        const errSeries = [], gemSeries = [], hostSeries = [];
+        visiblePon.forEach(m => {
+            const pts = m.pon;
+            const prefix = multi ? `${m.label} ` : '';
+            errSeries.push(
+                { name: `${prefix}BIP`, data: ponPoints(pts, 'bip') },
+                { name: `${prefix}FEC`, data: ponPoints(pts, 'fec') },
+                { name: `${prefix}FEC corrected`, data: ponPoints(pts, 'fecCorr') },
+                { name: `${prefix}HEC`, data: ponPoints(pts, 'hec') },
+                { name: `${prefix}GEM drops`, data: ponPoints(pts, 'gemDrop') },
+                { name: `${prefix}Allocs lost`, data: ponPoints(pts, 'allocLost') },
+            );
+            gemSeries.push(
+                { name: `${prefix}RX frames`, data: ponPoints(pts, 'gemRx') },
+                { name: `${prefix}TX frames`, data: ponPoints(pts, 'gemTx') },
+            );
+            hostSeries.push(
+                { name: `${prefix}FCS errors`, data: ponPoints(pts, 'lanFcs') },
+                { name: `${prefix}TX drops`, data: ponPoints(pts, 'lanDrop') },
+                { name: `${prefix}Buffer overflows`, data: ponPoints(pts, 'lanOvfl') },
+            );
+        });
+        ponErrChart.updateSeries(errSeries, false);
+        ponGemChart.updateSeries(gemSeries, false);
+        ponHostChart.updateSeries(hostSeries, false);
+        renderPonDetails(container, visiblePon);
+    } catch (e) { /* leave the previous render if a chart update fails */ }
 }
 
 async function loadAndUpdate() {
@@ -256,49 +283,8 @@ async function ensurePonChartsMounted() {
 }
 
 async function updatePonCharts(data) {
-    const withPon = (data.modules || []).filter(m => m.pon?.length);
-    ponCapableModules = withPon;
-    ponSeriesByModule = {};
-    if (!withPon.length) { syncPonSectionVisibility(); return; }
-    await ensurePonChartsMounted();
-    if (!ponErrChart) { syncPonSectionVisibility(); return; }
-
-    const errSeries = [], gemSeries = [], hostSeries = [];
-    withPon.forEach(m => {
-        const pts = m.pon;
-        // Prefix series with the module label only when several modules share the
-        // charts - the usual case is a single supplemented module.
-        const prefix = withPon.length > 1 ? `${m.label} ` : '';
-        const err = [
-            { name: `${prefix}BIP`, data: ponPoints(pts, 'bip') },
-            { name: `${prefix}FEC`, data: ponPoints(pts, 'fec') },
-            { name: `${prefix}FEC corrected`, data: ponPoints(pts, 'fecCorr') },
-            { name: `${prefix}HEC`, data: ponPoints(pts, 'hec') },
-            { name: `${prefix}GEM drops`, data: ponPoints(pts, 'gemDrop') },
-            { name: `${prefix}Allocs lost`, data: ponPoints(pts, 'allocLost') },
-        ];
-        const gem = [
-            { name: `${prefix}RX frames`, data: ponPoints(pts, 'gemRx') },
-            { name: `${prefix}TX frames`, data: ponPoints(pts, 'gemTx') },
-            { name: `${prefix}TX idle`, data: ponPoints(pts, 'gemTxIdle') },
-        ];
-        const host = [
-            { name: `${prefix}FCS errors`, data: ponPoints(pts, 'lanFcs') },
-            { name: `${prefix}TX drops`, data: ponPoints(pts, 'lanDrop') },
-            { name: `${prefix}Buffer overflows`, data: ponPoints(pts, 'lanOvfl') },
-        ];
-        ponSeriesByModule[m.id] = {
-            err: err.map(s => s.name), gem: gem.map(s => s.name), host: host.map(s => s.name),
-        };
-        errSeries.push(...err);
-        gemSeries.push(...gem);
-        hostSeries.push(...host);
-    });
-
-    ponErrChart.updateSeries(errSeries, false);
-    ponGemChart.updateSeries(gemSeries, false);
-    ponHostChart.updateSeries(hostSeries, false);
-    syncPonSectionVisibility();
+    ponCapableModules = (data.modules || []).filter(m => m.pon?.length);
+    await refreshPonSection();
 }
 
 function renderPonDetails(container, withPon) {
@@ -608,7 +594,6 @@ export function unmount() {
     containerId = null;
     moduleMeta = [];
     visibility = {};
-    ponSeriesByModule = {};
     ponCapableModules = [];
     lastData = null;
     currentRangeHours = 24;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -19,6 +19,9 @@ let ponErrChart = null;
 let ponGemChart = null;
 let ponHostChart = null;
 let ponSeriesByModule = {};
+// Modules that currently have PON data, whether visible or not. The PON section and
+// its detail table are shown only for the ones selected in the filter.
+let ponCapableModules = [];
 let pollTimer = null;
 let currentRangeHours = 24;
 let windowOffset = 0;
@@ -161,6 +164,18 @@ function updateVisibility() {
             });
         }
     });
+    syncPonSectionVisibility();
+}
+
+// Show the PON section (charts + detail table) only while at least one PON-capable
+// module is selected in the filter; the table lists just those selected modules.
+function syncPonSectionVisibility() {
+    const container = document.getElementById(containerId);
+    const section = container?.querySelector('.sfp-pon-section');
+    if (!section) return;
+    const visiblePon = ponCapableModules.filter(m => visibility[m.id] !== false);
+    section.style.display = visiblePon.length ? '' : 'none';
+    renderPonDetails(container, visiblePon);
 }
 
 async function loadAndUpdate() {
@@ -199,7 +214,7 @@ async function loadAndUpdate() {
         powerChart.updateSeries(powerSeries, false);
     }
     if (tempChart) tempChart.updateSeries(tSeries, false);
-    updatePonCharts(data);
+    await updatePonCharts(data);
 
     updateVisibility();
     lastData = data;
@@ -225,19 +240,29 @@ function ponPoints(pts, key) {
     return pts.filter(p => p[key] != null).map(p => ({ x: new Date(p.time).getTime(), y: p[key] }));
 }
 
-function updatePonCharts(data) {
+// Create the three PON charts on first use. Kept out of mount() so setups without
+// supplemental PON polling never pay for instances they'd never see.
+async function ensurePonChartsMounted() {
+    if (ponErrChart) return;
     const container = document.getElementById(containerId);
-    const section = container?.querySelector('.sfp-pon-section');
-    if (!section) return;
-    const withPon = (data.modules || []).filter(m => m.pon?.length);
-    if (!withPon.length || !ponErrChart) {
-        section.style.display = 'none';
-        ponSeriesByModule = {};
-        return;
-    }
-    section.style.display = '';
+    const ponErrEl = container?.querySelector('.sfp-pon-errors-chart');
+    const ponGemEl = container?.querySelector('.sfp-pon-gem-chart');
+    const ponHostEl = container?.querySelector('.sfp-pon-host-chart');
+    if (!ponErrEl || !ponGemEl || !ponHostEl) return;
+    ponErrChart = new ApexCharts(ponErrEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    ponGemChart = new ApexCharts(ponGemEl, { ...baseOpts(160, 'frames', fmtCount), series: [], colors: PALETTE });
+    ponHostChart = new ApexCharts(ponHostEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    await Promise.all([ponErrChart.render(), ponGemChart.render(), ponHostChart.render()]);
+}
 
+async function updatePonCharts(data) {
+    const withPon = (data.modules || []).filter(m => m.pon?.length);
+    ponCapableModules = withPon;
     ponSeriesByModule = {};
+    if (!withPon.length) { syncPonSectionVisibility(); return; }
+    await ensurePonChartsMounted();
+    if (!ponErrChart) { syncPonSectionVisibility(); return; }
+
     const errSeries = [], gemSeries = [], hostSeries = [];
     withPon.forEach(m => {
         const pts = m.pon;
@@ -273,7 +298,7 @@ function updatePonCharts(data) {
     ponErrChart.updateSeries(errSeries, false);
     ponGemChart.updateSeries(gemSeries, false);
     ponHostChart.updateSeries(hostSeries, false);
-    renderPonDetails(container, withPon);
+    syncPonSectionVisibility();
 }
 
 function renderPonDetails(container, withPon) {
@@ -481,23 +506,9 @@ export async function mount(elId) {
     await powerChart.render();
     await tempChart.render();
 
-    const ponErrEl = container.querySelector('.sfp-pon-errors-chart');
-    const ponGemEl = container.querySelector('.sfp-pon-gem-chart');
-    const ponHostEl = container.querySelector('.sfp-pon-host-chart');
-    if (ponErrEl && ponGemEl && ponHostEl) {
-        ponErrChart = new ApexCharts(ponErrEl, {
-            ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE,
-        });
-        ponGemChart = new ApexCharts(ponGemEl, {
-            ...baseOpts(160, 'frames', fmtCount), series: [], colors: PALETTE,
-        });
-        ponHostChart = new ApexCharts(ponHostEl, {
-            ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE,
-        });
-        await ponErrChart.render();
-        await ponGemChart.render();
-        await ponHostChart.render();
-    }
+    // PON charts are mounted lazily (ensurePonChartsMounted) only once a module with
+    // supplemental PON polling actually reports data - the ~99% of SFP setups without
+    // it never create these instances.
 
     container.querySelectorAll('[data-range]').forEach(btn => {
         btn.addEventListener('click', () => selectPresetRange(container, parseInt(btn.dataset.range)));
@@ -598,6 +609,7 @@ export function unmount() {
     moduleMeta = [];
     visibility = {};
     ponSeriesByModule = {};
+    ponCapableModules = [];
     lastData = null;
     currentRangeHours = 24;
     windowOffset = 0;

--- a/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
@@ -1,0 +1,158 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class NetOptCustomPonOntProviderTests
+{
+    // Real payload from the reference implementation (a GPON SFP stick relayed
+    // through the gateway), trimmed only in counter magnitudes.
+    private const string SamplePayload = """
+    {
+      "lan": { "mode": 15, "link_status": 5, "phy_duplex": 1 },
+      "lan_counters": {
+        "tx_frames": 671630919, "rx_frames": 850075595,
+        "tx_drop_events": 0, "rx_fcs_err": 3, "buffer_overflow": 0
+      },
+      "ploam": { "curr_state": 5, "previous_state": 4, "elapsed_msec": 4294791528 },
+      "gtc_status": {
+        "ds_state": 3, "onu_id": 49, "ds_fec_enable": 0, "us_fec_enable": 0,
+        "onu_response_time": 34992
+      },
+      "gtc_counters": {
+        "bip": 7, "hec_error_corr": 0, "hec_error_uncorr": 1,
+        "bwmap_error_corr": 0, "bwmap_error_uncorr": 0,
+        "fec_error_corr": 0, "fec_words_corr": 12, "fec_words_uncorr": 2,
+        "fec_words_total": 1000, "fec_seconds": 0,
+        "tx_gem_frames_total": 848555332, "tx_gem_bytes_total": 1774937051,
+        "tx_gem_idle_frames_total": 1076427353,
+        "rx_gem_frames_total": 682156109, "rx_gem_bytes_total": 0,
+        "rx_gem_frames_dropped": 1, "omci_drop": 0, "drop": 1,
+        "rx_oversized_frames": 0,
+        "allocations_total": 1629046208, "allocations_lost": 20
+      },
+      "gpe_pon": { "ibp_good": 670798566, "ibp_discard": 4, "ebp_good": 848843235, "ebp_discard": 0, "learning_discard": 0 },
+      "gpe_lan": { "ibp_good": 848843244, "ibp_discard": 0, "ebp_good": 670798569, "ebp_discard": 5, "learning_discard": 0 },
+      "sfp_uptime_s": 358825
+    }
+    """;
+
+    [Fact]
+    public void ParsePayload_FullSample_ParsesAllSections()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload(SamplePayload);
+
+        p.Should().NotBeNull();
+        p!.Error.Should().BeNull();
+        p.Ploam!.CurrState.Should().Be(5);
+        p.Ploam.PreviousState.Should().Be(4);
+        p.GtcStatus!.OnuId.Should().Be(49);
+        p.GtcCounters!.Bip.Should().Be(7);
+        p.GtcCounters.AllocationsLost.Should().Be(20);
+        p.GpePon!.IbpDiscard.Should().Be(4);
+        p.GpeLan!.EbpDiscard.Should().Be(5);
+        p.LanCounters!.RxFcsErr.Should().Be(3);
+        p.SfpUptimeS.Should().Be(358825);
+    }
+
+    [Fact]
+    public void MapToSupplemental_UsesStandardEncodingsAndCuratedFields()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload(SamplePayload)!;
+        var s = NetOptCustomPonOntProvider.MapToSupplemental(p);
+
+        // Standard concepts keep the ont measurement's encodings/semantics.
+        s.PonLinkStatus.Should().Be("operation");
+        s.PonLinkStatusPrev.Should().Be("ranging");
+        s.PloamStateRaw.Should().Be(5);
+        s.BipErrors.Should().Be(7);
+        s.FecErrors.Should().Be(2, "fec_errors is UNCORRECTABLE codewords, not corrected");
+        s.FecCorrectedWords.Should().Be(12);
+
+        s.HecUncorrected.Should().Be(1);
+        s.GemTxFrames.Should().Be(848555332);
+        s.GemTxIdleFrames.Should().Be(1076427353);
+        s.GemRxDropped.Should().Be(1);
+        s.AllocTotal.Should().Be(1629046208);
+        s.AllocLost.Should().Be(20);
+        s.GpePonIngressDiscard.Should().Be(4);
+        s.GpeLanEgressDiscard.Should().Be(5);
+        s.LanLinkStatus.Should().Be(5);
+        s.LanRxFcsErrors.Should().Be(3);
+        s.OnuId.Should().Be(49);
+        s.OnuResponseTime.Should().Be(34992);
+        s.DsFecEnabled.Should().Be(0);
+        s.SfpUptimeS.Should().Be(358825);
+    }
+
+    [Fact]
+    public void MapToOntStats_PopulatesStandardOntFields()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload(SamplePayload)!;
+        var stats = NetOptCustomPonOntProvider.MapToOntStats(p);
+
+        stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        stats.FecErrors.Should().Be(2);
+        stats.BipErrors.Should().Be(7);
+    }
+
+    [Fact]
+    public void ParsePayload_ErrorShape_SurfacesErrorCode()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload(
+            """{ "error": "sfp_unreachable", "message": "Could not reach SFP" }""");
+
+        p.Should().NotBeNull();
+        p!.Error.Should().Be("sfp_unreachable");
+        p.Message.Should().Be("Could not reach SFP");
+    }
+
+    [Fact]
+    public void ParsePayload_EmptyObject_AllSectionsNull()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload("{}");
+
+        p.Should().NotBeNull();
+        p!.Ploam.Should().BeNull();
+        p.GtcCounters.Should().BeNull();
+        p.SfpUptimeS.Should().BeNull();
+
+        var s = NetOptCustomPonOntProvider.MapToSupplemental(p);
+        s.PonLinkStatus.Should().BeNull();
+        s.BipErrors.Should().BeNull();
+        s.FecErrors.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParsePayload_StringNumbers_AreTolerated()
+    {
+        var p = NetOptCustomPonOntProvider.ParsePayload(
+            """{ "ploam": { "curr_state": "5" }, "gtc_status": { "onu_id": "49" } }""");
+
+        p!.Ploam!.CurrState.Should().Be(5);
+        p.GtcStatus!.OnuId.Should().Be(49);
+    }
+
+    [Fact]
+    public void ParsePayload_Garbage_ReturnsNull()
+    {
+        NetOptCustomPonOntProvider.ParsePayload("not json at all").Should().BeNull();
+        NetOptCustomPonOntProvider.ParsePayload("").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(1, PonLinkState.Initial)]
+    [InlineData(4, PonLinkState.Ranging)]
+    [InlineData(5, PonLinkState.Operation)]
+    [InlineData(6, PonLinkState.Popup)]
+    [InlineData(7, PonLinkState.EmergencyStop)]
+    [InlineData(0, PonLinkState.Unknown)]
+    [InlineData(8, PonLinkState.Unknown)]
+    [InlineData(null, PonLinkState.Unknown)]
+    public void ToPonLinkState_MapsItuStateNumbers(int? raw, PonLinkState expected)
+    {
+        NetOptCustomPonOntProvider.ToPonLinkState(raw).Should().Be(expected);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/OntAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/OntAlertEvaluatorTests.cs
@@ -99,19 +99,37 @@ public class OntAlertEvaluatorTests
     }
 
     [Fact]
-    public async Task BipDeltaAboveThreshold_PublishesBipSpike_AfterBaseline()
+    public async Task BipSpike_FecDisabled_UsesStrictThreshold()
     {
         var (evaluator, bus) = Create();
 
-        // First poll sets the baseline (no alert), second poll's +200 delta exceeds the 100 threshold.
-        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 0);
-        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 200);
+        // FEC off: BIP is uncorrected data loss, so the strict 25-error threshold applies.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 0, fecEnabled: false);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 50, fecEnabled: false);
 
         var bip = bus.Events.Where(e => e.EventType == "ont.bip_errors").ToList();
         bip.Should().HaveCount(1);
         bip[0].Source.Should().Be("ont");
-        bip[0].MetricValue.Should().Be(200);
-        bip[0].ThresholdValue.Should().Be(100);
+        bip[0].MetricValue.Should().Be(50);
+        bip[0].ThresholdValue.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task BipSpike_FecEnabled_UsesRelaxedThreshold()
+    {
+        var (evaluator, bus) = Create();
+
+        // FEC on: BIP counts pre-FEC line errors FEC corrects, so a 300-error step (below the
+        // relaxed 1000 threshold) must NOT alert, while a larger 1100-error step does.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 0, fecEnabled: true);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 300, fecEnabled: true);
+        bus.Events.Should().NotContain(e => e.EventType == "ont.bip_errors");
+
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 1400, fecEnabled: true);
+        var bip = bus.Events.Where(e => e.EventType == "ont.bip_errors").ToList();
+        bip.Should().HaveCount(1);
+        bip[0].MetricValue.Should().Be(1100);
+        bip[0].ThresholdValue.Should().Be(1000);
     }
 
     [Fact]
@@ -119,9 +137,9 @@ public class OntAlertEvaluatorTests
     {
         var (evaluator, bus) = Create();
 
-        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 5000);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 5000, fecEnabled: false);
         // ONT reboots; counter resets below the prior value -> negative step -> no alert.
-        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 10);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 10, fecEnabled: false);
 
         bus.Events.Should().NotContain(e => e.EventType == "ont.bip_errors");
     }

--- a/tests/NetworkOptimizer.Web.Tests/OntAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/OntAlertEvaluatorTests.cs
@@ -98,6 +98,64 @@ public class OntAlertEvaluatorTests
         bus.Events.Should().NotContain(e => e.EventType == TempEvent);
     }
 
+    [Fact]
+    public async Task BipDeltaAboveThreshold_PublishesBipSpike_AfterBaseline()
+    {
+        var (evaluator, bus) = Create();
+
+        // First poll sets the baseline (no alert), second poll's +200 delta exceeds the 100 threshold.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 0);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 200);
+
+        var bip = bus.Events.Where(e => e.EventType == "ont.bip_errors").ToList();
+        bip.Should().HaveCount(1);
+        bip[0].Source.Should().Be("ont");
+        bip[0].MetricValue.Should().Be(200);
+        bip[0].ThresholdValue.Should().Be(100);
+    }
+
+    [Fact]
+    public async Task BipCounterReset_DoesNotFakeSpike()
+    {
+        var (evaluator, bus) = Create();
+
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 5000);
+        // ONT reboots; counter resets below the prior value -> negative step -> no alert.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, null, bipErrors: 10);
+
+        bus.Events.Should().NotContain(e => e.EventType == "ont.bip_errors");
+    }
+
+    [Fact]
+    public async Task FecDisabled_EvaluatesHecNotFec()
+    {
+        var (evaluator, bus) = Create();
+
+        // With FEC disabled, a large FEC delta must be ignored and HEC drives the codeword alert.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, fecErrors: 0,
+            hecErrors: 0, fecEnabled: false);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, fecErrors: 100000,
+            hecErrors: 500, fecEnabled: false);
+
+        bus.Events.Should().NotContain(e => e.EventType == "ont.fec_errors");
+        var hec = bus.Events.Where(e => e.EventType == "ont.hec_errors").ToList();
+        hec.Should().HaveCount(1);
+        hec[0].MetricValue.Should().Be(500);
+    }
+
+    [Fact]
+    public async Task FecEnabledOrUnknown_EvaluatesFecNotHec()
+    {
+        var (evaluator, bus) = Create();
+
+        // Default (fecEnabled unknown/null, the standalone-ONT case): FEC drives the alert, HEC is ignored.
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, fecErrors: 0, hecErrors: 0);
+        await evaluator.EvaluateAsync(1, "ONT", SafeRx, PonLinkState.Operation, fecErrors: 2000, hecErrors: 9999);
+
+        bus.Events.Should().NotContain(e => e.EventType == "ont.hec_errors");
+        bus.Events.Count(e => e.EventType == "ont.fec_errors").Should().Be(1);
+    }
+
     private sealed class CapturingBus : IAlertEventBus
     {
         public List<AlertEvent> Events { get; } = new();


### PR DESCRIPTION
Adds a vendor-neutral way to pull deep PON-layer stats from a fiber ONT and fold them into the SFP module you already monitor, plus a couple of ONT/Monitoring polish items.

## ONT Device Monitoring

- **Network Optimizer Custom (HTTP JSON)** - a new ONT provider that polls a plain HTTP endpoint returning PON-layer stats as JSON: PLOAM activation state, GTC status and counters, GEM frame and allocation counters, bridge-port discards, and host-link counters. The JSON contract is vendor-neutral and documented (`docs/features/netopt-custom-pon-contract.md`), so anyone can implement it for their own ONT hardware; the first serving-side implementation gathers the data from a GPON SFP stick.
- **Attach to SFP Module** - a Network Optimizer Custom config can be attached to a monitored SFP module. Attached configs are polled on the gateway SFP cycle and their PON metrics merge into that module's existing SFP series, so the module's optics (DDM) and its PON internals form one picture. Attached configs deliberately do not appear as a standalone ONT - they stay out of the Dashboard ONT Stats card, the ONT Stats tab, and ISP Health.
- **Monitoring - SFP Stats** - for a supplemented module, new per-interval delta charts for PON errors, GEM frames, and host-link errors, plus a PLOAM detail table (state, ONU ID, FEC DS/US, response time, ONT uptime). The whole section appears only when a supplemented module is selected in the filter.
- **SFP ONT card** (Dashboard and Monitoring - ONT Stats) - now shows **PON Status** and a combined **BIP/FEC/Drops** counter when available. The middle counter shows **HEC** (the always-on header-error signal) instead of FEC when the link runs with payload FEC disabled, since FEC counters are meaningless there.
- **BIP / HEC error alerts** - new **ONT: BIP Error Spike** and **ONT: HEC Error Spike** rules (Alerts & Schedule - Rules) covering the always-on error signals. On a link running with payload FEC disabled, the existing FEC alert can never fire, so these close the gap; the codeword alert follows the same FEC-or-HEC adaptation as the card. BIP's threshold is FEC-state-aware - strict when FEC is off (every BIP is uncorrected data loss) and relaxed when FEC is on (BIP counts pre-FEC errors FEC corrects). Attaching augmented PON polling to an SFP ONT enables the rules automatically, matching how the other ONT alerts turn on when ONT monitoring is configured. Each ONT alert deep-links to the tab that shows the triggering device - SFP Stats for an attached module, ONT Stats for a standalone ONT.

## Monitoring

### ONT Stats

- **FEC / BIP Errors (per interval)** - new delta chart for external ONTs that report those counters. Cumulative counters are plotted as per-interval deltas so a steadily-climbing total doesn't render as an unreadable ramp.

### ISP Health

- Uniform hop badge height and text centering, so the "Lowest RTT" and "Not on path" badges line up cleanly next to the hop name regardless of badge type.

## Notes

- New provider, the `AttachedSfpId` column on ONT configs (with migration), and the SFP-side merge are all additive; existing SFP and ONT monitoring is unchanged.
- The extra PON charts are mounted lazily - setups without supplemental polling never create the chart instances, so there's no cost for the large majority who won't use this.
