### PR TITLE
Multi-Site: stop reverse proxies silently breaking the agent tunnel, and report agent(s) offline when it's down

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3711,9 +3711,10 @@
     }
 
     // At-a-glance agent state for a site's row in the Sites table. Uses the
-    // shared IsAgentLive definition (tunnel-connected or heartbeat-fresh) and is
-    // kept current by the agent poll timer, so it agrees with the other status
-    // surfaces instead of freezing at whatever page load saw.
+    // shared IsAgentLive definition (tunnel-connected, or heartbeat-fresh only
+    // when this server offers no tunnel) and is kept current by the agent poll
+    // timer, so it agrees with the other status surfaces instead of freezing at
+    // whatever page load saw.
     private (string Dot, string Label, string Tooltip) SiteAgentStatus(int siteId)
     {
         var agents = AgentsFor(siteId);
@@ -3847,7 +3848,7 @@
         if (_agentOnGateway.TryGetValue(site.Id, out var onGateway) && onGateway)
             return "none - the agent runs on the UniFi gateway; enter a separate box hosting the speed test";
         var lanIp = AgentsFor(site.Id)
-            .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsAgentLive(a))
+            .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsReachableForLanTest(a))
             .OrderByDescending(a => a.LastSeenAt)
             .Select(a => a.LanIp)
             .FirstOrDefault();

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3848,7 +3848,7 @@
         if (_agentOnGateway.TryGetValue(site.Id, out var onGateway) && onGateway)
             return "none - the agent runs on the UniFi gateway; enter a separate box hosting the speed test";
         var lanIp = AgentsFor(site.Id)
-            .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsReachableForLanTest(a))
+            .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsReachable(a))
             .OrderByDescending(a => a.LastSeenAt)
             .Select(a => a.LanIp)
             .FirstOrDefault();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -10,14 +10,12 @@ using NetworkOptimizer.Audit.Services;
 using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web;
 using NetworkOptimizer.Web.Endpoints;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.CableModemProviders;
 using NetworkOptimizer.Web.Services.Licensing;
-using NetworkOptimizer.Web.Services.CellularModemProviders;
 using NetworkOptimizer.Web.Services.OntProviders;
 using NetworkOptimizer.Web.Services.Ssh;
 using NetworkOptimizer.WiFi.Models;
@@ -1060,6 +1058,21 @@ if (!string.IsNullOrEmpty(canonicalHost))
 {
     app.Use(async (context, next) =>
     {
+        // The agent tunnel is gRPC, which cannot follow an HTTP redirect: a 302
+        // here silently breaks the tunnel whenever a reverse proxy forwards the
+        // gRPC path without presenting the canonical Host (e.g. Caddy proxying to
+        // the https://localhost tunnel upstream sends Host: localhost, so the app
+        // sees a non-canonical host and redirects the Connect stream to death -
+        // while REST heartbeats still land and keep the agent showing online).
+        // gRPC is machine-to-machine and has no canonical-host concern, so never
+        // redirect it; let it through to the gRPC endpoint regardless of Host.
+        var contentType = context.Request.ContentType;
+        if (contentType != null && contentType.StartsWith("application/grpc", StringComparison.OrdinalIgnoreCase))
+        {
+            await next();
+            return;
+        }
+
         var requestHost = context.Request.Host.Host;
 
         // Check if host matches (case-insensitive)

--- a/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentConnectionAlertMonitor.cs
@@ -9,9 +9,10 @@ namespace NetworkOptimizer.Web.Services;
 /// Periodically sweeps enrolled agents and raises alert events when one stays
 /// offline past the grace threshold, pairing each with a reconnect event when it
 /// comes back. Sweeps <see cref="AgentTunnelRegistry.IsAgentLive"/> (open tunnel,
-/// or heartbeat freshness for REST-only agents and reconnect gaps) instead of
-/// hooking tunnel teardown, so agent redeploys and transient tunnel bounces never
-/// alert - only an agent continuously offline for the full threshold does.
+/// its brief reconnect grace, or - only when this server offers no tunnel - REST
+/// heartbeat freshness) instead of hooking tunnel teardown, so agent redeploys
+/// and transient tunnel bounces never alert - only an agent continuously offline
+/// for the full threshold does.
 /// </summary>
 public class AgentConnectionAlertMonitor : BackgroundService
 {

--- a/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
@@ -227,17 +227,17 @@ public class AgentEnrollmentService
         if (site == null)
             return null;
 
-        // Filter to live agents FIRST (open tunnel is authoritative and instant,
-        // heartbeat freshness covers REST-only agents and reconnect gaps - the
-        // same IsAgentLive definition every status surface uses), then take the
-        // most recently seen, so a site with one stale and one live agent still
-        // resolves and the resolved target always matches what the UI shows.
+        // Filter to reachable agents FIRST (open tunnel, or a fresh REST heartbeat
+        // - the LAN speed test hits the agent's nginx directly, not the tunnel, so
+        // a heartbeat-only agent is still a valid target even when its tunnel is
+        // down), then take the most recently seen, so a site with one stale and one
+        // reachable agent still resolves.
         var agents = await db.SiteAgents.AsNoTracking()
             .Where(a => a.SiteId == site.Id && a.Enabled && a.EnrolledAt != null && a.LanIp != null)
             .OrderByDescending(a => a.LastSeenAt)
             .ToListAsync();
 
-        return agents.FirstOrDefault(a => _tunnelRegistry.IsAgentLive(a))?.LanIp;
+        return agents.FirstOrDefault(a => _tunnelRegistry.IsReachableForLanTest(a))?.LanIp;
     }
 
     /// <summary>Enables or disables an agent. Disabled agents cannot enroll or heartbeat.</summary>

--- a/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
@@ -237,7 +237,7 @@ public class AgentEnrollmentService
             .OrderByDescending(a => a.LastSeenAt)
             .ToListAsync();
 
-        return agents.FirstOrDefault(a => _tunnelRegistry.IsReachableForLanTest(a))?.LanIp;
+        return agents.FirstOrDefault(a => _tunnelRegistry.IsReachable(a))?.LanIp;
     }
 
     /// <summary>Enables or disables an agent. Disabled agents cannot enroll or heartbeat.</summary>

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -91,13 +91,16 @@ public class AgentTunnelRegistry
     }
 
     /// <summary>
-    /// Whether the agent is reachable enough to hand its LAN IP to a site client
-    /// for a LAN speed test. Deliberately looser than <see cref="IsAgentLive"/>:
-    /// the LAN speed test hits the agent's own nginx directly, not the tunnel, so
-    /// an agent with a fresh REST heartbeat is a valid target even when its tunnel
-    /// is down or unpublished. Open tunnel or heartbeat freshness both qualify.
+    /// Whether we've heard from the agent recently by any means - open tunnel or a
+    /// fresh REST heartbeat. Deliberately looser than <see cref="IsAgentLive"/>,
+    /// which requires a working tunnel: this is the reachability signal used to
+    /// pick a site's LAN speed-test target, since that test hits the agent's own
+    /// nginx directly rather than the tunnel, so a heartbeat-only agent is still a
+    /// candidate. It does NOT verify the agent actually hosts a speed test (LAN
+    /// testing is an opt-in agent flag the server has no signal for yet); the
+    /// resolver's on-gateway check is the only capability gate today.
     /// </summary>
-    public bool IsReachableForLanTest(NetworkOptimizer.Storage.Models.SiteAgent agent) =>
+    public bool IsReachable(NetworkOptimizer.Storage.Models.SiteAgent agent) =>
         IsConnected(agent.Id) || AgentEnrollmentService.IsOnline(agent.LastSeenAt);
 
     /// <summary>Live connections for a site (normally zero or one per agent).</summary>

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -15,6 +15,29 @@ public class AgentTunnelRegistry
 {
     private readonly ConcurrentDictionary<int, AgentTunnelConnection> _connections = new();
 
+    // Last time each agent had an open tunnel (stamped on connect and on drop).
+    // Bridges the brief gap while a previously-connected tunnel reconnects, so a
+    // real reconnect doesn't flap the online status - without letting a tunnel
+    // that never connected count as live.
+    private readonly ConcurrentDictionary<int, DateTime> _lastTunnelActivity = new();
+
+    // Whether this server bound the agent tunnel listener. When it did, an agent
+    // that only ever REST-heartbeats has a dead or unpublished tunnel (e.g. the
+    // gRPC path isn't reverse-proxied) and its tunnel-dependent features are all
+    // down, so heartbeat freshness alone must NOT read as online.
+    private readonly bool _tunnelEnabled;
+
+    // How long after a tunnel drops an agent still counts as live, covering the
+    // agent's dial-out backoff so a genuine reconnect doesn't blink the status
+    // offline. Sized just over the agent heartbeat interval (30s) plus a dial
+    // attempt; a tunnel down longer than this is a real outage, not a reconnect.
+    private static readonly TimeSpan TunnelReconnectGrace = TimeSpan.FromSeconds(75);
+
+    public AgentTunnelRegistry(AgentTunnelOptions tunnelOptions)
+    {
+        _tunnelEnabled = tunnelOptions.Enabled;
+    }
+
     /// <summary>Registers a new live connection, displacing any stale one for the same agent.</summary>
     public AgentTunnelConnection Register(int agentId, string siteSlug, string agentName)
     {
@@ -24,6 +47,7 @@ public class AgentTunnelRegistry
             old.Complete();
             return connection;
         });
+        _lastTunnelActivity[agentId] = DateTime.UtcNow;
         return connection;
     }
 
@@ -34,6 +58,9 @@ public class AgentTunnelRegistry
     public void Unregister(AgentTunnelConnection connection)
     {
         connection.Complete();
+        // Stamp the drop time so the reconnect grace is measured from when the
+        // tunnel actually went away, not from when it first connected.
+        _lastTunnelActivity[connection.AgentId] = DateTime.UtcNow;
         ((ICollection<KeyValuePair<int, AgentTunnelConnection>>)_connections)
             .Remove(new KeyValuePair<int, AgentTunnelConnection>(connection.AgentId, connection));
     }
@@ -42,13 +69,35 @@ public class AgentTunnelRegistry
     public bool IsConnected(int agentId) => _connections.ContainsKey(agentId);
 
     /// <summary>
-    /// Whether an agent counts as online for status displays: an open tunnel is
-    /// authoritative and instant; otherwise a fresh heartbeat (REST-only agents,
-    /// or the gap while a tunnel reconnects) keeps it online. The single
-    /// definition every status surface (site dropdown, All Sites, Multi-Site
-    /// settings) shares, so they can't disagree on what "online" means.
+    /// Whether an agent counts as online for status displays. An open tunnel is
+    /// authoritative and instant. When this server offers no tunnel at all, a
+    /// fresh REST heartbeat is the best signal and keeps the agent online. But
+    /// when the server DOES offer a tunnel, a heartbeat-only agent has a dead or
+    /// unpublished tunnel (e.g. the gRPC path isn't reverse-proxied) with every
+    /// tunnel-dependent feature down - reporting it online off REST heartbeats
+    /// alone would be dishonest - so only an open tunnel, or the brief grace
+    /// while a previously-connected one reconnects, counts. The single definition
+    /// every status surface (site dropdown, All Sites, Multi-Site settings)
+    /// shares, so they can't disagree on what "online" means.
     /// </summary>
-    public bool IsAgentLive(NetworkOptimizer.Storage.Models.SiteAgent agent) =>
+    public bool IsAgentLive(NetworkOptimizer.Storage.Models.SiteAgent agent)
+    {
+        if (IsConnected(agent.Id))
+            return true;
+        if (_tunnelEnabled)
+            return _lastTunnelActivity.TryGetValue(agent.Id, out var last)
+                && DateTime.UtcNow - last < TunnelReconnectGrace;
+        return AgentEnrollmentService.IsOnline(agent.LastSeenAt);
+    }
+
+    /// <summary>
+    /// Whether the agent is reachable enough to hand its LAN IP to a site client
+    /// for a LAN speed test. Deliberately looser than <see cref="IsAgentLive"/>:
+    /// the LAN speed test hits the agent's own nginx directly, not the tunnel, so
+    /// an agent with a fresh REST heartbeat is a valid target even when its tunnel
+    /// is down or unpublished. Open tunnel or heartbeat freshness both qualify.
+    /// </summary>
+    public bool IsReachableForLanTest(NetworkOptimizer.Storage.Models.SiteAgent agent) =>
         IsConnected(agent.Id) || AgentEnrollmentService.IsOnline(agent.LastSeenAt);
 
     /// <summary>Live connections for a site (normally zero or one per agent).</summary>

--- a/tests/NetworkOptimizer.Web.Tests/AgentEnrollmentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentEnrollmentServiceTests.cs
@@ -18,7 +18,7 @@ public class AgentEnrollmentServiceTests
     }
 
     private readonly TestDbFactory _factory;
-    private readonly AgentTunnelRegistry _tunnelRegistry = new();
+    private readonly AgentTunnelRegistry _tunnelRegistry = new(new AgentTunnelOptions(Enabled: true, Port: 0));
     private readonly AgentEnrollmentService _service;
 
     public AgentEnrollmentServiceTests()

--- a/tests/NetworkOptimizer.Web.Tests/AgentTunnelRegistryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentTunnelRegistryTests.cs
@@ -70,15 +70,15 @@ public class AgentTunnelRegistryTests
     }
 
     [Fact]
-    public void IsReachableForLanTest_HeartbeatFresh_ButBrokenTunnel_IsReachable()
+    public void IsReachable_HeartbeatFresh_ButBrokenTunnel_IsReachable()
     {
         // LAN speed tests hit the agent's nginx directly, so a heartbeat-only
-        // agent (tunnel enabled but never connected) is still a valid target -
-        // looser than IsAgentLive on purpose.
+        // agent (tunnel enabled but never connected) is still reachable - looser
+        // than IsAgentLive on purpose.
         var registry = Registry(tunnelEnabled: true);
         var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
 
         registry.IsAgentLive(agent).Should().BeFalse();
-        registry.IsReachableForLanTest(agent).Should().BeTrue();
+        registry.IsReachable(agent).Should().BeTrue();
     }
 }

--- a/tests/NetworkOptimizer.Web.Tests/AgentTunnelRegistryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentTunnelRegistryTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class AgentTunnelRegistryTests
+{
+    private static AgentTunnelRegistry Registry(bool tunnelEnabled) =>
+        new(new AgentTunnelOptions(Enabled: tunnelEnabled, Port: 0));
+
+    private static SiteAgent Agent(int id, DateTime? lastSeenAt) =>
+        new() { Id = id, Name = "Agent", EnrolledAt = DateTime.UtcNow, LastSeenAt = lastSeenAt };
+
+    [Fact]
+    public void IsAgentLive_TunnelConnected_IsLive()
+    {
+        var registry = Registry(tunnelEnabled: true);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
+        registry.Register(agent.Id, "branch-office", "Agent");
+
+        registry.IsAgentLive(agent).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAgentLive_TunnelEnabled_HeartbeatOnly_NeverTunneled_IsOffline()
+    {
+        // The reported bug: the gRPC tunnel path isn't reverse-proxied, so the
+        // agent never tunnels but its REST heartbeat stays fresh. That must NOT
+        // read as online when the server offers a tunnel.
+        var registry = Registry(tunnelEnabled: true);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
+
+        registry.IsAgentLive(agent).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAgentLive_TunnelEnabled_WithinReconnectGraceAfterDrop_StaysLive()
+    {
+        // A previously-connected tunnel that just dropped is mid-reconnect, not an
+        // outage - the grace keeps it live so the status doesn't flap.
+        var registry = Registry(tunnelEnabled: true);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
+        var connection = registry.Register(agent.Id, "branch-office", "Agent");
+        registry.Unregister(connection);
+
+        registry.IsConnected(agent.Id).Should().BeFalse();
+        registry.IsAgentLive(agent).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAgentLive_TunnelDisabled_HeartbeatFresh_IsLive()
+    {
+        // No tunnel listener at all (single-box / legacy deployment): REST
+        // heartbeat freshness is the best signal and keeps the agent online.
+        var registry = Registry(tunnelEnabled: false);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
+
+        registry.IsAgentLive(agent).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAgentLive_TunnelDisabled_HeartbeatStale_IsOffline()
+    {
+        var registry = Registry(tunnelEnabled: false);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow - AgentEnrollmentService.OnlineWindow - TimeSpan.FromMinutes(1));
+
+        registry.IsAgentLive(agent).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsReachableForLanTest_HeartbeatFresh_ButBrokenTunnel_IsReachable()
+    {
+        // LAN speed tests hit the agent's nginx directly, so a heartbeat-only
+        // agent (tunnel enabled but never connected) is still a valid target -
+        // looser than IsAgentLive on purpose.
+        var registry = Registry(tunnelEnabled: true);
+        var agent = Agent(1, lastSeenAt: DateTime.UtcNow);
+
+        registry.IsAgentLive(agent).Should().BeFalse();
+        registry.IsReachableForLanTest(agent).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Multi-Site

Two fixes to on-site agent connectivity and to how honestly agent status is reported.

### Agents now read offline when the tunnel is actually down

An agent could show **Online** on every status surface (the site dropdown, All Sites, the Multi-Site agent panel) as long as its REST heartbeat kept arriving, even when its gRPC tunnel was completely down. Whenever the tunnel path isn't reachable (not reverse-proxied, tunnel URL never published, or a proxy misconfig), the tunnel dial fails every time but the heartbeat POST keeps succeeding and refreshing last-seen, so the agent looked healthy while monitoring relay, config push, the proxied UniFi Console, and relayed speed tests were all dead. The offline alert never fired either, because the shared liveness check never went false.

Now, when the server offers a tunnel, only an open tunnel (or a short reconnect grace after a previously-connected one drops) counts as online. A heartbeat alone no longer masks a dead tunnel, so a broken or unpublished tunnel reads offline and raises the offline alert after the usual grace. Deployments with no tunnel listener at all (single-box or older setups) still treat REST heartbeat freshness as online. LAN speed-test targeting is unaffected: those tests hit the agent's own web server directly rather than the tunnel, so a heartbeat-only agent is still a valid LAN target.

### Reverse proxies that don't pass the original Host no longer silently break the tunnel

The canonical-host redirect (`REVERSE_PROXIED_HOST_NAME`) ran on the shared pipeline, so it also saw the agent tunnel's gRPC requests. A gRPC stream cannot follow an HTTP 302, so any reverse proxy that forwards the tunnel path without presenting the canonical Host had its `Connect` stream redirected to death, while REST heartbeats still landed and kept the agent showing Online. This bites proxies that rewrite Host by default (nginx) or present the upstream authority on an HTTP/2 backend (Caddy); Traefik's `passHostHeader` default happened to mask it. gRPC requests are now exempt from the canonical-host redirect, so the tunnel connects regardless of how the proxy handles the Host header.

Every online/offline surface shares one liveness definition, so they stay in agreement.
