### PR TITLE
Add Zyxel GPON-SFP (PMG3000) ONT provider

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1565,6 +1565,7 @@
                                 <option value="quantum-q1000k">Quantum Fiber Q1000K (HTTP)</option>
                                 <option value="telekom-modem2">Telekom Glasfaser-Modem 2 (HTTP)</option>
                                 <option value="nokia-xs010x-q">Nokia XS-010X-Q (HTTP)</option>
+                                <option value="zyxel-gpon-sfp">Zyxel GPON-SFP (PMG3000, HTTP)</option>
                                 <option value="generic-http-ont">Generic HTTP ONT</option>
                             </select>
                         </div>
@@ -5863,6 +5864,7 @@
         "quantum-q1000k" => "Quantum Fiber Q1000K (HTTP)",
         "telekom-modem2" => "Telekom Glasfaser-Modem 2 (HTTP)",
         "nokia-xs010x-q" => "Nokia XS-010X-Q (HTTP)",
+        "zyxel-gpon-sfp" => "Zyxel GPON-SFP (PMG3000, HTTP)",
         "generic-http-ont" => "Generic HTTP ONT",
         _ => provider,
     };

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1574,7 +1574,7 @@
                     <div class="form-row">
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Host / IP</label>
-                            <input type="text" class="form-control" @bind="_editingOnt.Host" placeholder="192.168.1.254" required />
+                            <input type="text" class="form-control" @bind="_editingOnt.Host" placeholder="@GetOntHostPlaceholder(_editingOnt.Provider)" required />
                             <small class="form-help">
                                 Behind your WAN and unreachable for polling?
                                 <a href="@MonitoringInterfaceLink(_editingOnt.Host, "ont")">Set up a monitoring interface →</a>
@@ -5844,9 +5844,20 @@
 
     private void OnOntProviderChanged(ChangeEventArgs e)
     {
+        var previousProvider = _editingOnt.Provider;
         var provider = e.Value?.ToString() ?? "att-gateway";
         _editingOnt.Provider = provider;
         _editingOnt.Port = GetOntProviderDefaultPort(provider);
+
+        // Suggest the provider's known management host, mirroring the port default. Fill when the
+        // field is empty, and replace a host that was auto-filled from the previous provider's
+        // default (so a stale suggestion is not saved for a different device) - but never
+        // overwrite a value the user actually typed.
+        if (string.IsNullOrWhiteSpace(_editingOnt.Host) ||
+            _editingOnt.Host == GetOntProviderDefaultHost(previousProvider))
+        {
+            _editingOnt.Host = GetOntProviderDefaultHost(provider);
+        }
     }
 
     private static int GetOntProviderDefaultPort(string provider) => provider switch
@@ -5855,6 +5866,21 @@
         "quantum-q1000k" => 443,
         _ => 80,
     };
+
+    // Known default management address for providers whose stick/box ships on a fixed IP;
+    // blank when there is no single sensible default (so nothing is prefilled).
+    private static string GetOntProviderDefaultHost(string provider) => provider switch
+    {
+        "zyxel-gpon-sfp" => "10.10.1.1",
+        _ => "",
+    };
+
+    // Host-field placeholder: the provider's known default when there is one, else a generic example.
+    private static string GetOntHostPlaceholder(string provider)
+    {
+        var suggested = GetOntProviderDefaultHost(provider);
+        return string.IsNullOrEmpty(suggested) ? "192.168.1.254" : suggested;
+    }
 
     private static string GetOntProviderDisplayName(string provider) => provider switch
     {

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -356,6 +356,7 @@ builder.Services.AddSingleton<IOntProvider, QuantumQ1000kOntProvider>();
 builder.Services.AddSingleton<IOntProvider, GenericHttpOntProvider>();
 builder.Services.AddSingleton<IOntProvider, TelekomModem2OntProvider>();
 builder.Services.AddSingleton<IOntProvider, NokiaXs010xOntProvider>();
+builder.Services.AddSingleton<IOntProvider, ZyxelGponSfpOntProvider>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).Ont);
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
@@ -75,9 +75,15 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
             {
                 snBody = await client.GetStringAsync($"{baseUrl}{SnPath}", cancellationToken);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw; // genuine caller-requested cancellation
+            }
             catch (Exception ex)
             {
+                // Includes an HttpClient.Timeout (surfaces as OperationCanceledException with our
+                // token NOT cancelled): get_sn is best-effort, so a slow/hung serial endpoint must
+                // not discard the optical telemetry we already have.
                 _logger.LogDebug(ex,
                     "Zyxel GPON-SFP ONT {Name}: serial enrichment (get_sn) failed, continuing with optical telemetry",
                     context.Name);
@@ -105,9 +111,14 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
 
             return stats;
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw; // genuine caller-requested cancellation
+        }
         catch (Exception ex)
         {
+            // A transport failure or an HttpClient.Timeout (OperationCanceledException with our
+            // token not cancelled) yields null per the IOntProvider contract, not an exception.
             _logger.LogWarning(ex, "Error polling Zyxel GPON-SFP ONT {Name} at {Host}",
                 context.Name, context.ConfiguredHost ?? context.Host);
             return null;
@@ -185,11 +196,10 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
         stats.DeviceModel = "Zyxel PMG3000";
         stats.PonType = "GPON";
 
-        // line_status is the raw ONU state ordinal (device returns "5"); prefix "O" so it
-        // reuses the shared O1-O7 parser.
+        // line_status is the raw ONU state ordinal (device returns "5").
         if (gpon.TryGetValue("line_status", out var lineStatus))
         {
-            var state = PonLinkStateExtensions.ParsePonLinkState("O" + lineStatus.Trim());
+            var state = MapLineStatus(lineStatus);
             stats.PonLinkStatus = state;
             stats.LinkState = state.ToDisplayString();
             stats.OperationalStatus = state switch
@@ -409,6 +419,24 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
         while (i < body.Length && char.IsWhiteSpace(body[i]))
             i++;
     }
+
+    /// <summary>
+    /// Maps the device's line_status to an ITU ONU state. The stick reports a single ordinal
+    /// "1".."7"; matched exactly (not via substring), so an unexpected/malformed value such as
+    /// "51" or "15" resolves to Unknown rather than being misread as a healthy O5 - reporting a
+    /// bad status as Up could suppress a genuine down alert.
+    /// </summary>
+    internal static PonLinkState MapLineStatus(string? raw) => raw?.Trim() switch
+    {
+        "1" => PonLinkState.Initial,
+        "2" => PonLinkState.Standby,
+        "3" => PonLinkState.SerialNumber,
+        "4" => PonLinkState.Ranging,
+        "5" => PonLinkState.Operation,
+        "6" => PonLinkState.Popup,
+        "7" => PonLinkState.EmergencyStop,
+        _ => PonLinkState.Unknown,
+    };
 
     /// <summary>
     /// Trims the value, strips a terminal "(ASCII)" suffix (only when terminal), and returns

--- a/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
@@ -1,0 +1,460 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.OntProviders;
+
+/// <summary>
+/// ONT provider for the Zyxel PMG3000 GPON-SFP stick (a MaxLinear/T&amp;W-based unit),
+/// used as an in-gateway ONT on GPON FTTH connections. The stick speaks plain HTTP
+/// with HTTP Basic auth (default admin/1234) and exposes two data-bearing CGI GETs:
+///
+///   GET /cgi/get_sn        -> {cur_sn:"..(ASCII)",sn:"..(ASCII)",cur_pass:"..(ASCII)"}
+///   GET /cgi/get_gpon_info -> {line_status:"5",loid_status:0,up_fec:"Disable",..,
+///                              temp:"67.85",voltage:"3.30",current:"28.89",
+///                              tx_power:"3.01",rx_power:"-17.17"}
+///
+/// These responses are JavaScript object literals, not strict JSON (unquoted keys,
+/// whitespace after colons, mixed value types, a terminal "(ASCII)" suffix inside
+/// strings), so they are decoded by a small provider-local lenient tokenizer rather
+/// than System.Text.Json.
+///
+/// get_gpon_info is the required telemetry endpoint; get_sn is best-effort identity
+/// enrichment only, and its body is never logged because it contains cur_pass.
+/// </summary>
+public sealed class ZyxelGponSfpOntProvider : IOntProvider
+{
+    public string ProviderKey => "zyxel-gpon-sfp";
+    public string DisplayName => "Zyxel GPON-SFP (PMG3000, HTTP)";
+
+    private const int TimeoutSeconds = 10;
+    private const string SnPath = "/cgi/get_sn";
+    private const string GponInfoPath = "/cgi/get_gpon_info";
+    private const string DefaultUsername = "admin";
+    private const string DefaultPassword = "1234";
+
+    // Keys in get_gpon_info that mark the response as a real PON status payload (rather
+    // than an HTML/login page returned with HTTP 200). Presence of at least one gates
+    // whether the poll is treated as valid.
+    private static readonly string[] RecognizedGponKeys =
+        { "line_status", "rx_power", "tx_power", "temp", "voltage", "current" };
+
+    private readonly ILogger<ZyxelGponSfpOntProvider> _logger;
+
+    public ZyxelGponSfpOntProvider(ILogger<ZyxelGponSfpOntProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Zyxel GPON-SFP ONT poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            using var client = CreateClient(context);
+            var baseUrl = BuildBaseUrl(context);
+
+            // Required: optical/link telemetry. A transport/HTTP failure here propagates
+            // to the outer catch and yields null.
+            var gponBody = await client.GetStringAsync($"{baseUrl}{GponInfoPath}", cancellationToken);
+
+            // Best-effort: serial identity. Losing this endpoint must not discard the
+            // optical telemetry we already have, so its failure is swallowed. The body is
+            // never logged, since get_sn carries cur_pass.
+            string? snBody = null;
+            try
+            {
+                snBody = await client.GetStringAsync($"{baseUrl}{SnPath}", cancellationToken);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex,
+                    "Zyxel GPON-SFP ONT {Name}: serial enrichment (get_sn) failed, continuing with optical telemetry",
+                    context.Name);
+            }
+
+            var stats = new OntStats
+            {
+                Timestamp = DateTime.UtcNow,
+                DeviceHost = context.ConfiguredHost ?? context.Host,
+                DeviceName = context.Name,
+            };
+
+            if (!ApplyResponses(snBody, gponBody, stats))
+            {
+                _logger.LogWarning(
+                    "Zyxel GPON-SFP ONT {Name}: get_gpon_info did not contain recognized PON status fields",
+                    context.Name);
+                return null;
+            }
+
+            _logger.LogDebug(
+                "Zyxel GPON-SFP ONT {Name} polled: Rx={Rx} dBm, Tx={Tx} dBm, Link={Link}, SN={Sn}",
+                context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
+                stats.TxPowerDbm?.ToString("F2") ?? "-", stats.LinkState ?? "-", stats.VendorSn ?? "-");
+
+            return stats;
+        }
+        catch (OperationCanceledException) { throw; }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error polling Zyxel GPON-SFP ONT {Name} at {Host}",
+                context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        OntPollContext context, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        try
+        {
+            using var client = CreateClient(context);
+            var baseUrl = BuildBaseUrl(context);
+
+            // Exercise the telemetry endpoint monitoring actually needs, so a success cannot
+            // be reported while get_gpon_info is broken.
+            using var response = await client.GetAsync($"{baseUrl}{GponInfoPath}", cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                return response.StatusCode switch
+                {
+                    HttpStatusCode.Unauthorized =>
+                        (false, "Authentication failed - check username/password (default is admin/1234)"),
+                    HttpStatusCode.Forbidden =>
+                        (false, "Access denied (HTTP 403)"),
+                    _ => (false, $"Device returned HTTP {(int)response.StatusCode} {response.ReasonPhrase}"),
+                };
+            }
+
+            var gponBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            var stats = new OntStats();
+            if (!ApplyResponses(null, gponBody, stats))
+                return (false, "Connected but response did not contain the expected GPON status fields");
+
+            return (true,
+                $"Connected (HTTP) - RX: {stats.RxPowerDbm?.ToString("F2") ?? "?"} dBm, Link: {stats.LinkState ?? "?"}");
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            // HttpClient.Timeout elapsed - surfaces as a cancellation not tied to our token.
+            return (false, "Connection timed out");
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // caller-requested cancellation
+        }
+        catch (HttpRequestException ex)
+        {
+            return (false, $"Connection failed - device unreachable ({ex.Message})");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Maps the two CGI responses onto <paramref name="stats"/>. get_gpon_info is required:
+    /// this returns false (and leaves <paramref name="stats"/> untouched) if it does not parse
+    /// or contains no recognized PON status field, so the caller can drop the poll. get_sn is
+    /// optional identity enrichment and its failure never affects the mapped optical telemetry.
+    /// Never throws for bad device data.
+    /// </summary>
+    internal static bool ApplyResponses(string? snBody, string gponBody, OntStats stats)
+    {
+        if (!TryParseObjectLiteral(gponBody, out var gpon) || !RecognizedGponKeys.Any(gpon.ContainsKey))
+            return false;
+
+        // Identity seeds, applied only once get_gpon_info is confirmed to be a real payload.
+        stats.VendorName = "Zyxel";
+        stats.DeviceModel = "Zyxel PMG3000";
+        stats.PonType = "GPON";
+
+        // line_status is the raw ONU state ordinal (device returns "5"); prefix "O" so it
+        // reuses the shared O1-O7 parser.
+        if (gpon.TryGetValue("line_status", out var lineStatus))
+        {
+            var state = PonLinkStateExtensions.ParsePonLinkState("O" + lineStatus.Trim());
+            stats.PonLinkStatus = state;
+            stats.LinkState = state.ToDisplayString();
+            stats.OperationalStatus = state switch
+            {
+                PonLinkState.Operation => "Up",
+                PonLinkState.Unknown => null,
+                _ => "Down",
+            };
+        }
+
+        stats.RxPowerDbm = ParseDouble(GetValue(gpon, "rx_power")) ?? stats.RxPowerDbm;
+        stats.TxPowerDbm = ParseDouble(GetValue(gpon, "tx_power")) ?? stats.TxPowerDbm;
+        stats.TemperatureC = ParseDouble(GetValue(gpon, "temp")) ?? stats.TemperatureC;
+        stats.VoltageV = ParseDouble(GetValue(gpon, "voltage")) ?? stats.VoltageV;
+        stats.BiasMa = ParseDouble(GetValue(gpon, "current")) ?? stats.BiasMa;
+
+        // up_fec/down_fec are FEC enablement flags, not cumulative error counts, so they are
+        // deliberately not mapped to OntStats.FecErrors.
+
+        if (snBody is not null && TryParseObjectLiteral(snBody, out var sn))
+        {
+            var serial = CleanSerial(GetValue(sn, "cur_sn") ?? GetValue(sn, "sn"));
+            if (!string.IsNullOrEmpty(serial))
+                stats.VendorSn = serial;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Hand-rolled linear tokenizer for the stick's JavaScript-object-literal responses.
+    /// Handles optional leading whitespace/BOM, identifier or quoted keys, single/double
+    /// quoted string values with escapes, bare scalar tokens (0, -17.17, Disable, null),
+    /// an optional trailing comma, a required closing brace, and rejects unexplained
+    /// trailing content. Duplicate keys resolve to the last value. Returns false (with an
+    /// empty dictionary) for any malformed input; it never throws. A regex is deliberately
+    /// avoided: it is fragile around quoted delimiters and escapes, and the repo forbids
+    /// adding a permissive-JSON dependency.
+    /// </summary>
+    internal static bool TryParseObjectLiteral(string body, out IReadOnlyDictionary<string, string> fields)
+    {
+        var result = new Dictionary<string, string>(StringComparer.Ordinal);
+        fields = result;
+
+        if (TryParseInto(body, result))
+            return true;
+
+        result.Clear(); // no partial results leak out on malformed input
+        return false;
+    }
+
+    private static bool TryParseInto(string body, Dictionary<string, string> result)
+    {
+        if (body is null)
+            return false;
+
+        var i = 0;
+        var n = body.Length;
+
+        if (n > 0 && body[0] == '﻿')
+            i = 1;
+
+        SkipWhitespace(body, ref i);
+        if (i >= n || body[i] != '{')
+            return false;
+        i++;
+
+        SkipWhitespace(body, ref i);
+        if (i < n && body[i] == '}')
+        {
+            i++;
+            SkipWhitespace(body, ref i);
+            return i == n;
+        }
+
+        while (true)
+        {
+            SkipWhitespace(body, ref i);
+            if (!TryReadKey(body, ref i, out var key))
+                return false;
+
+            SkipWhitespace(body, ref i);
+            if (i >= n || body[i] != ':')
+                return false;
+            i++;
+
+            SkipWhitespace(body, ref i);
+            if (!TryReadValue(body, ref i, out var value))
+                return false;
+
+            result[key] = value; // last write wins on duplicate keys
+
+            SkipWhitespace(body, ref i);
+            if (i >= n)
+                return false; // missing closing brace
+
+            if (body[i] == ',')
+            {
+                i++;
+                SkipWhitespace(body, ref i);
+                if (i < n && body[i] == '}') // trailing comma before close
+                {
+                    i++;
+                    SkipWhitespace(body, ref i);
+                    return i == n;
+                }
+                continue;
+            }
+
+            if (body[i] == '}')
+            {
+                i++;
+                SkipWhitespace(body, ref i);
+                return i == n;
+            }
+
+            return false; // unexpected character between pairs
+        }
+    }
+
+    private static bool TryReadKey(string body, ref int i, out string key)
+    {
+        key = "";
+        if (i >= body.Length)
+            return false;
+
+        var c = body[i];
+        if (c is '"' or '\'')
+            return TryReadQuoted(body, ref i, out key);
+
+        var start = i;
+        while (i < body.Length)
+        {
+            var ch = body[i];
+            if (char.IsWhiteSpace(ch) || ch is ':' or ',' or '{' or '}' or '"' or '\'')
+                break;
+            i++;
+        }
+
+        if (i == start)
+            return false;
+
+        key = body[start..i];
+        return true;
+    }
+
+    private static bool TryReadValue(string body, ref int i, out string value)
+    {
+        value = "";
+        if (i >= body.Length)
+            return false;
+
+        var c = body[i];
+        if (c is '"' or '\'')
+            return TryReadQuoted(body, ref i, out value);
+
+        var start = i;
+        while (i < body.Length)
+        {
+            var ch = body[i];
+            if (char.IsWhiteSpace(ch) || ch is ',' or '}')
+                break;
+            i++;
+        }
+
+        if (i == start)
+            return false; // empty/missing value
+
+        value = body[start..i];
+        return true;
+    }
+
+    private static bool TryReadQuoted(string body, ref int i, out string value)
+    {
+        value = "";
+        var quote = body[i];
+        i++; // opening quote
+
+        var sb = new StringBuilder();
+        while (i < body.Length)
+        {
+            var ch = body[i];
+            if (ch == '\\')
+            {
+                i++;
+                if (i >= body.Length)
+                    return false; // dangling escape
+                sb.Append(body[i] switch
+                {
+                    'n' => '\n',
+                    't' => '\t',
+                    'r' => '\r',
+                    'b' => '\b',
+                    'f' => '\f',
+                    var other => other, // includes \" \' \\ \/ and any unknown escape
+                });
+                i++;
+                continue;
+            }
+
+            if (ch == quote)
+            {
+                i++; // closing quote
+                value = sb.ToString();
+                return true;
+            }
+
+            sb.Append(ch);
+            i++;
+        }
+
+        return false; // unterminated quote
+    }
+
+    private static void SkipWhitespace(string body, ref int i)
+    {
+        while (i < body.Length && char.IsWhiteSpace(body[i]))
+            i++;
+    }
+
+    /// <summary>
+    /// Trims the value, strips a terminal "(ASCII)" suffix (only when terminal), and returns
+    /// null if nothing meaningful remains. Applied to serial fields only.
+    /// </summary>
+    private static string? CleanSerial(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return null;
+
+        var s = raw.Trim();
+        const string suffix = "(ASCII)";
+        if (s.EndsWith(suffix, StringComparison.Ordinal))
+            s = s[..^suffix.Length].Trim();
+
+        return s.Length == 0 ? null : s;
+    }
+
+    private static string? GetValue(IReadOnlyDictionary<string, string> fields, string key) =>
+        fields.TryGetValue(key, out var v) ? v : null;
+
+    private static double? ParseDouble(string? text) =>
+        double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var val) && double.IsFinite(val)
+            ? val
+            : null;
+
+    /// <summary>
+    /// Builds an HttpClient with preemptive HTTP Basic auth from the context credentials
+    /// (defaulting to admin/1234 when blank) and a 10-second per-request timeout. No internal
+    /// retry: the polling schedule is the retry mechanism and the stick is resource-constrained.
+    /// </summary>
+    internal static HttpClient CreateClient(OntPollContext context)
+    {
+        var user = string.IsNullOrWhiteSpace(context.Username) ? DefaultUsername : context.Username;
+        var pass = string.IsNullOrWhiteSpace(context.Password) ? DefaultPassword : context.Password;
+        var token = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{user}:{pass}"));
+
+        var client = new HttpClient { Timeout = TimeSpan.FromSeconds(TimeoutSeconds) };
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", token);
+        return client;
+    }
+
+    private static string BuildBaseUrl(OntPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var portSuffix = port == 80 ? "" : $":{port}";
+        return $"http://{context.Host}{portSuffix}";
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/ZyxelGponSfpOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ZyxelGponSfpOntProviderTests.cs
@@ -135,6 +135,11 @@ public class ZyxelGponSfpOntProviderTests
     [Theory]
     [InlineData("0")]
     [InlineData("9")]
+    [InlineData("51")]  // must NOT substring-match O5 -> Operation
+    [InlineData("15")]  // must NOT substring-match O1 -> Initial
+    [InlineData("55")]
+    [InlineData("O5")]  // literal, not a bare ordinal
+    [InlineData("")]
     public void ApplyResponses_LineStatusUnknown_LeavesOperationalStatusNull(string lineStatus)
     {
         var stats = new OntStats();
@@ -146,6 +151,17 @@ public class ZyxelGponSfpOntProviderTests
         stats.PonLinkStatus.Should().Be(PonLinkState.Unknown);
         stats.OperationalStatus.Should().BeNull();
         stats.LinkState.Should().Be("Unknown");
+    }
+
+    [Theory]
+    [InlineData("51")]
+    [InlineData("15")]
+    [InlineData("57")]
+    public void MapLineStatus_MultiDigit_IsNotMisreadAsHealthy(string lineStatus)
+    {
+        // Regression: substring parsing would have turned "51" into O5/Operation and reported
+        // the link Up, potentially suppressing a down alert.
+        ZyxelGponSfpOntProvider.MapLineStatus(lineStatus).Should().Be(PonLinkState.Unknown);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/ZyxelGponSfpOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ZyxelGponSfpOntProviderTests.cs
@@ -1,0 +1,398 @@
+using System.Text;
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.OntProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class ZyxelGponSfpOntProviderTests
+{
+    // Captured verbatim from the live Zyxel PMG3000 GPON-SFP stick on 2026-07-20, with the
+    // real cloned serial and cur_pass scrubbed to placeholders. These are JavaScript object
+    // literals, not strict JSON: unquoted keys, whitespace after colons, mixed value types,
+    // and a terminal "(ASCII)" suffix inside string values.
+    private const string SnBody =
+        """{cur_sn:"TW00ABCD1234(ASCII)",sn:    "TW00ABCD1234(ASCII)",cur_pass:"placeholder(ASCII)"}""";
+
+    private const string GponInfoBody =
+        """{line_status:"5",loid_status:0,up_fec:"Disable",down_fec:"Disable",encrypt:"Disable",temp:"67.85",voltage:"3.30",current:"28.89",tx_power:"3.01",rx_power:"-17.17"}""";
+
+    // --- Mapping cases -------------------------------------------------------
+
+    [Fact]
+    public void ApplyResponses_HappyPath_MapsAllFieldsWithUnits()
+    {
+        var stats = new OntStats();
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(SnBody, GponInfoBody, stats);
+
+        ok.Should().BeTrue();
+        stats.RxPowerDbm.Should().BeApproximately(-17.17, 0.0001);
+        stats.TxPowerDbm.Should().BeApproximately(3.01, 0.0001);
+        stats.TemperatureC.Should().BeApproximately(67.85, 0.0001);
+        stats.VoltageV.Should().BeApproximately(3.30, 0.0001);
+        stats.BiasMa.Should().BeApproximately(28.89, 0.0001);
+        stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        stats.OperationalStatus.Should().Be("Up");
+        stats.LinkState.Should().Be("Connected (O5)");
+        stats.VendorSn.Should().Be("TW00ABCD1234");
+        stats.VendorName.Should().Be("Zyxel");
+        stats.DeviceModel.Should().Be("Zyxel PMG3000");
+        stats.PonType.Should().Be("GPON");
+    }
+
+    [Fact]
+    public void ApplyResponses_NoUpFecMappedToFecErrors()
+    {
+        var stats = new OntStats();
+
+        ZyxelGponSfpOntProvider.ApplyResponses(SnBody, GponInfoBody, stats);
+
+        // up_fec/down_fec are enablement flags ("Disable"), not error counts.
+        stats.FecErrors.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyResponses_MissingGetSn_StillMapsOptics()
+    {
+        var stats = new OntStats();
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(null, GponInfoBody, stats);
+
+        ok.Should().BeTrue();
+        stats.RxPowerDbm.Should().BeApproximately(-17.17, 0.0001);
+        stats.TxPowerDbm.Should().BeApproximately(3.01, 0.0001);
+        stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        stats.VendorSn.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyResponses_MalformedGetSn_DoesNotDiscardOptics()
+    {
+        var stats = new OntStats();
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses("<html>login</html>", GponInfoBody, stats);
+
+        ok.Should().BeTrue();
+        stats.RxPowerDbm.Should().BeApproximately(-17.17, 0.0001);
+        stats.VendorSn.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyResponses_GponInfoWithoutRecognizedField_ReturnsFalse()
+    {
+        var stats = new OntStats();
+
+        // Parses fine, but contains no recognized PON status field.
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(SnBody, """{loid_status:0,encrypt:"Disable"}""", stats);
+
+        ok.Should().BeFalse();
+        stats.RxPowerDbm.Should().BeNull();
+        stats.VendorName.Should().BeNull();
+        stats.DeviceModel.Should().Be("");
+    }
+
+    [Theory]
+    [InlineData("<html><body>Login</body></html>")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("not an object")]
+    public void ApplyResponses_MalformedGponInfo_ReturnsFalseWithoutThrowing(string gponBody)
+    {
+        var stats = new OntStats();
+
+        var act = () => ZyxelGponSfpOntProvider.ApplyResponses(SnBody, gponBody, stats);
+
+        act.Should().NotThrow();
+        ZyxelGponSfpOntProvider.ApplyResponses(SnBody, gponBody, stats).Should().BeFalse();
+        stats.RxPowerDbm.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("1", PonLinkState.Initial, "Down", "Initializing (O1)")]
+    [InlineData("2", PonLinkState.Standby, "Down", "Standby (O2)")]
+    [InlineData("3", PonLinkState.SerialNumber, "Down", "Authenticating (O3)")]
+    [InlineData("4", PonLinkState.Ranging, "Down", "Ranging (O4)")]
+    [InlineData("5", PonLinkState.Operation, "Up", "Connected (O5)")]
+    [InlineData("6", PonLinkState.Popup, "Down", "Signal Lost (O6)")]
+    [InlineData("7", PonLinkState.EmergencyStop, "Down", "Disabled (O7)")]
+    public void ApplyResponses_LineStatus_MapsToPonState(
+        string lineStatus, PonLinkState expectedState, string expectedOp, string expectedLabel)
+    {
+        var stats = new OntStats();
+        var gpon = $$"""{line_status:"{{lineStatus}}",rx_power:"-17.17"}""";
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(null, gpon, stats);
+
+        ok.Should().BeTrue();
+        stats.PonLinkStatus.Should().Be(expectedState);
+        stats.OperationalStatus.Should().Be(expectedOp);
+        stats.LinkState.Should().Be(expectedLabel);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("9")]
+    public void ApplyResponses_LineStatusUnknown_LeavesOperationalStatusNull(string lineStatus)
+    {
+        var stats = new OntStats();
+        var gpon = $$"""{line_status:"{{lineStatus}}",rx_power:"-17.17"}""";
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(null, gpon, stats);
+
+        ok.Should().BeTrue();
+        stats.PonLinkStatus.Should().Be(PonLinkState.Unknown);
+        stats.OperationalStatus.Should().BeNull();
+        stats.LinkState.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void ApplyResponses_QuotedAndBareLineStatus_BothMapEqually()
+    {
+        var quoted = new OntStats();
+        var bare = new OntStats();
+
+        ZyxelGponSfpOntProvider.ApplyResponses(null, """{line_status:"5",rx_power:"-17.17"}""", quoted);
+        ZyxelGponSfpOntProvider.ApplyResponses(null, """{line_status:5,rx_power:-17.17}""", bare);
+
+        quoted.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        bare.PonLinkStatus.Should().Be(PonLinkState.Operation);
+        bare.RxPowerDbm.Should().BeApproximately(-17.17, 0.0001);
+    }
+
+    // --- Serial handling -----------------------------------------------------
+
+    [Fact]
+    public void ApplyResponses_PrefersCurSnOverSn()
+    {
+        var stats = new OntStats();
+        var sn = """{cur_sn:"AAAA1111(ASCII)",sn:"BBBB2222(ASCII)"}""";
+
+        ZyxelGponSfpOntProvider.ApplyResponses(sn, GponInfoBody, stats);
+
+        stats.VendorSn.Should().Be("AAAA1111");
+    }
+
+    [Fact]
+    public void ApplyResponses_FallsBackToSnWhenCurSnMissing()
+    {
+        var stats = new OntStats();
+        var sn = """{sn:"BBBB2222(ASCII)",cur_pass:"placeholder(ASCII)"}""";
+
+        ZyxelGponSfpOntProvider.ApplyResponses(sn, GponInfoBody, stats);
+
+        stats.VendorSn.Should().Be("BBBB2222");
+    }
+
+    [Fact]
+    public void ApplyResponses_StripsAsciiSuffixOnlyWhenTerminal()
+    {
+        var stats = new OntStats();
+        // "(ASCII)" appears mid-value, so it must be preserved.
+        var sn = """{cur_sn:"AB(ASCII)CD"}""";
+
+        ZyxelGponSfpOntProvider.ApplyResponses(sn, GponInfoBody, stats);
+
+        stats.VendorSn.Should().Be("AB(ASCII)CD");
+    }
+
+    // --- Parser cases --------------------------------------------------------
+
+    [Fact]
+    public void TryParseObjectLiteral_SnKeyNotMatchedInsideCurSn()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral(SnBody, out var fields).Should().BeTrue();
+
+        fields.Should().ContainKey("cur_sn");
+        fields.Should().ContainKey("sn");
+        fields["cur_sn"].Should().Be("TW00ABCD1234(ASCII)");
+        fields["sn"].Should().Be("TW00ABCD1234(ASCII)");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_KeyLikeStringInsideValueIsNotAKey()
+    {
+        // A value that itself looks like "key:value" must stay a single value.
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{note:"sn:should_not_be_key",rx_power:"-17.17"}""", out var fields)
+            .Should().BeTrue();
+
+        fields["note"].Should().Be("sn:should_not_be_key");
+        fields.Should().NotContainKey("should_not_be_key");
+        fields["rx_power"].Should().Be("-17.17");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_WhitespaceAfterColon()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{sn:    "value"}""", out var fields).Should().BeTrue();
+
+        fields["sn"].Should().Be("value");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_LeadingWhitespaceAndBom()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("﻿  \n {a:1}", out var fields).Should().BeTrue();
+
+        fields["a"].Should().Be("1");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_QuotedKeys()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{"line_status":"5","rx_power":"-17.17"}""", out var fields)
+            .Should().BeTrue();
+
+        fields["line_status"].Should().Be("5");
+        fields["rx_power"].Should().Be("-17.17");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_SingleQuotedValues()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{a:'hello',b:'wo,rld'}""", out var fields).Should().BeTrue();
+
+        fields["a"].Should().Be("hello");
+        fields["b"].Should().Be("wo,rld");
+    }
+
+    [Theory]
+    [InlineData("""{v:-17.17}""", "-17.17")]
+    [InlineData("""{v:3.30}""", "3.30")]
+    [InlineData("""{v:1e3}""", "1e3")]
+    [InlineData("""{v:0}""", "0")]
+    public void TryParseObjectLiteral_BareNumbers(string body, string expected)
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral(body, out var fields).Should().BeTrue();
+
+        fields["v"].Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("-Infinity")]
+    public void ApplyResponses_NonFiniteNumbers_RejectedAsNull(string value)
+    {
+        var stats = new OntStats();
+        var gpon = $$"""{line_status:"5",rx_power:{{value}}}""";
+
+        var ok = ZyxelGponSfpOntProvider.ApplyResponses(null, gpon, stats);
+
+        ok.Should().BeTrue(); // line_status keeps it a recognized response
+        stats.RxPowerDbm.Should().BeNull();
+    }
+
+    [Fact]
+    public void ApplyResponses_ExponentAndNegativeNumbersParse()
+    {
+        var stats = new OntStats();
+
+        ZyxelGponSfpOntProvider.ApplyResponses(null, """{line_status:"5",rx_power:-1.5e1,tx_power:2}""", stats);
+
+        stats.RxPowerDbm.Should().BeApproximately(-15.0, 0.0001);
+        stats.TxPowerDbm.Should().BeApproximately(2.0, 0.0001);
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_ValuesWithCommasColonsAndEscapes()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral(
+            """{a:"x,y:z",b:"quote\"here",c:"back\\slash"}""", out var fields).Should().BeTrue();
+
+        fields["a"].Should().Be("x,y:z");
+        fields["b"].Should().Be("quote\"here");
+        fields["c"].Should().Be("back\\slash");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_TrailingComma()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{a:1,b:2,}""", out var fields).Should().BeTrue();
+
+        fields["a"].Should().Be("1");
+        fields["b"].Should().Be("2");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_EmptyObject()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("{}", out var fields).Should().BeTrue();
+
+        fields.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_UnknownFieldsAndNullAndBool()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{x:null,y:true,z:false}""", out var fields).Should().BeTrue();
+
+        fields["x"].Should().Be("null");
+        fields["y"].Should().Be("true");
+        fields["z"].Should().Be("false");
+    }
+
+    [Fact]
+    public void TryParseObjectLiteral_DuplicateKeysLastWins()
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral("""{a:1,a:2,a:3}""", out var fields).Should().BeTrue();
+
+        fields["a"].Should().Be("3");
+    }
+
+    [Theory]
+    [InlineData("""{a 1}""")]          // missing colon
+    [InlineData("""{a:"unterminated}""")] // unterminated quote
+    [InlineData("""{a:1""")]            // missing closing brace
+    [InlineData("""{a:1}extra""")]      // trailing content
+    [InlineData("not an object")]      // no opening brace
+    [InlineData("")]                    // empty
+    public void TryParseObjectLiteral_MalformedInput_ReturnsFalse(string body)
+    {
+        ZyxelGponSfpOntProvider.TryParseObjectLiteral(body, out var fields).Should().BeFalse();
+        fields.Should().BeEmpty();
+    }
+
+    // --- Client / auth -------------------------------------------------------
+
+    [Fact]
+    public void CreateClient_SetsPreemptiveBasicAuthFromContext()
+    {
+        var context = new OntPollContext
+        {
+            Id = 1,
+            Name = "Zyxel",
+            Host = "10.10.1.1",
+            Username = "user",
+            Password = "secret",
+        };
+
+        using var client = ZyxelGponSfpOntProvider.CreateClient(context);
+
+        client.DefaultRequestHeaders.Authorization.Should().NotBeNull();
+        client.DefaultRequestHeaders.Authorization!.Scheme.Should().Be("Basic");
+        Encoding.UTF8.GetString(Convert.FromBase64String(client.DefaultRequestHeaders.Authorization.Parameter!))
+            .Should().Be("user:secret");
+        client.Timeout.Should().Be(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public void CreateClient_DefaultsToAdmin1234WhenBlank()
+    {
+        var context = new OntPollContext
+        {
+            Id = 1,
+            Name = "Zyxel",
+            Host = "10.10.1.1",
+            Username = "",
+            Password = "",
+        };
+
+        using var client = ZyxelGponSfpOntProvider.CreateClient(context);
+
+        Encoding.UTF8.GetString(Convert.FromBase64String(client.DefaultRequestHeaders.Authorization!.Parameter!))
+            .Should().Be("admin:1234");
+    }
+}


### PR DESCRIPTION
## What

Adds a read-only ONT telemetry provider for the Zyxel PMG3000 GPON-SFP stick (a MaxLinear/T&W-based GPON SFP module), following the existing `IOntProvider` strategy pattern.
It surfaces optics and link state for GPON FTTH setups that terminate the fiber in an SFP stick rather than a standalone ONT.

## How it works

The stick speaks plain HTTP with HTTP Basic auth (default `admin`/`1234`) and two data-bearing CGI endpoints:

- `GET /cgi/get_gpon_info` (required): `line_status`, `rx_power`, `tx_power`, `temp`, `voltage`, `current`
- `GET /cgi/get_sn` (best-effort identity): serial number

Both responses are JavaScript object literals, not strict JSON (unquoted keys, whitespace after colons, mixed value types, a terminal `(ASCII)` suffix inside string values), so they are decoded by a small provider-local lenient tokenizer rather than `System.Text.Json`.
No new dependency is added.

Mapping onto `OntStats`: `line_status` to `PonLinkStatus`/`LinkState`/`OperationalStatus`, plus `RxPowerDbm`, `TxPowerDbm`, `TemperatureC`, `VoltageV`, and `BiasMa`. `DeviceModel`/`PonType`/`VendorName` are seeded since the device does not report them.

## Notes / design choices

- `get_gpon_info` is treated as the required telemetry endpoint; `get_sn` is best-effort, so a slow or failing serial request never discards valid optical telemetry.
- `up_fec`/`down_fec` are FEC *enablement* flags, not error counts, so they are deliberately not mapped to `OntStats.FecErrors`.
- `line_status` is matched as an exact ITU ordinal (`1`-`7`); any unexpected value resolves to `Unknown` rather than being misread as a healthy link.
- Response bodies are never logged, because `get_sn` includes a `cur_pass` field.
- `PollAsync`/`TestConnectionAsync` return null / a typed failure message on transport, HTTP, timeout, and parse failures, and distinguish auth failure (401), access denied (403), timeout, and unreachable.
- Settings: the Add/Edit ONT form now suggests a provider-specific default host (mirroring the existing default-port behavior) instead of the same generic placeholder for every provider. Only the field's auto-filled value is replaced on provider change; a value the user typed is never clobbered.

I first tried the existing Realtek provider on this stick as it also covers some T&W modules, but it does not fit: the device uses HTTP Basic auth (not the Realtek cookie/form login) and none of the Realtek endpoints exist on it (`/status_pon.asp`, `/boaform/admin/formLogin` return 404).

## Testing

- Fixture-driven unit tests against a captured response from a live PMG3000 (serial and password scrubbed), covering the happy path, missing/malformed `get_sn`, the required-field gate, malformed/HTML/empty `get_gpon_info`, the full `line_status` ordinal range, serial `(ASCII)` handling, and the tokenizer edge cases (quoted vs bare values, escapes, commas/colons in values, duplicate keys, non-finite numbers, malformed input).
- Verified end to end against a live stick (Test Connection returns the expected Rx power and O5 link state).
- Full solution build and test suite green.

## Provider wiring (the usual 4 touch points)

- `ZyxelGponSfpOntProvider.cs` (new) + `ZyxelGponSfpOntProviderTests.cs` (new)
- `Program.cs` DI registration
- `Settings.razor` dropdown option, label map, and the host-suggestion helper
