### PR TITLE
ISP Health: P90 jitter scoring and a caveat for off-path transit scores

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -363,9 +363,9 @@ else
                                 <div class="isp-hop-stats">
                                     <span class="isp-target-stat"><span class="isp-target-stat-label">RTT</span>@FormatRtt(target.RttMs)</span>
                                     <span class="isp-target-stat">
-                                        <span class="isp-target-stat-label">P95 Jitter</span>
+                                        <span class="isp-target-stat-label">P90 Jitter</span>
                                         <span class="isp-target-stat-value">
-                                            @FormatJitter(target.P95JitterMs)
+                                            @FormatJitter(target.ScoredJitterMs)
                                             @if (target.JitterAssimilated)
                                             {
                                                 <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(target)">i</span>
@@ -515,9 +515,9 @@ else
                                     <div class="isp-asn-stat"><span class="detail-label">Mean RTT</span><span class="detail-value">@FormatRtt(asn.MeanRttMs)</span></div>
                                 }
                                 <div class="isp-asn-stat">
-                                    <span class="detail-label">P95 Jitter</span>
+                                    <span class="detail-label">P90 Jitter</span>
                                     <span class="detail-value">
-                                        @FormatJitter(asn.P95JitterMs)
+                                        @FormatJitter(asn.ScoredJitterMs)
                                         @if (asn.JitterAssimilated)
                                         {
                                             <span class="tooltip-icon tooltip-icon-sm isp-jitter-tip" data-tooltip="@JitterAssimilationTooltip(asn, isIspAsn)">i</span>
@@ -1400,11 +1400,11 @@ else
     private static string FormatJitter(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 
     private static string JitterAssimilationTooltip(IspAsnHealth asn, bool isIsp) => isIsp
-        ? $"Showing {FormatJitter(asn.P95JitterMs)} from the cleanest network beyond your ISP, not your ISP routers' {FormatJitter(asn.RawJitterMs)}. All traffic crosses the ISP to reach it, so the ISP is no jitterier - its higher reading is likely ICMP deprioritization."
-        : $"Showing {FormatJitter(asn.P95JitterMs)} from a router deeper in this network, not the {FormatJitter(asn.RawJitterMs)} a closer router reported. Traffic passes through the closer router to reach it, so the lower value is the true path jitter - the closer router just deprioritizes ICMP.";
+        ? $"Showing {FormatJitter(asn.ScoredJitterMs)} from the cleanest network beyond your ISP, not your ISP routers' {FormatJitter(asn.RawJitterMs)}. All traffic crosses the ISP to reach it, so the ISP is no jitterier - its higher reading is likely ICMP deprioritization."
+        : $"Showing {FormatJitter(asn.ScoredJitterMs)} from a router deeper in this network, not the {FormatJitter(asn.RawJitterMs)} a closer router reported. Traffic passes through the closer router to reach it, so the lower value is the true path jitter - the closer router just deprioritizes ICMP.";
 
     private static string JitterAssimilationTooltip(IspTargetHealth target) =>
-        $"Showing {FormatJitter(target.P95JitterMs)} measured to a network reached through this router, not its own {FormatJitter(target.RawJitterMs)}. Traffic passes through it cleanly, so the higher reading is this router deprioritizing ICMP, not real jitter.";
+        $"Showing {FormatJitter(target.ScoredJitterMs)} measured to a network reached through this router, not its own {FormatJitter(target.RawJitterMs)}. Traffic passes through it cleanly, so the higher reading is this router deprioritizing ICMP, not real jitter.";
 
     private static string FormatRtt(double? ms) => ms.HasValue ? $"{ms.Value:0.00} ms" : "--";
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -450,7 +450,7 @@ else
                                 <div class="isp-factor-bar-track">
                                     <div class="isp-factor-bar @BarClass(factor.Score)" style="width: @(factor.Score ?? 0)%"></div>
                                 </div>
-                                <span class="isp-factor-score @ScoreTextClass(factor.Score)">@(factor.Score?.ToString() ?? "--")</span>
+                                <span class="isp-factor-score @(ScoreTextClass(factor.Score) + CaveatClass(factor.LowReachScoreCaveat))" data-tooltip="@factor.LowReachScoreCaveat">@(factor.Score?.ToString() ?? "--")</span>
                             </div>
                             @if (!string.IsNullOrEmpty(factor.Description)
                                  && !(factor.Name == "Physical Link" && r.PhysicalLinkCandidates.Count > 1))
@@ -503,7 +503,7 @@ else
                                     </div>
                                     <div class="isp-asn-sub">@(isIspAsn ? "ISP network" : asn.AsnNumber < 0 ? "Direct peering" : "Transit") @(asn.AsnNumber > 0 ? $"· AS{asn.AsnNumber}" : "")</div>
                                 </div>
-                                <span class="isp-asn-grade @ScoreTextClass(asn.OverallScore)">@(asn.OverallScore?.ToString() ?? "--")</span>
+                                <span class="isp-asn-grade @(ScoreTextClass(asn.OverallScore) + CaveatClass(asn.LowReachScoreCaveat))" data-tooltip="@asn.LowReachScoreCaveat">@(asn.OverallScore?.ToString() ?? "--")</span>
                             </div>
                             <div class="isp-asn-stats">
                                 @if (showRange)
@@ -1428,6 +1428,9 @@ else
         >= 60 => "isp-score-fair",
         _ => "isp-score-poor"
     };
+
+    // Appended to a score's class list (with a leading space) when it carries a caveat tooltip.
+    private static string CaveatClass(string? caveat) => caveat != null ? " isp-score-caveat" : "";
 
     private static string BarClass(int? score) => score switch
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -146,7 +146,7 @@ public class IspAsnHealth
     /// attribution and zero forward-path reach; null otherwise.</summary>
     public string? LowReachScoreCaveat => AsnNumber > 0 && ShowInvolvement && InvolvementReach == 0
         && OverallScore is int s && s < 80
-        ? "Nothing you monitor routes through this network on the forward path, so a low score here may just be its routers deprioritizing ICMP rather than real path trouble - it's shown because it may carry your return path or a failover route."
+        ? "Lightly weighted - nothing we are monitoring routes through this network, so a low score is likely just ICMP deprioritization."
         : null;
 
     public int? LatencyStabilityScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -146,7 +146,7 @@ public class IspAsnHealth
     /// attribution and zero forward-path reach; null otherwise.</summary>
     public string? LowReachScoreCaveat => AsnNumber > 0 && ShowInvolvement && InvolvementReach == 0
         && OverallScore is int s && s < 80
-        ? "Lightly weighted - nothing we are monitoring routes through this network, so a low score is likely just ICMP deprioritization."
+        ? "Lightly weighted - nothing we are monitoring routes through this network; a low score is likely just ICMP deprioritization."
         : null;
 
     public int? LatencyStabilityScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -61,6 +61,10 @@ public class IspScoreFactor
     /// shows the fraction icon only when this is set.
     /// </summary>
     public string? InvolvementTooltip { get; init; }
+
+    /// <summary>For a reach-0 transit ASN scoring below 80: the score-text caveat about ICMP
+    /// deprioritization, copied from <see cref="IspAsnHealth.LowReachScoreCaveat"/>. Null otherwise.</summary>
+    public string? LowReachScoreCaveat { get; init; }
 }
 
 /// <summary>One of the three top-level score dimensions.</summary>
@@ -135,6 +139,15 @@ public class IspAsnHealth
         : InvolvementReach > 0
             ? $"Carries {InvolvementReach} of {InvolvementHostTotal} internet targets (forward path), {w * 100:0}% weight"
             : $"Off the forward path; held at {w * 100:0}% (likely the return path from popular services)";
+
+    /// <summary>Caveat for the score TEXT of a reach-0 transit ASN scoring below 80: nothing monitored
+    /// routes through it on the forward path, so a depressed score may be ICMP deprioritization at its
+    /// routers rather than real path trouble. Only for real transit ASNs (AsnNumber &gt; 0) with known
+    /// attribution and zero forward-path reach; null otherwise.</summary>
+    public string? LowReachScoreCaveat => AsnNumber > 0 && ShowInvolvement && InvolvementReach == 0
+        && OverallScore is int s && s < 80
+        ? "Nothing you monitor routes through this network on the forward path, so a low score here may just be its routers deprioritizing ICMP rather than real path trouble - it's shown because it may carry your return path or a failover route."
+        : null;
 
     public int? LatencyStabilityScore { get; init; }
     public int? JitterScore { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -96,7 +96,7 @@ public class IspAsnHealth
 
     public double? P95RttMs { get; init; }
     public double? MedianJitterMs { get; init; }
-    public double? P95JitterMs { get; init; }
+    public double? ScoredJitterMs { get; init; }
 
     /// <summary>True when the displayed jitter was assimilated from elsewhere (a cleaner
     /// farther cluster for transit, or the cleanest transit ASN for the ISP) rather than
@@ -157,10 +157,10 @@ public class IspTargetHealth
     /// <summary>Displayed RTT: winsorized mean over the window.</summary>
     public double? RttMs { get; init; }
 
-    /// <summary>Effective (absolved) P95 jitter this hop is graded on.</summary>
-    public double? P95JitterMs { get; init; }
+    /// <summary>Effective (absolved) jitter this hop is graded on.</summary>
+    public double? ScoredJitterMs { get; init; }
 
-    /// <summary>This hop's own measured P95 jitter, before any absolve.</summary>
+    /// <summary>This hop's own measured jitter, before any absolve.</summary>
     public double? RawJitterMs { get; init; }
 
     /// <summary>True when a cleaner witness (transit/sibling/destination) pulled this hop's jitter below its own reading.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -564,6 +564,15 @@ public class IspHealthOptions
     /// <summary>Weight of jitter in the per-ASN quality blend.</summary>
     public double AsnJitterWeight { get; set; } = 0.25;
 
+    /// <summary>
+    /// Percentile of a series' effective jitter used as its scored/displayed jitter and for the
+    /// path jitter floor, the absolve/witness comparisons, and the ISP/transit cap. P90 rather than
+    /// P95 so a link's harshest 5-10% of samples don't dominate the quality arm - intermittent bursts
+    /// are already caught by the separate congestion detector, so the quality arm reads the typical
+    /// tail, not the extreme. Scoring is floor-relative, so numerator and floor both use this value.
+    /// </summary>
+    public double AsnJitterScoringPercentile { get; set; } = 0.90;
+
     /// <summary>Weight of packet loss in the per-ASN quality blend.</summary>
     public double AsnLossWeight { get; set; } = 0.2;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -959,7 +959,7 @@ public class IspHealthScorer
             // The effective jitter: absolve-only across clusters (transit) or the ISP-wide
             // bound (ISP). This is what the card shows and what the ISP cap reads, so the
             // displayed value reflects the assimilation rather than the raw near hop.
-            P95JitterMs = effectiveJitter,
+            ScoredJitterMs = effectiveJitter,
             RttMadMs = mad,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             ReachDeltaMs = reachDelta,
@@ -975,7 +975,7 @@ public class IspHealthScorer
         };
     }
 
-    /// <summary>The path jitter floor: the lowest scoring (P95) jitter across all ISP hops
+    /// <summary>The path jitter floor: the lowest scoring (P90) jitter across all ISP hops
     /// and transit clusters. Null when no series carries jitter.</summary>
     private double? ComputeJitterFloor(IspHealthInputs inputs)
     {
@@ -995,15 +995,18 @@ public class IspHealthScorer
     }
 
     /// <summary>
-    /// The jitter statistic used for scoring, the ISP/transit cap, and the cards: P95 of
-    /// the effective jitter. P95 (not median) because the tail is what the cards show and
-    /// what users reason about, and what hurts real-time traffic. The ISP and transit
-    /// jitter shown and scored are the same value. Null when none reported jitter.
+    /// The jitter statistic used for scoring, the ISP/transit cap, and the cards: the
+    /// <see cref="IspHealthOptions.AsnJitterScoringPercentile"/> (P90) of the effective jitter.
+    /// A tail percentile - not the median - because the tail is what the cards show, what users
+    /// reason about, and what hurts real-time traffic; P90 rather than P95 so a link's harshest
+    /// few percent of samples don't dominate the quality arm (intermittent bursts are caught by
+    /// the separate congestion detector). The ISP and transit jitter shown and scored are the same
+    /// value. Null when none reported jitter.
     /// </summary>
-    private static double? ScoringJitterOf(IReadOnlyList<LatencySample> samples)
+    private double? ScoringJitterOf(IReadOnlyList<LatencySample> samples)
     {
         var js = samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        return js.Count > 0 ? SeriesStats.Percentile(js, 0.95) : null;
+        return js.Count > 0 ? SeriesStats.Percentile(js, _options.AsnJitterScoringPercentile) : null;
     }
 
     /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
@@ -1105,8 +1108,8 @@ public class IspHealthScorer
                 .ToList()
             : new List<(List<string> AncestorIps, double Jitter)>();
         var transitWitnesses = baseGrades
-            .Where(b => b.Grade.P95JitterMs.HasValue)
-            .Select(b => (b.Series.AsnNumber, b.Series.AncestorIps, Jitter: b.Grade.P95JitterMs!.Value))
+            .Where(b => b.Grade.ScoredJitterMs.HasValue)
+            .Select(b => (b.Series.AsnNumber, b.Series.AncestorIps, Jitter: b.Grade.ScoredJitterMs!.Value))
             .ToList();
 
         var grades = new List<IspAsnHealth>();
@@ -1173,7 +1176,7 @@ public class IspHealthScorer
     /// jitter/loss/stability/reach basis as a real transit ASN, and the grades are AVERAGED - the series are
     /// never pooled. Pooling samples across targets at different RTT baselines (a flat ~2 ms peer beside a
     /// flat ~6 ms peer) manufactures cross-target variance that craters the stability sub-score, and lets a
-    /// single target's jitter tail dominate the pooled P95; per-peer grading keeps each target coherent and
+    /// single target's jitter tail dominate the pooled P90; per-peer grading keeps each target coherent and
     /// lets one degraded destination count only 1/N. Distance stays low (peered), so each reach ceiling
     /// barely bites and the grade is driven by jitter and loss. A proximity absolution then buys back a
     /// fraction of the jitter penalty when peering delivers the internet far closer than the transit
@@ -1194,8 +1197,8 @@ public class IspHealthScorer
         foreach (var p in perPeer)
         {
             _logger?.LogDebug(
-                "ISP Health: IX Peering member {Name} -> {Overall} (stability {Stab}, jitter {Jit} @ P95 {P95j} ms, loss {Loss} @ {LossPct}%, reach ceiling {Reach})",
-                p.AsnName, p.OverallScore, p.LatencyStabilityScore, p.JitterScore, FormatMsOrNull(p.P95JitterMs),
+                "ISP Health: IX Peering member {Name} -> {Overall} (stability {Stab}, jitter {Jit} @ P{Pct} {Pj} ms, loss {Loss} @ {LossPct}%, reach ceiling {Reach})",
+                p.AsnName, p.OverallScore, p.LatencyStabilityScore, p.JitterScore, (int)Math.Round(_options.AsnJitterScoringPercentile * 100), FormatMsOrNull(p.ScoredJitterMs),
                 p.LossScore, p.LossPct?.ToString("0.###", CultureInfo.InvariantCulture) ?? "n/a", p.ReachLatencyScore);
         }
 
@@ -1246,7 +1249,7 @@ public class IspHealthScorer
             MeanRttMs = meanRtt,
             P95RttMs = AvgOf(p => p.P95RttMs),
             MedianJitterMs = AvgOf(p => p.MedianJitterMs),
-            P95JitterMs = AvgOf(p => p.P95JitterMs),
+            ScoredJitterMs = AvgOf(p => p.ScoredJitterMs),
             LossPct = AvgOf(p => p.LossPct),
             ReachDeltaMs = AvgOf(p => p.ReachDeltaMs),
             RawJitterMs = AvgOf(p => p.RawJitterMs),
@@ -1275,9 +1278,9 @@ public class IspHealthScorer
     {
         // Transit witnesses: each transit ASN's ancestor IPs + its effective jitter.
         var transitJitterByAsn = transitAsns
-            .Where(a => a.P95JitterMs.HasValue)
+            .Where(a => a.ScoredJitterMs.HasValue)
             .GroupBy(a => a.AsnNumber)
-            .ToDictionary(g => g.Key, g => g.Min(a => a.P95JitterMs!.Value));
+            .ToDictionary(g => g.Key, g => g.Min(a => a.ScoredJitterMs!.Value));
         var transitWitnesses = transitSeries
             .Where(s => transitJitterByAsn.ContainsKey(s.AsnNumber))
             .Select(s => (Ancestors: s.AncestorIps, Jitter: transitJitterByAsn[s.AsnNumber]))
@@ -1341,7 +1344,7 @@ public class IspHealthScorer
                 _logger?.LogDebug(
                     "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
                     hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore,
-                    FormatMsOrNull(measured), FormatMsOrNull(grade.P95JitterMs), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
+                    FormatMsOrNull(measured), FormatMsOrNull(grade.ScoredJitterMs), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
         }
@@ -1390,10 +1393,10 @@ public class IspHealthScorer
                     && (e.TargetIds.Count == 0 || e.TargetIds.Any(t => targetSet.Contains(t))))
                 .ToList();
             var means = hops.Select(h => h.MeanRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
-            // Each hop's P95JitterMs is its per-hop effective (absolved) jitter; RawJitterMs
+            // Each hop's ScoredJitterMs is its per-hop effective (absolved) jitter; RawJitterMs
             // is its own measured reading. The card shows the mean effective and flags
             // assimilation when that fell below the mean measured.
-            var effJitters = hops.Select(h => h.P95JitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
+            var effJitters = hops.Select(h => h.ScoredJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
             var rawJitters = hops.Select(h => h.RawJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
             double? effMean = effJitters.Count > 0 ? effJitters.Average() : null;
             double? rawMean = rawJitters.Count > 0 ? rawJitters.Average() : null;
@@ -1410,7 +1413,7 @@ public class IspHealthScorer
                 // RTT range across the ISP hops, on the same winsorized mean the hops display.
                 MinRttMs = means.Count > 0 ? means.Min() : null,
                 MaxRttMs = means.Count > 0 ? means.Max() : null,
-                P95JitterMs = effMean,
+                ScoredJitterMs = effMean,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
                 CongestionEventCount = asnEvents.Count,
@@ -1435,8 +1438,8 @@ public class IspHealthScorer
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
         var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
         // Jitter comes from the grade (the effective/absolved value the hop is scored on), so
-        // the row matches the grade beside it. Fall back to the hop's own raw P95 when ungraded.
-        var rawP95 = jitters.Count > 0 ? SeriesStats.Percentile(jitters, 0.95) : null;
+        // the row matches the grade beside it. Fall back to the hop's own raw jitter percentile when ungraded.
+        var rawScored = jitters.Count > 0 ? SeriesStats.Percentile(jitters, _options.AsnJitterScoringPercentile) : null;
         var isGraded = targetId == firstHopTargetId;
         var notTraced = notTracedTargetIds.Contains(targetId);
         return new IspTargetHealth
@@ -1444,8 +1447,8 @@ public class IspHealthScorer
             TargetId = targetId,
             Name = series.AsnName ?? targetId,
             RttMs = SeriesStats.WinsorizedMean(rtts, winsorPercentile),
-            P95JitterMs = grade?.P95JitterMs ?? rawP95,
-            RawJitterMs = grade?.RawJitterMs ?? rawP95,
+            ScoredJitterMs = grade?.ScoredJitterMs ?? rawScored,
+            RawJitterMs = grade?.RawJitterMs ?? rawScored,
             JitterAssimilated = grade?.JitterAssimilated ?? false,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             OverallScore = grade?.OverallScore,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1527,7 +1527,8 @@ public class IspHealthScorer
             Description = a.CongestionEventCount > 0
                 ? $"{a.CongestionEventCount} congestion event{(a.CongestionEventCount == 1 ? "" : "s")} in the window."
                 : null,
-            InvolvementTooltip = a.InvolvementTooltip
+            InvolvementTooltip = a.InvolvementTooltip,
+            LowReachScoreCaveat = a.LowReachScoreCaveat
         }).ToList();
 
         var scored = asns.Where(a => a.OverallScore.HasValue).ToList();

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -519,8 +519,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// True when this site's console is reached through its agent tunnel and that tunnel
     /// isn't up yet - a transient "waiting for the agent" state, not a misconfiguration.
     /// The UI should prompt to wait/refresh rather than steering to connection setup.
+    /// Requires a configured, credentialed console: awaiting-agent is meaningless without a
+    /// saved target, so a half-configured site falls through to the "set up in Settings" banner
+    /// instead of showing the wait/refresh one (which would tell you to open Settings while only
+    /// offering Refresh).
     /// </summary>
-    public bool IsAwaitingAgent => _awaitingAgent && !_isConnected;
+    public bool IsAwaitingAgent =>
+        _awaitingAgent && !_isConnected && _settings is { IsConfigured: true, HasCredentials: true };
     public DateTime? LastConnectedAt => _lastConnectedAt;
     public bool IsUniFiOs => _client?.IsUniFiOs ?? false;
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -16804,6 +16804,14 @@ a.isp-health-hero-speed:hover {
     font-size: 0.9rem;
     font-weight: 700;
     text-align: right;
+    cursor: default;
+}
+
+.isp-factor-score.isp-score-caveat,
+.isp-asn-grade.isp-score-caveat {
+    cursor: help;
+    text-decoration: underline dotted;
+    text-underline-offset: 3px;
 }
 
 .isp-factor-description {
@@ -16901,6 +16909,7 @@ a.isp-health-hero-speed:hover {
 .isp-asn-grade {
     font-size: 1.3rem;
     font-weight: 700;
+    cursor: default;
 }
 
 .isp-asn-stats {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -820,7 +820,7 @@ public class IspHealthScorerTests
 
         withJitteryTransit.IspAsnDimension.Score.Should().Be(noTransit.IspAsnDimension.Score,
             "a jittery transit ASN must not raise the ISP jitter (cap is min, not max)");
-        withJitteryTransit.IspAsns.Single().P95JitterMs.Should().BeApproximately(0.3, 0.05,
+        withJitteryTransit.IspAsns.Single().ScoredJitterMs.Should().BeApproximately(0.3, 0.05,
             "the displayed ISP jitter stays at the ISP mean when transit is not cleaner");
     }
 
@@ -1005,7 +1005,7 @@ public class IspHealthScorerTests
         graded.JitterScore.Should().BeGreaterThan(ungraded.JitterScore!.Value,
             "the clean farther cluster disproves the near hop's false jitter");
         graded.JitterScore.Should().BeGreaterThan(85);
-        graded.P95JitterMs.Should().BeApproximately(0.4, 0.1,
+        graded.ScoredJitterMs.Should().BeApproximately(0.4, 0.1,
             "the displayed jitter is the absolved value, not the near hop's 4 ms");
         graded.JitterAssimilated.Should().BeTrue("the farther cluster pulled the jitter down");
         graded.RawJitterMs.Should().BeApproximately(4.0, 0.1, "the raw near reading is kept for the tooltip");

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/JitterPercentileReplayTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/JitterPercentileReplayTests.cs
@@ -1,0 +1,99 @@
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Isolates the jitter-scoring lever (P95 -> P90 -> P50) over real exported latency data, to see
+/// where a lower percentile's relief lands. Reuses <see cref="RealDataReplayTests.LoadSeries"/> and
+/// the exact floor-relative jitter curve from IspHealthScorer.ScoreJitterVsFloor. Per target it
+/// reports the raw jitter percentile and the resulting 0-100 jitter sub-score; the path jitter floor
+/// tracks the chosen percentile (as ComputeJitterFloor does in production), so numerator and floor
+/// move together. Gated on ISP_HEALTH_REPLAY_DIR - a no-op in CI and on other machines.
+/// </summary>
+public class JitterPercentileReplayTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public JitterPercentileReplayTests(ITestOutputHelper output) => _output = output;
+
+    private static string? ReplayDir => Environment.GetEnvironmentVariable("ISP_HEALTH_REPLAY_DIR");
+
+    // Neutral (no per-tech band) floor-relative jitter curve, verbatim from IspHealthScorer.ScoreJitterVsFloor.
+    private static readonly IspHealthOptions Opt = new();
+
+    private static double JitterScore(double jitterMs, double floorMs)
+    {
+        var f = Math.Clamp(floorMs, Opt.JitterFloorMinMs, Opt.JitterFloorMaxMs);
+        return ScoreCurve.Interpolate(jitterMs,
+            (f, 100), (1.25 * f, 96), (1.5 * f, 91), (2.0 * f, 70), (5.0, 22), (12.0, 0));
+    }
+
+    // Matches SeriesStats.Percentile (linear, rank = p*(n-1)); inlined so the test needs no internals.
+    private static double Percentile(IReadOnlyList<double> sortedAsc, double p)
+    {
+        var rank = p * (sortedAsc.Count - 1);
+        int lo = (int)Math.Floor(rank), hi = (int)Math.Ceiling(rank);
+        return lo == hi ? sortedAsc[lo] : sortedAsc[lo] + (sortedAsc[hi] - sortedAsc[lo]) * (rank - lo);
+    }
+
+    private static string Band(double score) =>
+        score >= 90 ? "Excellent" : score >= 75 ? "Good" : score >= 60 ? "Fair" : "Poor";
+
+    private static string Signed(double d) => (d >= 0 ? "+" : "-") + Math.Abs(d).ToString("0.0");
+
+    [Fact]
+    public void Replay_jitter_percentile_comparison()
+    {
+        if (ReplayDir == null) return;
+        foreach (var file in Directory.GetFiles(ReplayDir, "*.csv", SearchOption.AllDirectories).OrderBy(f => f))
+        {
+            var header = File.ReadLines(file).FirstOrDefault(l => l.Contains("_time") && l.Contains("target_id"));
+            if (header == null || !header.Contains("jitter_ms")) continue; // only pivoted exports carry jitter
+
+            var series = RealDataReplayTests.LoadSeries(file);
+            var targets = series
+                .Select(s => (s.AsnName, Jit: s.Samples
+                    .Select(x => x.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value)
+                    .OrderBy(v => v).ToList()))
+                .Where(t => t.Jit.Count >= 20)
+                .Select(t => (t.AsnName, t.Jit, P50: Percentile(t.Jit, 0.50), P90: Percentile(t.Jit, 0.90), P95: Percentile(t.Jit, 0.95)))
+                .ToList();
+            if (targets.Count == 0) continue;
+
+            // Floor tracks the percentile, exactly as ComputeJitterFloor -> ScoringJitterOf does.
+            double floor95 = targets.Min(t => t.P95), floor90 = targets.Min(t => t.P90), floor50 = targets.Min(t => t.P50);
+
+            var rows = targets.Select(t => new
+            {
+                t.AsnName, t.Jit.Count, t.P50, t.P90, t.P95,
+                S95 = JitterScore(t.P95, floor95),
+                S90 = JitterScore(t.P90, floor90),
+                S50 = JitterScore(t.P50, floor50)
+            }).OrderByDescending(r => r.S90 - r.S95).ToList();
+
+            _output.WriteLine($"=== {Path.GetFileName(file)}  ({rows.Count} targets w/ jitter) ===");
+            _output.WriteLine($"Path jitter floor:  P95={floor95:0.00}ms  P90={floor90:0.00}ms  P50={floor50:0.00}ms");
+            _output.WriteLine($"{"target",-30} {"n",5} {"P50",6} {"P90",6} {"P95",6} | {"jScore95",8} {"jScore90",8} {"jScore50",8} | {"dP90",6} {"dP50",6}");
+            foreach (var r in rows)
+            {
+                _output.WriteLine(
+                    $"{Trunc(r.AsnName, 30),-30} {r.Count,5} {r.P50,6:0.00} {r.P90,6:0.00} {r.P95,6:0.00} | " +
+                    $"{r.S95,8:0.0} {r.S90,8:0.0} {r.S50,8:0.0} | {Signed(r.S90 - r.S95),6} {Signed(r.S50 - r.S95),6}");
+            }
+
+            int up90 = rows.Count(r => Band(r.S90) != Band(r.S95) && r.S90 > r.S95);
+            int down90 = rows.Count(r => Band(r.S90) != Band(r.S95) && r.S90 < r.S95);
+            int up50 = rows.Count(r => Band(r.S50) != Band(r.S95) && r.S50 > r.S95);
+            int down50 = rows.Count(r => Band(r.S50) != Band(r.S95) && r.S50 < r.S95);
+            _output.WriteLine($"Mean jitter score:  P95={rows.Average(r => r.S95):0.0}  P90={rows.Average(r => r.S90):0.0}  P50={rows.Average(r => r.S50):0.0}");
+            _output.WriteLine($"Band shifts vs P95 (Excellent>=90/Good>=75/Fair>=60/Poor):  P90: +{up90} / -{down90}   P50: +{up50} / -{down50}");
+            _output.WriteLine($"Biggest P90 mover: {rows.First().AsnName} {rows.First().S95:0.0} -> {rows.First().S90:0.0}  (P95 jit {rows.First().P95:0.00} -> P90 {rows.First().P90:0.00} ms)");
+            _output.WriteLine($"Jitter is AsnJitterWeight={Opt.AsnJitterWeight:0.##} of the ASN quality blend, so +D jitter pts => ~+{Opt.AsnJitterWeight:0.##}*D on the grade (below the reach ceiling).");
+            _output.WriteLine("");
+        }
+    }
+
+    private static string Trunc(string? s, int n) => (s ?? "") is { } v && v.Length > n ? v[..n] : s ?? "";
+}


### PR DESCRIPTION
## Monitoring - ISP Health

- **Jitter scored at P90 instead of P95** - The jitter figure that drives ISP and transit scoring (and the **P90 Jitter** stat on each network in the **Networks on Your Path** card) now uses the 90th percentile of a link's jitter rather than the 95th. P95 let a link's harshest 5-10% of samples dominate its jitter grade, which double-penalized short bursts that the congestion detector already accounts for on its own. P90 reads the typical tail instead, so intermittent spikes stop being counted twice, while sustained jitter and the absolute high-jitter thresholds still bite. Applies to ISP hops, transit ASNs, and IX Peering members alike.

- **Caveat tooltip on off-path transit scores** - A transit network that none of your monitored internet targets route through on the forward path is held at the lowest involvement weight (it may still carry your return path or a failover route). When one of those scores below 80, its score text on **Transit Health** and on the **Networks on Your Path** card now shows a tooltip noting the low grade may just be that network's routers deprioritizing ICMP rather than a real path problem. Score values also stop showing the text-select cursor.

- **Congestion events are unchanged** - Congestion is detected and scored on its own separate signal, so it still surfaces and still moves the score exactly as before. Only the standalone jitter quality grade got the percentile change.

## Fixes

- **Half-configured site no longer shows the "Waiting for the site's agent" banner** - A site whose console connection wasn't fully set up could land on the Dashboard's awaiting-agent banner, which offers only a Refresh button while its message tells you to open Settings - a dead end. The awaiting-agent state now requires a configured, credentialed console, so an unconfigured site falls through to the normal "Not Connected / Check Settings" banner that actually links to **UniFi Console Connection** setup.
