### PR TITLE
On-site agent installer: AppArmor-aware LAN speed test, clean uninstall, tidier output

### DIFF
--- a/scripts/agent/install-agent-gateway.sh
+++ b/scripts/agent/install-agent-gateway.sh
@@ -59,19 +59,34 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-err() { echo "Error: $*" >&2; exit 1; }
+# --- Output helpers -----------------------------------------------------------
+# Colorized, structured output; colors collapse to empty when stdout isn't a
+# terminal, so piped/logged output stays clean.
+if [ -t 1 ]; then
+    _b=$'\e[1m'; _dim=$'\e[2m'; _grn=$'\e[32m'; _ylw=$'\e[33m'; _red=$'\e[31m'; _cyn=$'\e[36m'; _rst=$'\e[0m'
+else
+    _b=; _dim=; _grn=; _ylw=; _red=; _cyn=; _rst=
+fi
+_rule="$(printf '\xe2\x94\x80%.0s' {1..52})"   # ── divider between sections
+step() { printf '\n%s%s%s\n%s==>%s %s%s%s\n' "$_dim" "$_rule" "$_rst" "${_cyn}${_b}" "$_rst" "$_b" "$*" "$_rst"; }
+ok()   { printf '  %s\xe2\x9c\x93%s %s\n' "$_grn" "$_rst" "$*"; }
+note() { printf '  %s%s%s\n' "$_dim" "$*" "$_rst"; }
+warn() { printf '  %s\xe2\x9a\xa0%s  %s\n' "$_ylw" "$_rst" "$*"; }
+err()  { printf '%sError:%s %s\n' "${_red}${_b}" "$_rst" "$*" >&2; exit 1; }
 
 [ "$(id -u)" -eq 0 ] || err "Run as root (the gateway's default SSH user is root)."
 command -v systemctl >/dev/null 2>&1 || err "systemd is required (systemctl not found)."
 
 # --- Teardown --------------------------------------------------------------
 if [ "$UNINSTALL" = true ]; then
-    echo "Removing ${SERVICE_NAME} and ${INSTALL_DIR}..."
+    step "Removing the Network Optimizer agent"
+    note "${SERVICE_NAME} + ${INSTALL_DIR}"
     systemctl disable --now "${SERVICE_NAME}.service" 2>/dev/null || true
     rm -f "/etc/systemd/system/${SERVICE_NAME}.service"
     systemctl daemon-reload 2>/dev/null || true
     rm -rf "$INSTALL_DIR"
-    echo "Done - the gateway is back to stock."
+    ok "Removed - the gateway is back to stock."
+    printf '\n'
     exit 0
 fi
 
@@ -96,36 +111,39 @@ esac
 # is already accounted for in MemAvailable).
 MIN_AVAILABLE_MB=256
 if ! systemctl is-active --quiet "${SERVICE_NAME}.service"; then
+    step "Memory pre-flight"
     AVAILABLE_MB="$(awk '/MemAvailable/ {print int($2/1024)}' /proc/meminfo)"
     if [ -z "$AVAILABLE_MB" ]; then
-        echo "Warning: could not read MemAvailable from /proc/meminfo - skipping the memory check." >&2
+        warn "could not read MemAvailable from /proc/meminfo - skipping the memory check."
     elif [ "$AVAILABLE_MB" -lt "$MIN_AVAILABLE_MB" ]; then
         err "only ${AVAILABLE_MB} MB of memory is available; the agent needs ${MIN_AVAILABLE_MB} MB of headroom so it stays well clear of routing/IPS. Free up memory (e.g. remove unused UniFi applications) or run the agent on a separate box (see install-native.sh)."
     else
-        echo "Memory check: ${AVAILABLE_MB} MB available (need ${MIN_AVAILABLE_MB} MB) - OK"
+        ok "${AVAILABLE_MB} MB available (need ${MIN_AVAILABLE_MB} MB)"
     fi
 fi
 
-echo "Installing Network Optimizer agent to ${INSTALL_DIR} (${RID}, monitoring-only)"
+printf '\n%sNetwork Optimizer on-site agent (gateway, monitoring-only)%s\n' "$_b" "$_rst"
+note "Installing to ${INSTALL_DIR}  (${RID})"
 mkdir -p "$INSTALL_DIR"
 
 # Download to a temp name and rename into place: writing over the binary while
 # the agent is running fails with ETXTBSY, but rename swaps the directory entry
 # and the running process keeps its old inode until the restart below.
-echo "Downloading agent binary..."
-curl -fSL "${RELEASE_BASE}/NetworkOptimizer.Agent-${RID}" -o "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
+step "Downloading agent binary"
+curl -fsSL "${RELEASE_BASE}/NetworkOptimizer.Agent-${RID}" -o "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
 chmod +x "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
 mv -f "${INSTALL_DIR}/NetworkOptimizer.Agent.new" "${INSTALL_DIR}/NetworkOptimizer.Agent"
+ok "agent (${RID})"
 
 CONFIG="${INSTALL_DIR}/agent.json"
 
+step "Configuring the agent"
 # Preserve an already-enrolled config so re-running to update the binary never
 # wipes the persisted key.
 if grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
-    echo "Existing enrolled agent config found - keeping it."
+    note "Existing enrollment found - keeping agent.json"
 else
     [ -n "$TOKEN" ] || err "--token is required for a first-time install."
-    echo "Writing ${CONFIG}"
     {
         echo "{"
         echo "  \"serverUrl\": \"${SERVER%/}\","
@@ -135,9 +153,10 @@ else
         echo "}"
     } > "$CONFIG"
     chmod 600 "$CONFIG"
+    ok "Wrote ${CONFIG}"
 fi
 
-echo "Installing ${SERVICE_NAME}.service"
+step "Installing the agent service"
 cat > "/etc/systemd/system/${SERVICE_NAME}.service" <<UNIT
 [Unit]
 Description=Network Optimizer Agent (${SERVICE_NAME})
@@ -163,15 +182,15 @@ WantedBy=multi-user.target
 UNIT
 
 systemctl daemon-reload
-systemctl enable "${SERVICE_NAME}.service"
+systemctl enable --quiet "${SERVICE_NAME}.service"
 # restart (not `enable --now`) so an upgrade re-run moves an already-running
 # agent onto the new binary; it starts a stopped/fresh service just the same
 systemctl restart "${SERVICE_NAME}.service"
+ok "${SERVICE_NAME}.service installed and started"
 
-echo
-echo "Agent started (monitoring-only). It enrolls, then holds a tunnel to ${SERVER%/}."
-echo "Watch it come Online in the web UI, or follow logs:"
-echo "  journalctl -u ${SERVICE_NAME} -f"
-echo
-echo "Remove it again with:"
-echo "  bash <(curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/agent/install-agent-gateway.sh) --uninstall"
+step "Done"
+ok "Agent installed and running (monitoring-only)"
+note "It enrolls, then holds a tunnel to ${SERVER%/} - watch it come Online in the web UI."
+note "Logs:   journalctl -u ${SERVICE_NAME} -f"
+note "Remove: bash <(curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/agent/install-agent-gateway.sh) --uninstall"
+printf '\n'

--- a/scripts/agent/install-docker.sh
+++ b/scripts/agent/install-docker.sh
@@ -37,7 +37,20 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-err() { echo "Error: $*" >&2; exit 1; }
+# --- Output helpers -----------------------------------------------------------
+# Colorized, structured output; colors collapse to empty when stdout isn't a
+# terminal, so piped/logged output stays clean.
+if [ -t 1 ]; then
+    _b=$'\e[1m'; _dim=$'\e[2m'; _grn=$'\e[32m'; _ylw=$'\e[33m'; _red=$'\e[31m'; _cyn=$'\e[36m'; _rst=$'\e[0m'
+else
+    _b=; _dim=; _grn=; _ylw=; _red=; _cyn=; _rst=
+fi
+_rule="$(printf '\xe2\x94\x80%.0s' {1..52})"   # ── divider between sections
+step() { printf '\n%s%s%s\n%s==>%s %s%s%s\n' "$_dim" "$_rule" "$_rst" "${_cyn}${_b}" "$_rst" "$_b" "$*" "$_rst"; }
+ok()   { printf '  %s\xe2\x9c\x93%s %s\n' "$_grn" "$_rst" "$*"; }
+note() { printf '  %s%s%s\n' "$_dim" "$*" "$_rst"; }
+warn() { printf '  %s\xe2\x9a\xa0%s  %s\n' "$_ylw" "$_rst" "$*"; }
+err()  { printf '%sError:%s %s\n' "${_red}${_b}" "$_rst" "$*" >&2; exit 1; }
 
 [ -n "$SERVER" ] || err "--server is required (the central server's HTTPS address)"
 case "$SERVER" in
@@ -61,21 +74,23 @@ if [ "$(id -u)" -ne 0 ]; then
     SUDO="sudo"
 fi
 
-echo "Installing Network Optimizer agent to ${INSTALL_DIR}"
+printf '\n%sNetwork Optimizer on-site agent (Docker)%s\n' "$_b" "$_rst"
+note "Installing to ${INSTALL_DIR}"
 $SUDO mkdir -p "${INSTALL_DIR}/data"
 
-# Compose template
+step "Fetching the compose template"
 $SUDO curl -fsSL "$COMPOSE_URL" -o "${INSTALL_DIR}/docker-compose.yml"
+ok "docker-compose.yml"
 
 CONFIG="${INSTALL_DIR}/data/agent.json"
 
+step "Configuring the agent"
 # Preserve an already-enrolled config so re-running the installer (e.g. to
 # update the image) never wipes the persisted agent key.
 if $SUDO grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
-    echo "Existing enrolled agent config found - keeping it."
+    note "Existing enrollment found - keeping agent.json"
 else
     [ -n "$TOKEN" ] || err "--token is required for a first-time install"
-    echo "Writing ${CONFIG}"
     TMP_CONFIG="$(mktemp)"
     {
         echo "{"
@@ -90,13 +105,16 @@ else
     } > "$TMP_CONFIG"
     $SUDO cp "$TMP_CONFIG" "$CONFIG"
     rm -f "$TMP_CONFIG"
+    ok "Wrote ${CONFIG}"
 fi
 
-echo "Starting agent..."
+step "Starting the agent"
 $SUDO $COMPOSE -f "${INSTALL_DIR}/docker-compose.yml" pull
 $SUDO $COMPOSE -f "${INSTALL_DIR}/docker-compose.yml" up -d
+ok "container up"
 
-echo
-echo "Agent started. It enrolls, then holds a tunnel to ${SERVER%/}."
-echo "Watch it come Online in the web UI, or follow logs:"
-echo "  ${SUDO} docker logs -f network-optimizer-agent"
+step "Done"
+ok "Agent started"
+note "It enrolls, then holds a tunnel to ${SERVER%/} - watch it come Online in the web UI."
+note "Logs: ${SUDO} docker logs -f network-optimizer-agent"
+printf '\n'

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -93,7 +93,7 @@ _aa_nginx_profile_file() {
     local pname fname dir cand file=""
     pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
     fname="$(_aa_profile_filename "$pname")"
-    for dir in /etc/apparmor.d /var/lib/snapd/apparmor/profiles; do
+    for dir in /etc/apparmor.d /usr/share/apparmor.d /var/lib/snapd/apparmor/profiles; do
         [ -d "$dir" ] || continue
         if [ -f "$dir/$fname" ]; then
             cand="$dir/$fname"
@@ -119,9 +119,13 @@ maybe_fix_apparmor_nginx() {
     local file base
     file="$(_aa_nginx_profile_file)"
     case "$file" in
-        /etc/apparmor.d/*) ;;
-        # Not file-backed under /etc/apparmor.d (non-standard or snap profile): a
-        # local/ override wouldn't be consumed. Leave it to the hint below.
+        # Vendor profiles under these dirs use the standard local/ include base
+        # (/etc/apparmor.d/local), so an override there applies. The override file
+        # always lives under /etc/apparmor.d/local regardless of where the profile
+        # itself ships; we reload the profile source wherever it was found.
+        /etc/apparmor.d/*|/usr/share/apparmor.d/*) ;;
+        # Snap or otherwise non-standard profile won't consume /etc/apparmor.d/local:
+        # a local override wouldn't apply. Leave it to the hint below.
         *) return 0 ;;
     esac
     base="$(basename "$file")"
@@ -148,29 +152,19 @@ maybe_fix_apparmor_nginx() {
 }
 
 # Actionable manual remediation, printed only when the speed test nginx still fails
-# because of an AppArmor denial (so it never nags on unrelated failures). Names the
-# real profile and picks the applicable fix: a local override when the profile is a
-# standard /etc/apparmor.d file, otherwise complain mode.
+# because of an AppArmor denial (so it never nags on unrelated failures). By the time
+# this prints, the automatic local-override fix has already been tried or wasn't
+# possible, so complain mode - which works regardless of how the profile is shipped -
+# is the reliable recommendation. Names the real profile.
 print_speedtest_apparmor_hint() {
     _aa_denied_install_dir || return 0
-    local pname file base
+    local pname
     pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
-    file="$(_aa_nginx_profile_file)"
-    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}."
-    case "$file" in
-        /etc/apparmor.d/*)
-            base="$(basename "$file")"
-            echo "  Fix - add a local override, then reload the profile:"
-            echo "    printf '%s\n%s\n' '${INSTALL_DIR}/ r,' '${INSTALL_DIR}/** rw,' | sudo tee /etc/apparmor.d/local/${base}"
-            echo "    sudo apparmor_parser -r ${file}"
-            echo "  Or relax it (logs but allows): sudo aa-complain '${pname}'"
-            ;;
-        *)
-            echo "  Its profile isn't a standard file under /etc/apparmor.d, so relax it (logs but allows):"
-            echo "    sudo aa-complain '${pname}'"
-            ;;
-    esac
-    echo "  Then: sudo systemctl start netopt-speedtest-nginx"
+    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}, and an additive"
+    echo "  local override didn't clear it (the profile likely has no local/ include hook)."
+    echo "  Relax it (logs but still allows), then start the service:"
+    echo "    sudo aa-complain '${pname}'"
+    echo "    sudo systemctl start ${SPEEDTEST_SERVICE}"
 }
 
 # Remove any AppArmor local override this installer added (marker-guarded, so a

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -19,12 +19,8 @@
 #   --dir PATH       Install directory (default: /opt/netopt-agent)
 #   --uninstall      Stop and remove the agent, its services, install dir, and any
 #                    AppArmor override this installer added, then exit
-#   --configure-apparmor  Only relevant with --lan-speed-test: the speed test is
-#                    served by nginx, and if the host's nginx AppArmor profile
-#                    blocks the speed test dir, this adds a persistent, scoped local
-#                    override (off by default - the installer won't modify host
-#                    security policy unless asked). Nothing else uses nginx; core
-#                    monitoring never touches it.
+#   --configure-apparmor  With --lan-speed-test: add a persistent AppArmor exception
+#                    if the host's nginx profile blocks the speed test (off by default)
 
 set -euo pipefail
 

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -177,19 +177,17 @@ print_speedtest_apparmor_hint() {
     _aa_denied_install_dir || return 0
     local pname
     pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
-    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}, and a scoped"
-    echo "  local override didn't clear it (no findable profile source / local hook)."
-    echo "  To serve the speed test, relax the nginx profile, then start the service:"
+    echo "  AppArmor profile '${pname}' denies nginx access to ${INSTALL_DIR}, and a scoped"
+    echo "  local override couldn't be applied (no findable profile source / local hook)."
+    echo "  The agent and monitoring are unaffected - this gates only the optional speed test page."
+    echo "  To enable it, grant that profile persistent access to ${INSTALL_DIR} (must survive a reboot):"
     if command -v aa-complain >/dev/null 2>&1; then
-        # Cleaner (complain mode: keeps the profile, just logs) - when apparmor-utils
-        # is present. Needs a profile source file, which appliance distros may lack.
+        # aa-complain edits the profile and reloads it, so the change persists.
         echo "    sudo aa-complain '${pname}'"
     else
-        # Tool-free and source-free: works by profile name on any confined box.
-        echo "    echo -n '${pname}' | sudo tee /sys/kernel/security/apparmor/.remove   # unload, until reboot"
+        echo "    add a persistent exception to that profile per your host's AppArmor policy"
     fi
     echo "    sudo systemctl start ${SPEEDTEST_SERVICE}"
-    echo "  The agent and monitoring work regardless - only the LAN speed test needs this."
 }
 
 # Remove any AppArmor local override this installer added (marker-guarded, so a

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -19,10 +19,12 @@
 #   --dir PATH       Install directory (default: /opt/netopt-agent)
 #   --uninstall      Stop and remove the agent, its services, install dir, and any
 #                    AppArmor override this installer added, then exit
-#   --configure-apparmor  If the host's nginx AppArmor profile blocks the speed
-#                    test dir, add a persistent, scoped local override (off by
-#                    default - the installer won't modify host security policy
-#                    unless asked)
+#   --configure-apparmor  Only relevant with --lan-speed-test: the speed test is
+#                    served by nginx, and if the host's nginx AppArmor profile
+#                    blocks the speed test dir, this adds a persistent, scoped local
+#                    override (off by default - the installer won't modify host
+#                    security policy unless asked). Nothing else uses nginx; core
+#                    monitoring never touches it.
 
 set -euo pipefail
 

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -480,7 +480,7 @@ UNIT
         else
             warn "nginx config test failed - the LAN speed test page won't serve."
             print_speedtest_apparmor_hint
-            note "Diagnose: $NGINX_BIN -t -c ${INSTALL_DIR}/nginx-speedtest.conf"
+            note "Diagnose: sudo $NGINX_BIN -t -c ${INSTALL_DIR}/nginx-speedtest.conf"
         fi
     fi
 fi

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -98,7 +98,9 @@ _aa_nginx_profile_file() {
         if [ -f "$dir/$fname" ]; then
             cand="$dir/$fname"
         else
-            cand="$(grep -rslF "$pname" "$dir" 2>/dev/null | grep -v '/local/' | head -1 || true)"
+            # Exclude local/ (include-only) and cache/ (compiled binaries, not loadable
+            # profile sources - matching one leads to a bogus apparmor_parser reload).
+            cand="$(grep -rslF "$pname" "$dir" 2>/dev/null | grep -vE '/(local|cache)/' | head -1 || true)"
         fi
         [ -n "$cand" ] && { file="$cand"; break; }
     done
@@ -146,7 +148,9 @@ maybe_fix_apparmor_nginx() {
         echo "$AA_MARK_END"
     } >> "$localfile"
 
-    apparmor_parser -r "$file" >/dev/null 2>&1 \
+    # -T skips the compiled cache, so a read-only cache dir (common on appliance
+    # distros) doesn't fail the reload; the profile still loads from source.
+    apparmor_parser -rT "$file" >/dev/null 2>&1 \
         || echo "  apparmor_parser reload failed; the override may not have taken (the profile may not include local/${base})."
     return 0
 }

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -19,6 +19,10 @@
 #   --dir PATH       Install directory (default: /opt/netopt-agent)
 #   --uninstall      Stop and remove the agent, its services, install dir, and any
 #                    AppArmor override this installer added, then exit
+#   --configure-apparmor  If the host's nginx AppArmor profile blocks the speed
+#                    test dir, add a persistent, scoped local override (off by
+#                    default - the installer won't modify host security policy
+#                    unless asked)
 
 set -euo pipefail
 
@@ -27,6 +31,7 @@ TOKEN=""
 LAN_SPEED_TEST=false
 INSECURE=false
 UNINSTALL=false
+CONFIGURE_APPARMOR=false
 INSTALL_DIR="/opt/netopt-agent"
 SERVICE_NAME="netopt-agent"
 SPEEDTEST_SERVICE="netopt-speedtest-nginx"
@@ -39,6 +44,7 @@ while [ $# -gt 0 ]; do
         --lan-speed-test) LAN_SPEED_TEST=true; shift ;;
         --insecure) INSECURE=true; shift ;;
         --uninstall) UNINSTALL=true; shift ;;
+        --configure-apparmor) CONFIGURE_APPARMOR=true; shift ;;
         --dir) INSTALL_DIR="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
@@ -122,12 +128,14 @@ _aa_nginx_profile_file() {
 }
 
 # Additive, local-only AppArmor override letting the confined nginx use the install
-# dir. Only attempted when the vendor profile is a file under /etc/apparmor.d (the
-# only place a local/ drop-in is consumed). Never edits the vendor profile; reloads
-# only that one profile. A parse error makes apparmor_parser abort and keep the
-# running profile, so a bad override can't unconfine the host's own nginx. Caller
-# re-tests `nginx -t` to judge the result.
+# dir. OPT-IN: only runs under --configure-apparmor, so the installer never modifies
+# host security policy unless explicitly asked. The override is scoped and persistent
+# (a file under /etc/apparmor.d/local); never edits the vendor profile; reloads only
+# that one profile. A parse error makes apparmor_parser abort and keep the running
+# profile, so a bad override can't unconfine the host's own nginx. Caller re-tests
+# `nginx -t` to judge the result.
 maybe_fix_apparmor_nginx() {
+    [ "$CONFIGURE_APPARMOR" = true ] || return 0
     command -v apparmor_parser >/dev/null 2>&1 || return 0
     _aa_denied_install_dir || return 0
 
@@ -177,17 +185,17 @@ print_speedtest_apparmor_hint() {
     _aa_denied_install_dir || return 0
     local pname
     pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
-    echo "  AppArmor profile '${pname}' denies nginx access to ${INSTALL_DIR}, and a scoped"
-    echo "  local override couldn't be applied (no findable profile source / local hook)."
+    echo "  AppArmor profile '${pname}' denies nginx access to ${INSTALL_DIR}."
     echo "  The agent and monitoring are unaffected - this gates only the optional speed test page."
-    echo "  To enable it, grant that profile persistent access to ${INSTALL_DIR} (must survive a reboot):"
-    if command -v aa-complain >/dev/null 2>&1; then
-        # aa-complain edits the profile and reloads it, so the change persists.
-        echo "    sudo aa-complain '${pname}'"
+    if [ "$CONFIGURE_APPARMOR" != true ]; then
+        echo "  To have the installer add a persistent, scoped AppArmor exception, re-run the"
+        echo "  install command with  --configure-apparmor  added."
     else
-        echo "    add a persistent exception to that profile per your host's AppArmor policy"
+        echo "  A scoped exception couldn't be applied here: this host's nginx profile has no"
+        echo "  source file or local/ include hook to attach one to. Enabling the speed test"
+        echo "  needs a persistent change to that profile by your admin, or serving it from a"
+        echo "  host whose nginx isn't AppArmor-confined."
     fi
-    echo "    sudo systemctl start ${SPEEDTEST_SERVICE}"
 }
 
 # Remove any AppArmor local override this installer added (marker-guarded, so a

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -44,7 +44,20 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-err() { echo "Error: $*" >&2; exit 1; }
+# --- Output helpers -----------------------------------------------------------
+# Colorized, structured output; colors collapse to empty when stdout isn't a
+# terminal (piped/redirected/logged), so captured output stays clean.
+if [ -t 1 ]; then
+    _b=$'\e[1m'; _dim=$'\e[2m'; _grn=$'\e[32m'; _ylw=$'\e[33m'; _red=$'\e[31m'; _cyn=$'\e[36m'; _rst=$'\e[0m'
+else
+    _b=; _dim=; _grn=; _ylw=; _red=; _cyn=; _rst=
+fi
+_rule="$(printf '\xe2\x94\x80%.0s' {1..52})"   # ── divider between sections
+step() { printf '\n%s%s%s\n%s==>%s %s%s%s\n' "$_dim" "$_rule" "$_rst" "${_cyn}${_b}" "$_rst" "$_b" "$*" "$_rst"; }
+ok()   { printf '  %s\xe2\x9c\x93%s %s\n' "$_grn" "$_rst" "$*"; }
+note() { printf '  %s%s%s\n' "$_dim" "$*" "$_rst"; }
+warn() { printf '  %s\xe2\x9a\xa0%s  %s\n' "$_ylw" "$_rst" "$*"; }
+err()  { printf '%sError:%s %s\n' "${_red}${_b}" "$_rst" "$*" >&2; exit 1; }
 
 # --- LAN speed test nginx: AppArmor remediation -------------------------------
 # Some distros ship an ENFORCING AppArmor profile on the nginx binary that only
@@ -190,7 +203,7 @@ remove_apparmor_override() {
         sed -i "/${AA_MARK_BEGIN}/,/${AA_MARK_END}/d" "$f"
         [ -s "$f" ] || rm -f "$f"   # nothing left but our block -> drop the file
         changed=1
-        echo "  Removed AppArmor override from ${f}."
+        note "Removed AppArmor override from ${f}"
     done
     [ "$changed" = 1 ] && systemctl reload apparmor >/dev/null 2>&1 || true
     AA_OVERRIDE_REMOVED="$changed"
@@ -221,7 +234,8 @@ _webroot_needs_root_worker() {
 # Leaves the host's own nginx untouched; removes only the AppArmor override this
 # installer itself added (if any), reporting accordingly.
 uninstall_agent() {
-    echo "Removing the Network Optimizer agent (${SERVICE_NAME}) and ${INSTALL_DIR}..."
+    step "Removing the Network Optimizer agent"
+    note "${SERVICE_NAME} + ${INSTALL_DIR}"
     # Whether this install ever set up the speed test (and thus borrowed nginx) - so
     # the summary only mentions nginx/AppArmor when they were actually involved.
     local had_speedtest=0
@@ -235,12 +249,13 @@ uninstall_agent() {
     remove_apparmor_override
     rm -rf "$INSTALL_DIR"
     if [ "${AA_OVERRIDE_REMOVED:-0}" = 1 ]; then
-        echo "Done - agent removed, including the AppArmor override it had added. The host's own nginx is untouched."
+        ok "Agent removed, including the AppArmor override it had added. The host's own nginx is untouched."
     elif [ "$had_speedtest" = 1 ]; then
-        echo "Done - agent removed. The host's own nginx is untouched."
+        ok "Agent removed. The host's own nginx is untouched."
     else
-        echo "Done - agent removed."
+        ok "Agent removed."
     fi
+    printf '\n'
 }
 
 [ "$(id -u)" -eq 0 ] || err "Run as root (needed to manage the systemd service): sudo bash install-native.sh ..."
@@ -266,35 +281,37 @@ case "$(uname -m)" in
     *) err "Unsupported architecture: $(uname -m). Build from source (see the agent README)." ;;
 esac
 
-echo "Installing Network Optimizer agent to ${INSTALL_DIR} (${RID})"
+printf '\n%sNetwork Optimizer on-site agent%s\n' "$_b" "$_rst"
+note "Installing to ${INSTALL_DIR}  (${RID})"
 mkdir -p "$INSTALL_DIR"
 
 # Binaries are downloaded to a temp name and renamed into place: writing over a
 # binary while it is running fails with ETXTBSY, but rename swaps the directory
 # entry and any running process keeps its old inode until the restart below.
 
+step "Downloading binaries"
 # Agent binary
-echo "Downloading agent binary..."
-curl -fSL "${RELEASE_BASE}/NetworkOptimizer.Agent-${RID}" -o "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
+curl -fsSL "${RELEASE_BASE}/NetworkOptimizer.Agent-${RID}" -o "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
 chmod +x "${INSTALL_DIR}/NetworkOptimizer.Agent.new"
 mv -f "${INSTALL_DIR}/NetworkOptimizer.Agent.new" "${INSTALL_DIR}/NetworkOptimizer.Agent"
+ok "agent (${RID})"
 
 # uwnspeedtest binary for site-local WAN speed tests; the agent resolves it next
 # to itself (AppContext.BaseDirectory/uwnspeedtest).
-echo "Downloading WAN speed test binary..."
-curl -fSL "${RELEASE_BASE}/uwnspeedtest-${RID}" -o "${INSTALL_DIR}/uwnspeedtest.new"
+curl -fsSL "${RELEASE_BASE}/uwnspeedtest-${RID}" -o "${INSTALL_DIR}/uwnspeedtest.new"
 chmod +x "${INSTALL_DIR}/uwnspeedtest.new"
 mv -f "${INSTALL_DIR}/uwnspeedtest.new" "${INSTALL_DIR}/uwnspeedtest"
+ok "WAN speed test helper"
 
 CONFIG="${INSTALL_DIR}/agent.json"
 
+step "Configuring the agent"
 # Preserve an already-enrolled config so re-running the installer (e.g. to
 # update the binary) never wipes the persisted agent key.
 if grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
-    echo "Existing enrolled agent config found - keeping it."
+    note "Existing enrollment found - keeping agent.json"
 else
     [ -n "$TOKEN" ] || err "--token is required for a first-time install"
-    echo "Writing ${CONFIG}"
     {
         echo "{"
         echo "  \"serverUrl\": \"${SERVER%/}\","
@@ -306,6 +323,7 @@ else
         fi
         printf '\n}\n'
     } > "$CONFIG"
+    ok "Wrote ${CONFIG}"
 fi
 
 # nginx serves the OpenSpeedTest page + the throughput-critical transfer legs
@@ -318,13 +336,13 @@ fi
 # conf.d file and running `systemctl restart nginx` would hijack or bounce that
 # unrelated instance, which is unacceptable. We only borrow the nginx *binary*.
 if [ "$LAN_SPEED_TEST" = true ]; then
-    echo "Setting up a dedicated nginx instance for the LAN speed test..."
+    step "Setting up the LAN speed test (nginx)"
     if ! command -v nginx >/dev/null 2>&1; then
         if command -v apt-get >/dev/null 2>&1; then apt-get update -qq && apt-get install -y -qq nginx
         elif command -v dnf >/dev/null 2>&1; then dnf install -y -q nginx
         elif command -v yum >/dev/null 2>&1; then yum install -y -q nginx
         elif command -v apk >/dev/null 2>&1; then apk add --no-cache nginx
-        else echo "WARNING: could not install nginx automatically - install it and re-run to enable the LAN speed test."; fi
+        else warn "could not install nginx automatically - install it and re-run to enable the LAN speed test."; fi
     fi
 
     NGINX_BIN="$(command -v nginx 2>/dev/null || echo /usr/sbin/nginx)"
@@ -334,7 +352,7 @@ if [ "$LAN_SPEED_TEST" = true ]; then
         WEBROOT="${INSTALL_DIR}/speedtest-web"
         RAW="https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main"
         mkdir -p "$WEBROOT/assets/js"
-        echo "Downloading OpenSpeedTest..."
+        note "Fetching the OpenSpeedTest page"
         TARBALL="$(mktemp)"; TMPX="$(mktemp -d)"
         curl -fsSL "https://github.com/Ozark-Connect/NetworkOptimizer/archive/refs/heads/main.tar.gz" -o "$TARBALL"
         tar -xzf "$TARBALL" -C "$TMPX" --strip-components=3 "NetworkOptimizer-main/src/OpenSpeedTest"
@@ -372,7 +390,7 @@ CFGJS
                 -e 's/^\([[:space:]]*listen[[:space:]][^;]*\) ssl\([^;]*;\)/\1\2/' \
                 -e '/^[[:space:]]*ssl_/d' \
                 "${INSTALL_DIR}/nginx-speedtest-server.conf"
-            echo "AGENT_SPEEDTEST_TLS=0 - LAN speed test will serve plain http on port 3000."
+            note "AGENT_SPEEDTEST_TLS=0 - serving plain http on port 3000"
         else
             # Persisted self-signed cert for the LAN speed test's TLS listener (secure context
             # for the browser Geolocation API / GPS-tagged results, no per-site reverse proxy).
@@ -389,7 +407,7 @@ CFGJS
                     -keyout "$CERTDIR/key.pem" -out "$CERTDIR/cert.pem" \
                     -subj "/CN=${CN:-agent}" -addext "subjectAltName=$SAN" >/dev/null 2>&1 \
                     && chmod 600 "$CERTDIR/key.pem" \
-                    || echo "WARNING: self-signed cert generation failed - the LAN speed test won't serve over TLS."
+                    || warn "self-signed cert generation failed - the LAN speed test won't serve over TLS."
             fi
             sed -i \
                 -e "s#__CERTFILE__#${CERTDIR}/cert.pem#" \
@@ -410,7 +428,7 @@ CFGJS
         # a world-traversable dir (the /opt default) keeps the safer unprivileged user.
         if _webroot_needs_root_worker "$WEBROOT"; then
             sed -i "1i user root;" "${INSTALL_DIR}/nginx-speedtest.conf"
-            echo "Note: ${INSTALL_DIR} isn't world-traversable, so the speed test nginx runs its workers as root."
+            note "${INSTALL_DIR} isn't world-traversable, so the speed test nginx runs its workers as root"
         fi
 
         # Dedicated systemd unit for OUR nginx master - separate from the system one.
@@ -452,19 +470,19 @@ UNIT
             # Enable now, but START it below, after the agent unit is installed and
             # running - nginx BindsTo the agent, so starting it before the agent exists
             # would immediately stop it again.
-            systemctl enable netopt-speedtest-nginx.service
+            systemctl enable --quiet netopt-speedtest-nginx.service
             START_SPEEDTEST_NGINX=1
-            echo "Dedicated nginx for OpenSpeedTest on port 3000 will start with the agent (netopt-speedtest-nginx.service)."
+            ok "LAN speed test ready on port 3000 (starts with the agent)"
         else
-            echo "WARNING: nginx config test failed - the LAN speed test page won't serve."
+            warn "nginx config test failed - the LAN speed test page won't serve."
             print_speedtest_apparmor_hint
-            echo "Diagnose with: $NGINX_BIN -t -c ${INSTALL_DIR}/nginx-speedtest.conf"
+            note "Diagnose: $NGINX_BIN -t -c ${INSTALL_DIR}/nginx-speedtest.conf"
         fi
     fi
 fi
 
 # systemd unit
-echo "Installing ${SERVICE_NAME}.service"
+step "Installing the agent service"
 cat > "/etc/systemd/system/${SERVICE_NAME}.service" <<UNIT
 [Unit]
 Description=Network Optimizer Agent (${SERVICE_NAME})
@@ -483,10 +501,11 @@ WantedBy=multi-user.target
 UNIT
 
 systemctl daemon-reload
-systemctl enable "${SERVICE_NAME}.service"
+systemctl enable --quiet "${SERVICE_NAME}.service"
 # restart (not `enable --now`) so an upgrade re-run moves an already-running
 # agent onto the new binary; it starts a stopped/fresh service just the same
 systemctl restart "${SERVICE_NAME}.service"
+ok "${SERVICE_NAME}.service installed and started"
 
 # nginx is bound to the agent (BindsTo), so it was stopped by the agent restart
 # (or was never started - starting it before the agent exists would immediately
@@ -496,7 +515,8 @@ if [ "${START_SPEEDTEST_NGINX:-0}" = 1 ] || systemctl is-enabled --quiet netopt-
     systemctl start netopt-speedtest-nginx.service
 fi
 
-echo
-echo "Agent started. It enrolls, then holds a tunnel to ${SERVER%/}."
-echo "Watch it come Online in the web UI, or follow logs:"
-echo "  journalctl -u ${SERVICE_NAME} -f"
+step "Done"
+ok "Agent installed and running"
+note "It enrolls, then holds a tunnel to ${SERVER%/} - watch it come Online in the web UI."
+note "Logs: journalctl -u ${SERVICE_NAME} -f"
+printf '\n'

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -17,6 +17,8 @@
 #   --lan-speed-test Host the LAN speed test page (port 3000) and iperf3 (5201)
 #   --insecure       Accept a self-signed cert on the server's reverse proxy
 #   --dir PATH       Install directory (default: /opt/netopt-agent)
+#   --uninstall      Stop and remove the agent, its services, install dir, and any
+#                    AppArmor override this installer added, then exit
 
 set -euo pipefail
 
@@ -24,8 +26,10 @@ SERVER=""
 TOKEN=""
 LAN_SPEED_TEST=false
 INSECURE=false
+UNINSTALL=false
 INSTALL_DIR="/opt/netopt-agent"
 SERVICE_NAME="netopt-agent"
+SPEEDTEST_SERVICE="netopt-speedtest-nginx"
 RELEASE_BASE="https://github.com/Ozark-Connect/NetworkOptimizer/releases/latest/download"
 
 while [ $# -gt 0 ]; do
@@ -34,6 +38,7 @@ while [ $# -gt 0 ]; do
         --token) TOKEN="$2"; shift 2 ;;
         --lan-speed-test) LAN_SPEED_TEST=true; shift ;;
         --insecure) INSECURE=true; shift ;;
+        --uninstall) UNINSTALL=true; shift ;;
         --dir) INSTALL_DIR="$2"; shift 2 ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
@@ -49,6 +54,11 @@ err() { echo "Error: $*" >&2; exit 1; }
 # permissions. Everything below runs ONLY after `nginx -t` has already failed and
 # only acts on a real AppArmor denial of our install dir, so any host where the
 # speed test already works never enters this path.
+
+# Markers bracketing our block inside an AppArmor local override, so it can be added
+# without clobbering a user's existing file and removed cleanly on --uninstall.
+AA_MARK_BEGIN="# NETOPT-AGENT-OVERRIDE BEGIN"
+AA_MARK_END="# NETOPT-AGENT-OVERRIDE END"
 
 # True when the kernel log shows AppArmor denying access to a path under the
 # install dir (recorded when the failing `nginx -t` ran). This is the trigger:
@@ -115,16 +125,22 @@ maybe_fix_apparmor_nginx() {
         *) return 0 ;;
     esac
     base="$(basename "$file")"
+    local localfile="/etc/apparmor.d/local/${base}"
 
-    echo "AppArmor is blocking ${INSTALL_DIR}; adding a local override (/etc/apparmor.d/local/${base}) and reloading."
+    echo "AppArmor is blocking ${INSTALL_DIR}; adding a local override (${localfile}) and reloading."
     mkdir -p /etc/apparmor.d/local
-    cat > "/etc/apparmor.d/local/${base}" <<AAOVERRIDE
-# Added by the Network Optimizer agent installer.
-# Lets the dedicated LAN speed test nginx master use its pid, logs, and webroot
-# under the install dir. Additive and local-only; delete this file to revert.
-${INSTALL_DIR}/ r,
-${INSTALL_DIR}/** rw,
-AAOVERRIDE
+    # Additive and idempotent: strip any prior block of ours (e.g. an earlier install
+    # to a different dir), then append the current one. Never clobbers a user's own
+    # rules in this file.
+    [ -f "$localfile" ] && sed -i "/${AA_MARK_BEGIN}/,/${AA_MARK_END}/d" "$localfile"
+    {
+        echo "$AA_MARK_BEGIN"
+        echo "# Added by the Network Optimizer agent installer - removed by --uninstall."
+        echo "# Lets the LAN speed test nginx master use its pid, logs, and webroot here."
+        echo "${INSTALL_DIR}/ r,"
+        echo "${INSTALL_DIR}/** rw,"
+        echo "$AA_MARK_END"
+    } >> "$localfile"
 
     apparmor_parser -r "$file" >/dev/null 2>&1 \
         || echo "  apparmor_parser reload failed; the override may not have taken (the profile may not include local/${base})."
@@ -157,13 +173,72 @@ print_speedtest_apparmor_hint() {
     echo "  Then: sudo systemctl start netopt-speedtest-nginx"
 }
 
-[ "$(id -u)" -eq 0 ] || err "Run as root (needed to install the systemd service): sudo bash install-native.sh ..."
+# Remove any AppArmor local override this installer added (marker-guarded, so a
+# user's own rules in the same file are preserved), then best-effort reload so the
+# removal takes effect. Called from teardown.
+remove_apparmor_override() {
+    local f changed=0
+    for f in /etc/apparmor.d/local/*; do
+        [ -f "$f" ] || continue
+        grep -q "$AA_MARK_BEGIN" "$f" 2>/dev/null || continue
+        sed -i "/${AA_MARK_BEGIN}/,/${AA_MARK_END}/d" "$f"
+        [ -s "$f" ] || rm -f "$f"   # nothing left but our block -> drop the file
+        changed=1
+        echo "  Removed AppArmor override from ${f}."
+    done
+    [ "$changed" = 1 ] && systemctl reload apparmor >/dev/null 2>&1 || true
+    return 0
+}
+
+# nginx workers drop privileges after start, so an install dir whose ancestors are
+# not world-traversable (e.g. under /root, mode 700) makes them 403 - they can't
+# reach the webroot. True in that case, so the wrapper should run workers as root.
+_webroot_needs_root_worker() {
+    local p mode
+    p="$(readlink -f "$1" 2>/dev/null || echo "$1")"
+    while [ -n "$p" ] && [ "$p" != "/" ]; do
+        mode="$(stat -c '%A' "$p" 2>/dev/null || echo '')"
+        case "$mode" in
+            "") ;;             # stat failed at this level; ignore
+            *x|*t) ;;          # other-execute set (x, or t with the sticky bit as on
+                               # /tmp) -> traversable, keep walking up
+            *) return 0 ;;     # last char '-' or 'T' -> blocks an unprivileged worker
+        esac
+        p="$(dirname "$p")"
+    done
+    return 1
+}
+
+# Stop and remove everything this installer created, in an order that never leaves a
+# running "ghost" unit (services are stopped before their unit files are deleted).
+# Leaves the host's own nginx and its AppArmor profile untouched.
+uninstall_agent() {
+    echo "Removing the Network Optimizer agent (${SERVICE_NAME}) and ${INSTALL_DIR}..."
+    systemctl disable --now "${SERVICE_NAME}.service" "${SPEEDTEST_SERVICE}.service" 2>/dev/null || true
+    rm -f "/etc/systemd/system/${SERVICE_NAME}.service" \
+          "/etc/systemd/system/${SPEEDTEST_SERVICE}.service" \
+          "/etc/systemd/system/multi-user.target.wants/${SERVICE_NAME}.service"
+    systemctl daemon-reload 2>/dev/null || true
+    systemctl reset-failed "${SERVICE_NAME}.service" "${SPEEDTEST_SERVICE}.service" 2>/dev/null || true
+    remove_apparmor_override
+    rm -rf "$INSTALL_DIR"
+    echo "Done - agent removed. The host's own nginx and AppArmor profile are untouched."
+}
+
+[ "$(id -u)" -eq 0 ] || err "Run as root (needed to manage the systemd service): sudo bash install-native.sh ..."
+command -v systemctl >/dev/null 2>&1 || err "systemd is required (systemctl not found)"
+
+# Teardown short-circuits the install: needs neither --server nor a token.
+if [ "$UNINSTALL" = true ]; then
+    uninstall_agent
+    exit 0
+fi
+
 [ -n "$SERVER" ] || err "--server is required (the central server's HTTPS address)"
 case "$SERVER" in
     https://*) ;;
     *) err "--server must be an https:// URL (the agent refuses cleartext)" ;;
 esac
-command -v systemctl >/dev/null 2>&1 || err "systemd is required (systemctl not found)"
 command -v curl >/dev/null 2>&1 || err "curl is required"
 
 # Map machine architecture to the published self-contained runtime identifier.
@@ -310,6 +385,15 @@ CFGJS
             -e "s#__ERRORLOG__#${INSTALL_DIR}/nginx-error.log#" \
             -e "s#__SERVERCONF__#${INSTALL_DIR}/nginx-speedtest-server.conf#" \
             "${INSTALL_DIR}/nginx-speedtest.conf"
+
+        # If the install dir isn't world-traversable (e.g. under /root, mode 700),
+        # unprivileged nginx workers can't reach the webroot and every request 403s.
+        # Run the workers as root in that case so the page serves wherever it lives;
+        # a world-traversable dir (the /opt default) keeps the safer unprivileged user.
+        if _webroot_needs_root_worker "$WEBROOT"; then
+            sed -i "1i user root;" "${INSTALL_DIR}/nginx-speedtest.conf"
+            echo "Note: ${INSTALL_DIR} isn't world-traversable, so the speed test nginx runs its workers as root."
+        fi
 
         # Dedicated systemd unit for OUR nginx master - separate from the system one.
         cat > /etc/systemd/system/netopt-speedtest-nginx.service <<UNIT

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -164,11 +164,19 @@ print_speedtest_apparmor_hint() {
     _aa_denied_install_dir || return 0
     local pname
     pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
-    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}, and an additive"
-    echo "  local override didn't clear it (the profile likely has no local/ include hook)."
-    echo "  Relax it (logs but still allows), then start the service:"
-    echo "    sudo aa-complain '${pname}'"
+    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}, and a scoped"
+    echo "  local override didn't clear it (no findable profile source / local hook)."
+    echo "  To serve the speed test, relax the nginx profile, then start the service:"
+    if command -v aa-complain >/dev/null 2>&1; then
+        # Cleaner (complain mode: keeps the profile, just logs) - when apparmor-utils
+        # is present. Needs a profile source file, which appliance distros may lack.
+        echo "    sudo aa-complain '${pname}'"
+    else
+        # Tool-free and source-free: works by profile name on any confined box.
+        echo "    echo -n '${pname}' | sudo tee /sys/kernel/security/apparmor/.remove   # unload, until reboot"
+    fi
     echo "    sudo systemctl start ${SPEEDTEST_SERVICE}"
+    echo "  The agent and monitoring work regardless - only the LAN speed test needs this."
 }
 
 # Remove any AppArmor local override this installer added (marker-guarded, so a
@@ -185,6 +193,7 @@ remove_apparmor_override() {
         echo "  Removed AppArmor override from ${f}."
     done
     [ "$changed" = 1 ] && systemctl reload apparmor >/dev/null 2>&1 || true
+    AA_OVERRIDE_REMOVED="$changed"
     return 0
 }
 
@@ -209,9 +218,14 @@ _webroot_needs_root_worker() {
 
 # Stop and remove everything this installer created, in an order that never leaves a
 # running "ghost" unit (services are stopped before their unit files are deleted).
-# Leaves the host's own nginx and its AppArmor profile untouched.
+# Leaves the host's own nginx untouched; removes only the AppArmor override this
+# installer itself added (if any), reporting accordingly.
 uninstall_agent() {
     echo "Removing the Network Optimizer agent (${SERVICE_NAME}) and ${INSTALL_DIR}..."
+    # Whether this install ever set up the speed test (and thus borrowed nginx) - so
+    # the summary only mentions nginx/AppArmor when they were actually involved.
+    local had_speedtest=0
+    [ -f "/etc/systemd/system/${SPEEDTEST_SERVICE}.service" ] && had_speedtest=1
     systemctl disable --now "${SERVICE_NAME}.service" "${SPEEDTEST_SERVICE}.service" 2>/dev/null || true
     rm -f "/etc/systemd/system/${SERVICE_NAME}.service" \
           "/etc/systemd/system/${SPEEDTEST_SERVICE}.service" \
@@ -220,7 +234,13 @@ uninstall_agent() {
     systemctl reset-failed "${SERVICE_NAME}.service" "${SPEEDTEST_SERVICE}.service" 2>/dev/null || true
     remove_apparmor_override
     rm -rf "$INSTALL_DIR"
-    echo "Done - agent removed. The host's own nginx and AppArmor profile are untouched."
+    if [ "${AA_OVERRIDE_REMOVED:-0}" = 1 ]; then
+        echo "Done - agent removed, including the AppArmor override it had added. The host's own nginx is untouched."
+    elif [ "$had_speedtest" = 1 ]; then
+        echo "Done - agent removed. The host's own nginx is untouched."
+    else
+        echo "Done - agent removed."
+    fi
 }
 
 [ "$(id -u)" -eq 0 ] || err "Run as root (needed to manage the systemd service): sudo bash install-native.sh ..."

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -59,39 +59,61 @@ _aa_denied_install_dir() {
         | grep -q "apparmor=\"DENIED\".*name=\"${INSTALL_DIR}" 2>/dev/null
 }
 
-# Path of the vendor AppArmor profile file confining nginx, discovered from the
-# denial record's profile name (falling back to the nginx binary path). Empty if
-# it can't be found. Cached after the first lookup.
-AA_NGINX_PROFILE_FILE=""
-_aa_nginx_profile_file() {
-    [ -n "$AA_NGINX_PROFILE_FILE" ] && { printf '%s' "$AA_NGINX_PROFILE_FILE"; return 0; }
-    local kern prof_name file
-    kern="$({ journalctl -k -n 400 --no-pager 2>/dev/null || dmesg 2>/dev/null || true; })"
-    prof_name="$(printf '%s\n' "$kern" \
+# The AppArmor profile NAME confining nginx (e.g. "/usr/bin/nginx"), read from the
+# denial record. Empty if none was logged.
+_aa_nginx_profile_name() {
+    { journalctl -k -n 400 --no-pager 2>/dev/null || dmesg 2>/dev/null || true; } \
         | grep "apparmor=\"DENIED\".*name=\"${INSTALL_DIR}" \
-        | grep -o 'profile="[^"]*"' | head -1 | sed 's/^profile="//; s/"$//' || true)"
-    [ -n "$prof_name" ] || prof_name="$NGINX_BIN"
-    # The .d file that DECLARES the profile (attachment path appears in it); never a
-    # file already under local/, which is the include-only drop-in dir.
-    file="$(grep -rslF "$prof_name" /etc/apparmor.d 2>/dev/null | grep -v '/local/' | head -1 || true)"
+        | grep -o 'profile="[^"]*"' | head -1 | sed 's/^profile="//; s/"$//' || true
+}
+
+# AppArmor's conventional on-disk filename for a profile name: drop the leading
+# '/', turn the remaining '/' into '.' - e.g. /usr/bin/nginx -> usr.bin.nginx.
+_aa_profile_filename() { local n="${1#/}"; printf '%s' "${n//\//.}"; }
+
+# Path of the vendor AppArmor profile file confining nginx: the conventionally-named
+# file first, else a content match, across the standard profile dirs. Empty when the
+# profile isn't file-backed there (e.g. a snap profile) - then a local/ override
+# can't apply and we fall back to the hint. Cached after the first lookup.
+AA_NGINX_PROFILE_FILE=""
+AA_NGINX_PROFILE_FILE_SET=""
+_aa_nginx_profile_file() {
+    [ -n "$AA_NGINX_PROFILE_FILE_SET" ] && { printf '%s' "$AA_NGINX_PROFILE_FILE"; return 0; }
+    AA_NGINX_PROFILE_FILE_SET=1
+    local pname fname dir cand file=""
+    pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
+    fname="$(_aa_profile_filename "$pname")"
+    for dir in /etc/apparmor.d /var/lib/snapd/apparmor/profiles; do
+        [ -d "$dir" ] || continue
+        if [ -f "$dir/$fname" ]; then
+            cand="$dir/$fname"
+        else
+            cand="$(grep -rslF "$pname" "$dir" 2>/dev/null | grep -v '/local/' | head -1 || true)"
+        fi
+        [ -n "$cand" ] && { file="$cand"; break; }
+    done
     AA_NGINX_PROFILE_FILE="$file"
     printf '%s' "$file"
 }
 
 # Additive, local-only AppArmor override letting the confined nginx use the install
-# dir. Never edits the vendor profile; reloads only that one profile. A parse error
-# makes apparmor_parser abort and keep the running profile, so a bad override can't
-# unconfine the host's own nginx. Caller re-tests `nginx -t` to judge the result.
+# dir. Only attempted when the vendor profile is a file under /etc/apparmor.d (the
+# only place a local/ drop-in is consumed). Never edits the vendor profile; reloads
+# only that one profile. A parse error makes apparmor_parser abort and keep the
+# running profile, so a bad override can't unconfine the host's own nginx. Caller
+# re-tests `nginx -t` to judge the result.
 maybe_fix_apparmor_nginx() {
     command -v apparmor_parser >/dev/null 2>&1 || return 0
     _aa_denied_install_dir || return 0
 
     local file base
     file="$(_aa_nginx_profile_file)"
-    if [ -z "$file" ]; then
-        echo "AppArmor is blocking ${INSTALL_DIR}, but its nginx profile file wasn't found under /etc/apparmor.d - see the fix hint below."
-        return 0
-    fi
+    case "$file" in
+        /etc/apparmor.d/*) ;;
+        # Not file-backed under /etc/apparmor.d (non-standard or snap profile): a
+        # local/ override wouldn't be consumed. Leave it to the hint below.
+        *) return 0 ;;
+    esac
     base="$(basename "$file")"
 
     echo "AppArmor is blocking ${INSTALL_DIR}; adding a local override (/etc/apparmor.d/local/${base}) and reloading."
@@ -110,17 +132,29 @@ AAOVERRIDE
 }
 
 # Actionable manual remediation, printed only when the speed test nginx still fails
-# because of an AppArmor denial (so it never nags on unrelated failures).
+# because of an AppArmor denial (so it never nags on unrelated failures). Names the
+# real profile and picks the applicable fix: a local override when the profile is a
+# standard /etc/apparmor.d file, otherwise complain mode.
 print_speedtest_apparmor_hint() {
     _aa_denied_install_dir || return 0
-    local base="usr.sbin.nginx" file
+    local pname file base
+    pname="$(_aa_nginx_profile_name)"; [ -n "$pname" ] || pname="$NGINX_BIN"
     file="$(_aa_nginx_profile_file)"
-    [ -n "$file" ] && base="$(basename "$file")"
-    echo "  Cause: an AppArmor profile on nginx is blocking ${INSTALL_DIR}."
-    echo "  Fix (add a local override, then reload the profile):"
-    echo "    printf '%s\n%s\n' '${INSTALL_DIR}/ r,' '${INSTALL_DIR}/** rw,' | sudo tee /etc/apparmor.d/local/${base}"
-    echo "    sudo apparmor_parser -r /etc/apparmor.d/${base}"
-    echo "  Or set the nginx profile to complain mode: sudo aa-complain ${NGINX_BIN}"
+    echo "  Cause: AppArmor profile '${pname}' is blocking ${INSTALL_DIR}."
+    case "$file" in
+        /etc/apparmor.d/*)
+            base="$(basename "$file")"
+            echo "  Fix - add a local override, then reload the profile:"
+            echo "    printf '%s\n%s\n' '${INSTALL_DIR}/ r,' '${INSTALL_DIR}/** rw,' | sudo tee /etc/apparmor.d/local/${base}"
+            echo "    sudo apparmor_parser -r ${file}"
+            echo "  Or relax it (logs but allows): sudo aa-complain '${pname}'"
+            ;;
+        *)
+            echo "  Its profile isn't a standard file under /etc/apparmor.d, so relax it (logs but allows):"
+            echo "    sudo aa-complain '${pname}'"
+            ;;
+    esac
+    echo "  Then: sudo systemctl start netopt-speedtest-nginx"
 }
 
 [ "$(id -u)" -eq 0 ] || err "Run as root (needed to install the systemd service): sudo bash install-native.sh ..."

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -41,6 +41,88 @@ done
 
 err() { echo "Error: $*" >&2; exit 1; }
 
+# --- LAN speed test nginx: AppArmor remediation -------------------------------
+# Some distros ship an ENFORCING AppArmor profile on the nginx binary that only
+# permits nginx's stock paths (/var/log/nginx, /run/nginx.pid, ...). Our dedicated
+# speed test master keeps its pid, logs, and webroot under the install dir, which
+# such a profile denies even to root - the failure is a MAC denial, not file
+# permissions. Everything below runs ONLY after `nginx -t` has already failed and
+# only acts on a real AppArmor denial of our install dir, so any host where the
+# speed test already works never enters this path.
+
+# True when the kernel log shows AppArmor denying access to a path under the
+# install dir (recorded when the failing `nginx -t` ran). This is the trigger:
+# without an actual denial we leave AppArmor entirely alone.
+_aa_denied_install_dir() {
+    [ -d /sys/kernel/security/apparmor ] || return 1
+    { journalctl -k -n 400 --no-pager 2>/dev/null || dmesg 2>/dev/null || true; } \
+        | grep -q "apparmor=\"DENIED\".*name=\"${INSTALL_DIR}" 2>/dev/null
+}
+
+# Path of the vendor AppArmor profile file confining nginx, discovered from the
+# denial record's profile name (falling back to the nginx binary path). Empty if
+# it can't be found. Cached after the first lookup.
+AA_NGINX_PROFILE_FILE=""
+_aa_nginx_profile_file() {
+    [ -n "$AA_NGINX_PROFILE_FILE" ] && { printf '%s' "$AA_NGINX_PROFILE_FILE"; return 0; }
+    local kern prof_name file
+    kern="$({ journalctl -k -n 400 --no-pager 2>/dev/null || dmesg 2>/dev/null || true; })"
+    prof_name="$(printf '%s\n' "$kern" \
+        | grep "apparmor=\"DENIED\".*name=\"${INSTALL_DIR}" \
+        | grep -o 'profile="[^"]*"' | head -1 | sed 's/^profile="//; s/"$//' || true)"
+    [ -n "$prof_name" ] || prof_name="$NGINX_BIN"
+    # The .d file that DECLARES the profile (attachment path appears in it); never a
+    # file already under local/, which is the include-only drop-in dir.
+    file="$(grep -rslF "$prof_name" /etc/apparmor.d 2>/dev/null | grep -v '/local/' | head -1 || true)"
+    AA_NGINX_PROFILE_FILE="$file"
+    printf '%s' "$file"
+}
+
+# Additive, local-only AppArmor override letting the confined nginx use the install
+# dir. Never edits the vendor profile; reloads only that one profile. A parse error
+# makes apparmor_parser abort and keep the running profile, so a bad override can't
+# unconfine the host's own nginx. Caller re-tests `nginx -t` to judge the result.
+maybe_fix_apparmor_nginx() {
+    command -v apparmor_parser >/dev/null 2>&1 || return 0
+    _aa_denied_install_dir || return 0
+
+    local file base
+    file="$(_aa_nginx_profile_file)"
+    if [ -z "$file" ]; then
+        echo "AppArmor is blocking ${INSTALL_DIR}, but its nginx profile file wasn't found under /etc/apparmor.d - see the fix hint below."
+        return 0
+    fi
+    base="$(basename "$file")"
+
+    echo "AppArmor is blocking ${INSTALL_DIR}; adding a local override (/etc/apparmor.d/local/${base}) and reloading."
+    mkdir -p /etc/apparmor.d/local
+    cat > "/etc/apparmor.d/local/${base}" <<AAOVERRIDE
+# Added by the Network Optimizer agent installer.
+# Lets the dedicated LAN speed test nginx master use its pid, logs, and webroot
+# under the install dir. Additive and local-only; delete this file to revert.
+${INSTALL_DIR}/ r,
+${INSTALL_DIR}/** rw,
+AAOVERRIDE
+
+    apparmor_parser -r "$file" >/dev/null 2>&1 \
+        || echo "  apparmor_parser reload failed; the override may not have taken (the profile may not include local/${base})."
+    return 0
+}
+
+# Actionable manual remediation, printed only when the speed test nginx still fails
+# because of an AppArmor denial (so it never nags on unrelated failures).
+print_speedtest_apparmor_hint() {
+    _aa_denied_install_dir || return 0
+    local base="usr.sbin.nginx" file
+    file="$(_aa_nginx_profile_file)"
+    [ -n "$file" ] && base="$(basename "$file")"
+    echo "  Cause: an AppArmor profile on nginx is blocking ${INSTALL_DIR}."
+    echo "  Fix (add a local override, then reload the profile):"
+    echo "    printf '%s\n%s\n' '${INSTALL_DIR}/ r,' '${INSTALL_DIR}/** rw,' | sudo tee /etc/apparmor.d/local/${base}"
+    echo "    sudo apparmor_parser -r /etc/apparmor.d/${base}"
+    echo "  Or set the nginx profile to complain mode: sudo aa-complain ${NGINX_BIN}"
+}
+
 [ "$(id -u)" -eq 0 ] || err "Run as root (needed to install the systemd service): sudo bash install-native.sh ..."
 [ -n "$SERVER" ] || err "--server is required (the central server's HTTPS address)"
 case "$SERVER" in
@@ -221,6 +303,14 @@ RestartSec=5
 WantedBy=multi-user.target
 UNIT
 
+        # If the first test fails only because an enforcing AppArmor profile denies
+        # our install dir, add a local override and let the re-test below decide. This
+        # is skipped entirely when the test already passes, so working hosts are
+        # untouched.
+        if ! "$NGINX_BIN" -t -c "${INSTALL_DIR}/nginx-speedtest.conf" >/dev/null 2>&1; then
+            maybe_fix_apparmor_nginx
+        fi
+
         if "$NGINX_BIN" -t -c "${INSTALL_DIR}/nginx-speedtest.conf" >/dev/null 2>&1; then
             systemctl daemon-reload
             # Enable now, but START it below, after the agent unit is installed and
@@ -231,6 +321,7 @@ UNIT
             echo "Dedicated nginx for OpenSpeedTest on port 3000 will start with the agent (netopt-speedtest-nginx.service)."
         else
             echo "WARNING: nginx config test failed - the LAN speed test page won't serve."
+            print_speedtest_apparmor_hint
             echo "Diagnose with: $NGINX_BIN -t -c ${INSTALL_DIR}/nginx-speedtest.conf"
         fi
     fi

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -126,6 +126,16 @@ Both scripts accept:
 - `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201)
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
+- `--uninstall` - stop and remove the agent, its services, and install dir, then exit
+
+To remove a bare-metal agent (stops the services first, then removes the units,
+install dir, and any AppArmor override the installer added; the host's own nginx
+is left untouched):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/main/scripts/agent/install-native.sh | sudo bash -s -- --uninstall
+# add --dir PATH if you installed somewhere other than /opt/netopt-agent
+```
 
 ### On a UniFi gateway (on-box)
 

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -123,11 +123,11 @@ Downloads the self-contained binary (no .NET runtime or Docker), writes
 
 Both scripts accept:
 
-- `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201)
+- `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201). This is the **only** thing that uses nginx; core monitoring needs neither nginx nor this flag.
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
 - `--uninstall` - stop and remove the agent, its services, and install dir, then exit
-- `--configure-apparmor` - if the host's nginx AppArmor profile blocks the speed test dir, add a persistent, scoped local override (off by default; the installer won't touch host security policy unless asked). The install output tells you to re-run with this flag when it applies.
+- `--configure-apparmor` - only relevant with `--lan-speed-test`: the speed test is served by nginx, so if the host's nginx AppArmor profile blocks the speed test dir, this adds a persistent, scoped local override (off by default; the installer won't touch host security policy unless asked). The install output tells you to re-run with this flag when it applies.
 
 To remove a bare-metal agent (stops the services first, then removes the units,
 install dir, and any AppArmor override the installer added; the host's own nginx

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -126,6 +126,9 @@ Both scripts accept:
 - `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201). The only feature that uses nginx.
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
+
+The bare-metal installer additionally accepts:
+
 - `--uninstall` - stop and remove the agent, its services, and install dir, then exit
 - `--configure-apparmor` - with `--lan-speed-test`, add a persistent AppArmor exception if the host's nginx profile blocks the speed test (off by default).
 
@@ -479,6 +482,13 @@ them to the central server tagged with the site slug and the client's real IP, s
 they land in the site's own database with no CORS or exposure of the central
 server to browsers. If an `iperf3` binary is on the agent's PATH, an iperf3 server
 (port 5201) runs alongside for wired/CLI throughput tests.
+
+If the host's nginx is confined by AppArmor, it may be denied access to the
+install dir and the page won't serve (the agent and monitoring are unaffected).
+Re-run `install-native.sh` with `--configure-apparmor` to add a persistent,
+scoped exception where the profile supports it; on a host whose profile has no
+source file or `local/` hook, an admin must grant the exception, or run the
+speed-test agent on a host whose nginx isn't AppArmor-confined.
 
 The address the central server hands to site clients for these tests is the
 agent's auto-detected LAN IPv4 (`DetectLocalIpFromInterfaces`). With the default

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -127,6 +127,7 @@ Both scripts accept:
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
 - `--uninstall` - stop and remove the agent, its services, and install dir, then exit
+- `--configure-apparmor` - if the host's nginx AppArmor profile blocks the speed test dir, add a persistent, scoped local override (off by default; the installer won't touch host security policy unless asked). The install output tells you to re-run with this flag when it applies.
 
 To remove a bare-metal agent (stops the services first, then removes the units,
 install dir, and any AppArmor override the installer added; the host's own nginx

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -123,11 +123,11 @@ Downloads the self-contained binary (no .NET runtime or Docker), writes
 
 Both scripts accept:
 
-- `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201). This is the **only** thing that uses nginx; core monitoring needs neither nginx nor this flag.
+- `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201). The only feature that uses nginx.
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
 - `--uninstall` - stop and remove the agent, its services, and install dir, then exit
-- `--configure-apparmor` - only relevant with `--lan-speed-test`: the speed test is served by nginx, so if the host's nginx AppArmor profile blocks the speed test dir, this adds a persistent, scoped local override (off by default; the installer won't touch host security policy unless asked). The install output tells you to re-run with this flag when it applies.
+- `--configure-apparmor` - with `--lan-speed-test`, add a persistent AppArmor exception if the host's nginx profile blocks the speed test (off by default).
 
 To remove a bare-metal agent (stops the services first, then removes the units,
 install dir, and any AppArmor override the installer added; the host's own nginx


### PR DESCRIPTION
Hardening and polish for the on-site agent install scripts (bare metal, Docker, and on-gateway).

## LAN speed test on AppArmor-confined hosts

- The bare-metal installer now detects when an enforcing nginx AppArmor profile denies the speed test directory. It stays non-fatal - the agent and monitoring are unaffected; only the optional LAN speed test page is gated - and reports clearly what's blocking it.
- New opt-in `--configure-apparmor` flag: when set, and the host's profile supports it, the installer adds a persistent, scoped local override so the speed test serves. It's off by default, so an install never modifies host security policy unless asked; the output tells you to re-run with the flag when it applies. On hosts whose profile ships no source file or `local/` hook, it says so plainly and defers to the admin rather than a temporary hack.

## LAN speed test serves from any install dir

- Installing under a directory that isn't world-traversable (e.g. `--dir /root`, mode 700) made nginx's unprivileged workers 403 on every request. The installer now detects that and runs the speed test nginx workers as root only in that case; a world-traversable dir (the `/opt` default) keeps the safer unprivileged worker.

## Clean uninstall

- New `--uninstall` for the bare-metal installer. It stops the services **before** removing their unit files (so nothing is left as a running "ghost" unit), removes the units, install dir, and any AppArmor override the installer itself added, and reports what it touched. The host's own nginx and AppArmor profile are left alone. The Docker and on-gateway installers are unchanged here (Docker tears down with `docker compose down`; the gateway installer already had `--uninstall`).

## Tidier installer output

- All three installers now print structured, colorized output - a title, per-section dividers and headers, success/warning markers, and dim detail lines - and silence the noisy curl progress tables on downloads. Everything collapses to plain text when stdout isn't a terminal, so piped or logged output stays clean.

## Docs

- Agent README: `--uninstall` and `--configure-apparmor` are now correctly scoped as bare-metal-only (the Docker installer has neither), made explicit that nginx is used solely for the LAN speed test, and added a short note on AppArmor-confined hosts.
