### PR TITLE
Add optional DDM optics to custom ONT contract

### DIFF
--- a/docs/features/netopt-custom-pon-contract.md
+++ b/docs/features/netopt-custom-pon-contract.md
@@ -57,6 +57,12 @@ numeric strings; 64-bit counters are expected.
 
 ```json
 {
+  "optics": {               // DDM optics, same units as SFP DDM (fallback - see note below)
+    "rx_power_dbm": -18.4,  // receive optical power, dBm
+    "tx_power_dbm": 2.1,    // transmit optical power, dBm
+    "temperature_c": 47.3,  // transceiver temperature, degrees C
+    "voltage_v": 3.28       // supply voltage, volts
+  },
   "lan": {
     "mode": 15,             // host-side PHY mode (raw device enum, informational)
     "link_status": 5,       // host (module-to-gateway) link state, raw enum
@@ -114,12 +120,6 @@ numeric strings; 64-bit counters are expected.
     "ebp_good": 670798569,  "ebp_discard": 0,
     "learning_discard": 0
   },
-  "optics": {               // DDM optics, same units as SFP DDM (fallback - see note below)
-    "rx_power_dbm": -18.4,  // receive optical power, dBm
-    "tx_power_dbm": 2.1,    // transmit optical power, dBm
-    "temperature_c": 47.3,  // transceiver temperature, degrees C
-    "voltage_v": 3.28       // supply voltage, volts
-  },
   "sfp_uptime_s": 358825    // seconds since the ONT module booted (counter-reset anchor)
 }
 ```
@@ -131,6 +131,8 @@ onto Network Optimizer's existing schema:
 
 | Contract field | Stored as | Notes |
 |---|---|---|
+| `optics.rx_power_dbm` / `tx_power_dbm` | `rx_power_dbm` / `tx_power_dbm` | DDM fallback; gateway SFP DDM wins (see below) |
+| `optics.temperature_c` / `voltage_v` | `temperature_c` / `voltage_v` | DDM fallback; gateway SFP DDM wins (see below) |
 | `ploam.curr_state` | `pon_link_status` | same encoding as the ont measurement: `initial`, `standby`, `serial_number`, `ranging`, `operation`, `popup`, `emergency_stop` |
 | `ploam.previous_state` | `pon_link_status_prev` | same encoding |
 | `ploam.elapsed_msec` | `ploam_elapsed_ms` | |
@@ -148,8 +150,6 @@ onto Network Optimizer's existing schema:
 | `gpe_pon` / `gpe_lan` discards | `gpe_{pon,lan}_{ingress,egress,learning}_discard` | good-frame counters are not stored |
 | `lan.link_status` | `lan_link_status` | |
 | `lan_counters.*` | `lan_tx_frames`, `lan_rx_frames`, `lan_tx_drop_events`, `lan_rx_fcs_err`, `lan_buffer_overflow` | |
-| `optics.rx_power_dbm` / `tx_power_dbm` | `rx_power_dbm` / `tx_power_dbm` | DDM fallback; gateway SFP DDM wins (see below) |
-| `optics.temperature_c` / `voltage_v` | `temperature_c` / `voltage_v` | DDM fallback; gateway SFP DDM wins (see below) |
 | `sfp_uptime_s` | `sfp_uptime_s` | |
 
 Not recorded: `lan.mode`, `lan.phy_duplex` (static config), GEM byte counters

--- a/docs/features/netopt-custom-pon-contract.md
+++ b/docs/features/netopt-custom-pon-contract.md
@@ -16,7 +16,9 @@ Configure it under Settings - ONT Device Monitoring with provider
   polled on the gateway SFP collection cycle instead, with the full metric set
   merged into that module's `sfp` measurement and charted on the SFP Stats tab.
   Use this when the ONT *is* the SFP module in your gateway, so its DDM optics
-  readings and its PON internals form one time series.
+  readings and its PON internals form one time series. The gateway reads DDM off
+  the SFP slot directly; the contract's optional `optics` section only fills DDM
+  the gateway can't read (see [Optics precedence](#optics-precedence)).
 
 ## Endpoint semantics
 
@@ -112,6 +114,12 @@ numeric strings; 64-bit counters are expected.
     "ebp_good": 670798569,  "ebp_discard": 0,
     "learning_discard": 0
   },
+  "optics": {               // DDM optics, same units as SFP DDM (fallback - see note below)
+    "rx_power_dbm": -18.4,  // receive optical power, dBm
+    "tx_power_dbm": 2.1,    // transmit optical power, dBm
+    "temperature_c": 47.3,  // transceiver temperature, degrees C
+    "voltage_v": 3.28       // supply voltage, volts
+  },
   "sfp_uptime_s": 358825    // seconds since the ONT module booted (counter-reset anchor)
 }
 ```
@@ -140,12 +148,29 @@ onto Network Optimizer's existing schema:
 | `gpe_pon` / `gpe_lan` discards | `gpe_{pon,lan}_{ingress,egress,learning}_discard` | good-frame counters are not stored |
 | `lan.link_status` | `lan_link_status` | |
 | `lan_counters.*` | `lan_tx_frames`, `lan_rx_frames`, `lan_tx_drop_events`, `lan_rx_fcs_err`, `lan_buffer_overflow` | |
+| `optics.rx_power_dbm` / `tx_power_dbm` | `rx_power_dbm` / `tx_power_dbm` | DDM fallback; gateway SFP DDM wins (see below) |
+| `optics.temperature_c` / `voltage_v` | `temperature_c` / `voltage_v` | DDM fallback; gateway SFP DDM wins (see below) |
 | `sfp_uptime_s` | `sfp_uptime_s` | |
 
 Not recorded: `lan.mode`, `lan.phy_duplex` (static config), GEM byte counters
 (32-bit wrap), `drop` / `omci_drop` / `rx_oversized_frames`,
 `fec_error_corr` / `fec_words_total` / `fec_seconds`, and the `gpe_*` good-frame
 counters (redundant with `lan_counters` and GEM frame counters).
+
+### Optics precedence
+
+The `optics` section is optional and exists for modules whose DDM the gateway
+cannot read off its SFP slot - many GPON sticks present no usable DDM there. When
+the config is **attached to a monitored SFP module**, the gateway's own DDM
+reading wins field by field: `optics.rx_power_dbm` is written only when the
+gateway slot reports no RX power, and likewise for TX power, temperature, and
+voltage. So supplying `optics` never overrides what the gateway can already see;
+it just fills the gaps. In **standalone** mode there is no gateway DDM to defer
+to, so the `optics` values flow straight to the ONT Stats tab.
+
+DDM alerts continue to run off the gateway's SFP DDM readings only; the
+contract-supplied fallback is charted and displayed but is not yet wired into DDM
+alert thresholds.
 
 ## Reference implementation
 

--- a/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
+++ b/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
@@ -10,6 +10,23 @@ namespace NetworkOptimizer.Core.Models;
 /// </summary>
 public class PonSupplementalStats
 {
+    /// <summary>
+    /// Optional DDM optics readings supplied by the endpoint, in SFP DDM units
+    /// (dBm / degrees C / volts). These are a fallback: when the config is attached
+    /// to a monitored SFP module and the gateway's own DDM poll reads the module,
+    /// the gateway value wins and these fill only the gaps it leaves.
+    /// </summary>
+    public double? RxPowerDbm { get; set; }
+
+    /// <summary>Transmit optical power in dBm. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? TxPowerDbm { get; set; }
+
+    /// <summary>Transceiver temperature in degrees Celsius. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? TemperatureC { get; set; }
+
+    /// <summary>Supply voltage in volts. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? VoltageV { get; set; }
+
     /// <summary>Raw ITU-T PLOAM state number (1-7 = O1-O7) for alert evaluation.</summary>
     public long? PloamStateRaw { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2216,23 +2216,34 @@ public class MonitoringCollectionAgent : BackgroundService
                 : (port.Name ?? string.Empty);
             if (string.IsNullOrEmpty(portName)) continue;
 
+            // Supplemental PON-layer stats from an attached ONT config, if any. Looked
+            // up before the DDM write so the endpoint's optional optics readings can
+            // fill DDM gaps the gateway slot can't read (GPON sticks often expose no
+            // DDM). The gateway's own reading always takes precedence over the
+            // contract-supplied fallback.
+            ponSupplemental.TryGetValue((mac, portName), out var ponStats);
+            var rxDbm = port.SfpRxPower ?? ponStats?.RxPowerDbm;
+            var txDbm = port.SfpTxPower ?? ponStats?.TxPowerDbm;
+            var tempC = port.SfpTemperature ?? ponStats?.TemperatureC;
+            var voltageV = port.SfpVoltage ?? ponStats?.VoltageV;
+
             // Write the DDM values to InfluxDB regardless of whether the user has
             // promoted this SFP to a monitored ONT — having the data is what enables
             // promotion later, and the longterm bucket keeps it cheap.
             _ = _influx.WriteSfpAsync(
                 deviceMac: mac,
                 portName: portName,
-                rxPowerDbm: port.SfpRxPower,
-                txPowerDbm: port.SfpTxPower,
+                rxPowerDbm: rxDbm,
+                txPowerDbm: txDbm,
                 txBiasMa: port.SfpCurrent,
-                temperatureC: port.SfpTemperature,
-                voltageV: port.SfpVoltage,
+                temperatureC: tempC,
+                voltageV: voltageV,
                 sfpLinkSpeedMbps: port.Speed > 0 ? port.Speed : null,
                 timestamp: timestamp);
 
-            // Supplemental PON-layer stats from an attached ONT config merge onto the
-            // same series and timestamp (field union with the DDM point above).
-            if (ponSupplemental.TryGetValue((mac, portName), out var ponStats))
+            // Supplemental PON-layer stats merge onto the same series and timestamp
+            // (field union with the DDM point above).
+            if (ponStats != null)
             {
                 _ = _influx.WriteSfpPonAsync(mac, portName, ponStats, timestamp);
                 // Mirror the key PON values into live stats so the SFP ONT card can show
@@ -2250,11 +2261,11 @@ public class MonitoringCollectionAgent : BackgroundService
             _liveStats.RecordSfp(
                 deviceMac: mac,
                 portName: portName,
-                rxDbm: port.SfpRxPower,
-                txDbm: port.SfpTxPower,
+                rxDbm: rxDbm,
+                txDbm: txDbm,
                 biasMa: port.SfpCurrent,
-                tempC: port.SfpTemperature,
-                voltageV: port.SfpVoltage,
+                tempC: tempC,
+                voltageV: voltageV,
                 timestamp: timestamp);
 
             // Reconcile the relational row so the UI knows the SFP exists and can offer

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -169,10 +169,16 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
     /// Map the contract payload onto the shared PON supplemental DTO. Standard
     /// concepts keep their standard encodings: PLOAM states use the same strings
     /// as the ont measurement's pon_link_status; fec_errors is uncorrectable
-    /// codewords; bip_errors is the raw BIP counter.
+    /// codewords; bip_errors is the raw BIP counter. DDM optics readings are a
+    /// fallback only - the gateway's own SFP DDM poll takes precedence when it can
+    /// read the module (see CollectSfpForDevice).
     /// </summary>
     internal static PonSupplementalStats MapToSupplemental(NetOptCustomPonPayload p) => new()
     {
+        RxPowerDbm = p.Optics?.RxPowerDbm,
+        TxPowerDbm = p.Optics?.TxPowerDbm,
+        TemperatureC = p.Optics?.TemperatureC,
+        VoltageV = p.Optics?.VoltageV,
         PloamStateRaw = p.Ploam?.CurrState,
         PonLinkStatus = EncodePloamState(p.Ploam?.CurrState),
         PonLinkStatusPrev = EncodePloamState(p.Ploam?.PreviousState),
@@ -212,8 +218,9 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
 
     /// <summary>
     /// Standalone mapping: the standard OntStats fields this contract can serve.
-    /// DDM optics readings are absent by design - in the SFP-module scenario the
-    /// gateway's DDM poll owns those.
+    /// DDM optics readings are populated only when the endpoint supplies the
+    /// optional <c>optics</c> section; in the SFP-module (attached) scenario the
+    /// gateway's own DDM poll owns those and takes precedence.
     /// </summary>
     internal static OntStats MapToOntStats(NetOptCustomPonPayload p) => new()
     {
@@ -221,6 +228,10 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
         PonLinkStatus = ToPonLinkState(p.Ploam?.CurrState),
         FecErrors = p.GtcCounters?.FecWordsUncorr,
         BipErrors = p.GtcCounters?.Bip,
+        RxPowerDbm = p.Optics?.RxPowerDbm,
+        TxPowerDbm = p.Optics?.TxPowerDbm,
+        TemperatureC = p.Optics?.TemperatureC,
+        VoltageV = p.Optics?.VoltageV,
     };
 
     /// <summary>Raw PLOAM state number (1-7 = O1-O7) to the shared enum.</summary>
@@ -268,9 +279,38 @@ public class NetOptCustomPonPayload
     [JsonPropertyName("gpe_lan")]
     public GpeBridgePortSection? GpeLan { get; set; }
 
+    [JsonPropertyName("optics")]
+    public OpticsSection? Optics { get; set; }
+
     /// <summary>Seconds since the ONT module booted.</summary>
     [JsonPropertyName("sfp_uptime_s")]
     public long? SfpUptimeS { get; set; }
+
+    /// <summary>
+    /// DDM optics readings, in the same units as SFP DDM (dBm / degrees C / volts).
+    /// Optional - serve these when the module exposes DDM but the gateway cannot
+    /// read it off the SFP slot (common with GPON sticks). When the config is
+    /// attached to a monitored SFP module and the gateway's own DDM poll returns a
+    /// value, that value wins; these are used only to fill the gaps.
+    /// </summary>
+    public class OpticsSection
+    {
+        /// <summary>Receive optical power in dBm.</summary>
+        [JsonPropertyName("rx_power_dbm")]
+        public double? RxPowerDbm { get; set; }
+
+        /// <summary>Transmit optical power in dBm.</summary>
+        [JsonPropertyName("tx_power_dbm")]
+        public double? TxPowerDbm { get; set; }
+
+        /// <summary>Transceiver temperature in degrees Celsius.</summary>
+        [JsonPropertyName("temperature_c")]
+        public double? TemperatureC { get; set; }
+
+        /// <summary>Supply voltage in volts.</summary>
+        [JsonPropertyName("voltage_v")]
+        public double? VoltageV { get; set; }
+    }
 
     public class LanSection
     {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -225,13 +225,13 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
     internal static OntStats MapToOntStats(NetOptCustomPonPayload p) => new()
     {
         Timestamp = DateTime.UtcNow,
-        PonLinkStatus = ToPonLinkState(p.Ploam?.CurrState),
-        FecErrors = p.GtcCounters?.FecWordsUncorr,
-        BipErrors = p.GtcCounters?.Bip,
         RxPowerDbm = p.Optics?.RxPowerDbm,
         TxPowerDbm = p.Optics?.TxPowerDbm,
         TemperatureC = p.Optics?.TemperatureC,
         VoltageV = p.Optics?.VoltageV,
+        PonLinkStatus = ToPonLinkState(p.Ploam?.CurrState),
+        FecErrors = p.GtcCounters?.FecWordsUncorr,
+        BipErrors = p.GtcCounters?.Bip,
     };
 
     /// <summary>Raw PLOAM state number (1-7 = O1-O7) to the shared enum.</summary>
@@ -258,6 +258,9 @@ public class NetOptCustomPonPayload
     [JsonPropertyName("message")]
     public string? Message { get; set; }
 
+    [JsonPropertyName("optics")]
+    public OpticsSection? Optics { get; set; }
+
     [JsonPropertyName("lan")]
     public LanSection? Lan { get; set; }
 
@@ -278,9 +281,6 @@ public class NetOptCustomPonPayload
 
     [JsonPropertyName("gpe_lan")]
     public GpeBridgePortSection? GpeLan { get; set; }
-
-    [JsonPropertyName("optics")]
-    public OpticsSection? Optics { get; set; }
 
     /// <summary>Seconds since the ONT module booted.</summary>
     [JsonPropertyName("sfp_uptime_s")]

--- a/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
@@ -35,6 +35,7 @@ public class NetOptCustomPonOntProviderTests
       },
       "gpe_pon": { "ibp_good": 670798566, "ibp_discard": 4, "ebp_good": 848843235, "ebp_discard": 0, "learning_discard": 0 },
       "gpe_lan": { "ibp_good": 848843244, "ibp_discard": 0, "ebp_good": 670798569, "ebp_discard": 5, "learning_discard": 0 },
+      "optics": { "rx_power_dbm": -18.4, "tx_power_dbm": 2.1, "temperature_c": 47.3, "voltage_v": 3.28 },
       "sfp_uptime_s": 358825
     }
     """;
@@ -54,6 +55,10 @@ public class NetOptCustomPonOntProviderTests
         p.GpePon!.IbpDiscard.Should().Be(4);
         p.GpeLan!.EbpDiscard.Should().Be(5);
         p.LanCounters!.RxFcsErr.Should().Be(3);
+        p.Optics!.RxPowerDbm.Should().Be(-18.4);
+        p.Optics.TxPowerDbm.Should().Be(2.1);
+        p.Optics.TemperatureC.Should().Be(47.3);
+        p.Optics.VoltageV.Should().Be(3.28);
         p.SfpUptimeS.Should().Be(358825);
     }
 
@@ -85,6 +90,12 @@ public class NetOptCustomPonOntProviderTests
         s.OnuResponseTime.Should().Be(34992);
         s.DsFecEnabled.Should().Be(0);
         s.SfpUptimeS.Should().Be(358825);
+
+        // Optional DDM optics carried as a fallback for gaps the gateway can't read.
+        s.RxPowerDbm.Should().Be(-18.4);
+        s.TxPowerDbm.Should().Be(2.1);
+        s.TemperatureC.Should().Be(47.3);
+        s.VoltageV.Should().Be(3.28);
     }
 
     [Fact]
@@ -96,6 +107,10 @@ public class NetOptCustomPonOntProviderTests
         stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
         stats.FecErrors.Should().Be(2);
         stats.BipErrors.Should().Be(7);
+        stats.RxPowerDbm.Should().Be(-18.4);
+        stats.TxPowerDbm.Should().Be(2.1);
+        stats.TemperatureC.Should().Be(47.3);
+        stats.VoltageV.Should().Be(3.28);
     }
 
     [Fact]
@@ -117,12 +132,15 @@ public class NetOptCustomPonOntProviderTests
         p.Should().NotBeNull();
         p!.Ploam.Should().BeNull();
         p.GtcCounters.Should().BeNull();
+        p.Optics.Should().BeNull();
         p.SfpUptimeS.Should().BeNull();
 
         var s = NetOptCustomPonOntProvider.MapToSupplemental(p);
         s.PonLinkStatus.Should().BeNull();
         s.BipErrors.Should().BeNull();
         s.FecErrors.Should().BeNull();
+        s.RxPowerDbm.Should().BeNull();
+        s.VoltageV.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
@@ -11,6 +11,7 @@ public class NetOptCustomPonOntProviderTests
     // through the gateway), trimmed only in counter magnitudes.
     private const string SamplePayload = """
     {
+      "optics": { "rx_power_dbm": -18.4, "tx_power_dbm": 2.1, "temperature_c": 47.3, "voltage_v": 3.28 },
       "lan": { "mode": 15, "link_status": 5, "phy_duplex": 1 },
       "lan_counters": {
         "tx_frames": 671630919, "rx_frames": 850075595,
@@ -35,7 +36,6 @@ public class NetOptCustomPonOntProviderTests
       },
       "gpe_pon": { "ibp_good": 670798566, "ibp_discard": 4, "ebp_good": 848843235, "ebp_discard": 0, "learning_discard": 0 },
       "gpe_lan": { "ibp_good": 848843244, "ibp_discard": 0, "ebp_good": 670798569, "ebp_discard": 5, "learning_discard": 0 },
-      "optics": { "rx_power_dbm": -18.4, "tx_power_dbm": 2.1, "temperature_c": 47.3, "voltage_v": 3.28 },
       "sfp_uptime_s": 358825
     }
     """;


### PR DESCRIPTION
Adds an optional `optics` section to the **Network Optimizer Custom (HTTP JSON)** ONT contract so an endpoint can report DDM optics (RX/TX power, temperature, voltage) for modules whose DDM the gateway can't read off its SFP slot, which is common with GPON sticks.

## Monitoring - SFP Stats

- **Contract `optics` fallback** - `optics.rx_power_dbm`, `tx_power_dbm`, `temperature_c`, and `voltage_v` merge into the module's `sfp` measurement, using the existing SFP DDM field names/units. When a config is attached to a monitored SFP module, the gateway's own DDM reading takes precedence **field by field** - the contract value fills only the gaps the gateway leaves (e.g. a GPON stick that exposes no DDM to the slot). No same-timestamp collision: DDM is written once, through the existing `WriteSfpAsync` path; `WriteSfpPonAsync` stays PON-layer only.

## Monitoring - ONT Stats

- **Standalone optics** - a standalone custom-ONT config now maps the `optics` section into its ONT series (`OntStats` -> the existing `WriteOntAsync` DDM fields). No gateway DDM to defer to in this mode, so the values flow straight through.

## Notes

- Every optics field is optional, consistent with the rest of the contract; absent values are simply not recorded.
- DDM **alerts** still run off the gateway's SFP DDM reading only. Alerting on the contract-supplied fallback is deferred ("for now").
- Docs updated (`docs/features/netopt-custom-pon-contract.md`): payload example, records table, and an "Optics precedence" section.
- Provider mapping tests extended to cover the optics section (parse, supplemental map, standalone map, absent-section).
