### PR TITLE
v2.3.1 Release Changes

### DIFF
--- a/docs/features/2026-07-21-monitoring-interface-disable-enable-design.md
+++ b/docs/features/2026-07-21-monitoring-interface-disable-enable-design.md
@@ -1,0 +1,142 @@
+# Monitoring Interface: Disable / Enable
+
+Status: Design (approved 2026-07-21)
+
+## Summary
+
+Add the ability to Disable (un-deploy) a configured monitoring interface without deleting its configuration, and to Enable it again later.
+A disabled interface has all of its gateway artifacts removed (macvlan, host route, SNAT/DNAT, boot script, cron watchdog), but its row and settings are kept, so it can be restored with a single click.
+This supports the common workflow of pausing an interface during testing and bringing it back later without re-entering it.
+
+## Goals
+
+- Per-interface Disable/Enable toggle (no global switch).
+- A disabled interface stays down across reboots and against the cron watchdog - this must be robust, not merely a UI flag.
+- Reuse the existing deploy/teardown primitives and match the repository's existing patterns (Performance Tweaks, the deployment service, the card UI).
+
+## Non-goals
+
+- No global "pause all" control.
+- No change to CM/ONT/modem polling behaviour (no monitor currently consumes `MonitoringInterface`).
+- No new external ONT provider (tracked separately).
+
+## Background: current architecture
+
+A monitoring interface deploys a macvlan on the WAN port with a stable MAC, a gateway-local IP, a `/32` host route (plus optional SNAT, plus optional alias DNAT for the duplicate-IP case), and a cron watchdog.
+Everything is applied over SSH by `MonitoringInterfaceDeploymentService.DeployAsync(mi)`, which writes an idempotent boot script to `/data/on_boot.d/30-monitoring-iface-<Name>.sh` and runs it.
+Reboot-safety comes from two mechanisms: udm-boot runs the boot script on boot, and the script self-installs a cron watchdog that re-applies after UniFi reprovisioning.
+`RemoveAsync(mi)` performs the gateway teardown only (cron entry, route, macvlan, SNAT/DNAT, boot script) and does not touch the database; the database delete is the separate `Repo.DeleteMonitoringInterfaceAsync(id)`.
+Status is computed on demand by `CheckStatusAsync`; there is no background poller and no persisted status.
+Today there is no enabled/disabled state on the entity (`IsManuallyDeployed` means "the user manages the gateway artifacts by hand" and is unrelated).
+
+## Why a naive flag is not enough
+
+A design review surfaced two correctness problems that rule out "just add a boolean and call the existing RemoveAsync":
+
+1. `RemoveAsync` success is unreliable.
+   It ignores the results of the cron, SNAT, route, macvlan, and boot-script removal steps and only fails on alias-cleanup errors, so a non-aliased interface on an unreachable gateway returns `success = true`.
+   Persisting `Disabled = true` off that would show a paused state while the interface is still deployed.
+
+2. There is a real watchdog race.
+   Removing the cron entry does not stop an already-running watchdog script, which recreates the cron entry and every artifact at its end.
+   The script never reads the database, so a database flag alone cannot pause it.
+
+Therefore Disable needs a gateway-side authority that the script honours, plus a hardened and verified teardown - not just a boolean.
+
+## Design
+
+### 1. Data model
+
+Add `bool Disabled` (default `false`) to `MonitoringInterface`.
+Add an EF Core migration that creates the column with `nullable: false, defaultValue: false`, so existing rows remain enabled, and update the model snapshot.
+Add a migration test seeded from the immediately preceding migration to confirm the default applies to existing rows.
+
+### 2. Gateway-side disabled marker (the core mechanism)
+
+Introduce a per-interface marker file at `/data/monitoring-ifaces.disabled/<Name>`.
+The marker lives in a dedicated directory under `/data`, deliberately not in `on_boot.d`, so udm-boot never executes it.
+Its presence means "do not deploy this interface."
+
+Change the boot-script template so that it checks for the marker in two places: at the very top (before applying any artifact) and again immediately before it (re)installs the cron watchdog.
+If the marker is present the script exits 0 without applying anything and without (re)installing cron.
+Wrap the script's apply section and the teardown in a shared per-interface `flock` (e.g. `/tmp/monitoring-iface-<Name>.lock`), so a teardown and a concurrently-running watchdog cannot interleave.
+
+### 3. Hardened `RemoveAsync`
+
+Check the result of every teardown SSH step (cron, SNAT, route, macvlan, boot script), not only the alias cleanup, and aggregate them into an honest success value with a specific error message on failure.
+After teardown, verify absence (interface, route, cron, and boot script gone) with one probe before reporting success; this verification also catches a watchdog that resurrected artifacts mid-teardown.
+This corrects an existing latent bug and is in scope because Disable builds directly on this primitive.
+
+### 4. Service orchestration
+
+Add `DisableAsync(mi)` and `EnableAsync(mi)` to `MonitoringInterfaceDeploymentService`.
+
+`DisableAsync(mi)`:
+
+1. Write the marker (this guards the teardown against a running watchdog).
+2. Take the flock and run the hardened `RemoveAsync` teardown.
+3. Verify absence.
+4. On success, persist `Disabled = true` via the targeted update (see below).
+   On failure, best-effort remove the marker, surface the error, and leave `Disabled = false`.
+   If the gateway is unreachable the marker write fails first, so Disable reports "gateway unreachable" and changes nothing.
+
+`EnableAsync(mi)`:
+
+1. Persist `Disabled = false`.
+2. Remove the marker.
+3. Run `DeployAsync(mi)` (writes a fresh boot script and cron).
+4. Report success only if `DeployAsync` succeeds; on deploy failure the row stays enabled with the existing "not deployed / needs re-apply" status rather than a fake success.
+
+Order rationale: for Disable, teardown-before-flag means a crash leaves an enabled row that looks "not deployed" (safe) instead of active artifacts hidden behind "Disabled".
+For Enable, flag-before-deploy means a crash cannot leave artifacts up while the UI still says "Disabled".
+A persisted pending/transition state is deliberately avoided; without a reconciliation worker it could get stuck, and strong teardown results plus live verification fit the current on-demand model better.
+
+### 5. `DeployAsync` guard
+
+`DeployAsync` rejects a call on a `Disabled` interface (no-op plus a clear message), so no path can silently deploy a paused row.
+
+### 6. Persistence
+
+Add a targeted `SetDisabledAsync(int id, bool value)` on the repository that updates only the `Disabled` column (and `UpdatedAt`) with an optimistic-concurrency check.
+This avoids `SaveMonitoringInterfaceAsync`, which copies every field from a detached object and could clobber a concurrent edit made in another browser tab after a slow SSH operation.
+
+### 7. UI (`MonitoringInterfacesCard.razor`)
+
+Add a Disable/Enable toggle button in the row action group, following the `RemoveInterface` handler, the `_busyId`/`_busyAction` busy-state, and the `_deploySteps`/`_message` conventions.
+An enabled row shows "Disable" (calls `DisableAsync`); a disabled row shows "Enable" (calls `EnableAsync`).
+`StatusBadge` gains a neutral "Disabled" branch, shown when `mi.Disabled`, distinct from Active (green) and error (red).
+Keep "Edit", "Check status", and "Remove" available for disabled rows; Check status is useful to diagnose leftover artifacts.
+`Snapshot()` must copy `Disabled`, otherwise editing a disabled row would silently save `false`.
+For a disabled row the edit form is save-only (`SaveOnly` must skip old-teardown for an already-disabled row), and "Save & Deploy" is presented as "Save & Enable" (save then `EnableAsync`); the edit form never calls `DeployAsync` on a disabled row.
+Clear the cached `_statuses` entry on every Disable/Enable transition so a stale "Active" badge cannot reappear.
+Hide Disable/Enable for manually-deployed rows (`IsManuallyDeployed == true`); we do not manage those artifacts.
+`SummaryLabel` may show a paused count (for example "4 configured, 1 paused") - optional.
+
+### 8. Queries and uniqueness
+
+Disabled rows keep participating in all uniqueness checks (`Name`, `AliasIp`, `GatewayLocalIp`, and cross-column), so two paused configurations cannot reserve the same gateway artifacts and collide when re-enabled.
+`GetByEffectiveIpAsync` keeps returning disabled rows; callers inspect `Disabled` rather than treating a disabled row as nonexistent.
+
+## Error handling summary
+
+- Disable, gateway unreachable: marker write fails, nothing changes, "gateway unreachable" surfaced, row stays enabled.
+- Disable, teardown step fails: no `Disabled` persisted, marker removed best-effort, specific error surfaced, row stays enabled.
+- Disable, watchdog resurrects mid-teardown: caught by post-teardown verification, treated as a teardown failure.
+- Enable, deploy fails: `Disabled` already cleared, marker removed, row shows "not deployed / needs re-apply", no fake success.
+- Concurrent Enable/Disable from two tabs: targeted `SetDisabledAsync` with optimistic concurrency; the loser gets a concurrency error rather than a clobber.
+
+## Testing
+
+- `DisableAsync`/`EnableAsync` orchestration: flag flips, call order, marker write/remove (gateway SSH and deploy mocked).
+- Teardown-failure paths: non-alias SSH failure and cron/script removal failure both prevent persisting `Disabled` and surface the error.
+- Watchdog exclusion: the script honours the marker at both check points (apply and cron install).
+- Post-teardown verification catches resurrection.
+- Edit: a disabled snapshot round-trips `Disabled`; "Save & Deploy" on a disabled row behaves as "Save & Enable"; `DeployAsync` rejects a disabled row.
+- Manual rows: Disable/Enable are hidden.
+- Enable with a failing deploy: the row stays enabled with no fake success.
+- Concurrency: interleaved Enable/Disable via `SetDisabledAsync` optimistic concurrency.
+- Migration: existing rows default to `Disabled = false` (seeded from the prior migration).
+
+## Open questions
+
+- While an interface is paused, any reachability check or alert against the modem/ONT IP elsewhere in the UI could still fire; no monitor consumes `MonitoringInterface` today, but if a surface does, it should reflect "paused" rather than "unreachable". Decide whether to annotate now or defer.

--- a/docs/features/netopt-custom-pon-contract.md
+++ b/docs/features/netopt-custom-pon-contract.md
@@ -16,7 +16,9 @@ Configure it under Settings - ONT Device Monitoring with provider
   polled on the gateway SFP collection cycle instead, with the full metric set
   merged into that module's `sfp` measurement and charted on the SFP Stats tab.
   Use this when the ONT *is* the SFP module in your gateway, so its DDM optics
-  readings and its PON internals form one time series.
+  readings and its PON internals form one time series. The gateway reads DDM off
+  the SFP slot directly; the contract's optional `optics` section only fills DDM
+  the gateway can't read (see [Optics precedence](#optics-precedence)).
 
 ## Endpoint semantics
 
@@ -55,6 +57,12 @@ numeric strings; 64-bit counters are expected.
 
 ```json
 {
+  "optics": {               // DDM optics, same units as SFP DDM (fallback - see note below)
+    "rx_power_dbm": -18.4,  // receive optical power, dBm
+    "tx_power_dbm": 2.1,    // transmit optical power, dBm
+    "temperature_c": 47.3,  // transceiver temperature, degrees C
+    "voltage_v": 3.28       // supply voltage, volts
+  },
   "lan": {
     "mode": 15,             // host-side PHY mode (raw device enum, informational)
     "link_status": 5,       // host (module-to-gateway) link state, raw enum
@@ -123,6 +131,8 @@ onto Network Optimizer's existing schema:
 
 | Contract field | Stored as | Notes |
 |---|---|---|
+| `optics.rx_power_dbm` / `tx_power_dbm` | `rx_power_dbm` / `tx_power_dbm` | DDM fallback; gateway SFP DDM wins (see below) |
+| `optics.temperature_c` / `voltage_v` | `temperature_c` / `voltage_v` | DDM fallback; gateway SFP DDM wins (see below) |
 | `ploam.curr_state` | `pon_link_status` | same encoding as the ont measurement: `initial`, `standby`, `serial_number`, `ranging`, `operation`, `popup`, `emergency_stop` |
 | `ploam.previous_state` | `pon_link_status_prev` | same encoding |
 | `ploam.elapsed_msec` | `ploam_elapsed_ms` | |
@@ -146,6 +156,21 @@ Not recorded: `lan.mode`, `lan.phy_duplex` (static config), GEM byte counters
 (32-bit wrap), `drop` / `omci_drop` / `rx_oversized_frames`,
 `fec_error_corr` / `fec_words_total` / `fec_seconds`, and the `gpe_*` good-frame
 counters (redundant with `lan_counters` and GEM frame counters).
+
+### Optics precedence
+
+The `optics` section is optional and exists for modules whose DDM the gateway
+cannot read off its SFP slot - many GPON sticks present no usable DDM there. When
+the config is **attached to a monitored SFP module**, the gateway's own DDM
+reading wins field by field: `optics.rx_power_dbm` is written only when the
+gateway slot reports no RX power, and likewise for TX power, temperature, and
+voltage. So supplying `optics` never overrides what the gateway can already see;
+it just fills the gaps. In **standalone** mode there is no gateway DDM to defer
+to, so the `optics` values flow straight to the ONT Stats tab.
+
+DDM alerts continue to run off the gateway's SFP DDM readings only; the
+contract-supplied fallback is charted and displayed but is not yet wired into DDM
+alert thresholds.
 
 ## Reference implementation
 

--- a/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
@@ -129,9 +129,11 @@ public static class NetworkFormatHelpers
         "Enterprises", "Services", "Technologies", "Networks", "Network",
         "Electric Cooperative", "Cooperative", "Co-op",
         "Corporation", "Incorporated", "Company", "Holdings", "Group", "Parent",
-        "LLC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P.", "LP",
-        "GmbH", "AG", "KG", "e.K.", "S.A.", "S.A.S.", "S.r.l.",
-        "B.V.", "B.V", "N.V.", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
+        // Entries must NOT carry a trailing '.' - CleanOrgName TrimEnd's ',' and '.' off the
+        // input before matching, so a dotted entry (e.g. "L.P.") could never fire. Use "L.P".
+        "LLC", "L.C", "LC", "Inc", "Corp", "Ltd", "Limited", "Co", "L.P", "LP",
+        "GmbH", "AG", "KG", "e.K", "S.A", "S.A.S", "S.r.l",
+        "B.V", "N.V", "Pty", "A/S", "AB", "Oy", "AS"
     };
 
     /// <summary>

--- a/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
+++ b/src/NetworkOptimizer.Core/Models/PonSupplementalStats.cs
@@ -10,6 +10,23 @@ namespace NetworkOptimizer.Core.Models;
 /// </summary>
 public class PonSupplementalStats
 {
+    /// <summary>
+    /// Optional DDM optics readings supplied by the endpoint, in SFP DDM units
+    /// (dBm / degrees C / volts). These are a fallback: when the config is attached
+    /// to a monitored SFP module and the gateway's own DDM poll reads the module,
+    /// the gateway value wins and these fill only the gaps it leaves.
+    /// </summary>
+    public double? RxPowerDbm { get; set; }
+
+    /// <summary>Transmit optical power in dBm. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? TxPowerDbm { get; set; }
+
+    /// <summary>Transceiver temperature in degrees Celsius. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? TemperatureC { get; set; }
+
+    /// <summary>Supply voltage in volts. Fallback; see <see cref="RxPowerDbm"/>.</summary>
+    public double? VoltageV { get; set; }
+
     /// <summary>Raw ITU-T PLOAM state number (1-7 = O1-O7) for alert evaluation.</summary>
     public long? PloamStateRaw { get; set; }
 

--- a/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
@@ -21,4 +21,10 @@ public interface IMonitoringInterfaceRepository
 
     Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default);
     Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flips the Disabled flag on a single row without touching any other field (targeted
+    /// update). Used by Disable/Enable so a paused interface keeps its full config.
+    /// </summary>
+    Task SetDisabledAsync(int id, bool disabled, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721000000_AddMonitoringInterfaceDisabled")]
+    partial class AddMonitoringInterfaceDisabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <summary>
+/// Adds MonitoringInterfaces.Disabled: true when the user disabled (un-deployed) an
+/// interface but kept its config for later re-enable. Defaults to false so existing
+/// rows stay deployed.
+/// </summary>
+public partial class AddMonitoringInterfaceDisabled : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "Disabled",
+            table: "MonitoringInterfaces",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Disabled",
+            table: "MonitoringInterfaces");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -89,6 +89,9 @@ public class MonitoringInterface
     /// </summary>
     public bool IsManuallyDeployed { get; set; }
 
+    /// <summary>True when the user disabled (un-deployed) this interface but kept its config for later re-enable.</summary>
+    public bool Disabled { get; set; }
+
     /// <summary>Last deployment/repair error message (null if last action succeeded).</summary>
     [MaxLength(1000)]
     public string? LastError { get; set; }

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -143,6 +143,7 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
                     existing.SnatEnabled = config.SnatEnabled;
                     existing.WatchdogIntervalMinutes = config.WatchdogIntervalMinutes;
                     existing.IsManuallyDeployed = config.IsManuallyDeployed;
+                    existing.Disabled = config.Disabled;
                     existing.LastError = config.LastError;
                     existing.UpdatedAt = DateTime.UtcNow;
                 }
@@ -167,6 +168,15 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
             _logger.LogError(ex, "Failed to save monitoring interface {Name}", config.Name);
             throw;
         }
+    }
+
+    public async Task SetDisabledAsync(int id, bool disabled, CancellationToken cancellationToken = default)
+    {
+        var existing = await _context.MonitoringInterfaces.FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+        if (existing == null) return;
+        existing.Disabled = disabled;
+        existing.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     public async Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -100,6 +100,31 @@ public class UniFiDeviceResponse
     [JsonPropertyName("displayable_version")]
     public string? DisplayableVersion { get; set; }
 
+    /// <summary>
+    /// Suricata (the CyberSecure IDS/IPS detection engine) version currently running on the
+    /// gateway. Absent until the engine has run a version; only present on CyberSecure-capable
+    /// gateways.
+    /// </summary>
+    [JsonPropertyName("suricata_version")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? SuricataVersion { get; set; }
+
+    /// <summary>
+    /// Highest Suricata engine version this gateway's firmware supports.
+    /// </summary>
+    [JsonPropertyName("supported_suricata_version")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? SupportedSuricataVersion { get; set; }
+
+    /// <summary>
+    /// Suricata engine version the gateway is offering to upgrade to. Present (and above the
+    /// running <see cref="SuricataVersion"/>) when an upgrade is available but not yet initiated
+    /// in UniFi Network -> Settings -> CyberSecure.
+    /// </summary>
+    [JsonPropertyName("suricata_upgrade_pending_target")]
+    [JsonConverter(typeof(FlexibleIntConverter))]
+    public int? SuricataUpgradePendingTarget { get; set; }
+
     [JsonPropertyName("adopted")]
     public bool Adopted { get; set; }
 

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -141,7 +141,7 @@ public class UniFiApiClient : IDisposable
     /// taken during teardown - never against a live client - so the happy path and
     /// single-site installs are behavior-identical.
     /// </summary>
-    private async Task<T> ExecuteRequestAsync<T>(Func<Task<T>> action)
+    internal async Task<T> ExecuteRequestAsync<T>(Func<Task<T>> action)
     {
         if (_disposed) return default!;
         try

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -39,6 +39,11 @@ public class UniFiApiClient : IDisposable
     private string? _csrfToken;
     private readonly AsyncRetryPolicy _retryPolicy;
     private readonly SemaphoreSlim _authLock = new(1, 1);
+    // Set in Dispose() before the HttpClient is torn down. A concurrent reconnect
+    // can dispose this client while a data call is in flight; the flag and the
+    // ObjectDisposedException catch in ExecuteRequestAsync turn that into a benign
+    // skip instead of a disposed-object crash.
+    private volatile bool _disposed;
     private List<UniFiDeviceResponse>? _cachedDeviceResponses;
     private DateTime _deviceResponseCacheTime = DateTime.MinValue;
     private static readonly TimeSpan DeviceResponseCacheTtl = TimeSpan.FromSeconds(15);
@@ -124,6 +129,30 @@ public class UniFiApiClient : IDisposable
                 });
 
         InitializeHttpClient();
+    }
+
+    /// <summary>
+    /// Runs an HTTP request through the shared retry policy, treating a disposed
+    /// client as a benign no-op. When a concurrent reconnect disposes this client's
+    /// <see cref="_httpClient"/> before or during the request, there is no live
+    /// client to complete against, so we return the same "couldn't complete" value
+    /// these methods already yield on failure (null / false / default) instead of
+    /// surfacing an <see cref="ObjectDisposedException"/> to the caller. Only ever
+    /// taken during teardown - never against a live client - so the happy path and
+    /// single-site installs are behavior-identical.
+    /// </summary>
+    private async Task<T> ExecuteRequestAsync<T>(Func<Task<T>> action)
+    {
+        if (_disposed) return default!;
+        try
+        {
+            return await _retryPolicy.ExecuteAsync(action);
+        }
+        catch (ObjectDisposedException)
+        {
+            _logger.LogDebug("UniFi API request skipped: client was disposed by a concurrent reconnect");
+            return default!;
+        }
     }
 
     private void InitializeHttpClient()
@@ -690,7 +719,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await apiCall();
 
@@ -802,7 +831,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(BuildApiPath("stat/device"), cancellationToken);
 
@@ -877,7 +906,7 @@ public class UniFiApiClient : IDisposable
 
         var url = BuildV2ApiPath($"site/{_site}/device");
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(url, cancellationToken);
 
@@ -1069,7 +1098,7 @@ public class UniFiApiClient : IDisposable
             return new List<UniFiClientDetailResponse>();
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/clients/active");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1115,7 +1144,7 @@ public class UniFiApiClient : IDisposable
             return new List<UniFiClientDetailResponse>();
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/clients/history?withinHours={withinHours}");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1475,7 +1504,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync($"{_controllerUrl}/api/self", cancellationToken);
 
@@ -1501,7 +1530,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(BuildApiPath("stat/health"), cancellationToken);
 
@@ -1547,7 +1576,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(
                 BuildV2ApiPath($"site/{_site}/trafficroutes"),
@@ -1578,7 +1607,7 @@ public class UniFiApiClient : IDisposable
             return false;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 route.RootElement.GetRawText(),
@@ -1629,7 +1658,7 @@ public class UniFiApiClient : IDisposable
 
         var url = $"{BuildApiPath("stat/report/hourly.site")}?start={startMs}&end={endMs}";
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(url, cancellationToken);
 
@@ -1665,7 +1694,7 @@ public class UniFiApiClient : IDisposable
             ? $"{_controllerUrl}/proxy/network/api/self/sites"
             : $"{_controllerUrl}/api/self/sites";
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(url, cancellationToken);
 
@@ -1695,7 +1724,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(BuildApiPath("rest/setting"), cancellationToken);
 
@@ -1739,7 +1768,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(BuildApiPath("stat/current-channel"), cancellationToken);
 
@@ -1815,7 +1844,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/qos-rules");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1845,7 +1874,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/wan/enriched-configuration");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1875,7 +1904,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/firewall-policies");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1905,7 +1934,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/nat");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1937,7 +1966,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"site/{_site}/firewall-rules/combined-traffic-firewall-rules?originType=all");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -1973,7 +2002,7 @@ public class UniFiApiClient : IDisposable
             return null;
         }
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var url = BuildV2ApiPath($"fingerprint_devices/{index}");
             var response = await _httpClient!.GetAsync(url, cancellationToken);
@@ -2165,7 +2194,7 @@ public class UniFiApiClient : IDisposable
             end = endMs
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(payload),
@@ -2226,7 +2255,7 @@ public class UniFiApiClient : IDisposable
             end = endMs
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(payload),
@@ -2288,7 +2317,7 @@ public class UniFiApiClient : IDisposable
             end = endMs
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(payload),
@@ -2331,7 +2360,7 @@ public class UniFiApiClient : IDisposable
 
         var url = BuildV2ApiPath($"site/{_site}/wlan/enriched-configuration");
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(url, cancellationToken);
 
@@ -2366,7 +2395,7 @@ public class UniFiApiClient : IDisposable
 
         var url = BuildV2ApiPath($"site/{_site}/wifi-connectivity/roaming/topology");
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             // This endpoint requires POST with empty body
             var content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
@@ -2408,7 +2437,7 @@ public class UniFiApiClient : IDisposable
 
         var url = BuildV2ApiPath($"site/{_site}/system-log/client-connection/{clientMac}?mac={clientMac}&separateConnectionSignalParam=false&limit={limit}");
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(url, cancellationToken);
 
@@ -2463,7 +2492,7 @@ public class UniFiApiClient : IDisposable
             ["clientDeviceMacs"] = apMac != null ? new[] { apMac } : Array.Empty<string>()
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(body),
@@ -2664,7 +2693,7 @@ public class UniFiApiClient : IDisposable
             ["clientDeviceMacs"] = Array.Empty<string>()
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(body),
@@ -2750,7 +2779,7 @@ public class UniFiApiClient : IDisposable
             ["skip_count"] = pageNumber > 0 // only count on first page
         };
 
-        return await _retryPolicy.ExecuteAsync(async () =>
+        return await ExecuteRequestAsync(async () =>
         {
             var content = new StringContent(
                 JsonSerializer.Serialize(body),
@@ -2780,6 +2809,9 @@ public class UniFiApiClient : IDisposable
 
     public void Dispose()
     {
+        // Flag first so any in-flight/queued request skips instead of racing the
+        // HttpClient teardown (see ExecuteRequestAsync).
+        _disposed = true;
         _authLock?.Dispose();
         _httpClient?.Dispose();
         GC.SuppressFinalize(this);

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -78,6 +78,9 @@ public class UniFiDiscovery
                 LastSeen = DateTimeOffset.FromUnixTimeSeconds(d.LastSeen).DateTime,
                 Upgradable = d.Upgradable,
                 UpgradeToFirmware = d.UpgradeToFirmware,
+                SuricataVersion = d.SuricataVersion,
+                SupportedSuricataVersion = d.SupportedSuricataVersion,
+                SuricataUpgradePendingTarget = d.SuricataUpgradePendingTarget,
                 UplinkMac = d.Uplink?.UplinkMac,
                 UplinkPort = d.Uplink?.UplinkRemotePort,
                 LocalUplinkPort = d.Uplink?.PortIdx,
@@ -768,6 +771,22 @@ public class DiscoveredDevice
     public DateTime LastSeen { get; set; }
     public bool Upgradable { get; set; }
     public string? UpgradeToFirmware { get; set; }
+
+    /// <summary>Running Suricata (CyberSecure IDS/IPS) engine version. Null until it has run one.</summary>
+    public int? SuricataVersion { get; set; }
+    /// <summary>Highest Suricata engine version this gateway's firmware supports.</summary>
+    public int? SupportedSuricataVersion { get; set; }
+    /// <summary>Suricata engine version the gateway is offering to upgrade to, when one is pending.</summary>
+    public int? SuricataUpgradePendingTarget { get; set; }
+
+    /// <summary>
+    /// True when the gateway is advertising a Suricata (CyberSecure IDS/IPS) engine upgrade it
+    /// hasn't taken yet: a pending target is set and above the running version (or the engine
+    /// isn't running any version yet). The upgrade is initiated in UniFi Network -> Settings -> CyberSecure.
+    /// </summary>
+    public bool SuricataUpgradeAvailable =>
+        SuricataUpgradePendingTarget is int target && target > (SuricataVersion ?? 0);
+
     public string? UplinkMac { get; set; }
     /// <summary>Remote port on the upstream device that this device connects to.</summary>
     public int? UplinkPort { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -18,6 +18,7 @@
 @inject ApMapService ApMapService
 @inject PullToRefreshState PtrState
 @inject SiteContextService SiteContext
+@inject MonitoringReadinessService Readiness
 @inject SiteSpeedTestTargetResolver SiteTarget
 
 @* Uses unified Iperf3Result model with Direction field to distinguish test sources *@
@@ -368,7 +369,7 @@
                                         <div class="expand-wrapper @(isExpanded ? "expanded" : "")">
                                             <div class="expand-content">
                                                 <div class="history-details">
-                                                    <SpeedTestDetails Result="result" PathAnalysis="result.PathAnalysis" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" />
+                                                    <SpeedTestDetails Result="result" PathAnalysis="result.PathAnalysis" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" ShowLiveViewLink="_liveViewLinkEnabled" />
                                                 </div>
                                             </div>
                                         </div>
@@ -854,10 +855,14 @@
     private int? expandedHistoryId = null;
     private int? _collapsingHistoryId = null; // Track row being collapsed for smooth transition
 
+    private bool _liveViewLinkEnabled;
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         // Load networks for VPN detection
         _networks = await ConnectionService.GetNetworksAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -8,6 +8,7 @@
 @using NetworkOptimizer.Core.Helpers
 @inject ClientSpeedTestService ClientSpeedTestService
 @inject SiteContextService SiteContext
+@inject MonitoringReadinessService Readiness
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject SystemSettingsService SettingsService
 @inject NavigationManager NavigationManager
@@ -381,7 +382,8 @@
                                                                           UseWanLabels="true"
                                                                           OnDelete="HandleDelete"
                                                                           OnNotesChanged="HandleNotesChanged"
-                                                                          IsInTableRow="true" />
+                                                                          IsInTableRow="true"
+                                                                          ShowLiveViewLink="_liveViewLinkEnabled" />
                                                     </div>
                                                 </div>
                                             </div>
@@ -787,10 +789,14 @@
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_filteredResults.Count / (double)PageSize));
     private IEnumerable<Iperf3Result> _pagedResults => _filteredResults.Skip((_page - 1) * PageSize).Take(PageSize);
 
+    private bool _liveViewLinkEnabled;
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadResults();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         InitializeChartOptions();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -119,6 +119,23 @@
 <NetworkOptimizer.Web.Components.Shared.SponsorshipBanner />
 <NetworkOptimizer.Web.Components.Shared.PwaBanner />
 
+@if (devices.Any(d => d.SuricataUpgradeAvailable))
+{
+    <div class="alert alert-info" style="margin-bottom: 1.5rem;">
+        <div class="banner-content">
+            <span class="banner-icon banner-icon-info">i</span>
+            <div class="banner-text" style="flex: 1;">
+                <strong>CyberSecure engine upgrade available</strong>
+                <span>
+                    Your gateway can upgrade its CyberSecure IDS/IPS detection engine (Suricata) to a newer
+                    version, bringing security fixes and better, more efficient threat detection. To initiate it,
+                    open the UniFi Network app and go to Settings &gt; CyberSecure.
+                </span>
+            </div>
+        </div>
+    </div>
+}
+
 <div class="dashboard-grid">
     @if (_layout != null)
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -427,9 +427,13 @@ else
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Latency &amp; Packet Loss</h2>
                 <div style="display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap;">
+                    @* Default the category filter to ISP when there are no enabled LAN (Fabric)
+                       targets, so a monitoring-only/agent site opens on a populated chart. mount()
+                       in latency-charts.js seeds currentCategory from whichever button is active. *@
+                    @{ var hasLanTargets = HasUpstreamTargets(MonitoringTargetType.Fabric); }
                     <div class="time-range-selector">
-                        <button class="time-btn active" data-category="Fabric">LAN</button>
-                        <button class="time-btn" data-category="AccessIsp">ISP</button>
+                        <button class="time-btn @(hasLanTargets ? "active" : "")" data-category="Fabric">LAN</button>
+                        <button class="time-btn @(hasLanTargets ? "" : "active")" data-category="AccessIsp">ISP</button>
                         <button class="time-btn" data-category="Transit">Transit</button>
                         <button class="time-btn" data-category="InternetService">Internet</button>
                         <button class="time-btn" data-category="Custom">Custom</button>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -16,6 +16,7 @@
 @using NetworkOptimizer.Core.Enums
 @using Microsoft.EntityFrameworkCore
 @inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject UniFiConnectionService ConnectionService
 @inject MonitoringInfluxClient InfluxClient
 @inject MonitoringLiveStats LiveStats
@@ -1590,6 +1591,11 @@ else
     [SupplyParameterFromQuery(Name = "tab")]
     public string? TabParam { get; set; }
 
+    // Deep link from a speed-test result: absolute epoch-ms instant to open Live View
+    // at, in historic playback (paused). Consumed once when the 3D map first mounts.
+    [SupplyParameterFromQuery(Name = "at")]
+    public string? AtParam { get; set; }
+
     [SupplyParameterFromQuery(Name = "discover")]
     public string? DiscoverParam { get; set; }
 
@@ -1708,6 +1714,7 @@ else
     // Chart mount tracking
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
+    private bool _initialAtApplied = false;
     private bool _wanLiveChartMounted = false;
     private bool _portStatsMounted = false;
     private bool _latencyChartsMounted;
@@ -2055,13 +2062,7 @@ else
 
         _monitoringEnabled = settings.Enabled;
 
-        bool sharedConnection;
-        await using (var mainDb = SiteDb.CreateForSite(SiteManagementService.DefaultSiteSlug, isDefault: true))
-        {
-            var shared = await mainDb.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync();
-            sharedConnection = !string.IsNullOrEmpty(shared?.InfluxDbToken)
-                && !string.IsNullOrEmpty(shared?.InfluxDbUrl);
-        }
+        bool sharedConnection = await Readiness.IsSharedInfluxConfiguredAsync();
 
         // A secondary site counts as configured only once its own buckets are reachable
         // on the shared InfluxDB. Until then report not-configured so the Setup tab drops
@@ -3665,14 +3666,30 @@ else
             try
             {
                 _mapDotNetRef ??= DotNetObjectReference.Create(this);
+                // Deep-linked timestamp (?at=): applied only on this first mount, so
+                // switching tabs away and back doesn't yank the map back to the past.
+                long initialAtMs = 0;
+                if (!_initialAtApplied && long.TryParse(AtParam, out var atMs) && atMs > 0)
+                {
+                    _initialAtApplied = true;
+                    initialAtMs = atMs;
+                }
+                // Per-mount values (storagePrefix, initialAt) MUST be arguments, never
+                // interpolated into the function body: JS interop resolves the
+                // identifier to a function reference once and keeps invoking that
+                // original closure, so a re-eval'd definition with different baked-in
+                // values is silently ignored on every mount after the first.
                 await JS.InvokeVoidAsync("eval",
-                    "window.__mountLanFlowMap = async function(canvasId, ref) {" +
+                    "window.__mountLanFlowMap = async function(canvasId, ref, storagePrefix, initialAt) {" +
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
-                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}' }});" +
+                    "  const opts = { storagePrefix: storagePrefix };" +
+                    "  if (initialAt > 0) opts.initialAt = initialAt;" +
+                    "  await m.mount(canvasId, opts);" +
                     "}");
-                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
+                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef,
+                    SiteCtx.ScopeStorageKey("lanFlowMap"), initialAtMs);
             }
             catch (Exception ex) { _mapMounted = false; Logger.LogDebug(ex, "3D map mount failed; will retry on next render"); }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3103,7 +3103,7 @@
                             <tbody>
                                 @foreach (var site in _sites)
                                 {
-                                    <tr>
+                                    <tr class="@(_expandedSiteId == site.Id ? "site-row-selected" : null)">
                                         <td>
                                             @if (_editingSiteId == site.Id)
                                             {
@@ -3118,7 +3118,7 @@
                                             else
                                             {
                                                 <span class="site-name-cell">
-                                                    <span>@site.Name</span>
+                                                    <span class="@(_expandedSiteId == site.Id ? "site-name-selected" : null)">@site.Name</span>
                                                     <button type="button" class="site-name-edit-btn" data-tooltip="Rename site"
                                                             aria-label="Rename site" @onclick="() => StartSiteNameEdit(site)">
                                                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -15,6 +15,7 @@
 @inject GatewaySpeedTestService GatewaySpeedTestService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
+@inject MonitoringReadinessService Readiness
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -239,7 +240,7 @@
                         </div>
                         <div class="result-box-details">
                             <div class="result-box-details-inner">
-                                <SpeedTestDetails GatewayResult="gatewayLastResult" />
+                                <SpeedTestDetails GatewayResult="gatewayLastResult" ShowLiveViewLink="_liveViewLinkEnabled" />
                             </div>
                         </div>
                     </div>
@@ -734,7 +735,7 @@
             <div class="card-body">
                 @if (currentResult.Success)
                 {
-                    <SpeedTestDetails Result="currentResult" OnTestAgain="HandleTestAgain" OnNotesChanged="HandleNotesChanged" />
+                    <SpeedTestDetails Result="currentResult" OnTestAgain="HandleTestAgain" OnNotesChanged="HandleNotesChanged" ShowLiveViewLink="_liveViewLinkEnabled" />
                 }
                 else
                 {
@@ -916,7 +917,7 @@
                                                         // Use stored path analysis if available, otherwise use result's analysis
                                                         var pathAnalysis = historyPathAnalysis.GetValueOrDefault(result.Id) ?? result.PathAnalysis;
                                                     }
-                                                    <SpeedTestDetails Result="result" PathAnalysis="pathAnalysis" OnTestAgain="HandleTestAgain" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" />
+                                                    <SpeedTestDetails Result="result" PathAnalysis="pathAnalysis" OnTestAgain="HandleTestAgain" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" ShowLiveViewLink="_liveViewLinkEnabled" />
 
                                                     @if (pathAnalysis == null && ConnectionService.IsConnected)
                                                     {
@@ -1480,10 +1481,14 @@
     private string testProgressPhaseVerbose = ""; // Verbose for alerts
     private System.Timers.Timer? progressTimer;
 
+    private bool _liveViewLinkEnabled;
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         // Check schedule banner dismissal and local iperf3 availability
         _lanScheduleBannerDismissed = await SettingsService.GetAsync("banner.lan_schedule_dismissed") != null;

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -122,6 +122,12 @@
                             Go to <a href="/settings#gateway-ssh">Settings</a> to configure Gateway SSH credentials before using Adaptive SQM.
                         </div>
                     }
+                    else if (deploymentStatus?.AwaitingAgent == true)
+                    {
+                        <div class="alert alert-info" style="margin-top: 1rem;">
+                            <span class="alert-text">@deploymentStatus.Error</span>
+                        </div>
+                    }
                     else if (!string.IsNullOrEmpty(deploymentStatus?.Error))
                     {
                         <div class="alert alert-danger alert-with-tooltip" style="margin-top: 1rem;">
@@ -2446,7 +2452,11 @@
                 // Gateway not connected - clear stale data and update cache
                 _cachedGatewayConfigured = gatewayConfigured;
                 _cachedGatewayConnected = false;
-                deploymentStatus = new SqmDeploymentStatus { Error = connectionResult.message };
+                // Distinguish a transient "agent not online yet" state (agent-routed
+                // sites at startup) from a real connection failure, so the UI can show
+                // a neutral waiting note rather than a red connection error.
+                var awaitingAgent = await DeploymentService.IsAwaitingAgentAsync();
+                deploymentStatus = new SqmDeploymentStatus { AwaitingAgent = awaitingAgent, Error = connectionResult.message };
                 _cachedDeploymentStatus = deploymentStatus;
                 sqmMonitorData = null;
                 tcInterfaces = null;

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1557,6 +1557,10 @@
     // Cache settings
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(5);
     private static DateTime _lastStatusCheck = DateTime.MinValue;
+    // Site the cache was populated for. The cache is static (shared across circuits),
+    // but a site switch is a full reload into the same static state - without this the
+    // new site would show the previous site's deployment status until the next refresh.
+    private static string? _cachedSlug;
     private static SqmDeploymentStatus? _cachedDeploymentStatus;
     private static List<TcInterfaceStats>? _cachedTcInterfaces;
     private static List<WanInterfaceInfo>? _cachedWanInterfaces;
@@ -1687,7 +1691,7 @@
         PtrState.NotifyStateChanged = StateHasChanged;
 
         // Check cache synchronously BEFORE first render to avoid loading flash
-        if (IsCacheValid())
+        if (IsCacheValid(SiteContext.Slug))
         {
             gatewayConnected = _cachedGatewayConnected;
             gatewayConfigured = _cachedGatewayConfigured;
@@ -2015,9 +2019,10 @@
         }
     }
 
-    private static bool IsCacheValid()
+    private static bool IsCacheValid(string slug)
     {
         return _cachedDeploymentStatus != null &&
+               _cachedSlug == slug &&
                DateTime.UtcNow - _lastStatusCheck < CacheDuration;
     }
 
@@ -2344,6 +2349,8 @@
 
     private async Task RefreshStatus(bool forceRefresh = true)
     {
+        // Every cache write below belongs to the site this refresh runs against.
+        _cachedSlug = SiteContext.Slug;
         // Mark that a refresh is in progress - if user navs away, next page load will re-fetch
         _refreshNeeded = true;
         isLoading = true;

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -2035,7 +2035,7 @@
     /// Tracks SmartQ disabled→enabled transitions to enforce a settle-time delay before deployment.
     /// The IFB virtual device takes ~45s to initialize after Smart Queues is enabled.
     /// </summary>
-    private static void TrackSmartqTransitions(List<WanInterfaceInfo>? oldInterfaces, List<WanInterfaceInfo> newInterfaces)
+    private static void TrackSmartqTransitions(string siteSlug, List<WanInterfaceInfo>? oldInterfaces, List<WanInterfaceInfo> newInterfaces)
     {
         // First load (no old data) - don't record anything to avoid false positives
         if (oldInterfaces == null)
@@ -2047,19 +2047,24 @@
         {
             oldLookup.TryGetValue(wan.Interface, out var wasEnabled);
 
+            // The timestamps dictionary is static (shared across sites), so key by
+            // site to keep same-named interfaces (e.g. "eth8") on different sites
+            // from sharing a settle timer.
+            var key = SmartqKey(siteSlug, wan.Interface);
+
             if (!wasEnabled && wan.SmartqEnabled)
             {
                 // Disabled → enabled: record transition time
-                _smartqEnabledTimestamps[wan.Interface] = DateTime.UtcNow;
+                _smartqEnabledTimestamps[key] = DateTime.UtcNow;
             }
             else if (wasEnabled && !wan.SmartqEnabled)
             {
                 // Enabled → disabled: remove entry
-                _smartqEnabledTimestamps.Remove(wan.Interface);
+                _smartqEnabledTimestamps.Remove(key);
             }
         }
 
-        // Clean up stale entries (>45s old)
+        // Clean up stale entries (>45s old) - age-based, so it prunes across all sites.
         var staleKeys = _smartqEnabledTimestamps
             .Where(kv => (DateTime.UtcNow - kv.Value).TotalSeconds > SmartqSettleSeconds)
             .Select(kv => kv.Key)
@@ -2067,6 +2072,9 @@
         foreach (var key in staleKeys)
             _smartqEnabledTimestamps.Remove(key);
     }
+
+    // Site-scoped key for the static SmartQ settle-timer dictionary.
+    private static string SmartqKey(string siteSlug, string iface) => $"{siteSlug}:{iface}";
 
     private void ApplyDetectedWanInterfaces()
     {
@@ -2410,7 +2418,7 @@
                 try
                 {
                     wanInterfaces = await wanInterfacesTask;
-                    TrackSmartqTransitions(_cachedWanInterfaces, wanInterfaces);
+                    TrackSmartqTransitions(SiteContext.Slug, _cachedWanInterfaces, wanInterfaces);
                     // Only apply detected interfaces if we don't have saved configs
                     if (!hasSavedConfigs)
                         ApplyDetectedWanInterfaces();
@@ -2628,7 +2636,7 @@
             deploymentSteps.Add("Checking Smart Queue configuration...");
             await ScrollDeploymentLog();
             wanInterfaces = await SqmService.GetWanInterfacesFromControllerAsync();
-            TrackSmartqTransitions(_cachedWanInterfaces, wanInterfaces);
+            TrackSmartqTransitions(SiteContext.Slug, _cachedWanInterfaces, wanInterfaces);
             _cachedWanInterfaces = wanInterfaces;
 
             // Validate WANs still have Smart Queues enabled - disable any that don't
@@ -2677,7 +2685,7 @@
             {
                 if (!wanConfig.Enabled) continue;
 
-                if (_smartqEnabledTimestamps.TryGetValue(wanConfig.Interface, out var enabledAt))
+                if (_smartqEnabledTimestamps.TryGetValue(SmartqKey(SiteContext.Slug, wanConfig.Interface), out var enabledAt))
                 {
                     var elapsed = (DateTime.UtcNow - enabledAt).TotalSeconds;
                     if (elapsed < SmartqSettleSeconds)

--- a/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ThreatDashboard.razor
@@ -2244,6 +2244,10 @@ else
     // IP to client name lookup for local devices (cached 30s)
     private static Dictionary<string, string> _clientNamesCache = new();
     private static DateTime _clientNamesCacheExpiry = DateTime.MinValue;
+    // Site the cache was populated for. The cache is static (shared across circuits),
+    // so a site switch (full reload into the same static state) would otherwise resolve
+    // IPs to the previous site's client names until the TTL expired.
+    private static string? _clientNamesCacheSlug;
     private static readonly object _clientNamesCacheLock = new();
     private Dictionary<string, string> _clientNames = new();
 
@@ -2510,7 +2514,8 @@ else
         // Check static cache first (shared across Blazor circuits, 30s TTL)
         lock (_clientNamesCacheLock)
         {
-            if (_clientNamesCacheExpiry > DateTime.UtcNow && _clientNamesCache.Count > 0)
+            if (_clientNamesCacheExpiry > DateTime.UtcNow && _clientNamesCache.Count > 0
+                && _clientNamesCacheSlug == SiteContext.Slug)
             {
                 _clientNames = _clientNamesCache;
                 return;
@@ -2542,6 +2547,7 @@ else
             {
                 _clientNamesCache = names;
                 _clientNamesCacheExpiry = DateTime.UtcNow.AddSeconds(30);
+                _clientNamesCacheSlug = SiteContext.Slug;
             }
             _clientNames = names;
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -16,6 +16,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
+@inject MonitoringReadinessService Readiness
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -252,7 +253,8 @@
                                   OnTestAgain="HandleTestAgain"
                                   OnNotesChanged="HandleNotesChanged"
                                   AvailableWans="_availableWans"
-                                  OnWanReassigned="HandleWanReassigned" />
+                                  OnWanReassigned="HandleWanReassigned"
+                                  ShowLiveViewLink="_liveViewLinkEnabled" />
             </div>
         </div>
     }
@@ -562,7 +564,8 @@
                                                                           OnNotesChanged="HandleNotesChanged"
                                                                           AvailableWans="_availableWans"
                                                                           OnWanReassigned="HandleWanReassigned"
-                                                                          IsInTableRow="true" />
+                                                                          IsInTableRow="true"
+                                                                          ShowLiveViewLink="_liveViewLinkEnabled" />
 
                                                         @if (pathAnalysis == null && ConnectionService.IsConnected)
                                                         {
@@ -794,10 +797,14 @@
 
     private bool IsWanVisible(WanSeriesInfo wan) => wan.IsSelected;
 
+    private bool _liveViewLinkEnabled;
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         _wanScheduleBannerDismissed = await SettingsService.GetAsync("banner.wan_schedule_dismissed") != null;
         InitializeChartOptions();

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -94,6 +94,15 @@
                 </div>
             }
         </div>
+        @if (Device.SuricataUpgradeAvailable)
+        {
+            <div class="device-upgrade-bar"
+                 data-tooltip="A newer CyberSecure IDS/IPS engine (Suricata) is available. In the UniFi Network app, go to Settings &gt; CyberSecure to initiate the upgrade. Benefits: security fixes, and better, more efficient detections."
+                 data-tooltip-hover-only>
+                <span class="device-upgrade-icon">i</span>
+                <span>CyberSecure upgrade available</span>
+            </div>
+        }
     </a>
 }
 
@@ -155,6 +164,32 @@
         gap: 0.75rem;
         color: var(--text-muted);
         font-size: 0.8rem;
+    }
+
+    .device-upgrade-bar {
+        margin-top: 0.5rem;
+        padding: 0.35rem 0.5rem;
+        border-radius: var(--border-radius);
+        background: rgba(71, 151, 255, 0.12);
+        color: var(--info-color);
+        font-size: 0.75rem;
+        font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 0.4rem;
+    }
+    .device-upgrade-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 15px;
+        height: 15px;
+        border-radius: 50%;
+        background: var(--info-color);
+        color: var(--text-primary);
+        font-size: 0.65rem;
+        font-weight: 700;
+        flex-shrink: 0;
     }
 </style>
 

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -97,7 +97,7 @@
         @if (Device.SuricataUpgradeAvailable)
         {
             <div class="device-upgrade-bar"
-                 data-tooltip="A newer CyberSecure IDS/IPS engine (Suricata) is available. In the UniFi Network app, go to Settings &gt; CyberSecure to initiate the upgrade. Benefits: security fixes, and better, more efficient detections."
+                 data-tooltip="A newer Suricata IDS/IPS engine is available. UniFi Network -&gt; Settings -&gt; CyberSecure to upgrade."
                  data-tooltip-hover-only>
                 <span class="device-upgrade-icon">i</span>
                 <span>CyberSecure upgrade available</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -412,7 +412,7 @@
                 : null;
 
             await using var db = CreateDb();
-            db.MonitoringTargets.Add(new MonitoringTarget
+            var entity = new MonitoringTarget
             {
                 TargetId = targetId,
                 Name = name,
@@ -429,8 +429,17 @@
                 CreatedAt = DateTime.UtcNow,
                 AsnNumber = asnNumber,
                 AsnName = asnName
-            });
+            };
+            db.MonitoringTargets.Add(entity);
             await db.SaveChangesAsync();
+
+            // Trace-on-save: an Internet/Custom target only absolves the ISP/transit hops it crosses
+            // once it has trace ancestry. Kick off an immediate trace so it can act as a witness now,
+            // instead of waiting for the next upstream discovery cycle. Resolve the "server" vantage
+            // executor here (synchronously, current site context) so external agent sites trace over
+            // the on-site agent tunnel and there's no scoped-context race in the fire-and-forget.
+            if (targetType is MonitoringTargetType.InternetService or MonitoringTargetType.Custom)
+                _ = TraceOnSaveForAncestryAsync(ExecutorFactory.GetServer(), entity.Id, address, SiteCtx.Slug, SiteCtx.IsDefault);
 
             _showAddTarget = false;
             _newTargetName = "";
@@ -449,6 +458,18 @@
         {
             _addingTarget = false;
         }
+    }
+
+    /// <summary>
+    /// Traces a just-added Internet/Custom target over the site's server/agent vantage and persists
+    /// its hop ancestry as an UpstreamDiscovery row, so ISP Health can immediately use it as a
+    /// routes-through witness. Best-effort; fire-and-forget (reads no component state).
+    /// </summary>
+    private async Task TraceOnSaveForAncestryAsync(NetworkOptimizer.Monitoring.Probes.IProbeExecutor executor,
+        int targetId, string address, string slug, bool isDefault)
+    {
+        await using var db = SiteDb.CreateForSite(slug, isDefault);
+        await NetworkOptimizer.Web.Services.Monitoring.TargetAncestry.TraceAndPersistAsync(executor, db, targetId, address);
     }
 
     private static string TargetTypeBadgeClass(MonitoringTargetType type) => type switch

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -249,13 +249,18 @@ else
             {
                 if (MapMode == "3d")
                 {
+                    // storagePrefix is per-site and must be an argument, not baked into
+                    // the body: JS interop keeps invoking the first-resolved function
+                    // reference, so a re-eval'd definition with a different baked-in
+                    // prefix is ignored (see the matching note in Monitoring.razor).
                     await JS.InvokeVoidAsync("eval",
-                        "window.__dashMountMap3d = async function(canvasId) {" +
+                        "window.__dashMountMap3d = async function(canvasId, storagePrefix) {" +
                         $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                         "  window.__dashLanFlowMap = m;" +
-                        $"  await m.mount(canvasId,{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap")}',signalHint:false}});" +
+                        "  await m.mount(canvasId,{storagePrefix:storagePrefix,signalHint:false});" +
                         "}");
-                    await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas");
+                    await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas",
+                        SiteCtx.ScopeStorageKey("dashLanFlowMap"));
                 }
                 else
                 {

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -73,20 +73,54 @@
                                 <td><code>@mi.GatewayLocalIp/@mi.SubnetPrefix</code></td>
                                 <td>@StatusBadge(mi)</td>
                                 <td>
-                                    <div class="btn-group-wrap">
+                                    <div class="btn-group-wrap mi-row-actions">
                                         <button class="btn btn-secondary btn-sm" @onclick="() => EditInterface(mi)" disabled="@(_busyId != null)">Edit</button>
-                                        <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
-                                            @if (_busyId == mi.Id && _busyAction == "deploy")
-                                            {
-                                                <span class="spinner spinner-sm"></span>
-                                                <span>Deploying...</span>
-                                            }
-                                            else
-                                            {
-                                                <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
-                                            }
-                                        </button>
+                                        @if (mi.Disabled)
+                                        {
+                                            @* Disabled rows expose exactly one forward action - Enable - in the primary
+                                               slot (it redeploys), so Deploy/Re-apply (which would just hit the disabled
+                                               guard) and the separate Disable toggle are both omitted here. *@
+                                            <button class="btn btn-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "enable")
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>Enabling...</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>Enable</span>
+                                                }
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "deploy")
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>Deploying...</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
+                                                }
+                                            </button>
+                                        }
                                         <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
+                                        @if (ShowDisableToggle(mi) && !mi.Disabled)
+                                        {
+                                            <button class="btn btn-outline-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "disable")
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>Disabling...</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>Disable</span>
+                                                }
+                                            </button>
+                                        }
                                         <button class="btn btn-danger btn-sm" @onclick="() => RemoveInterface(mi)" disabled="@(_busyId != null)">
                                             @if (_busyId == mi.Id && _busyAction == "remove")
                                             {
@@ -386,7 +420,11 @@
 
     private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
 
-    private static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
+    /// <summary>
+    /// Test-visible (internal, see NetworkOptimizer.Web.csproj InternalsVisibleTo) so the
+    /// Disabled-copy can be verified without a Blazor component-test harness.
+    /// </summary>
+    internal static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
     {
         Id = mi.Id,
         Name = mi.Name,
@@ -398,7 +436,9 @@
         GatewayLocalIp = mi.GatewayLocalIp,
         AliasIp = mi.AliasIp,
         SnatEnabled = mi.SnatEnabled,
-        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
+        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes,
+        IsManuallyDeployed = mi.IsManuallyDeployed,
+        Disabled = mi.Disabled
     };
 
     // A gateway re-teardown is needed when an edit changes anything the boot script bakes
@@ -515,8 +555,14 @@
     }
 
     private string SummaryLabel()
-        => _interfaces.Count == 0 ? "None configured"
+    {
+        if (_interfaces.Count == 0)
+            return "None configured";
+        var paused = _interfaces.Count(i => i.Disabled);
+        return paused > 0
+            ? $"{_interfaces.Count} configured, {paused} paused"
             : $"{_interfaces.Count} configured";
+    }
 
     private async Task LoadAsync()
     {
@@ -695,7 +741,11 @@
             return;
         }
 
-        var deployResult = await DeployInterfaceReturningResult(saved);
+        // A disabled row that's edited and re-saved should come back enabled: route through
+        // Enable so the paused flag and gateway marker are cleared before redeploying.
+        var deployResult = saved.Disabled
+            ? await EnableInterfaceReturningResult(saved)
+            : await DeployInterfaceReturningResult(saved);
 
         // On a Gate 2 collision, re-enter edit mode on the row we just saved so the user can
         // see and fill in the suggested Alias IP - SaveAndDeploy would otherwise leave the
@@ -760,17 +810,27 @@
         }
     }
 
-    private async Task<MonitoringInterfaceDeploymentService.DeployResult> DeployInterfaceReturningResult(MonitoringInterface mi)
+    private Task<MonitoringInterfaceDeploymentService.DeployResult> DeployInterfaceReturningResult(MonitoringInterface mi)
+        => RunDeployAsync(mi, "deploy", () => Deploy.DeployAsync(mi));
+
+    // "Save & Deploy" on a disabled row means "Save & Enable": Enable clears the paused flag and
+    // marker first, then redeploys - going through DeployAsync directly would hit its disabled
+    // guard and Skip.
+    private Task<MonitoringInterfaceDeploymentService.DeployResult> EnableInterfaceReturningResult(MonitoringInterface mi)
+        => RunDeployAsync(mi, "enable", () => Deploy.EnableAsync(mi));
+
+    private async Task<MonitoringInterfaceDeploymentService.DeployResult> RunDeployAsync(
+        MonitoringInterface mi, string action, Func<Task<MonitoringInterfaceDeploymentService.DeployResult>> operation)
     {
         _busyId = mi.Id;
-        _busyAction = "deploy";
+        _busyAction = action;
         _message = null;
         _deploySteps.Clear();
         DisarmAllForceRemove();
         StateHasChanged();
         try
         {
-            var result = await Deploy.DeployAsync(mi);
+            var result = await operation();
             _deploySteps = result.Steps;
             _message = result.Message;
             _messageSuccess = result.Success;
@@ -787,8 +847,8 @@
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Deploy failed for monitoring interface {Id}", mi.Id);
-            _message = $"Deploy failed: {ex.Message}";
+            Logger.LogError(ex, "{Action} failed for monitoring interface {Id}", action, mi.Id);
+            _message = $"{char.ToUpper(action[0]) + action[1..]} failed: {ex.Message}";
             _messageSuccess = false;
             return new MonitoringInterfaceDeploymentService.DeployResult(
                 false, MonitoringInterfaceDeploymentService.PreflightBlock.GatewayUnreachable, _message, _deploySteps);
@@ -802,6 +862,62 @@
     }
 
     private Task DeployInterface(MonitoringInterface mi) => DeployInterfaceReturningResult(mi);
+
+    /// <summary>
+    /// Toggle a row between disabled (torn down on the gateway, config kept) and enabled
+    /// (redeployed). Mirrors the deploy/remove busy pattern so the button spins and every other
+    /// action is disabled while it runs, then reloads to reflect the new persisted flag.
+    /// </summary>
+    private async Task ToggleDisable(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = mi.Disabled ? "enable" : "disable";
+        _message = null;
+        _deploySteps.Clear();
+        DisarmAllForceRemove();
+        StateHasChanged();
+        try
+        {
+            var enabledOk = false;
+            if (mi.Disabled)
+            {
+                var result = await Deploy.EnableAsync(mi);
+                _deploySteps = result.Steps;
+                _message = result.Message;
+                _messageSuccess = result.Success;
+                enabledOk = result.Success;
+            }
+            else
+            {
+                var (success, steps) = await Deploy.DisableAsync(mi);
+                _deploySteps = steps;
+                _message = success
+                    ? $"Monitoring interface {mi.Name} disabled. Its config is kept - click Enable to redeploy it."
+                    : $"Couldn't disable {mi.Name}. {(steps.Count > 0 ? steps[^1] : "")}".Trim();
+                _messageSuccess = success;
+            }
+            _statuses.Remove(mi.Id);
+            await LoadAsync();
+            // A successful Enable just (re)deployed the interface, so refresh its status silently -
+            // otherwise the badge sits at "Unknown" until a manual Check status, even though the
+            // deploy succeeded (mirrors the Deploy button's post-deploy refresh). After a Disable
+            // the badge reads "Disabled" straight from the flag and needs no probe.
+            if (enabledOk)
+                await CheckStatus(mi, silent: true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Disable/Enable toggle failed for monitoring interface {Id}", mi.Id);
+            _message = $"Action failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
 
     /// <summary>
     /// What a Remove click should do, given whether this row already had a failed attempt
@@ -913,37 +1029,40 @@
 
     private RenderFragment StatusBadge(MonitoringInterface mi) => builder =>
     {
-        string cls, text;
-        if (!_statuses.TryGetValue(mi.Id, out var s))
-        {
-            cls = "status-disconnected";
-            text = "Unknown";
-        }
-        else if (!s.GatewayReachable)
-        {
-            cls = "status-disconnected";
-            text = "Gateway unreachable";
-        }
-        else if (s.IsFullyApplied(mi))
-        {
-            cls = "status-connected";
-            text = "Active";
-        }
-        else if (s.InterfaceExists || s.BootScriptPresent)
-        {
-            cls = "status-disconnected";
-            text = "Needs re-apply";
-        }
-        else
-        {
-            cls = "status-disconnected";
-            text = "Not deployed";
-        }
+        var (cls, text) = StatusBadgeContent(mi, _statuses.TryGetValue(mi.Id, out var s) ? s : null);
         builder.OpenElement(0, "span");
         builder.AddAttribute(1, "class", $"status-badge {cls}");
         builder.AddContent(2, text);
         builder.CloseElement();
     };
+
+    /// <summary>
+    /// Pure badge decision (class + label) for a row given its last live status (null when never
+    /// probed). Extracted as internal (see NetworkOptimizer.Web.csproj InternalsVisibleTo) so it
+    /// can be unit-tested without a Blazor renderer, mirroring DecideRemoveOutcome. A disabled
+    /// row reads "Disabled" regardless of any stale status - it's paused by the user's choice.
+    /// </summary>
+    internal static (string cls, string text) StatusBadgeContent(
+        MonitoringInterface mi, MonitoringInterfaceDeploymentService.InterfaceStatus? s)
+    {
+        if (mi.Disabled)
+            return ("status-disconnected", "Disabled");
+        if (s == null)
+            return ("status-disconnected", "Unknown");
+        if (!s.GatewayReachable)
+            return ("status-disconnected", "Gateway unreachable");
+        if (s.IsFullyApplied(mi))
+            return ("status-connected", "Active");
+        if (s.InterfaceExists || s.BootScriptPresent)
+            return ("status-disconnected", "Needs re-apply");
+        return ("status-disconnected", "Not deployed");
+    }
+
+    /// <summary>
+    /// Whether the Disable/Enable toggle is shown for a row. Hidden for manually-deployed rows:
+    /// Disable/Enable operate on gateway artifacts this app deploys, not a hand-built config.
+    /// </summary>
+    internal static bool ShowDisableToggle(MonitoringInterface mi) => !mi.IsManuallyDeployed;
 
     private string WanLabelFor(MonitoringInterface mi)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -1,4 +1,5 @@
 @using NetworkOptimizer.Core.Helpers
+@using NetworkOptimizer.Core.Interfaces
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services
 @inject SiteManagementService SiteManagement
@@ -127,6 +128,35 @@
                 <input type="password" class="form-control" @bind="_apiKey" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
             </div>
         }
+        <div class="form-group">
+            <label class="form-label">Site</label>
+            <div class="input-with-button">
+                @if (_availableSites.Count > 0)
+                {
+                    <select class="form-control" @bind="_consoleSite">
+                        @foreach (var site in _availableSites)
+                        {
+                            <option value="@site.Name">@site.Description (@site.Name) - @site.DeviceCount devices</option>
+                        }
+                    </select>
+                }
+                else
+                {
+                    <input type="text" class="form-control" @bind="_consoleSite" placeholder="default" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
+                }
+                <button type="button" class="btn btn-secondary btn-sm" @onclick="ListConsoleSitesAsync" disabled="@(_loadingSites || string.IsNullOrWhiteSpace(_consoleUrl))">
+                    @if (_loadingSites)
+                    {
+                        <span class="spinner"></span>
+                    }
+                    else
+                    {
+                        <span>List Sites</span>
+                    }
+                </button>
+            </div>
+            <small class="form-help">Leave as "default" for most local UniFi OS devices. If this console hosts multiple sites, click "List Sites" to fetch and pick one.</small>
+        </div>
         <div class="action-buttons">
             <button type="button" class="btn btn-primary" @onclick="ConnectAsync" disabled="@(_busy || string.IsNullOrWhiteSpace(_consoleUrl))">
                 @if (_busy)
@@ -264,6 +294,9 @@
     private string _username = "";
     private string _password = "";
     private string _apiKey = "";
+    private string _consoleSite = "default";
+    private List<UniFiSite> _availableSites = new();
+    private bool _loadingSites;
     private bool _connected;
     private string? _consoleName;
 
@@ -328,6 +361,71 @@
         }
     }
 
+    private UniFiConnectionConfig BuildConfig() => new()
+    {
+        ControllerUrl = _consoleUrl.Trim(),
+        Username = _username,
+        Password = _password,
+        ApiKey = _useApiKey ? _apiKey : null,
+        Site = string.IsNullOrWhiteSpace(_consoleSite) ? "default" : _consoleSite.Trim(),
+    };
+
+    /// <summary>
+    /// Fetches the sites hosted on the entered console and populates the Site
+    /// dropdown, mirroring "List Sites" on Settings - UniFi Console Connection.
+    /// Selecting a site is optional; leaving it as "default" keeps the pre-existing
+    /// behaviour of connecting to the console's default site.
+    /// </summary>
+    private async Task ListConsoleSitesAsync()
+    {
+        if (_site == null || string.IsNullOrWhiteSpace(_consoleUrl))
+            return;
+
+        _loadingSites = true;
+        _message = "";
+        StateHasChanged();
+
+        try
+        {
+            var connection = SiteConnections.GetFor(_site.Slug);
+            var (success, error, sites) = await connection.GetSitesAsync(BuildConfig());
+
+            if (success)
+            {
+                _availableSites = sites;
+                if (sites.Count == 1)
+                {
+                    _consoleSite = sites[0].Name;
+                    _message = $"Found 1 site: {sites[0].Description}";
+                }
+                else
+                {
+                    _message = $"Found {sites.Count} sites. Select one from the dropdown.";
+                    // Keep the current selection if the console still lists it; otherwise
+                    // fall back to the first site so the dropdown always has a valid value.
+                    if (!sites.Any(s => s.Name == _consoleSite) && sites.Count > 0)
+                        _consoleSite = sites[0].Name;
+                }
+                _messageClass = "success";
+            }
+            else
+            {
+                _message = $"Failed to list sites: {error}";
+                _messageClass = "danger";
+            }
+        }
+        catch (Exception ex)
+        {
+            _message = $"Error listing sites: {ex.Message}";
+            _messageClass = "danger";
+        }
+        finally
+        {
+            _loadingSites = false;
+            StateHasChanged();
+        }
+    }
+
     private async Task ConnectAsync()
     {
         if (_site == null)
@@ -340,15 +438,7 @@
         try
         {
             var connection = SiteConnections.GetFor(_site.Slug);
-            var config = new UniFiConnectionConfig
-            {
-                ControllerUrl = _consoleUrl.Trim(),
-                Username = _username,
-                Password = _password,
-                ApiKey = _useApiKey ? _apiKey : null,
-            };
-
-            _connected = await connection.ConnectAsync(config);
+            _connected = await connection.ConnectAsync(BuildConfig());
             if (_connected)
             {
                 _consoleName = await connection.GetCachedConsoleNameAsync();
@@ -486,6 +576,9 @@
         _password = "";
         _apiKey = "";
         _useApiKey = false;
+        _consoleSite = "default";
+        _availableSites = new();
+        _loadingSites = false;
         _connected = false;
         _wantAgent = false;
         _agentToken = null;

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -115,8 +115,20 @@
         </div>
     }
     <div class="test-details">
-        <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
-        <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+        @if (ShowLiveViewLink)
+        {
+            <a href="/monitoring?tab=live&at=@LiveViewAtMs" class="settings-title-link speedtest-liveview-link"
+               @onclick:stopPropagation data-tooltip="View in Live View at this time">
+                <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
+                <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+            </a>
+        }
+        else
+        {
+            <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
+            <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+        }
         @if (_isMultiServerWan)
         {
             @if (!IsInTableRow)
@@ -416,6 +428,59 @@
     [Parameter] public int ParallelStreams { get; set; }
     [Parameter] public bool IsInTableRow { get; set; }
     [Parameter] public DateTime TestTime { get; set; }
+
+    /// <summary>
+    /// When true, the test date/time links into Monitoring - Live View, opening
+    /// historic playback paused at this test's timestamp. Set by parent pages only
+    /// when monitoring is enabled for the current site.
+    /// </summary>
+    [Parameter] public bool ShowLiveViewLink { get; set; }
+
+    /// <summary>TestTime as UTC epoch milliseconds, for the Live View deep link (?at=).</summary>
+    // The gateway speed test (GatewaySpeedTestService) is the one type that stamps
+    // TestTime at the START of the test, before its legs run; every other type stamps
+    // at the END. Its results reach us either live via GatewayResult or, in history,
+    // as an Iperf3Result with DeviceType "Gateway" (the device-iperf3 path excludes
+    // gateways, so that string is unambiguous). We do not touch the recording - just
+    // pick the right compensation here.
+    private bool LiveViewTestTimeIsStart => GatewayResult != null || Result?.DeviceType == "Gateway";
+
+    // The gateway stamps TestTime before establishing its SSH connection, so the
+    // actual throughput starts a couple of seconds later - nudge forward past that
+    // setup gap (the opposite direction from the end-stamped back-off below).
+    private const long GatewaySshSetupMs = 2000L;
+
+    // Where to drop the Live View playhead for this test, as an offset from TestTime:
+    //  - Start-stamped (gateway): TestTime is the start, before its SSH connection, so
+    //    nudge forward past the setup gap.
+    //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
+    //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
+    //    the measured phase. The recorded traffic (monitoring-vs-wall-clock skew) starts
+    //    around the phase midpoint, so land just before that visible onset (~0.55 of a
+    //    duration back) for a short lead-in rather than opening mid-traffic. (An earlier
+    //    larger back-off was compensating for a playback-seed drift that's since fixed;
+    //    with play now resuming exactly at the marker, this reads right.)
+    //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
+    //    after two sequential legs, so back off both - plus 1s. The two-leg-span start
+    //    sits a hair forward of true first-byte because of the inter-leg gap (and, for
+    //    SSH-managed devices, server-start setup); a flat 1s splits the difference between
+    //    the tight UniFi case (server already listening) and the SSH-managed case.
+    //  - Everything else is end-stamped after both directional phases, so back off both.
+    // A result without a stored duration backs off by 0 (1s for ServerToDevice).
+    private long LiveViewAtMs
+    {
+        get
+        {
+            var stampMs = new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+            if (LiveViewTestTimeIsStart)
+                return stampMs + GatewaySshSetupMs;
+            if (Result?.Direction == SpeedTestDirection.ClientToServer)
+                return stampMs - DurationSeconds * 550L;
+            if (Result?.Direction == SpeedTestDirection.ServerToDevice)
+                return stampMs - 2 * DurationSeconds * 1000L - 1000L;
+            return stampMs - 2 * DurationSeconds * 1000L;
+        }
+    }
     [Parameter] public double? PingMs { get; set; }
     [Parameter] public double? JitterMs { get; set; }
     [Parameter] public double? DownloadLatencyMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -118,7 +118,7 @@
         @if (ShowLiveViewLink)
         {
             <a href="/monitoring?tab=live&at=@LiveViewAtMs" class="settings-title-link speedtest-liveview-link"
-               @onclick:stopPropagation data-tooltip="View in Live View at this time">
+               @onclick:stopPropagation data-tooltip="Go to Live View at this time" data-tooltip-hover-only>
                 <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
                 <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
                 <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -354,6 +354,7 @@
                                         <th>Label</th>
                                         <th>Endpoint</th>
                                         <th>ASN</th>
+                                        <th>Via</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -370,6 +371,20 @@
                                             </td>
                                             <td><code>@host.PathProxyTarget</code></td>
                                             <td><code>AS@(host.AsnNumber)</code> <span class="text-muted">@host.AsnName</span></td>
+                                            <td>
+                                                @if (host.ViaAsnNumber is int viaAsn)
+                                                {
+                                                    <code>AS@(viaAsn)</code> <span class="text-muted">@host.ViaAsnName</span>
+                                                }
+                                                else if (host.ViaPathComplete)
+                                                {
+                                                    <span class="text-muted">peered</span>
+                                                }
+                                                else
+                                                {
+                                                    <span class="text-muted">&mdash;</span>
+                                                }
+                                            </td>
                                         </tr>
                                     }
                                 </tbody>

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -167,13 +167,12 @@ public static class MonitoringChartEndpoints
                 .Where(t => t.TargetType == targetType && t.Enabled
                     && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
                 .OrderBy(t => t.Name)
-                .Select(t => new { t.TargetId, t.Name })
+                .Select(t => new { t.TargetId, t.Name, t.AutoLabel })
                 .ToListAsync(ct);
 
             if (targets.Count == 0)
                 return Results.Ok(new { targets = Array.Empty<object>() });
 
-            var targetLookup = targets.ToDictionary(t => t.TargetId, t => t.Name);
             var data = await influx.QueryLatencyByTargetTypeAsync(targetType, queryFrom, queryTo, ct: ct);
 
             var result = targets.Select(t =>
@@ -184,6 +183,9 @@ public static class MonitoringChartEndpoints
                 {
                     targetId = t.TargetId,
                     name = t.Name,
+                    // Role label ("gateway"/"switch"/"ap"/...) so the LAN flaky detector can
+                    // identify the gateway target and mask out gateway-outage windows.
+                    autoLabel = t.AutoLabel,
                     rtt = pts.Select(p => new { time = p.Time.ToString("o"), value = p.RttAvgMs }),
                     loss = pts.Select(p => new { time = p.Time.ToString("o"), value = p.LossPercent }),
                 };

--- a/src/NetworkOptimizer.Web/Endpoints/SpeedTestEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SpeedTestEndpoints.cs
@@ -53,7 +53,8 @@ public static class SpeedTestEndpoints
         app.MapPost("/api/public/speedtest/results", async (HttpContext context,
             SpeedTestServiceRegistry speedTestRegistry,
             IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
-            NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory) =>
+            NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
+            ILoggerFactory loggerFactory) =>
         {
             // OpenSpeedTest sends data as URL query params: d, u, p, j, dd, ud, ua
             var query = context.Request.Query;
@@ -100,14 +101,27 @@ public static class SpeedTestEndpoints
             // External server identifier (WAN speed tests from remote OpenSpeedTest servers)
             var externalServerId = GetValue("srv");
 
-            // Optional site slug (multi-site: one WAN speed test server serving many sites).
-            // Cross-origin posts carry no site cookie, so the slug rides as a parameter.
-            // Invalid or unprovisioned slugs fall back to the default site.
+            // Optional site slug (multi-site: one WAN speed test server serving many sites, or an
+            // agent relaying a LAN client's test). Cross-origin posts carry no site cookie, so the
+            // slug rides as a parameter. An empty slug is the default site's own page. A non-empty
+            // slug that does not resolve to a provisioned site (a removed/renamed site, or a
+            // misconfigured/leftover relay) would silently pollute the main site if recorded there,
+            // so log and drop it rather than falling back.
             var siteSlug = GetValue("site")?.Trim().ToLowerInvariant();
-            if (!string.IsNullOrEmpty(siteSlug) &&
-                (!NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug) || !siteDbFactory.SiteDbExists(siteSlug)))
+            if (!string.IsNullOrEmpty(siteSlug))
             {
-                siteSlug = null;
+                if (!NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug))
+                {
+                    loggerFactory.CreateLogger("SpeedTestRelay")
+                        .LogWarning("Dropping relayed speed test result: '{Slug}' is not a valid site slug", siteSlug);
+                    return Results.BadRequest(new { error = "Invalid site slug" });
+                }
+                if (!siteDbFactory.SiteDbExists(siteSlug))
+                {
+                    loggerFactory.CreateLogger("SpeedTestRelay")
+                        .LogWarning("Dropping relayed speed test result: site '{Slug}' is not provisioned on this server", siteSlug);
+                    return Results.NotFound(new { error = $"Site '{siteSlug}' is not provisioned" });
+                }
             }
 
             // An agent relay posts on behalf of a LAN client and passes the real client
@@ -124,7 +138,7 @@ public static class SpeedTestEndpoints
             // enriches against that site's console. Cross-origin posts carry no site
             // cookie, so the slug parameter picks the instance here.
             var service = speedTestRegistry
-                .GetFor(siteSlug ?? SiteManagementService.DefaultSiteSlug)
+                .GetFor(string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug)
                 .ClientSpeedTest;
             var result = await service.RecordOpenSpeedTestResultAsync(
                 clientIp, download, upload, ping, jitter, downloadData, uploadData, userAgent,
@@ -234,14 +248,25 @@ public static class SpeedTestEndpoints
         // Called by OpenSpeedTest ~3 seconds into a test to capture wireless rates mid-test
         app.MapPost("/api/public/speedtest/topology-snapshots", (HttpContext context,
             SpeedTestServiceRegistry speedTestRegistry,
-            NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory) =>
+            NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
+            ILoggerFactory loggerFactory) =>
         {
             // Same optional site routing as the results endpoint: a slug-tagged test
             // captures the snapshot from that site's console.
             var siteSlug = context.Request.Query["site"].ToString().Trim().ToLowerInvariant();
-            var relayed = !string.IsNullOrEmpty(siteSlug)
-                && NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug)
-                && siteDbFactory.SiteDbExists(siteSlug);
+            // A non-empty slug that does not resolve to a provisioned site is a stray/misconfigured
+            // relay. Capturing against the default site's console would leave an orphan snapshot (the
+            // paired result is dropped, see the results endpoint) and query the wrong console, so log
+            // and no-op. Fire-and-forget, so the browser ignores this response anyway.
+            if (!string.IsNullOrEmpty(siteSlug) &&
+                (!NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug) || !siteDbFactory.SiteDbExists(siteSlug)))
+            {
+                loggerFactory.CreateLogger("SpeedTestRelay")
+                    .LogWarning("Skipping topology snapshot: site '{Slug}' is not provisioned on this server", siteSlug);
+                return Results.Ok(new { success = false, skipped = "unprovisioned site" });
+            }
+            // Empty slug = the default site's own page; a non-empty slug here is provisioned.
+            var relayed = !string.IsNullOrEmpty(siteSlug);
             if (!relayed)
             {
                 siteSlug = SiteManagementService.DefaultSiteSlug;

--- a/src/NetworkOptimizer.Web/Endpoints/SpeedTestEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SpeedTestEndpoints.cs
@@ -194,13 +194,27 @@ public static class SpeedTestEndpoints
             NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
             ILoggerFactory loggerFactory) =>
         {
-            // Same optional site routing as the results endpoint: a slug-tagged relay lands in that
-            // site's database; an invalid/unprovisioned slug falls back to the default site.
+            var logger = loggerFactory.CreateLogger("Iperf3ClientRelay");
+
+            // Site routing. This endpoint is used ONLY by on-site agents relaying a captured
+            // iperf3 -s result - the central server records its own default-site tests directly,
+            // never over HTTP. An empty slug is the default site's own relay and lands on the
+            // default site. A NON-empty slug that does not resolve to a provisioned site means a
+            // misconfigured, renamed, or removed agent site; recording it to the default site
+            // would silently pollute the main site, so log and drop it rather than falling back.
             var siteSlug = context.Request.Query["site"].ToString().Trim().ToLowerInvariant();
-            if (!string.IsNullOrEmpty(siteSlug) &&
-                (!NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug) || !siteDbFactory.SiteDbExists(siteSlug)))
+            if (!string.IsNullOrEmpty(siteSlug))
             {
-                siteSlug = null;
+                if (!NetworkOptimizer.Core.Helpers.StringUtilities.IsSlug(siteSlug))
+                {
+                    logger.LogWarning("Dropping relayed iperf3 result: '{Slug}' is not a valid site slug", siteSlug);
+                    return Results.BadRequest(new { error = "Invalid site slug" });
+                }
+                if (!siteDbFactory.SiteDbExists(siteSlug))
+                {
+                    logger.LogWarning("Dropping relayed iperf3 result: site '{Slug}' is not provisioned on this server", siteSlug);
+                    return Results.NotFound(new { error = $"Site '{siteSlug}' is not provisioned" });
+                }
             }
 
             using var reader = new StreamReader(context.Request.Body);
@@ -209,10 +223,9 @@ public static class SpeedTestEndpoints
                 return Results.BadRequest(new { error = "Missing iperf3 JSON body" });
 
             var clientSpeedTest = speedTestRegistry
-                .GetFor(siteSlug ?? SiteManagementService.DefaultSiteSlug)
+                .GetFor(string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug)
                 .ClientSpeedTest;
-            await Iperf3ClientResultRecorder.RecordAsync(
-                clientSpeedTest, json, loggerFactory.CreateLogger("Iperf3ClientRelay"));
+            await Iperf3ClientResultRecorder.RecordAsync(clientSpeedTest, json, logger);
 
             return Results.Ok(new { success = true });
         }).RequireCors("SpeedTestCors").RequireRateLimiting("PublicSpeedTest");

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -557,6 +557,7 @@ builder.Services.AddAuthorization();
 
 // Monitoring subsystem
 builder.Services.AddScoped<SnmpDetectionService>();
+builder.Services.AddScoped<MonitoringReadinessService>();
 // Per-site Influx clients (D1: bucket-per-site) live in the registry - the
 // default site's included. Scoped resolution forwards to the current site's
 // client so chart endpoints and pages read that site's buckets; singleton

--- a/src/NetworkOptimizer.Web/Services/DashboardService.cs
+++ b/src/NetworkOptimizer.Web/Services/DashboardService.cs
@@ -86,7 +86,8 @@ public class DashboardService : IDashboardService
                         IpAddress = d.DisplayIpAddress ?? "",
                         Model = d.FriendlyModelName,
                         Firmware = d.Firmware,
-                        Uptime = FormatUptime((long?)d.Uptime.TotalSeconds)
+                        Uptime = FormatUptime((long?)d.Uptime.TotalSeconds),
+                        SuricataUpgradeAvailable = d.SuricataUpgradeAvailable
                     };
                     // Merge live monitoring data when available. Stale data is dropped by the
                     // cache's prune step; here we just ignore an entry if no fresh values landed.
@@ -297,6 +298,13 @@ public class DeviceInfo
     public double? LiveCpuPercent { get; set; }
     public double? LiveMemoryPercent { get; set; }
     public double? LiveTemperatureC { get; set; }
+
+    /// <summary>
+    /// True when this device (a gateway) has a pending CyberSecure IDS/IPS (Suricata) engine
+    /// upgrade available but not yet initiated. Drives the Dashboard advisory banner and the
+    /// device card's upgrade bar.
+    /// </summary>
+    public bool SuricataUpgradeAvailable { get; set; }
 
     /// <summary>
     /// Get display name for the device type

--- a/src/NetworkOptimizer.Web/Services/ISqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/ISqmDeploymentService.cs
@@ -15,6 +15,13 @@ public interface ISqmDeploymentService
     Task<(bool success, string message)> TestConnectionAsync();
 
     /// <summary>
+    /// True when the gateway is unreachable only because this site's on-site agent
+    /// isn't online yet, rather than a real connection failure. Always false for a
+    /// directly-reached site.
+    /// </summary>
+    Task<bool> IsAwaitingAgentAsync();
+
+    /// <summary>
     /// Install udm-boot package on the gateway.
     /// This enables scripts in /data/on_boot.d/ to run automatically on boot
     /// and persist across firmware updates.

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -576,12 +576,18 @@ public class LanFlowMapService
         // was empty when fetched (data not written yet), so serving it there froze the maps
         // while fresh queries (Port Stats) stayed accurate. Refetch when `at` is within the
         // settle window of now so the live edge always reads freshly-written data.
-        var liveEdge = DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
+        var atLiveEdge = at > DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
         var cached = _cache.HistoricData;
-        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || at > liveEdge)
+        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || atLiveEdge)
         {
             cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
-            _cache.HistoricData = cached;
+            // Only promote a fetch to the reusable singleton when it is NOT a live-edge
+            // fetch. A live-edge window's near-present portion is still-arriving/incomplete;
+            // storing it poisons the cache so instants that later age past the settle window
+            // fall inside that stale window and keep reading empty (the "test didn't show for
+            // minutes, then appeared once the window rolled" symptom). Live-edge fetches are
+            // used for this response only and always re-fetched fresh next time.
+            if (!atLiveEdge) _cache.HistoricData = cached;
         }
 
         var ratesByDevice = cached.RatesByDevice;

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -204,6 +204,17 @@ public class LanFlowMapService
     /// </summary>
     private const double HistoricOnlineWindowSeconds = 60;
 
+    /// <summary>
+    /// Instants within this many seconds of now are the "live edge". The historic cache
+    /// fetches a window 5 min AHEAD of its fetch instant, but that ahead portion is empty
+    /// when fetched (the data isn't written yet), and an agent-run speed test can delay
+    /// writes ~2 min. Reusing the cached copy there froze the maps (all-offline / stuck
+    /// rates) while Port Stats - which queries fresh per instant - stayed accurate. So near
+    /// the live edge we bypass the cache and query fresh, matching Port Stats. Sized to the
+    /// worst observed agent-test write lag; older instants still use the cache.
+    /// </summary>
+    private const double HistoricLiveEdgeSettleSeconds = 150;
+
     /// <summary>Gateway / switch / AP - the fabric devices the map renders an explicit
     /// online/offline appearance for (clients track association, not device state).</summary>
     private static bool IsInfraKind(LanNodeKind kind) =>
@@ -559,11 +570,15 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Reuse cached InfluxDB results when the requested time falls within
-        // the previously fetched window. Fetches 5 min ahead so forward
-        // playback goes ~4 min before needing another round-trip.
+        // Reuse cached InfluxDB results when the requested time falls within the
+        // previously fetched window. Fetches 5 min ahead so forward playback goes ~4 min
+        // before another round-trip. But never reuse for the live edge: the ahead portion
+        // was empty when fetched (data not written yet), so serving it there froze the maps
+        // while fresh queries (Port Stats) stayed accurate. Refetch when `at` is within the
+        // settle window of now so the live edge always reads freshly-written data.
+        var liveEdge = DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
         var cached = _cache.HistoricData;
-        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30))
+        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || at > liveEdge)
         {
             cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
             _cache.HistoricData = cached;
@@ -879,6 +894,16 @@ public class LanFlowMapService
                 var onlineAtT = healthPt != null
                     && Math.Abs((healthPt.Time - at).TotalSeconds) <= HistoricOnlineWindowSeconds;
 
+                // A second liveness signal at the same proximity: interface rates are only
+                // recorded while a device is reachable and poll on a separate cadence from
+                // device_health, so a single health sample dropped to poll jitter must not
+                // dark a device that plainly had interface telemetry at T (the visible
+                // symptom was particle streams freezing mid-playback, then restoring).
+                // Bounded by the same window, so a genuine outage - no health AND no rate
+                // telemetry near T - still reads offline.
+                var rateNearT = ratesByDevice.TryGetValue(mac, out var rateHist) && rateHist.Count > 0
+                    && rateHist.Min(p => Math.Abs((p.Time - at).TotalSeconds)) <= HistoricOnlineWindowSeconds;
+
                 bool infraOnline = false;
                 if (isInfra)
                 {
@@ -890,7 +915,7 @@ public class LanFlowMapService
                     var hasHealthHistory =
                         cached.HealthByDevice.TryGetValue(mac, out var hh) && hh.Count > 0;
                     if (hasHealthHistory)
-                        infraOnline = onlineAtT;
+                        infraOnline = onlineAtT || rateNearT;
                     else
                         infraOnline = (fabIn != null || aggIn != null) || node.Online;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/AsnResolutionService.cs
@@ -159,7 +159,7 @@ internal static class AsnNameCleanup
     // common US / EU / UK / Nordic forms. Run iteratively because some names
     // have stacked suffixes (e.g. "Foo Holdings Ltd LLC").
     private static readonly Regex SuffixPattern = new(
-        @"\s*,?\s+(LLC|L\.L\.C\.?|Inc\.?|Incorporated|Corp\.?|Corporation|Co\.?|Company|Ltd\.?|Limited|B\.V\.?|BV|AB|AG|GmbH|S\.A\.?S?\.?|S\.r\.l\.?|SA|PLC|Pte\.?|N\.V\.?|NV|OY|OYJ)\.?\s*$",
+        @"\s*,?\s+(LLC|L\.L\.C\.?|L\.C\.?|LC|L\.P\.?|LP|Inc\.?|Incorporated|Corp\.?|Corporation|Co\.?|Company|Ltd\.?|Limited|B\.V\.?|BV|AB|AG|GmbH|S\.A\.?S?\.?|S\.r\.l\.?|SA|PLC|Pte\.?|N\.V\.?|NV|OY|OYJ)\.?\s*$",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // Specific brand overrides, applied AFTER suffix stripping. This is the ONLY place a name is

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -669,6 +669,15 @@ public class IspHealthInputs
     /// </summary>
     public List<AsnSeries> DestinationSeries { get; init; } = new();
 
+    /// <summary>
+    /// Witness-only series (user-added Custom targets, e.g. a known-stable CMTS/PoP ping). They join
+    /// the routes-through absolution witness pool alongside <see cref="DestinationSeries"/>, but are
+    /// deliberately NOT treated as internet destinations - they don't count toward transit
+    /// involvement and can't be selected as IX-peering-reached destinations (a nearby CMTS is
+    /// low-delta and crosses no transit, so it would otherwise be mistaken for a peered endpoint).
+    /// </summary>
+    public List<AsnSeries> WitnessSeries { get; init; } = new();
+
     /// <summary>WAN throughput over the window (primary WAN).</summary>
     public List<ThroughputSample> WanRates { get; init; } = new();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -601,6 +601,23 @@ public class IspHealthOptions
     public double JitterAssimilationMinDeltaMs { get; set; } = 0.05;
 
     /// <summary>
+    /// Dead-band for RTT-stability scoring: absolute median-absolute-deviation (MAD) at or below
+    /// this many ms counts as perfectly steady. Stability grades on MAD/median, which is scale-free,
+    /// so on a low-RTT fiber path (median ~2-3 ms) a few tenths of a ms of wander - operationally
+    /// trivial - becomes a large ratio and over-penalizes. The stability analog of
+    /// <see cref="JitterFloorMinMs"/>: the score reads off max(0, MAD - floor) / median, so sub-floor
+    /// wander is free and only the excess counts.
+    /// </summary>
+    public double StabilityMadFloorMs { get; set; } = 0.35;
+
+    /// <summary>
+    /// Minimum amount (absolute MAD, ms) a cleaner witness must sit below a hop's own RTT MAD before it
+    /// absolves the hop's stability. Within this band the difference is noise, so the hop keeps its own
+    /// wander. The stability analog of <see cref="JitterAssimilationMinDeltaMs"/>.
+    /// </summary>
+    public double StabilityAssimilationMinMadMs { get; set; } = 0.05;
+
+    /// <summary>
     /// Item D - how strongly the internet-relative reach ceiling absolves an ISP access hop's
     /// intra-ASN distance penalty. finalCeiling = C_intra + alpha * max(0, C_net - C_intra), so it
     /// only ever lifts (never lowers) and partially (alpha &lt; 1) - genuine distance/glass always
@@ -656,7 +673,16 @@ public sealed record AccessProfile(
     // to ISP and transit jitter, since every probe crosses the access medium.
     double? JitterIdealMs = null,
     double? JitterTypicalMs = null,
-    double? JitterPoorMs = null);
+    double? JitterPoorMs = null,
+    // Per-tech RTT-stability band (absolute median-absolute-deviation of RTT, ms). When set, stability
+    // is scored straight off the band - (ideal,100) (typical,90) (poor,25) (2*poor,0) - so a medium's
+    // inherent RTT wander reads as normal (fiber's sub-ms, Starlink's several-ms) instead of against a
+    // scale-free ratio that over-punishes low-RTT media. Null keeps the floored-ratio fallback. Applies
+    // path-wide (every probe crosses the access medium), after routes-through witness absolution has
+    // stripped per-hop ICMP-deprioritization artifact.
+    double? StabilityMadIdealMs = null,
+    double? StabilityMadTypicalMs = null,
+    double? StabilityMadPoorMs = null);
 
 /// <summary>
 /// Static catalog of access technology profiles. Returns null for
@@ -674,34 +700,47 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 1.0, LoadedLossDownHighPct: 2.0,
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
-            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
+            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0,
+            StabilityMadIdealMs: 0.15, StabilityMadTypicalMs: 0.4, StabilityMadPoorMs: 1.5),
 
-        // XGS-PON sits a notch below GPON on idle RTT: its low-latency DBA runs shorter upstream
-        // grant cycles than GPON's ~1-2 ms, and the 10G upstream cuts serialization, so the
-        // first-hop floor is lower. Loss/jitter/loaded bands stay as the optical defaults.
+        // XGS-PON is graded subtly stricter than GPON on idle RTT, jitter, AND stability. Same
+        // 125 us frame / DBA TDMA, but at a gig plan XGS uses ~10% of its 10G symmetric upstream vs
+        // GPON's ~80% of 1.244G - far less grant contention - and its 10G upstream cuts serialization
+        // ~8x. So its inherent wander is lower; the taper is gentle (most-distinguishable at the clean
+        // end, converging to GPON near "poor" where a fault is medium-agnostic). Measured: 4 optical
+        // NAS sites (research/monitoring/isp-health/stability-mad-calibration.md).
         AccessTechnology.XgsPon => new AccessProfile("XGS-PON",
             IdleRttIdealMs: 1.0, IdleRttNormalLowMs: 1.5, IdleRttNormalHighMs: 2.5, IdleRttPoorMs: 7.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.05,
             LoadedLossDownLowPct: 0.5, LoadedLossDownHighPct: 1.0,
             LoadedLossUpLowPct: 0.25, LoadedLossUpHighPct: 0.5,
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
-            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
+            JitterIdealMs: 0.35, JitterTypicalMs: 0.6, JitterPoorMs: 2.8,
+            StabilityMadIdealMs: 0.12, StabilityMadTypicalMs: 0.33, StabilityMadPoorMs: 1.35),
 
+        // DOCSIS stability band is near-fiber: the CMTS access hop is measured rock-steady
+        // (~0.30 ms MAD, 2 real CMTS). DOCSIS's jitter reputation is a loaded / end-to-end
+        // request-grant phenomenon, not a property of the (short, lightly-loaded) access segment.
         AccessTechnology.Docsis => new AccessProfile("DOCSIS",
             IdleRttIdealMs: 7.0, IdleRttNormalLowMs: 9.0, IdleRttNormalHighMs: 12.0, IdleRttPoorMs: 25.0,
             IdleLossIdealPct: 0.02, IdleLossAcceptablePct: 0.2,
             LoadedLossDownLowPct: 3.0, LoadedLossDownHighPct: 5.0,
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
             LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
-            JitterIdealMs: 1.75, JitterTypicalMs: 3.0, JitterPoorMs: 6.0),
+            JitterIdealMs: 1.75, JitterTypicalMs: 3.0, JitterPoorMs: 6.0,
+            StabilityMadIdealMs: 0.3, StabilityMadTypicalMs: 0.8, StabilityMadPoorMs: 3.0),
 
+        // Starlink stability band from real data: same dish/target across two plans - ideal
+        // (Local Priority) ~4.3 ms MAD, degraded backup ~9.2 ms. The several-ms steady-state wander
+        // is inherent LEO (handovers ~every 15 s); MAD is robust to the obstruction tail.
         AccessTechnology.Satellite => new AccessProfile("Satellite (LEO)",
             IdleRttIdealMs: 23.0, IdleRttNormalLowMs: 30.0, IdleRttNormalHighMs: 45.0, IdleRttPoorMs: 80.0,
             IdleLossIdealPct: 0.2, IdleLossAcceptablePct: 0.5,
             LoadedLossDownLowPct: 0.5, LoadedLossDownHighPct: 1.0,
             LoadedLossUpLowPct: 0.25, LoadedLossUpHighPct: 0.5,
             LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 25.0,
-            JitterIdealMs: 5.0, JitterTypicalMs: 6.5, JitterPoorMs: 15.0),
+            JitterIdealMs: 5.0, JitterTypicalMs: 6.5, JitterPoorMs: 15.0,
+            StabilityMadIdealMs: 5.0, StabilityMadTypicalMs: 9.0, StabilityMadPoorMs: 22.0),
 
         AccessTechnology.DirectEthernet => new AccessProfile("Active Ethernet",
             IdleRttIdealMs: 0.5, IdleRttNormalLowMs: 1.0, IdleRttNormalHighMs: 3.0, IdleRttPoorMs: 8.0,
@@ -710,15 +749,18 @@ public static class IspHealthProfiles
             LoadedLossUpLowPct: 0.5, LoadedLossUpHighPct: 1.0,
             LoadedDeltaExcellentMs: 2.0, LoadedDeltaAcceptableMs: 10.0,
             SharedMedium: false,
-            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0),
+            JitterIdealMs: 0.4, JitterTypicalMs: 0.7, JitterPoorMs: 3.0,
+            StabilityMadIdealMs: 0.15, StabilityMadTypicalMs: 0.4, StabilityMadPoorMs: 1.5),
 
+        // Common-sense (unvalidated) stability bands below - no real DSL/FW/Cellular sites yet.
         AccessTechnology.FixedWireless => new AccessProfile("Fixed Wireless",
             IdleRttIdealMs: 5.0, IdleRttNormalLowMs: 8.0, IdleRttNormalHighMs: 15.0, IdleRttPoorMs: 35.0,
             IdleLossIdealPct: 0.3, IdleLossAcceptablePct: 0.5,
             LoadedLossDownLowPct: 2.0, LoadedLossDownHighPct: 4.0,
             LoadedLossUpLowPct: 1.0, LoadedLossUpHighPct: 2.0,
             LoadedDeltaExcellentMs: 10.0, LoadedDeltaAcceptableMs: 20.0,
-            JitterIdealMs: 2.5, JitterTypicalMs: 4.0, JitterPoorMs: 12.0),
+            JitterIdealMs: 2.5, JitterTypicalMs: 4.0, JitterPoorMs: 12.0,
+            StabilityMadIdealMs: 0.8, StabilityMadTypicalMs: 2.0, StabilityMadPoorMs: 8.0),
 
         AccessTechnology.Cellular => new AccessProfile("Cellular",
             IdleRttIdealMs: 20.0, IdleRttNormalLowMs: 25.0, IdleRttNormalHighMs: 50.0, IdleRttPoorMs: 90.0,
@@ -726,8 +768,12 @@ public static class IspHealthProfiles
             LoadedLossDownLowPct: 2.0, LoadedLossDownHighPct: 4.0,
             LoadedLossUpLowPct: 2.0, LoadedLossUpHighPct: 4.0,
             LoadedDeltaExcellentMs: 20.0, LoadedDeltaAcceptableMs: 50.0,
-            JitterIdealMs: 4.0, JitterTypicalMs: 6.0, JitterPoorMs: 20.0),
+            JitterIdealMs: 4.0, JitterTypicalMs: 6.0, JitterPoorMs: 20.0,
+            StabilityMadIdealMs: 1.5, StabilityMadTypicalMs: 4.0, StabilityMadPoorMs: 15.0),
 
+        // DSL: a dedicated copper pair has no shared-medium contention, so a clean short loop can
+        // beat DOCSIS (tight ideal); aging DSLAM aggregation + old BNG (buffering, interleaving/FEC)
+        // drag the typical case, and a long/noisy loop pushes poor. Common-sense, unvalidated.
         AccessTechnology.Dsl => new AccessProfile("DSL",
             IdleRttIdealMs: 6.0, IdleRttNormalLowMs: 10.0, IdleRttNormalHighMs: 25.0, IdleRttPoorMs: 50.0,
             IdleLossIdealPct: 0.05, IdleLossAcceptablePct: 0.2,
@@ -735,7 +781,8 @@ public static class IspHealthProfiles
             LoadedLossUpLowPct: 3.0, LoadedLossUpHighPct: 5.0,
             LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
             SharedMedium: false,
-            JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0),
+            JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0,
+            StabilityMadIdealMs: 0.35, StabilityMadTypicalMs: 0.9, StabilityMadPoorMs: 3.5),
 
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),
         AccessTechnology.Other => NeutralProfile("Other"),
@@ -752,5 +799,8 @@ public static class IspHealthProfiles
         LoadedLossDownLowPct: 2.0, LoadedLossDownHighPct: 4.0,
         LoadedLossUpLowPct: 1.0, LoadedLossUpHighPct: 2.0,
         LoadedDeltaExcellentMs: 5.0, LoadedDeltaAcceptableMs: 20.0,
-        IsNeutral: true);
+        IsNeutral: true,
+        // Generic-conservative stability band so an unclassified medium isn't over-punished for
+        // sub-ms wander, but genuine ms-scale instability still grades down.
+        StabilityMadIdealMs: 0.3, StabilityMadTypicalMs: 0.8, StabilityMadPoorMs: 3.0);
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -91,7 +91,12 @@ public class IspHealthScorer
         var accessMedianRtt = SeriesStats.Median(
             inputs.FirstHopSeries.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList());
 
-        var transitAsns = GradeTransitAsns(inputs.TransitAsnSeries, inputs.DestinationSeries, inputs.HopOrderKnown,
+        // Absolution witnesses = internet destinations plus witness-only Custom targets. Peering
+        // selection and involvement counts below use inputs.DestinationSeries directly (internet
+        // only), so a witness-only CMTS/PoP never counts as an internet destination.
+        var witnessDestinations = inputs.DestinationSeries.Concat(inputs.WitnessSeries).ToList();
+
+        var transitAsns = GradeTransitAsns(inputs.TransitAsnSeries, witnessDestinations, inputs.HopOrderKnown,
             inputs.CongestionEvents, jitterFloor, accessMedianRtt, inputs.InternetMedianDeltaMs);
 
         // IX Peering: destinations reached over the access ISP's own peering/IX (see
@@ -167,7 +172,7 @@ public class IspHealthScorer
         // absolves a hop it is proven downstream of), so a divergent clean transit can't
         // clear a congested hop it never traverses. Hops further out on the same ISP also
         // get a soft intra-ASN reach ceiling. Access layer idle latency still uses FirstHopSeries.
-        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, inputs.DestinationSeries, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
+        var ispHopGrades = GradeIspHops(inputs.IspAsnSeries, inputs.TransitAsnSeries, transitAsns, witnessDestinations, inputs.CongestionEvents, jitterFloor, inputs.HopOrderKnown, accessMedianRtt, inputs.InternetMedianDeltaMs);
         // Collapse the per-hop grades to one entry per ASN for the Networks on Your Path card.
         var ispAsns = AggregateIspAsns(ispHopGrades, inputs.CongestionEvents, _options.JitterAssimilationMinDeltaMs);
         var transitDimension = BuildAsnDimension("Transit Health", _options.TransitWeight, transitAsns);
@@ -798,7 +803,8 @@ public class IspHealthScorer
         double? accessBaselineRtt,
         double? internetMedianDeltaMs,
         double? intraAsnFloorRttMs = null,
-        double? jitterOverrideMs = null)
+        double? jitterOverrideMs = null,
+        double? stabilityMadOverrideMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
@@ -826,7 +832,18 @@ public class IspHealthScorer
             && rawEffectiveJitter.Value > nearJitter.Value - _options.JitterAssimilationMinDeltaMs
             ? nearJitter
             : rawEffectiveJitter;
-        var stabilityRatio = EffectiveLower(series.Samples, series.JitterSourceSamples, StabilityRatioOf);
+        // RTT stability: take the steadier (lower absolute MAD) of this ASN's near and far clusters.
+        // Working in absolute MAD (not the ratio) keeps the near/far min honest and lets cross-target
+        // witness absolution (stabilityMadOverrideMs) compare MAD across targets sitting at different
+        // base RTTs. A witness proven to route through this hop that carries steadier end-to-end RTT
+        // proves the hop's own wander is a per-hop artifact (ICMP-deprioritized control plane), so it
+        // pulls the MAD down - absolve-only, and only past the assimilation band so a trivially-lower
+        // witness doesn't snap it. The resulting absolute MAD is graded against the per-tech band below.
+        var withinMad = EffectiveLower(series.Samples, series.JitterSourceSamples, RttMadOf);
+        var stabilityMad = withinMad;
+        if (stabilityMadOverrideMs.HasValue
+            && (!withinMad.HasValue || stabilityMadOverrideMs.Value < withinMad.Value - _options.StabilityAssimilationMinMadMs))
+            stabilityMad = stabilityMadOverrideMs.Value;
 
         // Assimilated when a witness (a farther transit cluster, or - for an ISP hop via
         // the override - a downstream transit/deeper ISP hop) pulled this jitter below the
@@ -842,9 +859,8 @@ public class IspHealthScorer
                 FormatMsOrNull(ScoringJitterOf(series.JitterSourceSamples)), FormatMsOrNull(effectiveJitter));
         }
 
-        int? stabilityScore = stabilityRatio.HasValue
-            ? (int)Math.Round(ScoreCurve.Interpolate(stabilityRatio.Value,
-                (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0)))
+        int? stabilityScore = stabilityMad.HasValue
+            ? (int)Math.Round(ScoreStabilityMad(stabilityMad.Value, medianRtt))
             : null;
 
         int? jitterScore = effectiveJitter.HasValue
@@ -1009,14 +1025,15 @@ public class IspHealthScorer
         return js.Count > 0 ? SeriesStats.Percentile(js, _options.AsnJitterScoringPercentile) : null;
     }
 
-    /// <summary>RTT stability ratio (MAD / median) of a sample set; lower is steadier. Null without RTT.</summary>
-    private static double? StabilityRatioOf(IReadOnlyList<LatencySample> samples)
+    /// <summary>Absolute RTT MAD (median absolute deviation, ms) of a sample set; lower is steadier.
+    /// Null without RTT. Callers normalize by the hop's own median (scale-free stability ratio) and
+    /// apply the <see cref="IspHealthOptions.StabilityMadFloorMs"/> dead-band.</summary>
+    private static double? RttMadOf(IReadOnlyList<LatencySample> samples)
     {
         var rtts = samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToArray();
         Array.Sort(rtts);
         var median = SeriesStats.MedianSorted(rtts);
-        var mad = median.HasValue ? SeriesStats.MadSorted(rtts, median.Value) : null;
-        return median is > 0 && mad.HasValue ? mad.Value / median.Value : null;
+        return median.HasValue ? SeriesStats.MadSorted(rtts, median.Value) : null;
     }
 
     /// <summary>
@@ -1058,6 +1075,28 @@ public class IspHealthScorer
         var f = Math.Clamp(floorMs ?? 0.4, _options.JitterFloorMinMs, _options.JitterFloorMaxMs);
         return ScoreCurve.Interpolate(jitterMs,
             (f, 100), (1.25 * f, 96), (1.5 * f, 91), (2.0 * f, 70), (5.0, 22), (12.0, 0));
+    }
+
+    /// <summary>
+    /// Scores RTT stability (absolute MAD, ms) against the per-tech band. The stability analog of
+    /// <see cref="ScoreJitterVsFloor"/>: a medium's inherent RTT wander reads as normal (fiber's
+    /// sub-ms, Starlink's several-ms) instead of being punished by the scale-free MAD/median ratio,
+    /// which over-weights proportional variation on low-RTT media. The MAD here is post-absolution,
+    /// so per-hop ICMP-deprioritization artifact has already been stripped. Techs with no band
+    /// (Unknown) fall back to the floored ratio, so we never over-punish sub-ms wander on a fast
+    /// line we can't classify.
+    /// </summary>
+    private double ScoreStabilityMad(double madMs, double? medianRttMs)
+    {
+        if (_profile is { StabilityMadIdealMs: { } ideal, StabilityMadTypicalMs: { } typical, StabilityMadPoorMs: { } poor })
+            return ScoreCurve.Interpolate(madMs, (ideal, 100), (typical, 90), (poor, 25), (2.0 * poor, 0));
+
+        if (medianRttMs is > 0)
+        {
+            var ratio = Math.Max(0, madMs - _options.StabilityMadFloorMs) / medianRttMs.Value;
+            return ScoreCurve.Interpolate(ratio, (0.02, 100), (0.10, 80), (0.25, 55), (0.5, 25), (1.0, 0));
+        }
+        return 100;
     }
 
     /// <summary>
@@ -1112,6 +1151,22 @@ public class IspHealthScorer
             .Select(b => (b.Series.AsnNumber, b.Series.AncestorIps, Jitter: b.Grade.ScoredJitterMs!.Value))
             .ToList();
 
+        // Stability witnesses in absolute RTT MAD, same sources and routes-through gate as jitter:
+        // a destination or a different transit ASN proven to route through this ASN whose end-to-end
+        // RTT is steadier bounds this ASN's true wander (its own MAD is a per-hop artifact).
+        var destMadWitnesses = hopOrderKnown
+            ? destinationSeries
+                .Select(d => (d.AncestorIps, Mad: RttMadOf(d.Samples)))
+                .Where(w => w.Mad.HasValue)
+                .Select(w => (w.AncestorIps, Mad: w.Mad!.Value))
+                .ToList()
+            : new List<(List<string> AncestorIps, double Mad)>();
+        var transitMadWitnesses = transitSeries
+            .Select(s => (s.AsnNumber, s.AncestorIps, Mad: RttMadOf(s.Samples)))
+            .Where(w => w.Mad.HasValue)
+            .Select(w => (w.AsnNumber, w.AncestorIps, Mad: w.Mad!.Value))
+            .ToList();
+
         var grades = new List<IspAsnHealth>();
         foreach (var (series, baseGrade) in baseGrades)
         {
@@ -1124,14 +1179,30 @@ public class IspHealthScorer
                     .Where(w => hopOrderKnown && w.AsnNumber != series.AsnNumber && RoutesThrough(w.AncestorIps, series.HopIps))
                     .Select(w => w.Jitter))
                 .ToList();
-            if (witnesses.Count == 0)
+            var stabWitnesses = destMadWitnesses
+                .Where(w => hopOrderKnown && RoutesThrough(w.AncestorIps, series.HopIps))
+                .Select(w => w.Mad)
+                .Concat(transitMadWitnesses
+                    .Where(w => hopOrderKnown && w.AsnNumber != series.AsnNumber && RoutesThrough(w.AncestorIps, series.HopIps))
+                    .Select(w => w.Mad))
+                .ToList();
+            double? stabOverride = stabWitnesses.Count > 0 ? stabWitnesses.Min() : (double?)null;
+            if (witnesses.Count == 0 && stabOverride == null)
             {
                 grades.Add(baseGrade);
                 continue;
             }
-            var effective = within.HasValue ? Math.Min(within.Value, witnesses.Min()) : witnesses.Min();
-            grades.Add(GradeAsn(series, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs,
-                jitterOverrideMs: effective));
+            double? jitterOverride = witnesses.Count > 0
+                ? (within.HasValue ? Math.Min(within.Value, witnesses.Min()) : witnesses.Min())
+                : null;
+            var transitGrade = GradeAsn(series, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs,
+                jitterOverrideMs: jitterOverride, stabilityMadOverrideMs: stabOverride);
+            _logger?.LogDebug(
+                "ISP Health: transit AS{Asn} ({Name}) graded {Score} - jitter within {Within} ms -> effective {Eff} ms ({JWit} witnesses); stability MAD measured {Mad} ms -> witness-floor {StabWit} ms ({SWit} witnesses) score {StabScore}",
+                series.AsnNumber, series.AsnName, transitGrade.OverallScore,
+                FormatMsOrNull(within), FormatMsOrNull(transitGrade.ScoredJitterMs), witnesses.Count,
+                FormatMsOrNull(RttMadOf(series.Samples)), FormatMsOrNull(stabOverride), stabWitnesses.Count, transitGrade.LatencyStabilityScore);
+            grades.Add(transitGrade);
         }
         return grades;
     }
@@ -1304,6 +1375,27 @@ public class IspHealthScorer
             .Select(s => (Series: s, Jitter: ScoringJitterOf(s.Samples)))
             .ToList();
 
+        // Stability witnesses (parallel to the jitter witnesses above): the same three sources,
+        // each carrying its absolute RTT MAD. A witness proven to route through a hop bounds the
+        // hop's true RTT wander - a steadier forwarded path proves the hop's own MAD is a per-hop
+        // artifact (ICMP-deprioritized control plane). Transit gate opens without hop order (always
+        // downstream); destinations and ISP siblings stay strict.
+        var transitMadWitnesses = transitSeries
+            .Select(s => (Ancestors: s.AncestorIps, Mad: RttMadOf(s.Samples)))
+            .Where(w => w.Mad.HasValue)
+            .Select(w => (w.Ancestors, Mad: w.Mad!.Value))
+            .ToList();
+        var destinationMadWitnesses = hopOrderKnown
+            ? destinationSeries
+                .Select(s => (s.AncestorIps, Mad: RttMadOf(s.Samples)))
+                .Where(w => w.Mad.HasValue)
+                .Select(w => (w.AncestorIps, Mad: w.Mad!.Value))
+                .ToList()
+            : new List<(List<string> AncestorIps, double Mad)>();
+        var ispHopMad = ispHopSeries
+            .Select(s => (Series: s, Mad: RttMadOf(s.Samples)))
+            .ToList();
+
         var grades = new List<IspAsnHealth>();
         foreach (var asnGroup in ispHopSeries.GroupBy(s => s.AsnNumber))
         {
@@ -1337,14 +1429,32 @@ public class IspHealthScorer
                 if (witnesses.Count > 0)
                     effective = measured.HasValue ? Math.Min(measured.Value, witnesses.Min()) : witnesses.Min();
 
+                // Same routes-through gate, in absolute RTT MAD, for the hop's stability.
+                var stabWitnesses = transitMadWitnesses
+                    .Where(w => !hopOrderKnown || RoutesThrough(w.Ancestors, hop.HopIps))
+                    .Select(w => w.Mad)
+                    .Concat(ispHopMad
+                        .Where(h => hopOrderKnown && !ReferenceEquals(h.Series, hop) && h.Mad.HasValue
+                            && RoutesThrough(h.Series.AncestorIps, hop.HopIps))
+                        .Select(h => h.Mad!.Value))
+                    .Concat(destinationMadWitnesses
+                        .Where(w => hopOrderKnown && RoutesThrough(w.AncestorIps, hop.HopIps))
+                        .Select(w => w.Mad))
+                    .ToList();
+                double? stabOverride = stabWitnesses.Count > 0 ? stabWitnesses.Min() : (double?)null;
+
                 var grade = GradeAsn(hop, congestionEvents, jitterFloorMs, accessBaselineRtt, internetMedianDeltaMs,
-                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective);
-                // Log the graded effective (post sub-0.05 ms assimilation snap in GradeAsn),
-                // not the raw witness min, so the log matches what the hop is actually scored on.
+                    intraAsnFloorRttMs: intraFloor, jitterOverrideMs: effective, stabilityMadOverrideMs: stabOverride);
+                // Log the graded effective (post sub-0.05 ms assimilation snap in GradeAsn), not the
+                // raw witness min, so the log matches what the hop is actually scored on. Stability is
+                // logged alongside jitter: its own measured RTT MAD, the witness-floor it was absolved
+                // to (n/a when no routes-through witness), the witness count, and the resulting score.
                 _logger?.LogDebug(
-                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - measured jitter {Jitter} ms, effective {Eff} ms ({Witnesses} routes-through witnesses), reach +{Reach} ms",
+                    "ISP Health: ISP hop {Target} (AS{Asn}) graded {Score} - jitter measured {Jitter} ms -> effective {Eff} ms ({JWit} witnesses); stability MAD measured {Mad} ms -> witness-floor {StabWit} ms ({SWit} witnesses) score {StabScore}; reach +{Reach} ms",
                     hop.TargetIds.FirstOrDefault(), hop.AsnNumber, grade.OverallScore,
-                    FormatMsOrNull(measured), FormatMsOrNull(grade.ScoredJitterMs), witnesses.Count, FormatMsOrNull(grade.ReachDeltaMs));
+                    FormatMsOrNull(measured), FormatMsOrNull(grade.ScoredJitterMs), witnesses.Count,
+                    FormatMsOrNull(RttMadOf(hop.Samples)), FormatMsOrNull(stabOverride), stabWitnesses.Count, grade.LatencyStabilityScore,
+                    FormatMsOrNull(grade.ReachDeltaMs));
                 grades.Add(grade);
             }
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -530,7 +530,12 @@ public class IspHealthService
             targets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
                     || t.TargetType == MonitoringTargetType.Transit
-                    || t.TargetType == MonitoringTargetType.InternetService))
+                    || t.TargetType == MonitoringTargetType.InternetService
+                    // Custom targets a user added (e.g. a known-stable CMTS/PoP ping) join the
+                    // destination witness pool: once traced (ancestry), a clean end-to-end reading
+                    // absolves the on-path ISP/transit hops it routes through, same strict gate as
+                    // an Internet target. Not graded as an ISP/transit card themselves.
+                    || t.TargetType == MonitoringTargetType.Custom))
                 .ToListAsync(ct);
 
             fabricTargets = await db.MonitoringTargets.AsNoTracking()
@@ -614,13 +619,14 @@ public class IspHealthService
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, outageQueryStart, windowEnd, aggregate, ct);
         var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
         var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, outageQueryStart, windowEnd, aggregate, ct);
+        var customSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Custom, windowStart, windowEnd, aggregate, ct);
         var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, aggregate, ct);
         var speedsTask = ResolveExpectedSpeedsAsync(ct);
         var speedTestsTask = LoadWanSpeedTestsAsync(windowStart, windowEnd, ct);
         var gatewaySeriesTask = gatewayTarget == null
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, outageQueryStart, windowEnd, aggregate, ct);
-        await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
+        await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, customSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
 
         // Extended (lead-in) series: used only to build the outage detector's trigger and hops below.
         var ispSeriesExt = ToSamples(await ispSeriesTask);
@@ -632,6 +638,7 @@ public class IspHealthService
         var ispSeries = TrimFrom(ispSeriesExt, windowStart);
         var transitSeries = ToSamples(await transitSeriesTask);
         var internetSeries = TrimFrom(internetSeriesExt, windowStart);
+        var customSeries = ToSamples(await customSeriesTask);
         var wanRates = await ratesTask;
         var (expectedDown, expectedUp, expectedSource, smartQueuesEnabled) = await speedsTask;
         var wanSpeedTests = await speedTestsTask;
@@ -747,6 +754,23 @@ public class IspHealthService
                 AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var destAnc) ? destAnc : new List<string>(),
                 // Internet/CDN endpoint (by TargetType): path-shift correlation prefers an
                 // on-path ISP/transit hop over these as the event label.
+                IsDestination = true
+            })
+            .ToList();
+
+        // User-added Custom targets (e.g. a known-stable CMTS/PoP ping) as destination witnesses:
+        // a clean end-to-end reading absolves the ISP/transit hops in its traced ancestry (strict
+        // routes-through gate). Witness-only - kept out of charts, loss pool, and localizer.
+        var customWitnessSeries = targets
+            .Where(t => t.TargetType == MonitoringTargetType.Custom && customSeries.ContainsKey(t.TargetId))
+            .Select(t => new AsnSeries
+            {
+                AsnNumber = t.AsnNumber ?? 0,
+                AsnName = t.Name,
+                TargetIds = { t.TargetId },
+                Samples = customSeries[t.TargetId],
+                HopIps = { t.Address },
+                AncestorIps = ancestorIpsByTargetId.TryGetValue(t.TargetId, out var custAnc) ? custAnc : new List<string>(),
                 IsDestination = true
             })
             .ToList();
@@ -1030,6 +1054,7 @@ public class IspHealthService
             TransitAsnSeries = transitGrading,
             IspAsnSeries = ispGrading,
             DestinationSeries = internetTargetSeries,
+            WitnessSeries = customWitnessSeries,
             WanRates = wanRates,
             InternetMedianDeltaMs = internetMedianDelta,
             ExpectedDownloadMbps = expectedDown,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1453,11 +1453,11 @@ public class IspHealthService
             .Select(t =>
             {
                 var resolvedAsn = t.AsnNumber ?? 0;
-                var asnName = t.AsnName;
+                var asnName = AsnNameCleanup.Clean(t.AsnName);
                 if (ispOverrides != null && ispOverrides.TryGetValue(t.TargetId, out var o))
                 {
                     resolvedAsn = o.Asn;
-                    asnName ??= o.Name;
+                    asnName ??= AsnNameCleanup.Clean(o.Name);
                 }
                 return new AsnSeries
                 {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/TargetAncestry.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/TargetAncestry.cs
@@ -1,0 +1,80 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Probes;
+using NetworkOptimizer.Storage;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Shared trace-and-persist for a monitored target's upstream hop ancestry. Used by both the
+/// on-save fast path (LatencyTargetsCard) and the periodic backfill (UpstreamTracerService via the
+/// re-discovery tick). Custom/Internet targets aren't part of the discovery sweep, so this is what
+/// gives them the ancestry that lets ISP Health use them as routes-through witnesses.
+/// </summary>
+public static class TargetAncestry
+{
+    /// <summary>
+    /// Traces <paramref name="address"/> over the given site vantage executor (server or on-site
+    /// agent) and upserts the ordered responding hops before the destination as the target's
+    /// UpstreamDiscovery ancestry. Returns true when ancestry was persisted. Best-effort: swallows
+    /// failures (the caller retries on the next cycle) and returns false when no hops respond.
+    /// </summary>
+    public static async Task<bool> TraceAndPersistAsync(
+        IProbeExecutor executor,
+        NetworkOptimizerDbContext db,
+        int targetId,
+        string address,
+        ILogger? logger = null,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var result = await executor.TracerouteAsync(
+                new ProbeTarget(address, ProbeMode.Icmp),
+                maxHops: 30,
+                perHopTimeout: TimeSpan.FromSeconds(2),
+                totalDeadline: TimeSpan.FromSeconds(20),
+                ct: ct);
+
+            // Ordered responding hops before the destination = the ancestry it routes through.
+            var ancestors = result.Hops
+                .Where(h => h.Responded && !string.Equals(h.Address, address, StringComparison.OrdinalIgnoreCase))
+                .Select(h => h.Address!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            if (ancestors.Count == 0) return false;
+
+            var existing = await db.UpstreamDiscoveries.FirstOrDefaultAsync(d => d.MonitoringTargetId == targetId, ct);
+            if (existing == null)
+            {
+                db.UpstreamDiscoveries.Add(new UpstreamDiscovery
+                {
+                    MonitoringTargetId = targetId,
+                    HopIp = address,
+                    HopNumber = ancestors.Count + 1,
+                    AncestorHopIps = string.Join(" ", ancestors),
+                    Role = UpstreamRole.PathProxy,
+                    IsActive = true,
+                    LastValidated = DateTime.UtcNow,
+                    LastTracerouteAt = DateTime.UtcNow
+                });
+            }
+            else
+            {
+                existing.AncestorHopIps = string.Join(" ", ancestors);
+                existing.HopNumber = ancestors.Count + 1;
+                existing.LastTracerouteAt = DateTime.UtcNow;
+                existing.LastValidated = DateTime.UtcNow;
+                existing.IsActive = true;
+            }
+            await db.SaveChangesAsync(ct);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Ancestry trace failed for target {TargetId} ({Address})", targetId, address);
+            return false;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -106,6 +106,12 @@ public class UpstreamRediscoveryService : BackgroundService
             : _siteDbFactory.CreateForSite(slug, isDefault: false);
         var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
         if (settings == null || !settings.Enabled) return;
+
+        // Keep Custom/Internet witness targets' ancestry filled and fresh every tick (hourly),
+        // independent of the 7-day full re-discovery cadence below. They aren't part of the sweep,
+        // so this is what keeps them usable as routes-through witnesses.
+        await tracer.BackfillWitnessAncestryAsync(ct);
+
         if (settings.UpstreamDiscoveryNeedsReview) return; // already flagged - waiting for user
         if (!settings.LastUpstreamDiscoveryAt.HasValue) return; // never committed - nothing to re-discover
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -92,6 +92,109 @@ public class UpstreamTracerService
 
     private record TraceEndpoint(string Label, string Address, bool IsTransitProbe = false, bool EndpointIsTransitHop = false);
 
+    // The anycast rotation bans unicast regionals (they'd force transpacific/transatlantic paths).
+    // AWS DynamoDB regional endpoints are unicast BUT ride paid transit (unlike the CDN/DNS targets,
+    // which peer at the local IX and cross no transit), so they surface more transit ASNs and seed
+    // clean routes-through witnesses for jitter/stability absolution. Because they're unicast, they
+    // are resolved + latency-ranked at discovery time and only the nearest sub-80ms region(s) are
+    // kept - never hardcoded. Comprehensive/global list so a site anywhere keeps its local region(s).
+    private static readonly string[] AwsRegions =
+    {
+        "us-east-1", "us-east-2", "us-west-1", "us-west-2", "ca-central-1",
+        "eu-west-1", "eu-west-2", "eu-west-3", "eu-central-1", "eu-north-1",
+        "ap-northeast-1", "ap-northeast-2", "ap-southeast-1", "ap-southeast-2",
+        "ap-south-1", "sa-east-1"
+    };
+    private const double AwsMaxRttMs = 80.0;
+
+    // A resolved AWS regional: the hostname (what we persist as the target address, since AWS rotates
+    // the regional IPs and the hostname re-resolves to a live in-region IP each poll) and the concrete
+    // IP resolved this run (used for the discovery traceroute, RTT rank, and ASN lookup - deterministic).
+    private record AwsRegional(string Region, string Hostname, string Ip, long RttMs);
+
+    // Per-run trace set: the static CDN/DNS rotation plus resolved AWS regionals (traced by IP).
+    // Defaults to the rotation so callers are safe before TraceAccessIspAsync populates it.
+    private List<TraceEndpoint> _traceEndpoints = CdnRotation.ToList();
+    private List<AwsRegional> _awsRegionals = new();
+
+    /// <summary>
+    /// Resolves every AWS DynamoDB regional hostname, pings it, and returns ALL that answer under
+    /// <see cref="AwsMaxRttMs"/> (sorted nearest-first). Not anycast, so this per-run resolve +
+    /// latency-rank is required - a far region would trace a transcontinental path and misrepresent
+    /// the transit. Every sub-80ms region becomes a monitorable target (see the AWS persist block);
+    /// only those whose trace crosses transit are pre-enabled. Best-effort: a region that won't
+    /// resolve or answer ICMP is skipped.
+    /// </summary>
+    private async Task<List<AwsRegional>> ResolveAwsRegionalsAsync(CancellationToken ct)
+    {
+        var found = new List<AwsRegional>();
+        foreach (var region in AwsRegions)
+        {
+            if (ct.IsCancellationRequested) break;
+            try
+            {
+                var host = $"dynamodb.{region}.amazonaws.com";
+                var addrs = await System.Net.Dns.GetHostAddressesAsync(host, ct);
+                var ip = addrs.FirstOrDefault(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork);
+                if (ip == null) continue;
+                using var ping = new System.Net.NetworkInformation.Ping();
+                var reply = await ping.SendPingAsync(ip, 800);
+                if (reply.Status != System.Net.NetworkInformation.IPStatus.Success || reply.RoundtripTime > AwsMaxRttMs) continue;
+                found.Add(new AwsRegional(region, host, ip.ToString(), reply.RoundtripTime));
+            }
+            catch { /* region won't resolve or answer - skip */ }
+        }
+        var chosen = found.OrderBy(r => r.RttMs).ToList();
+        if (chosen.Count > 0)
+            _logger.LogInformation("Tracer: {Count} sub-{Max}ms AWS DynamoDB regionals: {Regions}",
+                chosen.Count, AwsMaxRttMs, string.Join(", ", chosen.Select(r => r.Region)));
+        return chosen;
+    }
+
+    /// <summary>
+    /// The farthest (deepest) transit ASN on the trace to <paramref name="destIp"/> - what a path-end
+    /// host connects "via" - with a cleaned name. Walks that destination's trace hops in order and
+    /// keeps the last hop whose attributed ASN is neither an access ASN nor the destination's own org.
+    /// The destination match is by cleaned NAME, not just ASN number, so a provider that appears under
+    /// sibling ASNs (Amazon's AS16509 / AS14618, a transit's multiple ASNs) isn't mistaken for transit.
+    /// Null when the path crosses no transit (peered / IX). <paramref name="asnByHopIp"/> maps hop IP
+    /// to its attributed ASN from the merged pool, so no extra lookups are done here.
+    /// </summary>
+    private (int Asn, string Name)? FarthestTransitVia(string destIp, int destAsn, string destName,
+        HashSet<int> accessAsns, Dictionary<string, AsnLookup> asnByHopIp, out bool pathComplete)
+    {
+        var responded = _lastTraces
+            .Where(t => string.Equals(t.Target.Address, destIp, StringComparison.OrdinalIgnoreCase))
+            .SelectMany(t => t.Hops)
+            .Where(h => h.Responded && h.Address != null)
+            .ToList();
+        var respondedHopNums = responded.Select(h => h.HopNumber).ToHashSet();
+
+        (int Asn, string Name)? via = null;
+        int? accessStartHop = null;
+        int? destOrgHop = null;
+        foreach (var h in responded.OrderBy(h => h.HopNumber))
+        {
+            if (!asnByHopIp.TryGetValue(h.Address!, out var asn)) continue;
+            if (accessAsns.Contains(asn.Asn)) { accessStartHop ??= h.HopNumber; continue; }
+            var name = CleanAsnName(asn.Name);
+            if (asn.Asn == destAsn || string.Equals(name, destName, StringComparison.OrdinalIgnoreCase))
+            {
+                destOrgHop ??= h.HopNumber;
+                continue;
+            }
+            if (destOrgHop == null) via = (asn.Asn, name); // farthest transit before we reach the dest org
+        }
+
+        // "Peered" is only provable when we reached the destination's org AND every hop from the
+        // access ASN to it responded - a star in between could be hiding transit. Otherwise the
+        // caller shows a dash (unknown), not "peered".
+        var from = accessStartHop ?? 1;
+        pathComplete = destOrgHop is int dh && dh >= from
+            && Enumerable.Range(from, dh - from + 1).All(n => respondedHopNums.Contains(n));
+        return via;
+    }
+
     // Built per site by UpstreamTracerRegistry, which resolves the site's console,
     // gateway SSH, ISP Health, and "server" probe vantage (local on the default site,
     // on-site agent on a secondary site).
@@ -126,6 +229,61 @@ public class UpstreamTracerService
     /// <summary>The site's own database for persisting upstream discovery state.</summary>
     private async Task<NetworkOptimizerDbContext> CreateDbAsync(CancellationToken ct = default) =>
         _isDefault ? await _dbFactory.CreateDbContextAsync(ct) : _siteDbFactory.CreateForSite(_siteSlug, isDefault: false);
+
+    private static readonly TimeSpan WitnessAncestryTtl = TimeSpan.FromHours(12);
+    private const int MaxWitnessTracesPerTick = 6;
+
+    /// <summary>
+    /// Fills and refreshes hop ancestry for this site's enabled Custom + InternetService targets.
+    /// They aren't part of the discovery sweep (only the built-in CDN/AWS probes and discovered
+    /// ISP/transit hops are), so without this they'd never become - or would go stale as -
+    /// routes-through witnesses. Traces those whose ancestry is missing or older than
+    /// <see cref="WitnessAncestryTtl"/> over this site's vantage (server or on-site agent),
+    /// rate-limited to <see cref="MaxWitnessTracesPerTick"/> per call. Called every re-discovery
+    /// tick (hourly), independent of the full re-discovery cadence. Best-effort.
+    /// </summary>
+    public async Task BackfillWitnessAncestryAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await using var db = await CreateDbAsync(ct);
+            var targets = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.Custom
+                    || t.TargetType == MonitoringTargetType.InternetService))
+                .ToListAsync(ct);
+            if (targets.Count == 0) return;
+
+            // A target is "fresh" only when it has a NON-EMPTY ancestry row traced within the TTL. An
+            // empty row (e.g. a hostname-addressed AWS regional whose discovery same-path pass couldn't
+            // attribute it, but which stamped LastTracerouteAt) must NOT count as fresh, or it would
+            // never get real ancestry and would read as carrying no transit in ISP Health.
+            var cutoff = DateTime.UtcNow - WitnessAncestryTtl;
+            var freshIds = (await db.UpstreamDiscoveries.AsNoTracking()
+                .Where(d => d.MonitoringTargetId != null
+                    && d.AncestorHopIps != null && d.AncestorHopIps != ""
+                    && d.LastTracerouteAt > cutoff)
+                .Select(d => d.MonitoringTargetId!.Value)
+                .Distinct()
+                .ToListAsync(ct))
+                .ToHashSet();
+
+            var traced = 0;
+            foreach (var t in targets)
+            {
+                if (ct.IsCancellationRequested || traced >= MaxWitnessTracesPerTick) break;
+                if (freshIds.Contains(t.Id)) continue;
+                await using var wdb = await CreateDbAsync(ct);
+                if (await TargetAncestry.TraceAndPersistAsync(_traceExecutor, wdb, t.Id, t.Address, _logger, ct))
+                    traced++;
+            }
+            if (traced > 0)
+                _logger.LogInformation("Tracer: backfilled/refreshed ancestry for {Count} witness target(s) on site {Site}", traced, _siteSlug);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Witness ancestry backfill failed for site {Site}", _siteSlug);
+        }
+    }
 
     /// <summary>
     /// Rehydrate the in-memory <see cref="State"/> from persisted DB rows when
@@ -825,11 +983,17 @@ public class UpstreamTracerService
         State.CurrentActivity = "Running parallel traceroutes to major internet endpoints...";
         State.Traces = new List<TraceSummary>();
 
-        // Spawn 10 traceroutes (5 endpoints × 2 modes) in parallel and merge once
-        // they all settle. Each traceroute is capped at 10s, so wall-clock for the
-        // whole sweep is ~10s + a bit of overhead.
+        // Build this run's endpoint set: the anycast rotation plus every sub-80ms AWS regional
+        // (resolved live, traced by IP), which surface paid-transit ASNs and seed clean witnesses.
+        _awsRegionals = await ResolveAwsRegionalsAsync(ct);
+        _traceEndpoints = CdnRotation
+            .Concat(_awsRegionals.Select(r => new TraceEndpoint($"AWS-{r.Region}", r.Ip)))
+            .ToList();
+
+        // Spawn traceroutes (each endpoint × 2 modes) in parallel and merge once they all settle.
+        // Each traceroute is capped at 10s, so wall-clock for the whole sweep is ~10s + overhead.
         var tasks = new List<Task<(string Label, TracerouteResult Result)>>();
-        foreach (var endpoint in CdnRotation)
+        foreach (var endpoint in _traceEndpoints)
         {
             tasks.Add(TraceOneAsync(endpoint, ProbeMode.Icmp, ct));
             tasks.Add(TraceOneAsync(endpoint, ProbeMode.Udp, ct));
@@ -1220,9 +1384,17 @@ public class UpstreamTracerService
         var asnsInTrace = new HashSet<int>(_mergedHops
             .Where(h => h.Asn != null)
             .Select(h => h.Asn!.Asn));
-        foreach (var endpoint in CdnRotation)
+        // Hop IP -> attributed ASN, from the merged pool, for the "Via" (farthest transit) column.
+        var asnByHopIp = _mergedHops
+            .Where(h => h.Asn != null)
+            .GroupBy(h => h.Address, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First().Asn!, StringComparer.OrdinalIgnoreCase);
+        foreach (var endpoint in _traceEndpoints)
         {
             if (endpoint.IsTransitProbe) continue;
+            // AWS regionals are persisted per-region by the dedicated block below, not ASN-deduped
+            // here (they all share Amazon's ASN, which would collapse them to one target).
+            if (endpoint.Label.StartsWith("AWS-", StringComparison.Ordinal)) continue;
             var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);
             if (destAsn == null) continue;
             if (accessAsnNumbers.Contains(destAsn.Asn)) continue;
@@ -1232,18 +1404,57 @@ public class UpstreamTracerService
             if (!reachedOrTraversed) continue;
             if (!pathProxyAsnsSeen.Add(destAsn.Asn)) continue;
 
+            var cdnName = CleanAsnName(destAsn.Name);
+            var via = FarthestTransitVia(endpoint.Address, destAsn.Asn, cdnName, accessAsnNumbers, asnByHopIp, out var cdnComplete);
             candidates.Add(new TransitAsnCandidate
             {
                 AsnNumber = destAsn.Asn,
-                AsnName = CleanAsnName(destAsn.Name),
+                AsnName = cdnName,
                 Label = endpoint.Label,
                 Method = DiscoveryMethod.PathProxy,
                 TargetId = $"path-{endpoint.Label.ToLowerInvariant()}-as{destAsn.Asn}",
                 HopAddress = endpoint.Address,
                 PathProxyTarget = endpoint.Address,
                 RespondedTo = ProbeMode.Icmp,
-                Enabled = true
+                Enabled = true,
+                ViaAsnNumber = via?.Asn,
+                ViaAsnName = via?.Name,
+                ViaPathComplete = cdnComplete
             });
+        }
+
+        // AWS DynamoDB regionals: add EVERY sub-80ms region as its own path-end target (not
+        // ASN-deduped - they all share Amazon's ASN), so ops/SWE users can monitor any of them.
+        // Persist the HOSTNAME (AWS rotates the regional IPs; it re-resolves to a live in-region IP
+        // each poll) even though the trace/rank used the concrete IP. Pre-enable a region only if its
+        // trace crossed a transit ASN (surfacing transit is the point); the rest come in disabled for
+        // the user to tick on. Toggle survives re-discovery via the address-keyed reconcile below.
+        if (_awsRegionals.Count > 0)
+        {
+            var amazon = await _asnResolution.ResolveAsync(_awsRegionals[0].Ip, ct);
+            var amazonAsn = amazon?.Asn ?? 0;
+            var amazonName = string.IsNullOrEmpty(amazon?.Name) ? "Amazon" : CleanAsnName(amazon.Name);
+            foreach (var r in _awsRegionals)
+            {
+                // The via (farthest transit) both labels the row and decides pre-enable: a region is
+                // pre-checked only when its trace actually crosses transit.
+                var via = FarthestTransitVia(r.Ip, amazonAsn, amazonName, accessAsnNumbers, asnByHopIp, out var awsComplete);
+                candidates.Add(new TransitAsnCandidate
+                {
+                    AsnNumber = amazonAsn,
+                    AsnName = amazonName,
+                    Label = $"AWS {r.Region}",
+                    Method = DiscoveryMethod.PathProxy,
+                    TargetId = $"aws-{r.Region}",
+                    HopAddress = r.Hostname,
+                    PathProxyTarget = r.Hostname,
+                    RespondedTo = ProbeMode.Icmp,
+                    Enabled = via != null,
+                    ViaAsnNumber = via?.Asn,
+                    ViaAsnName = via?.Name,
+                    ViaPathComplete = awsComplete
+                });
+            }
         }
 
         // Reconcile ALL candidates (transit + path-end) and access hops against
@@ -1910,6 +2121,15 @@ public class UpstreamTracerService
         }
         foreach (var transit in State.TransitAsns.Where(t => !t.Enabled))
         {
+            // Path-end Internet targets (AWS regionals, CDN/DNS) the user left unchecked are saved as
+            // PAUSED rows - so the decline sticks (re-discovery reconciles against the disabled row
+            // instead of re-suggesting them checked) and they appear in the target list to enable
+            // later. Transit ASNs stay on their off-path / miss-counter mechanism (update-only).
+            if (transit.Method == DiscoveryMethod.PathProxy)
+            {
+                await UpsertTransitTargetAsync(db, transit, wanInterface, ct, enabled: false);
+                continue;
+            }
             var addr = transit.HopAddress ?? transit.PathProxyTarget;
             if (string.IsNullOrEmpty(addr)) continue;
             var existing = await db.MonitoringTargets.FirstOrDefaultAsync(t => t.Address == addr, ct);
@@ -2030,6 +2250,12 @@ public class UpstreamTracerService
 
         var monitoredAddrs = targets.Select(t => t.Address).Where(a => !string.IsNullOrEmpty(a))
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        // AWS regionals are persisted by hostname but were traced by IP, so the trace's AWS-endpoint
+        // hop (an IP) isn't recognized as monitored above. Register the traced IPs so the ancestry
+        // pass records the access/transit hops upstream of each AWS region; the persist loop below
+        // resolves each AWS target's ancestry via that IP.
+        foreach (var r in _awsRegionals)
+            if (!string.IsNullOrEmpty(r.Ip)) monitoredAddrs.Add(r.Ip);
 
         // Ancestor sets from ALL traces: for each monitored hop, the monitored hops that
         // appear before it on any trace it was seen on (its proven upstream). Every trace
@@ -2057,7 +2283,11 @@ public class UpstreamTracerService
         var written = 0;
         foreach (var t in targets)
         {
-            var ancestors = ancestorsByIp.TryGetValue(t.Address, out var anc)
+            // AWS regionals: resolve ancestry/hop distance via the IP we actually traced this run,
+            // not the persisted hostname (which the trace never saw).
+            var lookupAddr = _awsRegionals.FirstOrDefault(r => string.Equals(r.Hostname, t.Address, StringComparison.OrdinalIgnoreCase))?.Ip
+                ?? t.Address;
+            var ancestors = ancestorsByIp.TryGetValue(lookupAddr, out var anc)
                 ? anc.OrderBy(a => a).ToList()
                 : new List<string>();
             db.UpstreamDiscoveries.Add(new UpstreamDiscovery
@@ -2066,7 +2296,7 @@ public class UpstreamTracerService
                 AsnNumber = t.AsnNumber!.Value,
                 AsnName = t.AsnName,
                 HopIp = t.Address,
-                HopNumber = minTtlByIp.TryGetValue(t.Address, out var ttl) ? ttl : 0,
+                HopNumber = minTtlByIp.TryGetValue(lookupAddr, out var ttl) ? ttl : 0,
                 // Non-null (even if empty) marks that ancestor data exists, so ISP Health can
                 // tell "no discovery yet" (open gate) from "on-path but no ancestors" (a first hop).
                 AncestorHopIps = string.Join(" ", ancestors),
@@ -2150,7 +2380,7 @@ public class UpstreamTracerService
         }
     }
 
-    private static async Task UpsertTransitTargetAsync(NetworkOptimizerDbContext db, TransitAsnCandidate transit, string wanInterface, CancellationToken ct)
+    private static async Task UpsertTransitTargetAsync(NetworkOptimizerDbContext db, TransitAsnCandidate transit, string wanInterface, CancellationToken ct, bool enabled = true)
     {
         if (transit.Method == DiscoveryMethod.Unresolved || string.IsNullOrEmpty(transit.TargetId)) return;
 
@@ -2177,7 +2407,7 @@ public class UpstreamTracerService
                 VantagePoint = "server",
                 PollIntervalSeconds = 15,
                 PingCount = 5,
-                Enabled = true,
+                Enabled = enabled,
                 PtrHostname = transit.HopHostname,
                 AutoDiscovered = true,
                 DiscoveryMethod = transit.Method,
@@ -2188,7 +2418,7 @@ public class UpstreamTracerService
         }
         else
         {
-            existing.Enabled = true;
+            existing.Enabled = enabled;
             existing.Name = transit.Label ?? transit.AsnName;
             existing.Address = transit.HopAddress ?? transit.PathProxyTarget ?? existing.Address;
             existing.ProbeMode = transit.RespondedTo ?? existing.ProbeMode;
@@ -2262,7 +2492,7 @@ public class UpstreamTracerService
     {
         _destinationAsns.Clear();
         _destinationOrgs.Clear();
-        foreach (var endpoint in CdnRotation)
+        foreach (var endpoint in _traceEndpoints)
         {
             if (endpoint.IsTransitProbe) continue;
             var destAsn = await _asnResolution.ResolveAsync(endpoint.Address, ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerState.cs
@@ -121,6 +121,17 @@ public class TransitAsnCandidate
     /// <summary>For PathProxy tier: the CDN endpoint we monitor as a proxy for this ASN.</summary>
     public string? PathProxyTarget { get; set; }
 
+    /// <summary>For PathProxy tier: the farthest (deepest) transit ASN the trace to this
+    /// path-end host crosses - i.e. what it connects "via" - or null when the path crosses no
+    /// transit (peered / IX). Shown in the path-end hosts table; drives AWS-region pre-enable.</summary>
+    public int? ViaAsnNumber { get; set; }
+    public string? ViaAsnName { get; set; }
+
+    /// <summary>For PathProxy tier with no transit found: true only when we reached the destination's
+    /// org with no unresponsive hops in between (so "peered" is provable). False means the path had
+    /// gaps that could hide transit - shown as a dash, not "peered".</summary>
+    public bool ViaPathComplete { get; set; }
+
     /// <summary>
     /// Trace hop number of this candidate, used by post-verification auto-selection
     /// to order an ASN's hops and split them into RTT clumps (an ASN's run typically

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2216,23 +2216,34 @@ public class MonitoringCollectionAgent : BackgroundService
                 : (port.Name ?? string.Empty);
             if (string.IsNullOrEmpty(portName)) continue;
 
+            // Supplemental PON-layer stats from an attached ONT config, if any. Looked
+            // up before the DDM write so the endpoint's optional optics readings can
+            // fill DDM gaps the gateway slot can't read (GPON sticks often expose no
+            // DDM). The gateway's own reading always takes precedence over the
+            // contract-supplied fallback.
+            ponSupplemental.TryGetValue((mac, portName), out var ponStats);
+            var rxDbm = port.SfpRxPower ?? ponStats?.RxPowerDbm;
+            var txDbm = port.SfpTxPower ?? ponStats?.TxPowerDbm;
+            var tempC = port.SfpTemperature ?? ponStats?.TemperatureC;
+            var voltageV = port.SfpVoltage ?? ponStats?.VoltageV;
+
             // Write the DDM values to InfluxDB regardless of whether the user has
             // promoted this SFP to a monitored ONT — having the data is what enables
             // promotion later, and the longterm bucket keeps it cheap.
             _ = _influx.WriteSfpAsync(
                 deviceMac: mac,
                 portName: portName,
-                rxPowerDbm: port.SfpRxPower,
-                txPowerDbm: port.SfpTxPower,
+                rxPowerDbm: rxDbm,
+                txPowerDbm: txDbm,
                 txBiasMa: port.SfpCurrent,
-                temperatureC: port.SfpTemperature,
-                voltageV: port.SfpVoltage,
+                temperatureC: tempC,
+                voltageV: voltageV,
                 sfpLinkSpeedMbps: port.Speed > 0 ? port.Speed : null,
                 timestamp: timestamp);
 
-            // Supplemental PON-layer stats from an attached ONT config merge onto the
-            // same series and timestamp (field union with the DDM point above).
-            if (ponSupplemental.TryGetValue((mac, portName), out var ponStats))
+            // Supplemental PON-layer stats merge onto the same series and timestamp
+            // (field union with the DDM point above).
+            if (ponStats != null)
             {
                 _ = _influx.WriteSfpPonAsync(mac, portName, ponStats, timestamp);
                 // Mirror the key PON values into live stats so the SFP ONT card can show
@@ -2250,11 +2261,11 @@ public class MonitoringCollectionAgent : BackgroundService
             _liveStats.RecordSfp(
                 deviceMac: mac,
                 portName: portName,
-                rxDbm: port.SfpRxPower,
-                txDbm: port.SfpTxPower,
+                rxDbm: rxDbm,
+                txDbm: txDbm,
                 biasMa: port.SfpCurrent,
-                tempC: port.SfpTemperature,
-                voltageV: port.SfpVoltage,
+                tempC: tempC,
+                voltageV: voltageV,
                 timestamp: timestamp);
 
             // Reconcile the relational row so the UI knows the SFP exists and can offer

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -687,7 +687,12 @@ public class MonitoringInterfaceDeploymentService
         // (apply-already-holds-lock, and apply-takes-lock-after-the-marker). If the drain times
         // out an apply is stuck holding the lock, so abort instead of tearing down underneath it -
         // roll the marker back and leave the row enabled to retry.
-        var drain = await RunAsync($"flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null");
+        // Guard on flock's presence (see the boot script's note): a gateway without it skips the
+        // drain (the if is a no-op success) and proceeds straight to teardown - RemoveAsync
+        // physically removes cron+script and verifies absence, which is the real resurrection
+        // guard; the lock only closed the narrow in-flight-apply window.
+        var drain = await RunAsync(
+            $"if command -v flock >/dev/null 2>&1; then flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null; fi");
         if (!drain.success)
         {
             await RunAsync($"rm -f '{marker}' 2>/dev/null || true");
@@ -996,8 +1001,14 @@ fail=0
 # Serialize a manual apply against the cron watchdog tick on a per-interface lock. flock holds
 # fd 9 in the CURRENT shell (not a subshell), so changed/fail set below still reach the final
 # status check; non-blocking, so if another apply already holds the lock we skip this tick.
-exec 9>""/tmp/monitoring-iface-__IFACE__.lock""
-flock -n 9 || { log ""apply already running, skipping""; exit 0; }
+# Guard on flock's presence (standard on UniFi OS via util-linux, but be safe): a gateway that
+# lacked it would hit the || early-out and skip the apply ENTIRELY - fail-closed. Guarding
+# degrades a flock-less box to an unlocked apply (pre-lock behaviour) instead, keeping the
+# feature working; the lock only closed the narrow apply-vs-watchdog race.
+if command -v flock >/dev/null 2>&1; then
+    exec 9>""/tmp/monitoring-iface-__IFACE__.lock""
+    flock -n 9 || { log ""apply already running, skipping""; exit 0; }
+fi
 # Re-check the marker now that we hold the lock: Disable may have written it (and drained the
 # lock) while we were between the top-of-script check and acquiring this lock. Bail before
 # applying anything so a paused apply cannot resurrect artifacts after Disable's teardown.

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -3,6 +3,7 @@ using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 using System.Text;
 using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web.Services.Ssh;
@@ -23,19 +24,34 @@ public class MonitoringInterfaceDeploymentService
     private readonly IGatewaySshService _gatewaySsh;
     private readonly IUdmBootService _udmBoot;
     private readonly UniFiConnectionService _connection;
+    private readonly IMonitoringInterfaceRepository _repo;
 
     private const string OnBootDir = "/data/on_boot.d";
+
+    /// <summary>
+    /// Directory (under <c>/data</c>, so it survives reboots and firmware updates like the boot
+    /// scripts) holding one marker file per disabled interface. The boot script and cron
+    /// watchdog early-out when this interface's marker is present, so a disabled interface stays
+    /// torn down without deleting its script. Deliberately NOT under <c>on_boot.d</c> - a file
+    /// there would be executed at boot.
+    /// </summary>
+    public const string DisabledMarkerDir = "/data/monitoring-ifaces.disabled";
+
+    /// <summary>Marker path for a given interface (see <see cref="DisabledMarkerDir"/>).</summary>
+    public static string DisabledMarkerPath(MonitoringInterface mi) => $"{DisabledMarkerDir}/{mi.Name}";
 
     public MonitoringInterfaceDeploymentService(
         ILogger<MonitoringInterfaceDeploymentService> logger,
         IGatewaySshService gatewaySsh,
         IUdmBootService udmBoot,
-        UniFiConnectionService connection)
+        UniFiConnectionService connection,
+        IMonitoringInterfaceRepository repo)
     {
         _logger = logger;
         _gatewaySsh = gatewaySsh;
         _udmBoot = udmBoot;
         _connection = connection;
+        _repo = repo;
     }
 
     private static string ScriptName(MonitoringInterface mi) => $"30-monitoring-iface-{mi.Name}.sh";
@@ -396,6 +412,15 @@ public class MonitoringInterfaceDeploymentService
     {
         var steps = new List<string>();
 
+        // A disabled interface must never (re)deploy - Enable clears the flag first (and sets
+        // mi.Disabled=false on the instance it passes here). Guards both the UI path and any
+        // direct caller that hands us a still-disabled row.
+        if (mi.Disabled)
+            return new DeployResult(false, PreflightBlock.Skipped, "Interface is disabled; enable it first.", steps);
+
+        // Validate before building any SSH command from mi (boot script, marker path, gates).
+        EnsureShellSafeStrings(mi);
+
         var preflight = await PreflightAsync(mi, ct);
         if (!preflight.Ok)
             return new DeployResult(false, preflight.Block, preflight.Message, steps);
@@ -453,6 +478,16 @@ public class MonitoringInterfaceDeploymentService
                 : "Skipped mark/table range check (gateway unreachable) - deploying without it risks the " +
                   "boot script sweeping or overwriting a foreign rule in this range undetected.");
         }
+
+        // We are (re)deploying, so this interface must not carry a stale disabled marker - a
+        // leftover one (e.g. from a Disable whose marker rollback could not reach the gateway)
+        // would make the boot script we write below early-out and silently no-op the deploy.
+        // Check the result: if the marker cannot be cleared the script would bail, so fail
+        // loudly rather than reporting a deploy that did nothing.
+        var markerClear = await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null");
+        if (!markerClear.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable,
+                "Could not clear the disabled marker on the gateway; the boot script would no-op. Retry when the gateway is reachable.", steps);
 
         // Write and run the idempotent boot script.
         var script = GenerateBootScript(mi);
@@ -532,20 +567,170 @@ public class MonitoringInterfaceDeploymentService
             steps.Add("Alias id is outside the aliasable range - no alias mark/DNAT/policy-route artifacts existed to remove.");
         }
 
+        // Base teardown: guard-check-then-act and capture each result (mirroring the alias
+        // block above), so "nothing to remove" stays a clean success while a genuine removal
+        // failure flips success - rather than the old fire-and-forget "|| true" that swallowed
+        // every failure. Each guard confirms the artifact is present before deleting it, so an
+        // aliased row (no main-table route/SNAT to remove) or a never-fully-deployed one simply
+        // finds nothing and succeeds.
         if (mi.SnatEnabled)
         {
-            await RunAsync($"iptables -w 5 -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null || true");
-            steps.Add("Removed SNAT rule.");
+            var snatDel = await RunAsync(
+                $"if iptables -w 5 -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null; " +
+                $"then iptables -w 5 -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null; fi");
+            if (!snatDel.success)
+            {
+                success = false;
+                steps.Add("WARNING: failed to remove SNAT rule - check the gateway manually.");
+            }
+            else
+            {
+                steps.Add("Removed SNAT rule.");
+            }
         }
 
-        await RunAsync($"ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null || true");
-        await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
-        steps.Add("Removed route and macvlan interface.");
+        var routeDel = await RunAsync(
+            $"if ip route show {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null | grep -q .; " +
+            $"then ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null; fi");
+        var linkDel = await RunAsync(
+            $"if ip link show {mi.Name} >/dev/null 2>&1; then ip link del {mi.Name} 2>/dev/null; fi");
+        if (!routeDel.success || !linkDel.success)
+        {
+            success = false;
+            steps.Add("WARNING: failed to remove route/macvlan - check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Removed route and macvlan interface.");
+        }
 
-        await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null || true");
-        steps.Add("Removed boot script.");
+        // rm -f is a no-op success for an absent file; a nonzero here is a real error (e.g. a
+        // read-only /data), so capture it instead of masking it with "|| true".
+        var scriptDel = await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null");
+        if (!scriptDel.success)
+        {
+            success = false;
+            steps.Add("WARNING: failed to remove boot script - check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Removed boot script.");
+        }
+
+        // Absence verification: re-probe the interface, main-table route, cron entry, and boot
+        // script. If any is still present after teardown, the cron watchdog may have re-applied
+        // it mid-teardown (a race Disable closes with the marker, Task 4) - flag it rather than
+        // reporting a clean removal. Trailing "true" keeps the SSH exit code tied to reachability,
+        // not to whether a probe matched.
+        var verifyProbes =
+            $"ip link show {mi.Name} >/dev/null 2>&1 && echo IFACE; " +
+            $"ip route show {mi.TargetIp}/32 2>/dev/null | grep -q \"dev {mi.Name}\" && echo ROUTE; " +
+            $"crontab -l 2>/dev/null | grep -qF '{path}' && echo CRON; " +
+            $"test -f '{path}' && echo SCRIPT; ";
+        // Also verify the SNAT rule and (for an aliased row) the mangle mark, nat DNAT, policy
+        // rule, and private route table are gone - a teardown step that silently failed to remove
+        // one of these would otherwise coexist with a "clean" result.
+        if (mi.SnatEnabled)
+            verifyProbes += $"iptables -w 5 -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null && echo SNAT; ";
+        if (mi.AliasIp != null && IsAliasableId(mi.Id))
+        {
+            var vmark = AliasMark(mi.Id);
+            var vtable = AliasTable(mi.Id);
+            verifyProbes +=
+                $"iptables -w 5 -t mangle -C PREROUTING -d {mi.AliasIp} -j MARK --set-xmark {vmark}/{AliasMarkMask} 2>/dev/null && echo AMARK; " +
+                $"iptables -w 5 -t nat -C PREROUTING -m mark --mark {vmark}/{AliasMarkMask} -j DNAT --to-destination {mi.TargetIp} 2>/dev/null && echo ADNAT; " +
+                $"ip rule show 2>/dev/null | grep -qF 'fwmark {vmark}/{AliasMarkMask} lookup {vtable}' && echo ARULE; " +
+                $"ip route show table {vtable} 2>/dev/null | grep -q . && echo ATABLE; ";
+        }
+        var verify = await RunAsync(verifyProbes + "true");
+        if (!verify.success)
+        {
+            success = false;
+            steps.Add("WARNING: could not verify teardown (gateway unreachable) - check the gateway manually.");
+        }
+        else if (verify.output.Contains("IFACE") || verify.output.Contains("ROUTE") ||
+                 verify.output.Contains("CRON") || verify.output.Contains("SCRIPT") ||
+                 verify.output.Contains("SNAT") || verify.output.Contains("AMARK") ||
+                 verify.output.Contains("ADNAT") || verify.output.Contains("ARULE") ||
+                 verify.output.Contains("ATABLE"))
+        {
+            success = false;
+            steps.Add("WARNING: teardown verification failed - artifacts still present (watchdog resurrection?). Check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Verified teardown: no residual artifacts.");
+        }
 
         return (success, steps);
+    }
+
+    /// <summary>
+    /// Disable a monitoring interface: write the gateway marker FIRST (so the cron watchdog and
+    /// a boot run early-out and can't re-apply mid-teardown), then run the hardened+verified
+    /// teardown. Only on a clean teardown is the DB flag set. A teardown failure rolls the marker
+    /// back and leaves the row enabled, so the interface is never left half-paused. The config
+    /// row is kept for later <see cref="EnableAsync"/>.
+    /// </summary>
+    public async Task<(bool success, List<string> steps)> DisableAsync(MonitoringInterface mi)
+    {
+        EnsureShellSafeStrings(mi);
+        var marker = DisabledMarkerPath(mi);
+        var write = await RunAsync($"mkdir -p '{DisabledMarkerDir}' && : > '{marker}'");
+        if (!write.success)
+            return (false, new List<string> { "Could not reach the gateway to disable (marker write failed)." });
+
+        // Drain any in-flight watchdog apply before tearing down: block on the boot script's
+        // per-interface apply lock so an apply that started before the marker existed finishes and
+        // cannot recreate artifacts after our teardown. Together with the boot script re-checking
+        // the marker AFTER it acquires this lock, this closes the resurrection race both ways
+        // (apply-already-holds-lock, and apply-takes-lock-after-the-marker). If the drain times
+        // out an apply is stuck holding the lock, so abort instead of tearing down underneath it -
+        // roll the marker back and leave the row enabled to retry.
+        var drain = await RunAsync($"flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null");
+        if (!drain.success)
+        {
+            await RunAsync($"rm -f '{marker}' 2>/dev/null || true");
+            return (false, new List<string>
+            {
+                "A gateway apply for this interface is still running (lock not released in time); try disabling again in a moment."
+            });
+        }
+
+        var (removed, steps) = await RemoveAsync(mi);
+        if (!removed)
+        {
+            await RunAsync($"rm -f '{marker}' 2>/dev/null || true");
+            steps.Add("Teardown failed; interface left enabled.");
+            return (false, steps);
+        }
+
+        await _repo.SetDisabledAsync(mi.Id, true);
+        steps.Add("Interface disabled (config kept).");
+        return (true, steps);
+    }
+
+    /// <summary>
+    /// Enable a previously disabled interface: clear the DB flag and remove the gateway marker
+    /// first, then redeploy. A deploy failure does not re-disable the row - the failed
+    /// <see cref="DeployResult"/> is returned as-is so the user sees the real reason.
+    /// </summary>
+    public async Task<DeployResult> EnableAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        // Validate up front so a corrupt name fails before we mutate DB state or build any SSH
+        // command from it (Codex review: Enable previously skipped this).
+        EnsureShellSafeStrings(mi);
+        await _repo.SetDisabledAsync(mi.Id, false);
+        mi.Disabled = false;
+        // Clear the marker up front (checked) so Enable un-pauses the interface even if the
+        // deploy below fails. If the marker cannot be cleared the boot script would no-op, so
+        // surface that instead of the unchecked "|| true" the review flagged.
+        var markerClear = await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null");
+        if (!markerClear.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable,
+                "Could not clear the disabled marker on the gateway; retry when it is reachable.",
+                new List<string>());
+        return await DeployAsync(mi, ct);
     }
 
     /// <summary>
@@ -777,6 +962,7 @@ MASK=""__MASK__""
 TABLE=""__TABLE__""
 WATCHDOG_MIN=""__WATCHDOG_MIN__""
 SCRIPT=""__SCRIPT_PATH__""
+MARKER=""/data/monitoring-ifaces.disabled/__IFACE__""
 LOG=""/tmp/netopt-moniface-__IFACE__.log""
 
 log() { echo ""$(date '+%Y-%m-%d %H:%M:%S') $1"" >> ""$LOG"" 2>/dev/null; }
@@ -797,11 +983,25 @@ cleanup_marked_rules() {
     rm -f ""$tmp""
 }
 
+# If disabled by the app, do nothing and do not (re)install cron. The marker lets a disabled
+# interface stay torn down across reboots without deleting this script.
+[ -f ""$MARKER"" ] && { log ""disabled marker present, skipping""; exit 0; }
+
 # The physical WAN port must exist; if not (boot race), let the watchdog retry later.
 ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferring""; exit 0; }
 
 changed=0
 fail=0
+
+# Serialize a manual apply against the cron watchdog tick on a per-interface lock. flock holds
+# fd 9 in the CURRENT shell (not a subshell), so changed/fail set below still reach the final
+# status check; non-blocking, so if another apply already holds the lock we skip this tick.
+exec 9>""/tmp/monitoring-iface-__IFACE__.lock""
+flock -n 9 || { log ""apply already running, skipping""; exit 0; }
+# Re-check the marker now that we hold the lock: Disable may have written it (and drained the
+# lock) while we were between the top-of-script check and acquiring this lock. Bail before
+# applying anything so a paused apply cannot resurrect artifacts after Disable's teardown.
+[ -f ""$MARKER"" ] && { log ""disabled marker appeared after lock, skipping""; exit 0; }
 
 # 0. resolve the macvlan parent. With a VLAN, the parent is the subinterface (e.g.
 # eth6.100) so frames are tagged; UniFi creates it for a VLAN WAN, but if it's absent
@@ -896,8 +1096,10 @@ if [ ""$SNAT_ENABLED"" = ""1"" ]; then
     fi
 fi
 
-# 5. self-install the cron watchdog (re-applies after reprovision)
-if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
+# 5. self-install the cron watchdog (re-applies after reprovision). Re-check the marker first:
+# Disable may have written it after the top-of-script check but before we reached here, and we
+# must not reinstall the cron that would immediately re-apply the interface it just tore down.
+if [ ! -f ""$MARKER"" ] && ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
     (crontab -l 2>/dev/null; echo ""*/$WATCHDOG_MIN * * * * $SCRIPT >/dev/null 2>&1"") | crontab -
     changed=1
 fi

--- a/src/NetworkOptimizer.Web/Services/MonitoringReadinessService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringReadinessService.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Central readiness checks for the monitoring subsystem, shared by the Monitoring page
+/// and by features that deep-link into it (e.g. a speed-test result linking into Live
+/// View historic playback). Keeps the "is monitoring usable for this site" rule in one
+/// place so callers don't re-derive it and drift.
+/// </summary>
+public class MonitoringReadinessService
+{
+    private readonly SnmpDetectionService _snmp;
+    private readonly SiteContextService _siteContext;
+    private readonly SiteDbContextFactory _siteDb;
+
+    public MonitoringReadinessService(
+        SnmpDetectionService snmp,
+        SiteContextService siteContext,
+        SiteDbContextFactory siteDb)
+    {
+        _snmp = snmp;
+        _siteContext = siteContext;
+        _siteDb = siteDb;
+    }
+
+    /// <summary>
+    /// Whether the shared InfluxDB connection is configured. InfluxDB is a single central
+    /// instance whose token/url live on the default site; secondary (managed) sites inherit
+    /// them and carry no token in their own <see cref="Storage.Models.MonitoringSettings"/>
+    /// row. This always reads the default site's row, so it answers the same regardless of
+    /// which site is current.
+    /// </summary>
+    public async Task<bool> IsSharedInfluxConfiguredAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await using var mainDb = _siteDb.CreateForSite(SiteManagementService.DefaultSiteSlug, isDefault: true);
+            var shared = await mainDb.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            return !string.IsNullOrEmpty(shared?.InfluxDbToken)
+                && !string.IsNullOrEmpty(shared?.InfluxDbUrl);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether Live View historic playback is available for the CURRENT site, so a
+    /// speed-test result can offer a deep link into it: monitoring must be enabled for this
+    /// site AND the shared InfluxDB connection must be configured. Mirrors the Monitoring
+    /// page's own readiness gate (<c>_monitoringEnabled &amp;&amp; _influxConfigured</c>).
+    /// </summary>
+    public async Task<bool> IsHistoricPlaybackAvailableAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var settings = await _snmp.GetOrCreateSettingsAsync(ct);
+            return settings.Enabled && await IsSharedInfluxConfiguredAsync(ct);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -169,10 +169,16 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
     /// Map the contract payload onto the shared PON supplemental DTO. Standard
     /// concepts keep their standard encodings: PLOAM states use the same strings
     /// as the ont measurement's pon_link_status; fec_errors is uncorrectable
-    /// codewords; bip_errors is the raw BIP counter.
+    /// codewords; bip_errors is the raw BIP counter. DDM optics readings are a
+    /// fallback only - the gateway's own SFP DDM poll takes precedence when it can
+    /// read the module (see CollectSfpForDevice).
     /// </summary>
     internal static PonSupplementalStats MapToSupplemental(NetOptCustomPonPayload p) => new()
     {
+        RxPowerDbm = p.Optics?.RxPowerDbm,
+        TxPowerDbm = p.Optics?.TxPowerDbm,
+        TemperatureC = p.Optics?.TemperatureC,
+        VoltageV = p.Optics?.VoltageV,
         PloamStateRaw = p.Ploam?.CurrState,
         PonLinkStatus = EncodePloamState(p.Ploam?.CurrState),
         PonLinkStatusPrev = EncodePloamState(p.Ploam?.PreviousState),
@@ -212,12 +218,17 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
 
     /// <summary>
     /// Standalone mapping: the standard OntStats fields this contract can serve.
-    /// DDM optics readings are absent by design - in the SFP-module scenario the
-    /// gateway's DDM poll owns those.
+    /// DDM optics readings are populated only when the endpoint supplies the
+    /// optional <c>optics</c> section; in the SFP-module (attached) scenario the
+    /// gateway's own DDM poll owns those and takes precedence.
     /// </summary>
     internal static OntStats MapToOntStats(NetOptCustomPonPayload p) => new()
     {
         Timestamp = DateTime.UtcNow,
+        RxPowerDbm = p.Optics?.RxPowerDbm,
+        TxPowerDbm = p.Optics?.TxPowerDbm,
+        TemperatureC = p.Optics?.TemperatureC,
+        VoltageV = p.Optics?.VoltageV,
         PonLinkStatus = ToPonLinkState(p.Ploam?.CurrState),
         FecErrors = p.GtcCounters?.FecWordsUncorr,
         BipErrors = p.GtcCounters?.Bip,
@@ -247,6 +258,9 @@ public class NetOptCustomPonPayload
     [JsonPropertyName("message")]
     public string? Message { get; set; }
 
+    [JsonPropertyName("optics")]
+    public OpticsSection? Optics { get; set; }
+
     [JsonPropertyName("lan")]
     public LanSection? Lan { get; set; }
 
@@ -271,6 +285,32 @@ public class NetOptCustomPonPayload
     /// <summary>Seconds since the ONT module booted.</summary>
     [JsonPropertyName("sfp_uptime_s")]
     public long? SfpUptimeS { get; set; }
+
+    /// <summary>
+    /// DDM optics readings, in the same units as SFP DDM (dBm / degrees C / volts).
+    /// Optional - serve these when the module exposes DDM but the gateway cannot
+    /// read it off the SFP slot (common with GPON sticks). When the config is
+    /// attached to a monitored SFP module and the gateway's own DDM poll returns a
+    /// value, that value wins; these are used only to fill the gaps.
+    /// </summary>
+    public class OpticsSection
+    {
+        /// <summary>Receive optical power in dBm.</summary>
+        [JsonPropertyName("rx_power_dbm")]
+        public double? RxPowerDbm { get; set; }
+
+        /// <summary>Transmit optical power in dBm.</summary>
+        [JsonPropertyName("tx_power_dbm")]
+        public double? TxPowerDbm { get; set; }
+
+        /// <summary>Transceiver temperature in degrees Celsius.</summary>
+        [JsonPropertyName("temperature_c")]
+        public double? TemperatureC { get; set; }
+
+        /// <summary>Supply voltage in volts.</summary>
+        [JsonPropertyName("voltage_v")]
+        public double? VoltageV { get; set; }
+    }
 
     public class LanSection
     {

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -52,6 +52,9 @@ public class SqmDeploymentService : ISqmDeploymentService
     private Task<(bool success, string output)> RunCommandAsync(string command, TimeSpan? timeout = null)
         => _gatewaySsh.RunCommandAsync(command, timeout);
 
+    /// <inheritdoc />
+    public Task<bool> IsAwaitingAgentAsync() => _gatewaySsh.IsAwaitingAgentTunnelAsync();
+
     /// <summary>
     /// Test SSH connection to the gateway
     /// </summary>
@@ -1369,6 +1372,14 @@ public class SqmDeploymentStatus
     public bool SpeedtestCliInstalled { get; set; }
     public bool BcInstalled { get; set; }
     public string? Error { get; set; }
+
+    /// <summary>
+    /// True when the gateway is unreachable only because this site's on-site agent
+    /// isn't online yet (a transient startup state on an agent-routed site), not a
+    /// real connection failure. The UI shows a neutral "waiting" note rather than a
+    /// connection error. Always false for a directly-reached site.
+    /// </summary>
+    public bool AwaitingAgent { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Ssh/GatewaySshService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/GatewaySshService.cs
@@ -25,6 +25,15 @@ public class GatewaySshService : IGatewaySshService
     private DateTime _cacheTime = DateTime.MinValue;
     private readonly TimeSpan _cacheExpiry = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// Shown when the gateway is reached through this site's on-site agent, which
+    /// isn't online yet - dialing the loopback tunnel proxy now would just get a
+    /// closed socket that SSH.NET reports as a raw "no identification string"
+    /// protocol error. Mirrors the console's awaiting-agent message.
+    /// </summary>
+    public const string AwaitingAgentMessage =
+        "Waiting for the on-site agent to connect. This site's gateway is reached through its agent; SQM will connect automatically once the agent is online.";
+
     public GatewaySshService(
         ILogger<GatewaySshService> logger,
         IServiceProvider serviceProvider,
@@ -76,6 +85,23 @@ public class GatewaySshService : IGatewaySshService
         (connection.Host, connection.Port) = await routing.RouteAsync(_siteSlug, connection.Host, connection.Port);
         return connection;
     }
+
+    /// <summary>
+    /// True when this site's gateway is reached through its on-site agent but no
+    /// agent is currently online. Callers short-circuit on this so they report a
+    /// clear "waiting for the agent" state (see <see cref="AwaitingAgentMessage"/>)
+    /// instead of dialing the refusing loopback proxy - which surfaces a bogus SSH
+    /// protocol error to the user and logs a warning for a transient startup state.
+    /// </summary>
+    private async Task<bool> IsAwaitingAgentAsync()
+    {
+        var routing = _serviceProvider.GetService<SiteTunnelRouting>();
+        if (routing == null) return false;
+        return await routing.IsViaAgentAsync(_siteSlug) && !routing.IsAgentOnline(_siteSlug);
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsAwaitingAgentTunnelAsync() => IsAwaitingAgentAsync();
 
     /// <inheritdoc />
     public async Task<GatewaySshSettings> GetSettingsAsync(bool forceRefresh = false)
@@ -157,6 +183,11 @@ public class GatewaySshService : IGatewaySshService
             return (false, "SSH credentials not configured");
         }
 
+        if (await IsAwaitingAgentAsync())
+        {
+            return (false, AwaitingAgentMessage);
+        }
+
         try
         {
             var connection = await CreateConnectionInfoAsync(settings);
@@ -203,6 +234,11 @@ public class GatewaySshService : IGatewaySshService
         if (string.IsNullOrEmpty(password) && string.IsNullOrEmpty(privateKeyPath))
         {
             return (false, "SSH credentials not configured");
+        }
+
+        if (await IsAwaitingAgentAsync())
+        {
+            return (false, AwaitingAgentMessage);
         }
 
         try
@@ -262,6 +298,11 @@ public class GatewaySshService : IGatewaySshService
             return (false, "SSH credentials not configured");
         }
 
+        if (await IsAwaitingAgentAsync())
+        {
+            return (false, AwaitingAgentMessage);
+        }
+
         var connection = await CreateConnectionInfoAsync(settings);
         var result = await _sshClient.ExecuteCommandAsync(connection, command, timeout, cancellationToken);
 
@@ -273,6 +314,8 @@ public class GatewaySshService : IGatewaySshService
     {
         var settings = await GetSettingsAsync();
         if (!settings.Enabled || string.IsNullOrEmpty(settings.Host) || !settings.HasCredentials)
+            return null;
+        if (await IsAwaitingAgentAsync())
             return null;
         return await CreateConnectionInfoAsync(settings);
     }

--- a/src/NetworkOptimizer.Web/Services/Ssh/IGatewaySshService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/IGatewaySshService.cs
@@ -26,6 +26,14 @@ public interface IGatewaySshService
     Task<(bool success, string message)> TestConnectionAsync();
 
     /// <summary>
+    /// True when this site's gateway is reached through its on-site agent but no
+    /// agent is currently online, so an SSH attempt would just hit the refusing
+    /// tunnel proxy. Callers use this to show a "waiting for the agent" state
+    /// instead of a connection error. Always false for a directly-reached site.
+    /// </summary>
+    Task<bool> IsAwaitingAgentTunnelAsync();
+
+    /// <summary>
     /// Test SSH connection to the gateway using provided settings (for testing form values before save)
     /// </summary>
     /// <param name="host">Gateway hostname or IP</param>

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -37,6 +37,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     private readonly ICredentialProtectionService _credentialProtection;
 
     private UniFiApiClient? _client;
+    // Serializes every connection-lifecycle mutation of _client (connect, reconnect,
+    // tunnel-drop, disconnect). Without it, concurrent connect attempts during the
+    // startup/tunnel-up window null _client out from under an in-flight login, which
+    // NPE'd when the failure branch read _client.LastLoginError. OnConnectionChanged
+    // is always fired AFTER the gate is released so a subscriber can't re-enter and
+    // deadlock.
+    private readonly SemaphoreSlim _connectGate = new(1, 1);
     private UniFiConnectionSettings? _settings;
     private bool _isConnected;
     private string? _lastError;
@@ -314,24 +321,35 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     public async Task OnAgentTunnelDroppedAsync()
     {
         if (IsAgentOnline()) return; // another agent still carries the site
-        if (!_isConnected && _client == null) return;
-        if (!await IsConsoleViaAgentAsync()) return;
 
-        // Re-check after the await: a fast agent bounce can reconnect (and the
-        // connected hook re-establish the console) while the DB read above was in
-        // flight - disposing the fresh client here would fabricate an up-to-60s
-        // "awaiting agent" outage on a healthy tunnel.
-        if (IsAgentOnline()) return;
+        await _connectGate.WaitAsync();
+        var notify = false;
+        try
+        {
+            if (!_isConnected && _client == null) return;
+            if (!await IsConsoleViaAgentAsync()) return;
 
-        _logger.LogInformation(
-            "Agent tunnel for site {Slug} dropped; marking its console as awaiting the agent", SiteSlug);
-        _client?.Dispose();
-        _client = null;
-        _isConnected = false;
-        _awaitingAgent = true;
-        _lastError = AwaitingAgentMessage;
-        ResetConsoleFailureCount();
-        OnConnectionChanged?.Invoke();
+            // Re-check after the await: a fast agent bounce can reconnect (and the
+            // connected hook re-establish the console) while the DB read above was in
+            // flight - disposing the fresh client here would fabricate an up-to-60s
+            // "awaiting agent" outage on a healthy tunnel.
+            if (IsAgentOnline()) return;
+
+            _logger.LogInformation(
+                "Agent tunnel for site {Slug} dropped; marking its console as awaiting the agent", SiteSlug);
+            _client?.Dispose();
+            _client = null;
+            _isConnected = false;
+            _awaitingAgent = true;
+            _lastError = AwaitingAgentMessage;
+            ResetConsoleFailureCount();
+            notify = true;
+        }
+        finally
+        {
+            _connectGate.Release();
+            if (notify) OnConnectionChanged?.Invoke();
+        }
     }
 
     /// <summary>
@@ -350,17 +368,27 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public async Task NoteTunnelUnreachableAsync()
     {
-        if (!_isConnected && _client == null) return; // already down / awaiting - idempotent
-        if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles ride the tunnel
-        _logger.LogInformation(
-            "Site {Slug}'s agent tunnel is unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
-        _client?.Dispose();
-        _client = null;
-        _isConnected = false;
-        _awaitingAgent = true;
-        _lastError = AwaitingAgentMessage;
-        ResetConsoleFailureCount();
-        OnConnectionChanged?.Invoke();
+        await _connectGate.WaitAsync();
+        var notify = false;
+        try
+        {
+            if (!_isConnected && _client == null) return; // already down / awaiting - idempotent
+            if (!await IsConsoleViaAgentAsync()) return;   // only agent-routed consoles ride the tunnel
+            _logger.LogInformation(
+                "Site {Slug}'s agent tunnel is unreachable; flipping its console to awaiting-agent ahead of the watchdog", SiteSlug);
+            _client?.Dispose();
+            _client = null;
+            _isConnected = false;
+            _awaitingAgent = true;
+            _lastError = AwaitingAgentMessage;
+            ResetConsoleFailureCount();
+            notify = true;
+        }
+        finally
+        {
+            _connectGate.Release();
+            if (notify) OnConnectionChanged?.Invoke();
+        }
     }
 
     /// <summary>
@@ -645,6 +673,8 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
         _logger.LogInformation("Connecting to UniFi controller at {Url}", config.ControllerUrl);
 
+        await _connectGate.WaitAsync();
+        var notify = false;
         try
         {
             // Dispose existing client
@@ -708,8 +738,8 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
                 _logger.LogInformation("Successfully connected to UniFi controller (UniFi OS: {IsUniFiOs})", _client.IsUniFiOs);
 
-                // Notify subscribers to refresh their data
-                OnConnectionChanged?.Invoke();
+                // Notify subscribers to refresh their data (fired after the gate releases)
+                notify = true;
 
                 return true;
             }
@@ -736,6 +766,11 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
         }
+        finally
+        {
+            _connectGate.Release();
+            if (notify) OnConnectionChanged?.Invoke();
+        }
     }
 
     /// <summary>
@@ -745,8 +780,13 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     {
         if (!settings.HasCredentials) return false;
 
+        await _connectGate.WaitAsync();
+        var notify = false;
+
         // Use a shorter timeout for startup auto-connect so the dashboard
-        // shows the "unreachable" banner quickly instead of waiting 60s+
+        // shows the "unreachable" banner quickly instead of waiting 60s+. Created
+        // after the gate so its 8s budget covers the connect itself, not time spent
+        // queued behind another in-flight connect.
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
 
         try
@@ -850,7 +890,9 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 // Critical for agent-tunneled consoles: when a site's console was
                 // unreachable at initial load and the agent tunnel later comes up,
                 // this reconnect fires the event that triggers the dashboard refresh.
-                OnConnectionChanged?.Invoke();
+                // Fired after the gate releases (see finally) so a subscriber can't
+                // re-enter a gated connect and deadlock.
+                notify = true;
 
                 return true;
             }
@@ -884,6 +926,11 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _client = null;
             await PreferAwaitingAgentOnDeadTunnelAsync();
             return false;
+        }
+        finally
+        {
+            _connectGate.Release();
+            if (notify) OnConnectionChanged?.Invoke();
         }
     }
 
@@ -965,26 +1012,34 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public async Task DisconnectAsync()
     {
-        if (_client != null)
+        await _connectGate.WaitAsync();
+        try
         {
-            try
+            if (_client != null)
             {
-                await _client.LogoutAsync();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Error during logout");
+                try
+                {
+                    await _client.LogoutAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Error during logout");
+                }
+
+                _client.Dispose();
+                _client = null;
             }
 
-            _client.Dispose();
-            _client = null;
+            _isConnected = false;
+            ResetConsoleFailureCount();
+            ClearCaches();
+            _logger.LogInformation("Disconnected from UniFi controller");
         }
-
-        _isConnected = false;
-        ResetConsoleFailureCount();
-        ClearCaches();
-        _logger.LogInformation("Disconnected from UniFi controller");
-        OnConnectionChanged?.Invoke();
+        finally
+        {
+            _connectGate.Release();
+            OnConnectionChanged?.Invoke();
+        }
     }
 
     /// <summary>
@@ -1558,6 +1613,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     internal void DisposeOwned()
     {
         _client?.Dispose();
+        _connectGate.Dispose();
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2245,6 +2245,19 @@ a.btn-sm {
     gap: 0.5rem;
 }
 
+/* Monitoring Interfaces row actions: keep the action buttons on one line by overriding the
+   global .btn min-width and tightening spacing. The table-responsive wrapper provides
+   horizontal scroll on very narrow screens. */
+.mi-row-actions {
+    flex-wrap: nowrap;
+    gap: 0.375rem;
+}
+
+.mi-row-actions .btn {
+    min-width: 0;
+    padding: 0 12px;
+}
+
 .btn-lg {
     height: 44px;
     padding: 0 24px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -546,6 +546,10 @@ h1:focus {
     color: var(--primary-color);
 }
 
+.speedtest-liveview-link {
+    gap: 4px;
+}
+
 .card-header-right {
     display: flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17914,6 +17914,14 @@ body.kiosk-mode .status-indicators {
     background: transparent;
 }
 
+.data-table tr.site-row-selected {
+    background: var(--bg-hover);
+}
+
+.site-name-selected {
+    font-weight: 600;
+}
+
 .site-config-panel {
     position: relative;
     display: flex;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18232,6 +18232,20 @@ body.kiosk-mode .status-indicators {
     margin-top: 1.25rem;
 }
 
+.card .card .site-wizard .btn-secondary,
+.card .card .site-wizard .btn-ghost,
+.site-wizard .btn-secondary,
+.site-wizard .btn-ghost {
+    background: var(--bg-elevated);
+}
+
+.card .card .site-wizard .btn-secondary:hover:not(:disabled),
+.card .card .site-wizard .btn-ghost:hover:not(:disabled),
+.site-wizard .btn-secondary:hover:not(:disabled),
+.site-wizard .btn-ghost:hover:not(:disabled) {
+    background: var(--btn-map-hover);
+}
+
 .site-wizard pre {
     background: var(--bg-primary);
     padding: 0.75rem;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -88,6 +88,23 @@ export function publishScrubberWindow(win) {
     _notify('scrubber-window');
 }
 
+// Restore live-mode playback defaults. Called by the 3D map (the playback
+// authority) at the start of each of its mounts, so state left behind by a
+// previous Live View session - historic mode, a paused flag, a parked
+// scrubber - can't leak into the new one. This module is a singleton that
+// outlives SPA navigations while the map instance itself is rebuilt fresh,
+// so without this every remount inherits whatever the last session left.
+// Notifies so any still-mounted consumer UI syncs to the clean state.
+export function resetPlayback() {
+    _paused = false;
+    _mode = 'live';
+    _scrubberValue = 10000;
+    _scrubberRight = 'Live';
+    _playbackSpeed = 1;
+    _notify('playstate');
+    _notify('scrubber');
+}
+
 // Render local-midnight tick marks onto a scrubber track overlay so multi-day
 // windows have day-boundary orientation. Shared by the 3D scrubber and its 2D
 // mirror. Windows under two days get no ticks; wide windows thin to ~12 ticks.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -3,7 +3,7 @@
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 // KEEP IN SYNC: lan-flow-map.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 function demoMask(text) {
     const dm = window.DemoMask;
@@ -274,7 +274,12 @@ class LanFlowMap2D {
     }
 
     async start(){
-        if(flowData.isPaused())flowData.publishPlayState(false,'live');
+        // Standalone (dashboard) mounts have no 3D map to reset stale playback
+        // state a previous Monitoring session left in the shared store, so do it
+        // here. On the Monitoring page the 3D map (the playback authority) has
+        // already reset the store - and may have re-entered historic for a
+        // deep-linked timestamp - so a full mount must never force it back live.
+        if(this._liveOnly&&flowData.isPaused())flowData.publishPlayState(false,'live');
         this._createCanvas();
         const snap=flowData.getSnapshot();
         if(snap){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -15,7 +15,7 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js?v=1';
 // KEEP IN SYNC: lan-flow-map-2d.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 const COLORS = {
     background: 0x202023,
@@ -211,6 +211,9 @@ export class LanFlowMap {
         // discovery hint to keep its compact chrome clean (it also hides the
         // scrubber/status). Full Monitoring page leaves it on.
         this._signalHintEnabled = options.signalHint ?? true;
+        // Deep-link entry point (e.g. from a speed-test result): an absolute epoch-ms
+        // instant to open in historic playback, paused. Applied once at the end of start().
+        this._initialAtMs = Number.isFinite(options.initialAt) ? options.initialAt : null;
 
         this._snapshot = null;
         this._deviceScale = 1;          // property-size factor for device radii (set in _layoutNodes)
@@ -513,6 +516,24 @@ export class LanFlowMap {
         await this._loadInitialSpeedTests();
         this._startAnimation();
         this._startPolling();
+        this._applyInitialSeek();
+    }
+
+    // Honor a deep-linked timestamp (options.initialAt) by dropping straight into
+    // historic playback, paused, at that instant. Widens the timeline window first
+    // if the target predates the current span so the instant is reachable rather
+    // than clamping to the left edge (an instant older than retention still clamps).
+    _applyInitialSeek() {
+        const ms = this._initialAtMs;
+        if (!Number.isFinite(ms)) return;
+        this._initialAtMs = null; // one-shot
+        const needed = Date.now() - ms;
+        if (needed > this._scrubSpan) {
+            const preset = flowData.SCRUBBER_PRESETS.find(p => (p.ms ?? Infinity) >= needed)
+                || flowData.SCRUBBER_PRESETS[flowData.SCRUBBER_PRESETS.length - 1];
+            this._setScrubSpan(preset.key);
+        }
+        this.seekTo(ms);
     }
 
     dispose() {
@@ -2046,16 +2067,16 @@ export class LanFlowMap {
         clearTimeout(this._scrubberInputDebounce);
         const pending = this._pendingScrubAt;
         this._pendingScrubAt = null;
-        // Otherwise seed from the exact parked instant when known - requantizing
-        // through the slider value can be minutes off on a wide window. But only
-        // when the thumb still agrees with it; if not, the thumb position is the
-        // user's intent, not the stale instant.
+        // Otherwise seed from the ABSOLUTE parked instant - never the slider-derived
+        // fromValue. The timeline window trails now, so a fixed slider value maps to a
+        // later time as the page sits; seeding from it added the whole sit-duration to
+        // the resume point (park at T, sit 2 min, play started at T+2 min). historicAt
+        // is an absolute Date kept current on every commit path (deep-link, drag,
+        // keyboard scrub), so it never drifts; pending covers an in-flight scrub not yet
+        // committed; fromValue is only a last-resort fallback if neither is set.
         const fromValue = this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
-        const stepMs = this._scrubSpan / 10000;
-        this._playbackTime = pending
-            ?? ((this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
-                ? this._historicAt : fromValue);
+        this._playbackTime = pending ?? this._historicAt ?? fromValue;
         // Publish the seed position immediately instead of waiting for the first
         // 1s tick: consumers re-baseline their playhead on a confirmed seek, and
         // an adopted pending scrub gets its data loaded now rather than a tick late.
@@ -2626,6 +2647,10 @@ export class LanFlowMap {
     _enterHistoricScrub() {
         this._mode = 'historic';
         this._paused = true;
+        // Mirror the transition into the shared store immediately. The debounced
+        // _onScrubberChange republishes 0-500ms later, but consumers mounting in
+        // that window must not read a stale 'live' state.
+        flowData.publishPlayState(this._paused, this._mode);
         this._syncPlayPauseIcon();
         this._stopHistoricPlayback();
         if (this._panels.modeBadge) {
@@ -4288,6 +4313,11 @@ export async function mount(canvasId, options = {}) {
     }
     const el = document.getElementById(canvasId);
     if (!el) throw new Error(`Canvas #${canvasId} not found`);
+    // The map is the playback authority and mounts before the other Live View
+    // consumers (2D map, WAN chart, port table). Clear playback state a prior
+    // session left in the shared store so every mount starts from Live; a
+    // deep-linked initialAt then re-enters historic through the normal seek path.
+    flowData.resetPlayback();
     _instance = new LanFlowMap(el, options);
     await _instance.start();
     return _instance;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -282,6 +282,12 @@ function updateChartVisibility() {
 // abnormal, so even a fraction of a percent is worth flagging as a poor measurement target.
 const LAN_FLAKY_LOSS_PCT = 0.5;
 
+// A loss sample on the gateway fabric target at or above this marks that timestamp as a gateway
+// outage: with the gateway down, LAN targets behind it lose too, and that loss is the gateway's
+// fault, not the target's. High bar so an outage (near-total unreachability) is masked while a
+// merely-flaky gateway isn't - we only want to drop true outage windows.
+const GATEWAY_OUTAGE_LOSS_PCT = 50;
+
 // Report the current LAN (Fabric) category's flaky targets to Blazor so it can render the
 // "flaky LAN target" advisory. Detection only; the role/dismissed gating and the notice itself
 // live in Blazor (Monitoring.razor), which has the target metadata. Entirely best-effort:
@@ -293,8 +299,21 @@ function notifyLanFlakyHints(data) {
         if (!ref) return;
         let ids = [];
         if (currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
+            // Timestamps the gateway target itself was out (>= GATEWAY_OUTAGE_LOSS_PCT). Loss on
+            // any other LAN target at these times rode a gateway outage, so it's excluded from
+            // that target's average below. Union across gateways covers multi-gateway sites.
+            const gatewayOutageTimes = new Set();
+            data.targets.forEach(t => {
+                if (t.autoLabel !== 'gateway') return;
+                (t.loss || []).forEach(p => {
+                    if (p.value != null && p.value >= GATEWAY_OUTAGE_LOSS_PCT) gatewayOutageTimes.add(p.time);
+                });
+            });
             ids = data.targets.filter(t => {
-                const vals = (t.loss || []).map(p => p.value).filter(v => v != null);
+                if (t.autoLabel === 'gateway') return false;
+                const vals = (t.loss || [])
+                    .filter(p => p.value != null && !gatewayOutageTimes.has(p.time))
+                    .map(p => p.value);
                 if (!vals.length) return false;
                 const mean = vals.reduce((a, b) => a + b, 0) / vals.length;
                 return mean >= LAN_FLAKY_LOSS_PCT;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -282,11 +282,17 @@ function updateChartVisibility() {
 // abnormal, so even a fraction of a percent is worth flagging as a poor measurement target.
 const LAN_FLAKY_LOSS_PCT = 0.5;
 
-// A loss sample on the gateway fabric target at or above this marks that timestamp as a gateway
-// outage: with the gateway down, LAN targets behind it lose too, and that loss is the gateway's
-// fault, not the target's. High bar so an outage (near-total unreachability) is masked while a
-// merely-flaky gateway isn't - we only want to drop true outage windows.
-const GATEWAY_OUTAGE_LOSS_PCT = 50;
+// A loss sample at or above this marks a target as "down" in that timestamp. Used for both outage
+// masks below. High bar so only true unreachability counts, never the low-level flaky loss
+// (>= LAN_FLAKY_LOSS_PCT) we actually want to surface.
+const OUTAGE_LOSS_PCT = 50;
+// Fraction of the reporting fabric pool that must be down in a timestamp for it to read as a
+// systemic (gateway/shared-switch) outage rather than one target's own trouble.
+const SHARED_OUTAGE_POOL_FRACTION = 0.5;
+// The shared-outage test needs a real pool to infer "systemic": with only a target or two, one
+// down device is already "half the pool," so we lean on the gateway signal alone and never mask
+// a genuinely-down single target as shared loss.
+const SHARED_OUTAGE_MIN_TARGETS = 3;
 
 // Report the current LAN (Fabric) category's flaky targets to Blazor so it can render the
 // "flaky LAN target" advisory. Detection only; the role/dismissed gating and the notice itself
@@ -299,20 +305,38 @@ function notifyLanFlakyHints(data) {
         if (!ref) return;
         let ids = [];
         if (currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
-            // Timestamps the gateway target itself was out (>= GATEWAY_OUTAGE_LOSS_PCT). Loss on
-            // any other LAN target at these times rode a gateway outage, so it's excluded from
-            // that target's average below. Union across gateways covers multi-gateway sites.
-            const gatewayOutageTimes = new Set();
+            // Mask out timestamps whose loss rode an outage rather than one target's own flakiness,
+            // so a switch isn't flagged for loss the gateway (or a shared upstream) caused. A
+            // timestamp is an outage when EITHER holds:
+            //   - the gateway fabric target itself was down (>= OUTAGE_LOSS_PCT) - catches a gateway
+            //     outage even when it only downs some LAN targets, and
+            //   - most of the reporting fabric pool was down at once - catches a shared-switch
+            //     outage and covers sites with no monitored gateway target.
+            // Neither test trips on a single flaky target's solo loss, so it still surfaces.
+            const outageTimes = new Set();
+            const perTime = new Map(); // time -> { down, reporting }
             data.targets.forEach(t => {
-                if (t.autoLabel !== 'gateway') return;
+                const isGateway = t.autoLabel === 'gateway';
                 (t.loss || []).forEach(p => {
-                    if (p.value != null && p.value >= GATEWAY_OUTAGE_LOSS_PCT) gatewayOutageTimes.add(p.time);
+                    if (p.value == null) return;
+                    const down = p.value >= OUTAGE_LOSS_PCT;
+                    if (isGateway && down) outageTimes.add(p.time);
+                    const agg = perTime.get(p.time) || { down: 0, reporting: 0 };
+                    agg.reporting++;
+                    if (down) agg.down++;
+                    perTime.set(p.time, agg);
                 });
+            });
+            perTime.forEach((agg, time) => {
+                if (agg.reporting >= SHARED_OUTAGE_MIN_TARGETS
+                    && agg.down / agg.reporting >= SHARED_OUTAGE_POOL_FRACTION) {
+                    outageTimes.add(time);
+                }
             });
             ids = data.targets.filter(t => {
                 if (t.autoLabel === 'gateway') return false;
                 const vals = (t.loss || [])
-                    .filter(p => p.value != null && !gatewayOutageTimes.has(p.time))
+                    .filter(p => p.value != null && !outageTimes.has(p.time))
                     .map(p => p.value);
                 if (!vals.length) return false;
                 const mean = vals.reduce((a, b) => a + b, 0) / vals.length;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -563,6 +563,11 @@ export async function mount(elId) {
     const container = document.getElementById(elId);
     if (!container) return;
 
+    // Seed the category from whichever filter button the server rendered active (LAN by
+    // default, ISP when the site has no LAN targets), so the initial load matches the UI.
+    const activeCategoryBtn = container.querySelector('[data-category].active');
+    if (activeCategoryBtn) currentCategory = activeCategoryBtn.dataset.category;
+
     const rttEl = container.querySelector('.latency-rtt-chart');
     const lossEl = container.querySelector('.latency-loss-chart');
     if (!rttEl || !lossEl) return;

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -490,10 +490,24 @@ export function mount(el, mountOpts = {}) {
     if (Array.isArray(mountOpts.deviceMeta)) {
         for (const d of mountOpts.deviceMeta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
     }
+    // Playback state is module-level and outlives unmount; a paused or historic
+    // state left by a previous session would silently block startPoll() below.
     currentAt = null;
+    paused = false;
     window.__portStatsTable = api;
     loadAndRender();
     startPoll();
+
+    // Converge to the 3D map's (the playback authority's) current state - the
+    // seek/pause push from Blazor can race this mount and be lost (see the
+    // matching pull in wan-live-chart.js).
+    const mapInst = window.__lanFlowMap?.getInstance?.();
+    if (mapInst && mapInst._mode === 'historic') {
+        const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
+        if (at) api.seekTime(at.toISOString());
+    } else if (mapInst && mapInst._paused) {
+        api.pause();
+    }
 }
 
 export const seekTime = (...a) => api.seekTime(...a);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -3,7 +3,7 @@
 // /api/monitoring/live-stats for real-time updates.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 const HISTORY_MINUTES = 5;
 // Poll faster than the 5s SNMP fast tier so no sample is missed when the two
@@ -490,6 +490,20 @@ export async function mount(containerId, opts) {
         }
     };
     document.addEventListener('visibilitychange', visHandler);
+
+    // Converge to the 3D map's (the playback authority's) current state. This
+    // mount runs concurrently with the map's deep-link/scrub seeks, so the
+    // seekTime push from Blazor's OnMapTimeChanged can land before the chart is
+    // ready and be lost (or be wiped by the live polling started above). Pulling
+    // once at mount completion closes that race: pushes that already fired are
+    // recovered here, and pushes still pending find a fully mounted chart.
+    const mapInst = window.__lanFlowMap?.getInstance?.();
+    if (mapInst && mapInst._mode === 'historic') {
+        const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
+        if (at) await seekTime(at.toISOString());
+    } else if (mapInst && mapInst._paused) {
+        pause();
+    }
 }
 
 export function pause() {
@@ -511,10 +525,15 @@ export function resume() {
 // Hovering holds redraws (same as live updateChart) so values can be inspected
 // without the chart shifting under the cursor - EXCEPT briefly after a click on
 // the chart, which must draw its playhead even though the pointer (and so the
-// tooltip) is still over the plot.
-function renderHistoric(at) {
+// tooltip) is still over the plot. `force` bypasses the hover-hold for a discrete
+// paused seek (a deep-link or manual scrub) - its single draw must land even under
+// the cursor, or it's swallowed and never retried while paused. Callers must NOT
+// force during active playback: the per-tick seeks would then redraw through a
+// hover, kicking the user out of tooltip inspection while the background timeline
+// advances - the exact behavior the hover-hold exists to preserve.
+function renderHistoric(at, force = false) {
     if (!chart || buffer.length === 0) return;
-    if (Date.now() > clickRenderUntil) {
+    if (!force && Date.now() > clickRenderUntil) {
         const el = document.getElementById(elId);
         if (el?.classList.contains('apexcharts-tooltip-active')) return;
     }
@@ -617,7 +636,11 @@ export async function seekTime(isoTimestamp) {
         }));
     } catch { return; }
     if (buffer.length === 0) return;
-    renderHistoric(at);
+    // Force the reposition draw only for a discrete/paused seek (deep-link, manual
+    // scrub): it must land even under the cursor or it's never retried while paused.
+    // During active playback leave it unforced so a hover still holds the redraw for
+    // inspection while the background timeline (2D/3D maps) keeps advancing.
+    renderHistoric(at, mapPlaybackRate() <= 0);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkFormatHelpersTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkFormatHelpersTests.cs
@@ -15,6 +15,17 @@ public class NetworkFormatHelpersTests
     // and "Zayo Group, LLC") both collapse to the same household name.
     [InlineData("Zayo Bandwidth", "Zayo")]
     [InlineData("Zayo Group, LLC", "Zayo")]
+    // "L.C." / "L.C" / "LC" legal forms (e.g. XMission registers as "XMission, L.C.").
+    [InlineData("XMission, L.C.", "XMission")]
+    [InlineData("XMission, L.C", "XMission")]
+    [InlineData("XMission LC", "XMission")]
+    // Dotted legal forms must strip even though the input's trailing '.' is trimmed first
+    // (OrgSuffixes entries are stored dotless so they still match the trimmed tail).
+    [InlineData("Orange S.A.", "Orange")]
+    [InlineData("KPN B.V.", "KPN")]
+    [InlineData("Ziggo N.V.", "Ziggo")]
+    [InlineData("Hurricane Electric, L.P.", "Hurricane Electric")]
+    [InlineData("Hurricane Electric LP", "Hurricane Electric")]
     public void CleanOrgName_strips_industry_and_legal_suffixes(string raw, string expected)
         => NetworkFormatHelpers.CleanOrgName(raw).Should().Be(expected);
 

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceMigrationTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceMigrationTests.cs
@@ -161,4 +161,16 @@ public class MonitoringInterfaceMigrationTests : IDisposable
                 .WithMessage("*change*");
         }
     }
+
+    [Fact]
+    public void Disabled_DefaultsToFalse_ForExistingAndNewRows()
+    {
+        using var context = CreateContext();
+        MigrationSafety.MigrateWithFriendlyErrors(context);
+        context.Database.ExecuteSqlRaw(
+            "INSERT INTO MonitoringInterfaces (Name, WanIfName, TargetIp, SubnetPrefix, GatewayLocalIp, SnatEnabled, WatchdogIntervalMinutes, IsManuallyDeployed, CreatedAt, UpdatedAt) " +
+            "VALUES ('modem0','eth4','192.168.100.1',24,'192.168.100.2',1,5,0,'2026-01-01','2026-01-01');");
+        var disabled = context.Database.SqlQueryRaw<bool>("SELECT Disabled FROM MonitoringInterfaces WHERE Name='modem0'").AsEnumerable().Single();
+        disabled.Should().BeFalse();
+    }
 }

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceRepositoryTests.cs
@@ -163,4 +163,29 @@ public class MonitoringInterfaceRepositoryTests : IDisposable
         byTarget!.Name.Should().Be("ont0");
         byAlias!.Name.Should().Be("starlink0");
     }
+
+    [Fact]
+    public async Task SetDisabledAsync_TogglesFlagAndBumpsUpdatedAt()
+    {
+        var mi = Valid("modem0", "eth4", "192.168.100.1", "192.168.100.2");
+        await _repository.SaveMonitoringInterfaceAsync(mi);
+        var before = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!.UpdatedAt;
+        await _repository.SetDisabledAsync(mi.Id, true);
+        var after = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!;
+        after.Disabled.Should().BeTrue();
+        after.UpdatedAt.Should().BeOnOrAfter(before);
+        after.TargetIp.Should().Be(mi.TargetIp);
+    }
+
+    [Fact]
+    public async Task SaveMonitoringInterfaceAsync_PreservesDisabledOnEdit()
+    {
+        var mi = Valid("modem0", "eth4", "192.168.100.1", "192.168.100.2");
+        await _repository.SaveMonitoringInterfaceAsync(mi);
+        await _repository.SetDisabledAsync(mi.Id, true);
+        var edit = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!;
+        edit.WatchdogIntervalMinutes = 7;
+        await _repository.SaveMonitoringInterfaceAsync(edit);
+        (await _repository.GetMonitoringInterfaceAsync(mi.Id))!.Disabled.Should().BeTrue();
+    }
 }

--- a/tests/NetworkOptimizer.UniFi.Tests/UniFiApiClientDisposedRequestTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/UniFiApiClientDisposedRequestTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Regression coverage for the disposed-client request guard: a concurrent
+/// reconnect can dispose a <see cref="UniFiApiClient"/> while a data call is in
+/// flight, so <c>ExecuteRequestAsync</c> must turn an
+/// <see cref="ObjectDisposedException"/> (and a disposed client) into the same
+/// "couldn't complete" value these methods already yield on failure, rather than
+/// letting the exception surface as a crash.
+/// </summary>
+public class UniFiApiClientDisposedRequestTests
+{
+    private static UniFiApiClient CreateClient() =>
+        new(NullLogger<UniFiApiClient>.Instance, "unifi.example.test", "user", "pass");
+
+    [Fact]
+    public async Task ExecuteRequestAsync_returns_action_result_on_happy_path()
+    {
+        using var client = CreateClient();
+
+        var result = await client.ExecuteRequestAsync(async () =>
+        {
+            await Task.Yield();
+            return 42;
+        });
+
+        // Happy path is untouched: the wrapper returns exactly what the action produced.
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_swallows_ObjectDisposedException_and_returns_default()
+    {
+        using var client = CreateClient();
+
+        // Mid-flight disposal: the in-flight request throws ObjectDisposedException
+        // (the retry policy does not handle it, so it would otherwise propagate).
+        var result = await client.ExecuteRequestAsync<string?>(() =>
+            throw new ObjectDisposedException(nameof(UniFiApiClient)));
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteRequestAsync_short_circuits_after_dispose_without_invoking_action()
+    {
+        var client = CreateClient();
+        client.Dispose();
+
+        var actionInvoked = false;
+        var result = await client.ExecuteRequestAsync(async () =>
+        {
+            actionInvoked = true;
+            await Task.Yield();
+            return 42;
+        });
+
+        // Disposed fast-path: the action never runs and the wrapper returns default.
+        actionInvoked.Should().BeFalse();
+        result.Should().Be(0);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -700,6 +700,43 @@ public class IspHealthScorerTests
         RoleTargetIds = { targetId }
     };
 
+    // TestSeries.Flat holds RttAvgMs constant (MAD 0); this alternates the per-minute RTT by
+    // +/- madMs around rttMs so the sample set has a median of rttMs and an RTT MAD of exactly
+    // madMs, while EffectiveJitterMs stays at a low fixed value (so jitter scoring is out of the way
+    // and only stability moves). Used to exercise the MAD floor and stability witness absolution.
+    private static List<LatencySample> Wander(double rttMs, double madMs, double jitterMs = 0.3, double lossPct = 0)
+    {
+        var samples = new List<LatencySample>();
+        var i = 0;
+        for (var t = TestSeries.Start; t < TestSeries.Start + Day; t = t.AddMinutes(1))
+        {
+            var rtt = rttMs + (i++ % 2 == 0 ? -madMs : madMs);
+            samples.Add(new LatencySample(t, rtt, rtt + jitterMs, jitterMs, lossPct));
+        }
+        return samples;
+    }
+
+    private static AsnSeries IspHopMad(string targetId, string name, double rttMs, double madMs, string hopIp) => new()
+    {
+        AsnNumber = 64496,
+        AsnName = name,
+        TargetIds = { targetId },
+        RoleTargetIds = { targetId },
+        HopIps = { hopIp },
+        Samples = Wander(rttMs, madMs)
+    };
+
+    private static AsnSeries DestMad(string ip, double rttMs, double madMs, params string[] ancestors) => new()
+    {
+        AsnNumber = 0,
+        AsnName = ip,
+        TargetIds = { $"dest-{ip}" },
+        HopIps = { ip },
+        AncestorIps = ancestors.ToList(),
+        Samples = Wander(rttMs, madMs),
+        IsDestination = true
+    };
+
     [Fact]
     public void All_isp_hops_are_graded_independently()
     {
@@ -822,6 +859,83 @@ public class IspHealthScorerTests
             "a jittery transit ASN must not raise the ISP jitter (cap is min, not max)");
         withJitteryTransit.IspAsns.Single().ScoredJitterMs.Should().BeApproximately(0.3, 0.05,
             "the displayed ISP jitter stays at the ISP mean when transit is not cleaner");
+    }
+
+    [Fact]
+    public void Rtt_wander_below_the_tech_ideal_scores_perfect_stability()
+    {
+        // Everything else held equal (same RTT, jitter, no loss, single hop so reach is 0), OverallScore
+        // isolates stability. MAD at/below the tech's ideal MAD band anchor (GPON 0.15 ms) is perfect;
+        // MAD out toward the poor anchor is penalized - the per-tech absolute-MAD band, not a ratio.
+        var steady = IspHopMad("h", "H", 3.0, 0.1, "192.0.2.1");
+        var wobbly = IspHopMad("h", "H", 3.0, 0.8, "192.0.2.1");
+
+        var steadyScore = new IspHealthScorer(Options)
+            .Score(BuildInputs(ispAsn: new() { steady }, ispTargets: new() { steady }, firstHopTargetId: "h"), Gpon)
+            .IspTargets.Single().OverallScore;
+        var wobblyScore = new IspHealthScorer(Options)
+            .Score(BuildInputs(ispAsn: new() { wobbly }, ispTargets: new() { wobbly }, firstHopTargetId: "h"), Gpon)
+            .IspTargets.Single().OverallScore;
+
+        steadyScore.Should().Be(100, "0.1 ms MAD is below the GPON ideal (0.15 ms)");
+        wobblyScore.Should().BeLessThan(100, "0.8 ms MAD is well past the GPON typical (0.4 ms)");
+    }
+
+    [Fact]
+    public void Same_rtt_wander_grades_by_access_tech()
+    {
+        // The band is tech-aware: 3 ms MAD is a disaster on fiber but normal on LEO. The same hop
+        // scores near-zero stability on GPON and near-perfect on the Satellite (Starlink) profile.
+        var satellite = IspHealthProfiles.GetProfile(AccessTechnology.Satellite)!;
+        var hop = IspHopMad("s", "S", 30.0, 3.0, "192.0.2.1");
+
+        var onGpon = new IspHealthScorer(Options)
+            .Score(BuildInputs(ispAsn: new() { hop }, ispTargets: new() { hop }, firstHopTargetId: "s"), Gpon)
+            .IspTargets.Single().OverallScore;
+        var onSatellite = new IspHealthScorer(Options)
+            .Score(BuildInputs(ispAsn: new() { hop }, ispTargets: new() { hop }, firstHopTargetId: "s"), satellite)
+            .IspTargets.Single().OverallScore;
+
+        onSatellite.Should().BeGreaterThan(onGpon!.Value + 20,
+            "3 ms RTT MAD is normal LEO wander but far past fiber's poor anchor");
+    }
+
+    [Fact]
+    public void Clean_destination_routing_through_a_hop_absolves_its_rtt_wander()
+    {
+        // The ISP hop's own RTT wanders (0.8 ms MAD - ICMP-deprioritized control plane), but a
+        // monitored destination proven to route through it is steady end-to-end (0.10 ms MAD). That
+        // upper-bounds the hop's true wander, so its stability is absolved to perfect (below GPON ideal).
+        const string hopIp = "192.0.2.1";
+        var wobbly = IspHopMad("isp", "ISP", 3.0, 0.8, hopIp);
+        var cleanDest = DestMad("203.0.113.9", 3.0, 0.10, hopIp);
+
+        var absolved = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new() { wobbly }, ispTargets: new() { wobbly }, destinations: new() { cleanDest },
+                firstHopTargetId: "isp", hopOrderKnown: true), Gpon);
+        var alone = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new() { wobbly }, ispTargets: new() { wobbly }, firstHopTargetId: "isp"), Gpon);
+
+        absolved.IspTargets.Single().OverallScore.Should().Be(100,
+            "a steadier forwarded path proves the hop's own wander is a per-hop artifact");
+        absolved.IspTargets.Single().OverallScore.Should().BeGreaterThan(
+            alone.IspTargets.Single().OverallScore!.Value);
+    }
+
+    [Fact]
+    public void A_clean_destination_that_does_not_cross_a_hop_does_not_absolve_it()
+    {
+        // Same wobbly hop, but the clean destination routes through a DIFFERENT hop. The
+        // routes-through gate must block it - a clean path says nothing about a hop it doesn't cross.
+        var wobbly = IspHopMad("isp", "ISP", 3.0, 0.8, "192.0.2.1");
+        var offPathDest = DestMad("203.0.113.9", 3.0, 0.15, "198.51.100.7");
+
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(ispAsn: new() { wobbly }, ispTargets: new() { wobbly }, destinations: new() { offPathDest },
+                firstHopTargetId: "isp", hopOrderKnown: true), Gpon);
+
+        report.IspTargets.Single().OverallScore.Should().BeLessThan(100,
+            "a clean path that does not cross the hop must not absolve its wander");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AsnNameCleanupTests.cs
@@ -11,6 +11,13 @@ public class AsnNameCleanupTests
     [InlineData("Akamai International B.V.", "Akamai International")]
     [InlineData("Arelion Sweden AB", "Arelion")]
     [InlineData("Arelion Sweden", "Arelion")]
+    // "L.C." / "L.C" / "LC" legal forms (e.g. XMission registers as "XMission, L.C.").
+    [InlineData("XMission, L.C.", "XMission")]
+    [InlineData("XMission, L.C", "XMission")]
+    [InlineData("XMission LC", "XMission")]
+    // Limited partnership forms.
+    [InlineData("Hurricane Electric, L.P.", "Hurricane Electric")]
+    [InlineData("Hurricane Electric LP", "Hurricane Electric")]
     public void Strips_corporate_suffixes_and_applies_brand_overrides(string raw, string expected)
         => AsnNameCleanup.Clean(raw).Should().Be(expected);
 

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web.Services;
@@ -13,8 +14,10 @@ public class MonitoringInterfaceDeploymentServiceTests
 {
     // RemoveAsync/CheckStatusAsync only depend on IGatewaySshService (UniFiConnectionService is
     // only touched by PreflightAsync's UniFi-overlap gate, which these tests never exercise).
-    private static MonitoringInterfaceDeploymentService BuildService(Mock<IGatewaySshService> ssh)
-        => new(Mock.Of<ILogger<MonitoringInterfaceDeploymentService>>(), ssh.Object, Mock.Of<IUdmBootService>(), null!);
+    private static MonitoringInterfaceDeploymentService BuildService(
+        Mock<IGatewaySshService> ssh, Mock<IMonitoringInterfaceRepository>? repo = null)
+        => new(Mock.Of<ILogger<MonitoringInterfaceDeploymentService>>(), ssh.Object, Mock.Of<IUdmBootService>(),
+            null!, (repo ?? new Mock<IMonitoringInterfaceRepository>()).Object);
     private static MonitoringInterface Valid(int? vlan = null) => new()
     {
         Name = "modem0",
@@ -608,6 +611,119 @@ public class MonitoringInterfaceDeploymentServiceTests
         script.Should().Contain("grep \"inet $LOCAL_IP/$PREFIX \" | grep -q noprefixroute");
     }
 
+    [Fact]
+    public async Task DisableAsync_WritesMarkerBeforeTeardownAndFlagsDisabledOnSuccess()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, steps) = await service.DisableAsync(mi);
+
+        success.Should().BeTrue();
+        // The marker must be written first - before any teardown command - so the cron watchdog
+        // cannot re-apply the interface between teardown steps.
+        commands.Should().NotBeEmpty();
+        commands[0].Should().Contain(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi));
+        commands[0].Should().Contain(": >");
+        var firstTeardown = commands.FindIndex(c => c.Contains("crontab"));
+        firstTeardown.Should().BeGreaterThan(0);
+        // On a clean teardown the DB flag is set.
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableAsync_TeardownFails_LeavesEnabledAndRemovesMarker()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("ip route del") ? (false, "err") : (true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, _) = await service.DisableAsync(mi);
+
+        success.Should().BeFalse();
+        // A failed teardown must NOT flag the row disabled, and must roll the marker back so the
+        // interface isn't left half-paused (marker present but artifacts still up).
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+    }
+
+    [Fact]
+    public async Task EnableAsync_ClearsFlagAndMarkerThenDeploys_NoReDisableOnDeployFailure()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        mi.Disabled = true;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var result = await service.EnableAsync(mi);
+
+        // Enable clears the flag and marker up front, then deploys. A deploy failure (no real
+        // gateway behind the mocks) must NOT silently re-disable - the row stays enabled and the
+        // failed DeployResult surfaces.
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, false, It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+        mi.Disabled.Should().BeFalse();
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeployAsync_DisabledInterface_ReturnsSkippedWithoutTouchingGateway()
+    {
+        var mi = Valid();
+        mi.Disabled = true;
+        var ssh = new Mock<IGatewaySshService>();
+        var service = BuildService(ssh);
+
+        var result = await service.DeployAsync(mi);
+
+        result.Success.Should().BeFalse();
+        result.Block.Should().Be(MonitoringInterfaceDeploymentService.PreflightBlock.Skipped);
+        ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public void BootScript_HonoursDisabledMarkerAndLocksApply()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid());
+
+        // Marker var + early-out before doing any work, so a disabled interface's boot script
+        // and cron watchdog become inert without needing to be deleted.
+        script.Should().Contain("MARKER=\"/data/monitoring-ifaces.disabled/modem0\"");
+        script.Should().Contain("[ -f \"$MARKER\" ] && { log \"disabled marker present, skipping\"; exit 0; }");
+
+        // Re-check the marker immediately before (re)installing the cron watchdog, closing the
+        // race where Disable writes the marker after the top check but before cron install.
+        script.Should().Contain("if [ ! -f \"$MARKER\" ] && ! crontab -l 2>/dev/null | grep -qF \"$SCRIPT\"; then");
+
+        // Per-interface flock serializes a manual apply against the cron watchdog tick.
+        script.Should().Contain("flock -n 9");
+        script.Should().Contain("/tmp/monitoring-iface-modem0.lock");
+    }
+
     private static NetworkInfo UniFiNet(string name, string subnet, bool wan = false, bool enabled = true) => new()
     {
         Name = name,
@@ -675,6 +791,139 @@ public class MonitoringInterfaceDeploymentServiceTests
         steps.Should().Contain(s => s.Contains("outside the aliasable range"));
         steps.Should().NotContain(s => s.Contains("WARNING"));
         steps.Should().NotContain(s => s.Contains("Removed alias mark/DNAT rules"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NonAliased_AllTeardownStepsSucceedAndNothingLingers_ReportsSuccess()
+    {
+        // Happy path: every teardown command succeeds and the absence verification finds no
+        // residual artifacts (empty probe output) - Remove reports success with no WARNING.
+        var mi = Valid();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeTrue();
+        steps.Should().NotContain(s => s.Contains("WARNING"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NonAliased_RouteDeleteFails_ReportsFailureWithWarning()
+    {
+        // A genuine base-teardown failure (the guarded route delete returns nonzero) must flip
+        // success to false and surface a WARNING step - not be swallowed by fire-and-forget.
+        var mi = Valid();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("ip route del") ? (false, "route del failed") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("WARNING") && s.Contains("route"));
+    }
+
+    [Fact]
+    public async Task EnableAsync_UnsafeName_ThrowsBeforeTouchingGatewayOrDb()
+    {
+        // Enable must validate up front like Disable/Remove (Codex review): a name that fails
+        // shell-safety has to throw before any SSH command or DB write, not later in DeployAsync.
+        var mi = Valid();
+        mi.Id = 5;
+        mi.Name = "bad name"; // the space fails the shell-safe regex
+        var ssh = new Mock<IGatewaySshService>();
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.EnableAsync(mi));
+
+        ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.SetDisabledAsync(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DisableAsync_DrainsApplyLockBeforeTeardown()
+    {
+        // Watchdog-resurrection guard: after writing the marker, Disable blocks on the boot
+        // script's per-interface apply lock so an in-flight apply finishes before teardown.
+        var mi = Valid();
+        mi.Id = 8;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var service = BuildService(ssh, new Mock<IMonitoringInterfaceRepository>());
+
+        await service.DisableAsync(mi);
+
+        commands.Should().Contain(c => c.Contains("flock -w 30") && c.Contains($"/tmp/monitoring-iface-{mi.Name}.lock"));
+    }
+
+    [Fact]
+    public async Task DisableAsync_DrainTimesOut_AbortsAndRollsBackMarker()
+    {
+        // If an in-flight apply will not release the lock in time, Disable must abort (not tear
+        // down underneath it), roll the marker back, and leave the row enabled.
+        var mi = Valid();
+        mi.Id = 9;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("flock -w 30") ? (false, "") : (true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, _) = await service.DisableAsync(mi);
+
+        success.Should().BeFalse();
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_VerificationFindsResidualAliasDnat_ReportsFailure()
+    {
+        // Aliased teardown "succeeds" per-command, but verification finds the DNAT rule still
+        // present - Remove must flip success and warn (covers the alias probes added to verify).
+        var mi = ValidAliased(id: 9);
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("echo IFACE") ? (true, "ADNAT\n") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("verification failed"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_VerificationFindsResidualSnat_ReportsFailure()
+    {
+        // Every teardown command "succeeds", but the absence verification still finds the SNAT
+        // rule present (a silently-failed removal or a watchdog resurrection) - Remove must flip
+        // success and warn rather than reporting a clean teardown.
+        var mi = Valid(); // SnatEnabled defaults to true, so the verify includes the SNAT probe
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("echo IFACE") ? (true, "SNAT\n") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("verification failed"));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -722,6 +722,10 @@ public class MonitoringInterfaceDeploymentServiceTests
         // Per-interface flock serializes a manual apply against the cron watchdog tick.
         script.Should().Contain("flock -n 9");
         script.Should().Contain("/tmp/monitoring-iface-modem0.lock");
+
+        // The lock is guarded on flock's presence so a gateway lacking it degrades to an unlocked
+        // apply rather than the || early-out skipping the apply entirely (fail-open, not fail-closed).
+        script.Should().Contain("if command -v flock >/dev/null 2>&1; then");
     }
 
     private static NetworkInfo UniFiNet(string name, string subnet, bool wan = false, bool enabled = true) => new()
@@ -863,6 +867,9 @@ public class MonitoringInterfaceDeploymentServiceTests
         await service.DisableAsync(mi);
 
         commands.Should().Contain(c => c.Contains("flock -w 30") && c.Contains($"/tmp/monitoring-iface-{mi.Name}.lock"));
+        // The drain is guarded on flock's presence so a flock-less gateway proceeds to teardown
+        // instead of aborting (teardown removes cron+script and verifies absence regardless).
+        commands.Should().Contain(c => c.Contains("command -v flock") && c.Contains("flock -w 30"));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Web.Components.Shared;
+using NetworkOptimizer.Web.Services;
 using Xunit;
 
 namespace NetworkOptimizer.Web.Tests;
@@ -68,6 +70,60 @@ public class MonitoringInterfacesCardTests
     }
 
     [Fact]
+    public void StatusBadgeContent_DisabledRow_ShowsDisabledRegardlessOfLiveStatus()
+    {
+        // A disabled interface reads "Disabled" no matter what the last live probe found - even
+        // a fully-applied status (a probe taken before Disable finished) must not override it.
+        var mi = new MonitoringInterface { Name = "modem0", Disabled = true };
+        var fullyApplied = new MonitoringInterfaceDeploymentService.InterfaceStatus
+        {
+            GatewayReachable = true,
+            InterfaceExists = true,
+            LocalIpAssigned = true,
+            RoutePresent = true,
+            SnatPresent = true,
+            WatchdogCronPresent = true,
+            BootScriptPresent = true,
+        };
+
+        var withStatus = MonitoringInterfacesCard.StatusBadgeContent(mi, fullyApplied);
+        withStatus.text.Should().Be("Disabled");
+        withStatus.cls.Should().Contain("status-disconnected");
+
+        MonitoringInterfacesCard.StatusBadgeContent(mi, null).text.Should().Be("Disabled");
+    }
+
+    [Fact]
+    public void StatusBadgeContent_EnabledRow_KeepsStatusDrivenLabels()
+    {
+        // Regression guard: a non-disabled row keeps the existing status-driven labels.
+        var mi = new MonitoringInterface { Name = "modem0" };
+        MonitoringInterfacesCard.StatusBadgeContent(mi, null).text.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void Snapshot_CopiesDisabledFlag()
+    {
+        var mi = new MonitoringInterface { Name = "modem0", TargetIp = "192.168.100.1", Disabled = true };
+
+        var copy = MonitoringInterfacesCard.Snapshot(mi);
+
+        copy.Disabled.Should().BeTrue();
+        copy.TargetIp.Should().Be("192.168.100.1");
+    }
+
+    [Fact]
+    public void ShowDisableToggle_HiddenForManuallyDeployedRows()
+    {
+        // Disable/Enable tears down and redeploys gateway artifacts we own; a manually-deployed
+        // row is the user's own hand-built config, so the toggle must not appear for it.
+        MonitoringInterfacesCard.ShowDisableToggle(new MonitoringInterface { IsManuallyDeployed = false })
+            .Should().BeTrue();
+        MonitoringInterfacesCard.ShowDisableToggle(new MonitoringInterface { IsManuallyDeployed = true })
+            .Should().BeFalse();
+    }
+
+    [Fact]
     public void DisarmAllForceRemove_ClearsEntireArmedSet_NotJustOneRow()
     {
         // The armed flag is a transient "you just saw this error" confirmation - any edit,
@@ -83,5 +139,27 @@ public class MonitoringInterfacesCardTests
         card.DisarmAllForceRemove();
 
         card._forceRemoveArmed.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Snapshot_CopiesIsManuallyDeployedAndDisabled()
+    {
+        // Codex review: Snapshot omitting IsManuallyDeployed made editing a manually-deployed
+        // row silently flip it to app-managed (its hidden Disable/Enable toggle then reappeared).
+        var mi = new MonitoringInterface
+        {
+            Id = 3,
+            Name = "modem0",
+            WanIfName = "eth1",
+            TargetIp = "192.168.100.1",
+            GatewayLocalIp = "192.168.100.2",
+            IsManuallyDeployed = true,
+            Disabled = true,
+        };
+
+        var snap = MonitoringInterfacesCard.Snapshot(mi);
+
+        snap.IsManuallyDeployed.Should().BeTrue();
+        snap.Disabled.Should().BeTrue();
     }
 }

--- a/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NetOptCustomPonOntProviderTests.cs
@@ -11,6 +11,7 @@ public class NetOptCustomPonOntProviderTests
     // through the gateway), trimmed only in counter magnitudes.
     private const string SamplePayload = """
     {
+      "optics": { "rx_power_dbm": -18.4, "tx_power_dbm": 2.1, "temperature_c": 47.3, "voltage_v": 3.28 },
       "lan": { "mode": 15, "link_status": 5, "phy_duplex": 1 },
       "lan_counters": {
         "tx_frames": 671630919, "rx_frames": 850075595,
@@ -54,6 +55,10 @@ public class NetOptCustomPonOntProviderTests
         p.GpePon!.IbpDiscard.Should().Be(4);
         p.GpeLan!.EbpDiscard.Should().Be(5);
         p.LanCounters!.RxFcsErr.Should().Be(3);
+        p.Optics!.RxPowerDbm.Should().Be(-18.4);
+        p.Optics.TxPowerDbm.Should().Be(2.1);
+        p.Optics.TemperatureC.Should().Be(47.3);
+        p.Optics.VoltageV.Should().Be(3.28);
         p.SfpUptimeS.Should().Be(358825);
     }
 
@@ -85,6 +90,12 @@ public class NetOptCustomPonOntProviderTests
         s.OnuResponseTime.Should().Be(34992);
         s.DsFecEnabled.Should().Be(0);
         s.SfpUptimeS.Should().Be(358825);
+
+        // Optional DDM optics carried as a fallback for gaps the gateway can't read.
+        s.RxPowerDbm.Should().Be(-18.4);
+        s.TxPowerDbm.Should().Be(2.1);
+        s.TemperatureC.Should().Be(47.3);
+        s.VoltageV.Should().Be(3.28);
     }
 
     [Fact]
@@ -96,6 +107,10 @@ public class NetOptCustomPonOntProviderTests
         stats.PonLinkStatus.Should().Be(PonLinkState.Operation);
         stats.FecErrors.Should().Be(2);
         stats.BipErrors.Should().Be(7);
+        stats.RxPowerDbm.Should().Be(-18.4);
+        stats.TxPowerDbm.Should().Be(2.1);
+        stats.TemperatureC.Should().Be(47.3);
+        stats.VoltageV.Should().Be(3.28);
     }
 
     [Fact]
@@ -117,12 +132,15 @@ public class NetOptCustomPonOntProviderTests
         p.Should().NotBeNull();
         p!.Ploam.Should().BeNull();
         p.GtcCounters.Should().BeNull();
+        p.Optics.Should().BeNull();
         p.SfpUptimeS.Should().BeNull();
 
         var s = NetOptCustomPonOntProvider.MapToSupplemental(p);
         s.PonLinkStatus.Should().BeNull();
         s.BipErrors.Should().BeNull();
         s.FecErrors.Should().BeNull();
+        s.RxPowerDbm.Should().BeNull();
+        s.VoltageV.Should().BeNull();
     }
 
     [Fact]


### PR DESCRIPTION
Release PR: `dev` â†’ `main` for v2.3.1. Net changes on dev since the last release.

## Dashboard

- **CyberSecure engine upgrade advisory** - When your gateway has a newer CyberSecure IDS/IPS detection engine (Suricata) available but hasn't taken it yet, the Dashboard shows an info banner: it explains the upgrade brings security fixes and better, more efficient threat detection, and points to UniFi Network > Settings > CyberSecure to initiate it. The gateway's **Device Status** card also carries a small "CyberSecure upgrade available" bar whose tooltip spells out the same path. Nothing shows once the gateway is on the latest supported engine.

## Monitoring

### Live View

- **Speed-test timestamp deep link** - On every speed-test result detail (WAN Speed Test, LAN Speed Test, Client WAN Test, Client Speed Test), the date/time is now a link (with the external-link icon) that opens Live View in historic playback, paused just before that test. The landing point is computed per test type, since each stamps its timestamp differently (gateway SSH setup gap, client-iperf3 merged-phase, server-device inter-leg gap). The link only shows when Monitoring is enabled and the shared InfluxDB is configured, so managed/agent sites (which inherit the central InfluxDB) gate correctly (#1039).
- **Historic playback reliability** - Bundled with the deep link: consumers converge deterministically on the map's state across SPA navigations, play resumes exactly at the parked marker (no sliding-window drift), the WAN chart playhead renders on a paused seek while keeping its hover-hold during playback, and infra liveness no longer flaps a device offline on a single jittered health sample (interface-rate presence is a second signal) (#1039).
- **Near-present playback no longer freezes** - Historic map reads near the live edge bypass the 5-min-ahead singleton cache (whose ahead window is empty at fetch time) and no longer store those fetches back into it, so playback during or right after an agent-run speed test tracks Port Statistics instead of showing all devices offline or throughput stuck. Past-window playback and the offline/liveness behavior are unchanged (#1039, #1041).

### ISP Health

- **Per-tech RTT stability grading, path-witness absolution, and AWS path-end targets** (#1040).
- **Cleaner ISP names** - strip ASN-name noise at display, and drop `L.C` / `LC` / `L.P` legal-entity suffixes from org names.

### Network Performance

- **Defaults to the ISP filter when a site has no LAN targets**, so the view isn't empty on a fresh or single UniFi device gateway-as-agent site.

### ONT Stats

- **Optional DDM optics in the custom ONT contract** (#1036).

### Monitoring Interfaces

- **Disable/Enable toggle for Monitoring Interfaces** - Every deployed interface on the **Monitoring Interfaces** card now has a **Disable** button that tears down its gateway artifacts (macvlan, route, SNAT, boot script, and cron watchdog) while keeping the saved config, and an **Enable** button that redeploys it all with one click - handy for pausing an interface during testing without losing its settings. A paused row shows a **Disabled** badge, the card summary notes how many are paused, and the pause survives reboots and the cron watchdog. Manually-deployed interfaces keep their hands-off treatment and don't get the toggle. (#1042, thanks @Optic00)

## Multi-Site

- **Pick a UniFi site while adding a site** - the Add-a-Site wizard's Console step (Settings - Multi-Site) now carries the same optional **Site** field and **List Sites** button as Settings - UniFi Console Connection, so a console that hosts several UniFi sites can be pointed at the right one during onboarding instead of only afterward. Leaving it as `default` connects to the console's default site exactly as before.
- **The Sites list highlights the site whose Configuration is currently open.**

## Adaptive SQM

- **SmartQ settle-timer is site-keyed** to avoid cross-site collisions on multi-site servers.
- **Deployment status reloads on site switch.**

## Threat Intelligence

- **Client-name cache is keyed by site** so names can't bleed across sites.

## Fixes

- **UniFi Console Connection** - serialize the connection lifecycle to fix a connect-time NPE, and skip API requests on a disposed client instead of crashing (with a regression guard).
- **Agent sites** show "waiting for agent" instead of an SSH error while the tunnel is still coming up.
- **Speed-test relays** drop results and topology snapshots tagged with an unprovisioned site slug instead of routing them onto the main site (both the OpenSpeedTest and iperf3 relays).
- **Flaky LAN target advisory no longer blames the gateway** - The advisory under the LAN latency chart (Monitoring - Network Performance) averaged each LAN device's packet loss across the whole window, so a brief gateway outage - which drops every device behind it - inflated a switch's loss and false-flagged it as a flaky measurement target. Outage loss is now excluded from the average: a timestamp is dropped when the gateway target itself was unreachable, or when most of the LAN fabric was down at once (which also covers a shared-switch outage, or a site with no monitored gateway). A single target's own flaky loss still counts, so it's flagged only for loss that's genuinely its own.

