### PR TITLE
Speed-test results link into Monitoring - Live View at the test's moment

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -18,6 +18,7 @@
 @inject ApMapService ApMapService
 @inject PullToRefreshState PtrState
 @inject SiteContextService SiteContext
+@inject SnmpDetectionService SnmpDetection
 @inject SiteSpeedTestTargetResolver SiteTarget
 
 @* Uses unified Iperf3Result model with Direction field to distinguish test sources *@
@@ -368,7 +369,7 @@
                                         <div class="expand-wrapper @(isExpanded ? "expanded" : "")">
                                             <div class="expand-content">
                                                 <div class="history-details">
-                                                    <SpeedTestDetails Result="result" PathAnalysis="result.PathAnalysis" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" />
+                                                    <SpeedTestDetails Result="result" PathAnalysis="result.PathAnalysis" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" ShowLiveViewLink="_liveViewLinkEnabled" />
                                                 </div>
                                             </div>
                                         </div>
@@ -854,10 +855,29 @@
     private int? expandedHistoryId = null;
     private int? _collapsingHistoryId = null; // Track row being collapsed for smooth transition
 
+    private bool _liveViewLinkEnabled;
+
+    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
+    // configured for this site (matches the Monitoring page's own readiness gate), so the
+    // link never lands on a Live View with no historic data to play back.
+    private async Task LoadLiveViewLinkStateAsync()
+    {
+        try
+        {
+            var s = await SnmpDetection.GetOrCreateSettingsAsync();
+            _liveViewLinkEnabled = s.Enabled
+                && !string.IsNullOrEmpty(s.InfluxDbToken)
+                && !string.IsNullOrEmpty(s.InfluxDbUrl);
+        }
+        catch { _liveViewLinkEnabled = false; }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        await LoadLiveViewLinkStateAsync();
 
         // Load networks for VPN detection
         _networks = await ConnectionService.GetNetworksAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -18,7 +18,7 @@
 @inject ApMapService ApMapService
 @inject PullToRefreshState PtrState
 @inject SiteContextService SiteContext
-@inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject SiteSpeedTestTargetResolver SiteTarget
 
 @* Uses unified Iperf3Result model with Direction field to distinguish test sources *@
@@ -857,27 +857,12 @@
 
     private bool _liveViewLinkEnabled;
 
-    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
-    // configured for this site (matches the Monitoring page's own readiness gate), so the
-    // link never lands on a Live View with no historic data to play back.
-    private async Task LoadLiveViewLinkStateAsync()
-    {
-        try
-        {
-            var s = await SnmpDetection.GetOrCreateSettingsAsync();
-            _liveViewLinkEnabled = s.Enabled
-                && !string.IsNullOrEmpty(s.InfluxDbToken)
-                && !string.IsNullOrEmpty(s.InfluxDbUrl);
-        }
-        catch { _liveViewLinkEnabled = false; }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
 
-        await LoadLiveViewLinkStateAsync();
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         // Load networks for VPN detection
         _networks = await ConnectionService.GetNetworksAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -8,7 +8,7 @@
 @using NetworkOptimizer.Core.Helpers
 @inject ClientSpeedTestService ClientSpeedTestService
 @inject SiteContextService SiteContext
-@inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject SystemSettingsService SettingsService
 @inject NavigationManager NavigationManager
@@ -791,27 +791,12 @@
 
     private bool _liveViewLinkEnabled;
 
-    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
-    // configured for this site (matches the Monitoring page's own readiness gate), so the
-    // link never lands on a Live View with no historic data to play back.
-    private async Task LoadLiveViewLinkStateAsync()
-    {
-        try
-        {
-            var s = await SnmpDetection.GetOrCreateSettingsAsync();
-            _liveViewLinkEnabled = s.Enabled
-                && !string.IsNullOrEmpty(s.InfluxDbToken)
-                && !string.IsNullOrEmpty(s.InfluxDbUrl);
-        }
-        catch { _liveViewLinkEnabled = false; }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadResults();
         PtrState.NotifyStateChanged = StateHasChanged;
 
-        await LoadLiveViewLinkStateAsync();
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         InitializeChartOptions();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -8,6 +8,7 @@
 @using NetworkOptimizer.Core.Helpers
 @inject ClientSpeedTestService ClientSpeedTestService
 @inject SiteContextService SiteContext
+@inject SnmpDetectionService SnmpDetection
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject SystemSettingsService SettingsService
 @inject NavigationManager NavigationManager
@@ -381,7 +382,8 @@
                                                                           UseWanLabels="true"
                                                                           OnDelete="HandleDelete"
                                                                           OnNotesChanged="HandleNotesChanged"
-                                                                          IsInTableRow="true" />
+                                                                          IsInTableRow="true"
+                                                                          ShowLiveViewLink="_liveViewLinkEnabled" />
                                                     </div>
                                                 </div>
                                             </div>
@@ -787,10 +789,29 @@
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_filteredResults.Count / (double)PageSize));
     private IEnumerable<Iperf3Result> _pagedResults => _filteredResults.Skip((_page - 1) * PageSize).Take(PageSize);
 
+    private bool _liveViewLinkEnabled;
+
+    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
+    // configured for this site (matches the Monitoring page's own readiness gate), so the
+    // link never lands on a Live View with no historic data to play back.
+    private async Task LoadLiveViewLinkStateAsync()
+    {
+        try
+        {
+            var s = await SnmpDetection.GetOrCreateSettingsAsync();
+            _liveViewLinkEnabled = s.Enabled
+                && !string.IsNullOrEmpty(s.InfluxDbToken)
+                && !string.IsNullOrEmpty(s.InfluxDbUrl);
+        }
+        catch { _liveViewLinkEnabled = false; }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadResults();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        await LoadLiveViewLinkStateAsync();
 
         InitializeChartOptions();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1590,6 +1590,11 @@ else
     [SupplyParameterFromQuery(Name = "tab")]
     public string? TabParam { get; set; }
 
+    // Deep link from a speed-test result: absolute epoch-ms instant to open Live View
+    // at, in historic playback (paused). Consumed once when the 3D map first mounts.
+    [SupplyParameterFromQuery(Name = "at")]
+    public string? AtParam { get; set; }
+
     [SupplyParameterFromQuery(Name = "discover")]
     public string? DiscoverParam { get; set; }
 
@@ -1708,6 +1713,7 @@ else
     // Chart mount tracking
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
+    private bool _initialAtApplied = false;
     private bool _wanLiveChartMounted = false;
     private bool _portStatsMounted = false;
     private bool _latencyChartsMounted;
@@ -3665,12 +3671,20 @@ else
             try
             {
                 _mapDotNetRef ??= DotNetObjectReference.Create(this);
+                // Deep-linked timestamp (?at=): applied only on this first mount, so
+                // switching tabs away and back doesn't yank the map back to the past.
+                var initialAtOpt = "";
+                if (!_initialAtApplied && long.TryParse(AtParam, out var atMs) && atMs > 0)
+                {
+                    _initialAtApplied = true;
+                    initialAtOpt = $", initialAt: {atMs}";
+                }
                 await JS.InvokeVoidAsync("eval",
                     "window.__mountLanFlowMap = async function(canvasId, ref) {" +
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
-                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}' }});" +
+                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}'{initialAtOpt} }});" +
                     "}");
                 await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -16,6 +16,7 @@
 @using NetworkOptimizer.Core.Enums
 @using Microsoft.EntityFrameworkCore
 @inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject UniFiConnectionService ConnectionService
 @inject MonitoringInfluxClient InfluxClient
 @inject MonitoringLiveStats LiveStats
@@ -2061,13 +2062,7 @@ else
 
         _monitoringEnabled = settings.Enabled;
 
-        bool sharedConnection;
-        await using (var mainDb = SiteDb.CreateForSite(SiteManagementService.DefaultSiteSlug, isDefault: true))
-        {
-            var shared = await mainDb.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync();
-            sharedConnection = !string.IsNullOrEmpty(shared?.InfluxDbToken)
-                && !string.IsNullOrEmpty(shared?.InfluxDbUrl);
-        }
+        bool sharedConnection = await Readiness.IsSharedInfluxConfiguredAsync();
 
         // A secondary site counts as configured only once its own buckets are reachable
         // on the shared InfluxDB. Until then report not-configured so the Setup tab drops

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1715,6 +1715,14 @@ else
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
     private bool _initialAtApplied = false;
+
+    // Diagnostic (LiveViewDbg): per-instance id so logs distinguish component
+    // reuse from recreation across navigations. Strip with the rest of the
+    // [LiveViewDbg] lines once the deep-link lifecycle issue is closed.
+    private readonly string _dbgId = Guid.NewGuid().ToString("N")[..6];
+
+    [JSInvokable]
+    public void OnMapDebug(string msg) => Logger.LogDebug("[LiveViewDbg:{Id}][js] {Msg}", _dbgId, msg);
     private bool _wanLiveChartMounted = false;
     private bool _portStatsMounted = false;
     private bool _latencyChartsMounted;
@@ -1798,6 +1806,7 @@ else
         _activeTab = tab;
         ResetThresholdSavedFlags();
         var uri = "/monitoring?tab=" + tab;
+        Logger.LogDebug("[LiveViewDbg:{Id}] SetActiveTab {Tab}: navigating {From} -> {To}", _dbgId, tab, NavigationManager.Uri, uri);
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
     }
@@ -1819,6 +1828,8 @@ else
 
     protected override void OnParametersSet()
     {
+        Logger.LogDebug("[LiveViewDbg:{Id}] OnParametersSet: TabParam={TabParam} AtParam={AtParam} activeTab={ActiveTab} uri={Uri}",
+            _dbgId, TabParam, AtParam, _activeTab, NavigationManager.Uri);
         if (TabParam != _lastTabParam && _lastTabParam != null)
         {
             // Route through ResolveDefaultTab so the _monitoringReady guard applies to
@@ -1916,6 +1927,8 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        Logger.LogDebug("[LiveViewDbg:{Id}] OnInitializedAsync (new component): TabParam={TabParam} AtParam={AtParam} uri={Uri}",
+            _dbgId, TabParam, AtParam, NavigationManager.Uri);
         ConnectionService.OnConnectionChanged += OnConnectionChanged;
 
         // Restore tab visibility persisted from prerender so the interactive render
@@ -2893,6 +2906,8 @@ else
     [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
+        Logger.LogDebug("[LiveViewDbg:{Id}] OnMapTimeChanged {Iso} (wanMounted={Wan} portMounted={Port})",
+            _dbgId, isoTimestamp, _wanLiveChartMounted, _portStatsMounted);
         // Sync WAN live chart to the same timeline position
         if (_wanLiveChartMounted)
         {
@@ -3674,6 +3689,8 @@ else
                     _initialAtApplied = true;
                     initialAtOpt = $", initialAt: {atMs}";
                 }
+                Logger.LogDebug("[LiveViewDbg:{Id}] map mount block: AtParam={AtParam} applied={Applied} opt='{Opt}' uri={Uri}",
+                    _dbgId, AtParam, _initialAtApplied, initialAtOpt, NavigationManager.Uri);
                 await JS.InvokeVoidAsync("eval",
                     "window.__mountLanFlowMap = async function(canvasId, ref) {" +
                     "  window.__monitoringRef = ref;" +
@@ -3690,6 +3707,7 @@ else
             _mapMounted = false;
             _mapHistoricAt = null;
             _historicSnapshot = null;
+            Logger.LogDebug("[LiveViewDbg:{Id}] map unmount block: tab={Tab}", _dbgId, _activeTab);
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3683,22 +3683,30 @@ else
                 _mapDotNetRef ??= DotNetObjectReference.Create(this);
                 // Deep-linked timestamp (?at=): applied only on this first mount, so
                 // switching tabs away and back doesn't yank the map back to the past.
-                var initialAtOpt = "";
+                long initialAtMs = 0;
                 if (!_initialAtApplied && long.TryParse(AtParam, out var atMs) && atMs > 0)
                 {
                     _initialAtApplied = true;
-                    initialAtOpt = $", initialAt: {atMs}";
+                    initialAtMs = atMs;
                 }
-                Logger.LogDebug("[LiveViewDbg:{Id}] map mount block: AtParam={AtParam} applied={Applied} opt='{Opt}' uri={Uri}",
-                    _dbgId, AtParam, _initialAtApplied, initialAtOpt, NavigationManager.Uri);
+                Logger.LogDebug("[LiveViewDbg:{Id}] map mount block: AtParam={AtParam} applied={Applied} initialAtMs={InitialAt} uri={Uri}",
+                    _dbgId, AtParam, _initialAtApplied, initialAtMs, NavigationManager.Uri);
+                // Per-mount values (storagePrefix, initialAt) MUST be arguments, never
+                // interpolated into the function body: JS interop resolves the
+                // identifier to a function reference once and keeps invoking that
+                // original closure, so a re-eval'd definition with different baked-in
+                // values is silently ignored on every mount after the first.
                 await JS.InvokeVoidAsync("eval",
-                    "window.__mountLanFlowMap = async function(canvasId, ref) {" +
+                    "window.__mountLanFlowMap = async function(canvasId, ref, storagePrefix, initialAt) {" +
                     "  window.__monitoringRef = ref;" +
                     $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                     "  window.__lanFlowMap = m;" +
-                    $"  await m.mount(canvasId, {{ storagePrefix: '{SiteCtx.ScopeStorageKey("lanFlowMap")}'{initialAtOpt} }});" +
+                    "  const opts = { storagePrefix: storagePrefix };" +
+                    "  if (initialAt > 0) opts.initialAt = initialAt;" +
+                    "  await m.mount(canvasId, opts);" +
                     "}");
-                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef);
+                await JS.InvokeVoidAsync("__mountLanFlowMap", "lan-flow-map-canvas", _mapDotNetRef,
+                    SiteCtx.ScopeStorageKey("lanFlowMap"), initialAtMs);
             }
             catch (Exception ex) { _mapMounted = false; Logger.LogDebug(ex, "3D map mount failed; will retry on next render"); }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1715,14 +1715,6 @@ else
     private bool _mapMounted = false;
     private bool _map2dMounted = false;
     private bool _initialAtApplied = false;
-
-    // Diagnostic (LiveViewDbg): per-instance id so logs distinguish component
-    // reuse from recreation across navigations. Strip with the rest of the
-    // [LiveViewDbg] lines once the deep-link lifecycle issue is closed.
-    private readonly string _dbgId = Guid.NewGuid().ToString("N")[..6];
-
-    [JSInvokable]
-    public void OnMapDebug(string msg) => Logger.LogDebug("[LiveViewDbg:{Id}][js] {Msg}", _dbgId, msg);
     private bool _wanLiveChartMounted = false;
     private bool _portStatsMounted = false;
     private bool _latencyChartsMounted;
@@ -1806,7 +1798,6 @@ else
         _activeTab = tab;
         ResetThresholdSavedFlags();
         var uri = "/monitoring?tab=" + tab;
-        Logger.LogDebug("[LiveViewDbg:{Id}] SetActiveTab {Tab}: navigating {From} -> {To}", _dbgId, tab, NavigationManager.Uri, uri);
         NavigationManager.NavigateTo(uri, forceLoad: false, replace: false);
         _lastTabParam = tab;
     }
@@ -1828,8 +1819,6 @@ else
 
     protected override void OnParametersSet()
     {
-        Logger.LogDebug("[LiveViewDbg:{Id}] OnParametersSet: TabParam={TabParam} AtParam={AtParam} activeTab={ActiveTab} uri={Uri}",
-            _dbgId, TabParam, AtParam, _activeTab, NavigationManager.Uri);
         if (TabParam != _lastTabParam && _lastTabParam != null)
         {
             // Route through ResolveDefaultTab so the _monitoringReady guard applies to
@@ -1927,8 +1916,6 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Logger.LogDebug("[LiveViewDbg:{Id}] OnInitializedAsync (new component): TabParam={TabParam} AtParam={AtParam} uri={Uri}",
-            _dbgId, TabParam, AtParam, NavigationManager.Uri);
         ConnectionService.OnConnectionChanged += OnConnectionChanged;
 
         // Restore tab visibility persisted from prerender so the interactive render
@@ -2906,8 +2893,6 @@ else
     [JSInvokable]
     public async Task OnMapTimeChanged(string? isoTimestamp)
     {
-        Logger.LogDebug("[LiveViewDbg:{Id}] OnMapTimeChanged {Iso} (wanMounted={Wan} portMounted={Port})",
-            _dbgId, isoTimestamp, _wanLiveChartMounted, _portStatsMounted);
         // Sync WAN live chart to the same timeline position
         if (_wanLiveChartMounted)
         {
@@ -3689,8 +3674,6 @@ else
                     _initialAtApplied = true;
                     initialAtMs = atMs;
                 }
-                Logger.LogDebug("[LiveViewDbg:{Id}] map mount block: AtParam={AtParam} applied={Applied} initialAtMs={InitialAt} uri={Uri}",
-                    _dbgId, AtParam, _initialAtApplied, initialAtMs, NavigationManager.Uri);
                 // Per-mount values (storagePrefix, initialAt) MUST be arguments, never
                 // interpolated into the function body: JS interop resolves the
                 // identifier to a function reference once and keeps invoking that
@@ -3715,7 +3698,6 @@ else
             _mapMounted = false;
             _mapHistoricAt = null;
             _historicSnapshot = null;
-            Logger.LogDebug("[LiveViewDbg:{Id}] map unmount block: tab={Tab}", _dbgId, _activeTab);
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -15,6 +15,7 @@
 @inject GatewaySpeedTestService GatewaySpeedTestService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
+@inject SnmpDetectionService SnmpDetection
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -239,7 +240,7 @@
                         </div>
                         <div class="result-box-details">
                             <div class="result-box-details-inner">
-                                <SpeedTestDetails GatewayResult="gatewayLastResult" />
+                                <SpeedTestDetails GatewayResult="gatewayLastResult" ShowLiveViewLink="_liveViewLinkEnabled" />
                             </div>
                         </div>
                     </div>
@@ -734,7 +735,7 @@
             <div class="card-body">
                 @if (currentResult.Success)
                 {
-                    <SpeedTestDetails Result="currentResult" OnTestAgain="HandleTestAgain" OnNotesChanged="HandleNotesChanged" />
+                    <SpeedTestDetails Result="currentResult" OnTestAgain="HandleTestAgain" OnNotesChanged="HandleNotesChanged" ShowLiveViewLink="_liveViewLinkEnabled" />
                 }
                 else
                 {
@@ -916,7 +917,7 @@
                                                         // Use stored path analysis if available, otherwise use result's analysis
                                                         var pathAnalysis = historyPathAnalysis.GetValueOrDefault(result.Id) ?? result.PathAnalysis;
                                                     }
-                                                    <SpeedTestDetails Result="result" PathAnalysis="pathAnalysis" OnTestAgain="HandleTestAgain" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" />
+                                                    <SpeedTestDetails Result="result" PathAnalysis="pathAnalysis" OnTestAgain="HandleTestAgain" OnDelete="HandleDeleteResult" OnNotesChanged="HandleNotesChanged" IsInTableRow="true" ShowLiveViewLink="_liveViewLinkEnabled" />
 
                                                     @if (pathAnalysis == null && ConnectionService.IsConnected)
                                                     {
@@ -1480,10 +1481,29 @@
     private string testProgressPhaseVerbose = ""; // Verbose for alerts
     private System.Timers.Timer? progressTimer;
 
+    private bool _liveViewLinkEnabled;
+
+    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
+    // configured for this site (matches the Monitoring page's own readiness gate), so the
+    // link never lands on a Live View with no historic data to play back.
+    private async Task LoadLiveViewLinkStateAsync()
+    {
+        try
+        {
+            var s = await SnmpDetection.GetOrCreateSettingsAsync();
+            _liveViewLinkEnabled = s.Enabled
+                && !string.IsNullOrEmpty(s.InfluxDbToken)
+                && !string.IsNullOrEmpty(s.InfluxDbUrl);
+        }
+        catch { _liveViewLinkEnabled = false; }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        await LoadLiveViewLinkStateAsync();
 
         // Check schedule banner dismissal and local iperf3 availability
         _lanScheduleBannerDismissed = await SettingsService.GetAsync("banner.lan_schedule_dismissed") != null;

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -15,7 +15,7 @@
 @inject GatewaySpeedTestService GatewaySpeedTestService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
-@inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -1483,27 +1483,12 @@
 
     private bool _liveViewLinkEnabled;
 
-    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
-    // configured for this site (matches the Monitoring page's own readiness gate), so the
-    // link never lands on a Live View with no historic data to play back.
-    private async Task LoadLiveViewLinkStateAsync()
-    {
-        try
-        {
-            var s = await SnmpDetection.GetOrCreateSettingsAsync();
-            _liveViewLinkEnabled = s.Enabled
-                && !string.IsNullOrEmpty(s.InfluxDbToken)
-                && !string.IsNullOrEmpty(s.InfluxDbUrl);
-        }
-        catch { _liveViewLinkEnabled = false; }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
 
-        await LoadLiveViewLinkStateAsync();
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         // Check schedule banner dismissal and local iperf3 availability
         _lanScheduleBannerDismissed = await SettingsService.GetAsync("banner.lan_schedule_dismissed") != null;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -16,7 +16,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
-@inject SnmpDetectionService SnmpDetection
+@inject MonitoringReadinessService Readiness
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -799,27 +799,12 @@
 
     private bool _liveViewLinkEnabled;
 
-    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
-    // configured for this site (matches the Monitoring page's own readiness gate), so the
-    // link never lands on a Live View with no historic data to play back.
-    private async Task LoadLiveViewLinkStateAsync()
-    {
-        try
-        {
-            var s = await SnmpDetection.GetOrCreateSettingsAsync();
-            _liveViewLinkEnabled = s.Enabled
-                && !string.IsNullOrEmpty(s.InfluxDbToken)
-                && !string.IsNullOrEmpty(s.InfluxDbUrl);
-        }
-        catch { _liveViewLinkEnabled = false; }
-    }
-
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
 
-        await LoadLiveViewLinkStateAsync();
+        _liveViewLinkEnabled = await Readiness.IsHistoricPlaybackAvailableAsync();
 
         _wanScheduleBannerDismissed = await SettingsService.GetAsync("banner.wan_schedule_dismissed") != null;
         InitializeChartOptions();

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -16,6 +16,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
+@inject SnmpDetectionService SnmpDetection
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
@@ -252,7 +253,8 @@
                                   OnTestAgain="HandleTestAgain"
                                   OnNotesChanged="HandleNotesChanged"
                                   AvailableWans="_availableWans"
-                                  OnWanReassigned="HandleWanReassigned" />
+                                  OnWanReassigned="HandleWanReassigned"
+                                  ShowLiveViewLink="_liveViewLinkEnabled" />
             </div>
         </div>
     }
@@ -562,7 +564,8 @@
                                                                           OnNotesChanged="HandleNotesChanged"
                                                                           AvailableWans="_availableWans"
                                                                           OnWanReassigned="HandleWanReassigned"
-                                                                          IsInTableRow="true" />
+                                                                          IsInTableRow="true"
+                                                                          ShowLiveViewLink="_liveViewLinkEnabled" />
 
                                                         @if (pathAnalysis == null && ConnectionService.IsConnected)
                                                         {
@@ -794,10 +797,29 @@
 
     private bool IsWanVisible(WanSeriesInfo wan) => wan.IsSelected;
 
+    private bool _liveViewLinkEnabled;
+
+    // Live View deep-link is offered only when monitoring is enabled AND InfluxDB is
+    // configured for this site (matches the Monitoring page's own readiness gate), so the
+    // link never lands on a Live View with no historic data to play back.
+    private async Task LoadLiveViewLinkStateAsync()
+    {
+        try
+        {
+            var s = await SnmpDetection.GetOrCreateSettingsAsync();
+            _liveViewLinkEnabled = s.Enabled
+                && !string.IsNullOrEmpty(s.InfluxDbToken)
+                && !string.IsNullOrEmpty(s.InfluxDbUrl);
+        }
+        catch { _liveViewLinkEnabled = false; }
+    }
+
     protected override async Task OnInitializedAsync()
     {
         PtrState.RefreshCallback = () => LoadHistory();
         PtrState.NotifyStateChanged = StateHasChanged;
+
+        await LoadLiveViewLinkStateAsync();
 
         _wanScheduleBannerDismissed = await SettingsService.GetAsync("banner.wan_schedule_dismissed") != null;
         InitializeChartOptions();

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -249,13 +249,18 @@ else
             {
                 if (MapMode == "3d")
                 {
+                    // storagePrefix is per-site and must be an argument, not baked into
+                    // the body: JS interop keeps invoking the first-resolved function
+                    // reference, so a re-eval'd definition with a different baked-in
+                    // prefix is ignored (see the matching note in Monitoring.razor).
                     await JS.InvokeVoidAsync("eval",
-                        "window.__dashMountMap3d = async function(canvasId) {" +
+                        "window.__dashMountMap3d = async function(canvasId, storagePrefix) {" +
                         $"  const m = await import('{VersionedJs("/js/lan-flow-map.js")}');" +
                         "  window.__dashLanFlowMap = m;" +
-                        $"  await m.mount(canvasId,{{storagePrefix:'{SiteCtx.ScopeStorageKey("dashLanFlowMap")}',signalHint:false}});" +
+                        "  await m.mount(canvasId,{storagePrefix:storagePrefix,signalHint:false});" +
                         "}");
-                    await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas");
+                    await JS.InvokeVoidAsync("__dashMountMap3d", "dashboard-lan-flow-map-canvas",
+                        SiteCtx.ScopeStorageKey("dashLanFlowMap"));
                 }
                 else
                 {

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -445,16 +445,21 @@
     // pick the right compensation here.
     private bool LiveViewTestTimeIsStart => GatewayResult != null || Result?.DeviceType == "Gateway";
 
-    // Land Live View at the START of the test. For start-stamped results TestTime is
-    // already the start (offset 0). For end-stamped results TestTime sits after both
-    // directional phases (DurationSeconds is per direction), so back off by both. A
-    // result without a stored duration offsets by 0.
+    // The gateway stamps TestTime before establishing its SSH connection, so the
+    // actual throughput starts a couple of seconds later - nudge forward past that
+    // setup gap (the opposite direction from the end-stamped back-off below).
+    private const long GatewaySshSetupMs = 2000L;
+
+    // Land Live View at the START of the test. Start-stamped (gateway) results push
+    // forward past the SSH setup gap; end-stamped results sit after both directional
+    // phases (DurationSeconds is per direction), so back off by both. A result without
+    // a stored duration backs off by 0.
     private long LiveViewAtMs
     {
         get
         {
             var stampMs = new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
-            return LiveViewTestTimeIsStart ? stampMs : stampMs - 2 * DurationSeconds * 1000L;
+            return LiveViewTestTimeIsStart ? stampMs + GatewaySshSetupMs : stampMs - 2 * DurationSeconds * 1000L;
         }
     }
     [Parameter] public double? PingMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -437,12 +437,14 @@
     [Parameter] public bool ShowLiveViewLink { get; set; }
 
     /// <summary>TestTime as UTC epoch milliseconds, for the Live View deep link (?at=).</summary>
-    // Land Live View at the START of the test, not its stored timestamp. TestTime
-    // sits between the two directional phases (one per-direction duration in), so
-    // back off by DurationSeconds; a result without a stored duration offsets by 0.
+    // Land Live View at the START of the test, not its stored timestamp. Every
+    // result type stamps TestTime at the END of the full test (LAN iperf3 via the
+    // repository save, WAN/client types at result ingest) and stores DurationSeconds
+    // per direction, so the test spans roughly the two directional phases before
+    // TestTime - back off by both. A result without a stored duration offsets by 0.
     private long LiveViewAtMs =>
         new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds()
-        - DurationSeconds * 1000L;
+        - 2 * DurationSeconds * 1000L;
     [Parameter] public double? PingMs { get; set; }
     [Parameter] public double? JitterMs { get; set; }
     [Parameter] public double? DownloadLatencyMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -455,11 +455,17 @@
     //    nudge forward past the setup gap.
     //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
     //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
-    //    the measured phase. Landing at the phase start (a full duration back) put the
-    //    playhead in the TCP slow-start ramp and read as "too far in the past", so land
-    //    at the phase MIDPOINT instead - a half-duration back, squarely in the traffic.
+    //    the measured phase. The recorded throughput bump sits in the back of that phase
+    //    window (monitoring-vs-wall-clock skew), so a half-duration back landed several
+    //    seconds into flat pre-traffic. A quarter-duration back lands just ahead of the
+    //    bump, so playback ramps in rather than starting on dead air.
+    //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
+    //    after two sequential legs, so back off both - plus 1s. The two-leg-span start
+    //    sits a hair forward of true first-byte because of the inter-leg gap (and, for
+    //    SSH-managed devices, server-start setup); a flat 1s splits the difference between
+    //    the tight UniFi case (server already listening) and the SSH-managed case.
     //  - Everything else is end-stamped after both directional phases, so back off both.
-    // A result without a stored duration backs off by 0.
+    // A result without a stored duration backs off by 0 (1s for ServerToDevice).
     private long LiveViewAtMs
     {
         get
@@ -468,7 +474,9 @@
             if (LiveViewTestTimeIsStart)
                 return stampMs + GatewaySshSetupMs;
             if (Result?.Direction == SpeedTestDirection.ClientToServer)
-                return stampMs - DurationSeconds * 500L;
+                return stampMs - DurationSeconds * 250L;
+            if (Result?.Direction == SpeedTestDirection.ServerToDevice)
+                return stampMs - 2 * DurationSeconds * 1000L - 1000L;
             return stampMs - 2 * DurationSeconds * 1000L;
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -450,16 +450,26 @@
     // setup gap (the opposite direction from the end-stamped back-off below).
     private const long GatewaySshSetupMs = 2000L;
 
+    // How many directional phases run BEFORE the recorded TestTime, i.e. how far back
+    // the test's start sits. Most end-stamped tests record TestTime after both phases.
+    // Client-initiated iperf3 is the exception: it arrives as two separate single-
+    // direction runs merged into one record that keeps the FIRST run's ingest time, so
+    // TestTime lands one phase in, not two - back off by a single duration.
+    private int LiveViewPhasesBeforeStamp =>
+        Result?.Direction == SpeedTestDirection.ClientToServer ? 1 : 2;
+
     // Land Live View at the START of the test. Start-stamped (gateway) results push
-    // forward past the SSH setup gap; end-stamped results sit after both directional
-    // phases (DurationSeconds is per direction), so back off by both. A result without
+    // forward past the SSH setup gap; end-stamped results sit after their directional
+    // phase(s) (DurationSeconds is per direction), so back off by them. A result without
     // a stored duration backs off by 0.
     private long LiveViewAtMs
     {
         get
         {
             var stampMs = new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
-            return LiveViewTestTimeIsStart ? stampMs + GatewaySshSetupMs : stampMs - 2 * DurationSeconds * 1000L;
+            return LiveViewTestTimeIsStart
+                ? stampMs + GatewaySshSetupMs
+                : stampMs - LiveViewPhasesBeforeStamp * DurationSeconds * 1000L;
         }
     }
     [Parameter] public double? PingMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -450,26 +450,26 @@
     // setup gap (the opposite direction from the end-stamped back-off below).
     private const long GatewaySshSetupMs = 2000L;
 
-    // How many directional phases run BEFORE the recorded TestTime, i.e. how far back
-    // the test's start sits. Most end-stamped tests record TestTime after both phases.
-    // Client-initiated iperf3 is the exception: it arrives as two separate single-
-    // direction runs merged into one record that keeps the FIRST run's ingest time, so
-    // TestTime lands one phase in, not two - back off by a single duration.
-    private int LiveViewPhasesBeforeStamp =>
-        Result?.Direction == SpeedTestDirection.ClientToServer ? 1 : 2;
-
-    // Land Live View at the START of the test. Start-stamped (gateway) results push
-    // forward past the SSH setup gap; end-stamped results sit after their directional
-    // phase(s) (DurationSeconds is per direction), so back off by them. A result without
-    // a stored duration backs off by 0.
+    // Where to drop the Live View playhead for this test, as an offset from TestTime:
+    //  - Start-stamped (gateway): TestTime is the start, before its SSH connection, so
+    //    nudge forward past the setup gap.
+    //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
+    //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
+    //    the measured phase. Landing at the phase start (a full duration back) put the
+    //    playhead in the TCP slow-start ramp and read as "too far in the past", so land
+    //    at the phase MIDPOINT instead - a half-duration back, squarely in the traffic.
+    //  - Everything else is end-stamped after both directional phases, so back off both.
+    // A result without a stored duration backs off by 0.
     private long LiveViewAtMs
     {
         get
         {
             var stampMs = new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
-            return LiveViewTestTimeIsStart
-                ? stampMs + GatewaySshSetupMs
-                : stampMs - LiveViewPhasesBeforeStamp * DurationSeconds * 1000L;
+            if (LiveViewTestTimeIsStart)
+                return stampMs + GatewaySshSetupMs;
+            if (Result?.Direction == SpeedTestDirection.ClientToServer)
+                return stampMs - DurationSeconds * 500L;
+            return stampMs - 2 * DurationSeconds * 1000L;
         }
     }
     [Parameter] public double? PingMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -437,7 +437,12 @@
     [Parameter] public bool ShowLiveViewLink { get; set; }
 
     /// <summary>TestTime as UTC epoch milliseconds, for the Live View deep link (?at=).</summary>
-    private long LiveViewAtMs => new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+    // Land Live View at the START of the test, not its stored timestamp. TestTime
+    // sits between the two directional phases (one per-direction duration in), so
+    // back off by DurationSeconds; a result without a stored duration offsets by 0.
+    private long LiveViewAtMs =>
+        new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds()
+        - DurationSeconds * 1000L;
     [Parameter] public double? PingMs { get; set; }
     [Parameter] public double? JitterMs { get; set; }
     [Parameter] public double? DownloadLatencyMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -437,14 +437,26 @@
     [Parameter] public bool ShowLiveViewLink { get; set; }
 
     /// <summary>TestTime as UTC epoch milliseconds, for the Live View deep link (?at=).</summary>
-    // Land Live View at the START of the test, not its stored timestamp. Every
-    // result type stamps TestTime at the END of the full test (LAN iperf3 via the
-    // repository save, WAN/client types at result ingest) and stores DurationSeconds
-    // per direction, so the test spans roughly the two directional phases before
-    // TestTime - back off by both. A result without a stored duration offsets by 0.
-    private long LiveViewAtMs =>
-        new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds()
-        - 2 * DurationSeconds * 1000L;
+    // The gateway speed test (GatewaySpeedTestService) is the one type that stamps
+    // TestTime at the START of the test, before its legs run; every other type stamps
+    // at the END. Its results reach us either live via GatewayResult or, in history,
+    // as an Iperf3Result with DeviceType "Gateway" (the device-iperf3 path excludes
+    // gateways, so that string is unambiguous). We do not touch the recording - just
+    // pick the right compensation here.
+    private bool LiveViewTestTimeIsStart => GatewayResult != null || Result?.DeviceType == "Gateway";
+
+    // Land Live View at the START of the test. For start-stamped results TestTime is
+    // already the start (offset 0). For end-stamped results TestTime sits after both
+    // directional phases (DurationSeconds is per direction), so back off by both. A
+    // result without a stored duration offsets by 0.
+    private long LiveViewAtMs
+    {
+        get
+        {
+            var stampMs = new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+            return LiveViewTestTimeIsStart ? stampMs : stampMs - 2 * DurationSeconds * 1000L;
+        }
+    }
     [Parameter] public double? PingMs { get; set; }
     [Parameter] public double? JitterMs { get; set; }
     [Parameter] public double? DownloadLatencyMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -115,8 +115,20 @@
         </div>
     }
     <div class="test-details">
-        <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
-        <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+        @if (ShowLiveViewLink)
+        {
+            <a href="/monitoring?tab=live&at=@LiveViewAtMs" class="settings-title-link speedtest-liveview-link"
+               @onclick:stopPropagation data-tooltip="View in Live View at this time">
+                <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
+                <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+            </a>
+        }
+        else
+        {
+            <span class="hide-mobile">@TestTime.ToLocalTime().ToString("g")</span>
+            <span class="show-mobile">@TimeFormatHelper.FormatRelativeTimeShort(TestTime)</span>
+        }
         @if (_isMultiServerWan)
         {
             @if (!IsInTableRow)
@@ -416,6 +428,16 @@
     [Parameter] public int ParallelStreams { get; set; }
     [Parameter] public bool IsInTableRow { get; set; }
     [Parameter] public DateTime TestTime { get; set; }
+
+    /// <summary>
+    /// When true, the test date/time links into Monitoring - Live View, opening
+    /// historic playback paused at this test's timestamp. Set by parent pages only
+    /// when monitoring is enabled for the current site.
+    /// </summary>
+    [Parameter] public bool ShowLiveViewLink { get; set; }
+
+    /// <summary>TestTime as UTC epoch milliseconds, for the Live View deep link (?at=).</summary>
+    private long LiveViewAtMs => new DateTimeOffset(DateTime.SpecifyKind(TestTime, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
     [Parameter] public double? PingMs { get; set; }
     [Parameter] public double? JitterMs { get; set; }
     [Parameter] public double? DownloadLatencyMs { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -455,10 +455,10 @@
     //    nudge forward past the setup gap.
     //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
     //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
-    //    the measured phase. The recorded throughput bump sits in the back of that phase
-    //    window (monitoring-vs-wall-clock skew), so a half-duration back landed several
-    //    seconds into flat pre-traffic. A quarter-duration back lands just ahead of the
-    //    bump, so playback ramps in rather than starting on dead air.
+    //    the measured phase. Land just BEFORE the test so playback opens on the run
+    //    starting rather than partway through it. The recorded bump sits late in the
+    //    phase window (monitoring-vs-wall-clock skew), so a full duration back was a hair
+    //    too far into dead air; three-quarters of a duration lands just ahead of the run.
     //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
     //    after two sequential legs, so back off both - plus 1s. The two-leg-span start
     //    sits a hair forward of true first-byte because of the inter-leg gap (and, for
@@ -474,7 +474,7 @@
             if (LiveViewTestTimeIsStart)
                 return stampMs + GatewaySshSetupMs;
             if (Result?.Direction == SpeedTestDirection.ClientToServer)
-                return stampMs - DurationSeconds * 250L;
+                return stampMs - DurationSeconds * 750L;
             if (Result?.Direction == SpeedTestDirection.ServerToDevice)
                 return stampMs - 2 * DurationSeconds * 1000L - 1000L;
             return stampMs - 2 * DurationSeconds * 1000L;

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -456,8 +456,8 @@
     //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
     //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
     //    the measured phase. The recorded traffic (monitoring-vs-wall-clock skew) starts
-    //    around the phase midpoint, so land ~0.64 of a duration back - a hair before that
-    //    visible onset - for a short lead-in rather than opening mid-traffic. (An earlier
+    //    around the phase midpoint, so land just before that visible onset (~0.55 of a
+    //    duration back) for a short lead-in rather than opening mid-traffic. (An earlier
     //    larger back-off was compensating for a playback-seed drift that's since fixed;
     //    with play now resuming exactly at the marker, this reads right.)
     //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
@@ -475,7 +475,7 @@
             if (LiveViewTestTimeIsStart)
                 return stampMs + GatewaySshSetupMs;
             if (Result?.Direction == SpeedTestDirection.ClientToServer)
-                return stampMs - DurationSeconds * 640L;
+                return stampMs - DurationSeconds * 550L;
             if (Result?.Direction == SpeedTestDirection.ServerToDevice)
                 return stampMs - 2 * DurationSeconds * 1000L - 1000L;
             return stampMs - 2 * DurationSeconds * 1000L;

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -455,10 +455,10 @@
     //    nudge forward past the setup gap.
     //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
     //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
-    //    the measured phase. Land just BEFORE the test so playback opens on the run
-    //    starting rather than partway through it. The recorded bump sits late in the
-    //    phase window (monitoring-vs-wall-clock skew), so a full duration back was a hair
-    //    too far into dead air; three-quarters of a duration lands just ahead of the run.
+    //    the measured phase. Land at the phase MIDPOINT (half a duration back), squarely
+    //    in the traffic. (An earlier "land before the test" tuning was compensating for a
+    //    playback-seed drift that's since fixed; with play now resuming exactly at the
+    //    marker, the midpoint reads right.)
     //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
     //    after two sequential legs, so back off both - plus 1s. The two-leg-span start
     //    sits a hair forward of true first-byte because of the inter-leg gap (and, for
@@ -474,7 +474,7 @@
             if (LiveViewTestTimeIsStart)
                 return stampMs + GatewaySshSetupMs;
             if (Result?.Direction == SpeedTestDirection.ClientToServer)
-                return stampMs - DurationSeconds * 750L;
+                return stampMs - DurationSeconds * 500L;
             if (Result?.Direction == SpeedTestDirection.ServerToDevice)
                 return stampMs - 2 * DurationSeconds * 1000L - 1000L;
             return stampMs - 2 * DurationSeconds * 1000L;

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -455,10 +455,11 @@
     //    nudge forward past the setup gap.
     //  - Client-initiated iperf3: arrives as separate single-direction runs merged into
     //    one record that keeps the FIRST run's ingest time, so TestTime marks the end of
-    //    the measured phase. Land at the phase MIDPOINT (half a duration back), squarely
-    //    in the traffic. (An earlier "land before the test" tuning was compensating for a
-    //    playback-seed drift that's since fixed; with play now resuming exactly at the
-    //    marker, the midpoint reads right.)
+    //    the measured phase. The recorded traffic (monitoring-vs-wall-clock skew) starts
+    //    around the phase midpoint, so land ~0.64 of a duration back - a hair before that
+    //    visible onset - for a short lead-in rather than opening mid-traffic. (An earlier
+    //    larger back-off was compensating for a playback-seed drift that's since fixed;
+    //    with play now resuming exactly at the marker, this reads right.)
     //  - Server-initiated LAN device iperf3 (gateway already handled above): end-stamped
     //    after two sequential legs, so back off both - plus 1s. The two-leg-span start
     //    sits a hair forward of true first-byte because of the inter-leg gap (and, for
@@ -474,7 +475,7 @@
             if (LiveViewTestTimeIsStart)
                 return stampMs + GatewaySshSetupMs;
             if (Result?.Direction == SpeedTestDirection.ClientToServer)
-                return stampMs - DurationSeconds * 500L;
+                return stampMs - DurationSeconds * 640L;
             if (Result?.Direction == SpeedTestDirection.ServerToDevice)
                 return stampMs - 2 * DurationSeconds * 1000L - 1000L;
             return stampMs - 2 * DurationSeconds * 1000L;

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -557,6 +557,7 @@ builder.Services.AddAuthorization();
 
 // Monitoring subsystem
 builder.Services.AddScoped<SnmpDetectionService>();
+builder.Services.AddScoped<MonitoringReadinessService>();
 // Per-site Influx clients (D1: bucket-per-site) live in the registry - the
 // default site's included. Scoped resolution forwards to the current site's
 // client so chart endpoints and pages read that site's buckets; singleton

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -879,6 +879,16 @@ public class LanFlowMapService
                 var onlineAtT = healthPt != null
                     && Math.Abs((healthPt.Time - at).TotalSeconds) <= HistoricOnlineWindowSeconds;
 
+                // A second liveness signal at the same proximity: interface rates are only
+                // recorded while a device is reachable and poll on a separate cadence from
+                // device_health, so a single health sample dropped to poll jitter must not
+                // dark a device that plainly had interface telemetry at T (the visible
+                // symptom was particle streams freezing mid-playback, then restoring).
+                // Bounded by the same window, so a genuine outage - no health AND no rate
+                // telemetry near T - still reads offline.
+                var rateNearT = ratesByDevice.TryGetValue(mac, out var rateHist) && rateHist.Count > 0
+                    && rateHist.Min(p => Math.Abs((p.Time - at).TotalSeconds)) <= HistoricOnlineWindowSeconds;
+
                 bool infraOnline = false;
                 if (isInfra)
                 {
@@ -890,7 +900,7 @@ public class LanFlowMapService
                     var hasHealthHistory =
                         cached.HealthByDevice.TryGetValue(mac, out var hh) && hh.Count > 0;
                     if (hasHealthHistory)
-                        infraOnline = onlineAtT;
+                        infraOnline = onlineAtT || rateNearT;
                     else
                         infraOnline = (fabIn != null || aggIn != null) || node.Online;
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -204,6 +204,17 @@ public class LanFlowMapService
     /// </summary>
     private const double HistoricOnlineWindowSeconds = 60;
 
+    /// <summary>
+    /// Instants within this many seconds of now are the "live edge". The historic cache
+    /// fetches a window 5 min AHEAD of its fetch instant, but that ahead portion is empty
+    /// when fetched (the data isn't written yet), and an agent-run speed test can delay
+    /// writes ~2 min. Reusing the cached copy there froze the maps (all-offline / stuck
+    /// rates) while Port Stats - which queries fresh per instant - stayed accurate. So near
+    /// the live edge we bypass the cache and query fresh, matching Port Stats. Sized to the
+    /// worst observed agent-test write lag; older instants still use the cache.
+    /// </summary>
+    private const double HistoricLiveEdgeSettleSeconds = 150;
+
     /// <summary>Gateway / switch / AP - the fabric devices the map renders an explicit
     /// online/offline appearance for (clients track association, not device state).</summary>
     private static bool IsInfraKind(LanNodeKind kind) =>
@@ -559,11 +570,15 @@ public class LanFlowMapService
         }
         catch { }
 
-        // Reuse cached InfluxDB results when the requested time falls within
-        // the previously fetched window. Fetches 5 min ahead so forward
-        // playback goes ~4 min before needing another round-trip.
+        // Reuse cached InfluxDB results when the requested time falls within the
+        // previously fetched window. Fetches 5 min ahead so forward playback goes ~4 min
+        // before another round-trip. But never reuse for the live edge: the ahead portion
+        // was empty when fetched (data not written yet), so serving it there froze the maps
+        // while fresh queries (Port Stats) stayed accurate. Refetch when `at` is within the
+        // settle window of now so the live edge always reads freshly-written data.
+        var liveEdge = DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
         var cached = _cache.HistoricData;
-        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30))
+        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || at > liveEdge)
         {
             cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
             _cache.HistoricData = cached;

--- a/src/NetworkOptimizer.Web/Services/MonitoringReadinessService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringReadinessService.cs
@@ -1,0 +1,68 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Central readiness checks for the monitoring subsystem, shared by the Monitoring page
+/// and by features that deep-link into it (e.g. a speed-test result linking into Live
+/// View historic playback). Keeps the "is monitoring usable for this site" rule in one
+/// place so callers don't re-derive it and drift.
+/// </summary>
+public class MonitoringReadinessService
+{
+    private readonly SnmpDetectionService _snmp;
+    private readonly SiteContextService _siteContext;
+    private readonly SiteDbContextFactory _siteDb;
+
+    public MonitoringReadinessService(
+        SnmpDetectionService snmp,
+        SiteContextService siteContext,
+        SiteDbContextFactory siteDb)
+    {
+        _snmp = snmp;
+        _siteContext = siteContext;
+        _siteDb = siteDb;
+    }
+
+    /// <summary>
+    /// Whether the shared InfluxDB connection is configured. InfluxDB is a single central
+    /// instance whose token/url live on the default site; secondary (managed) sites inherit
+    /// them and carry no token in their own <see cref="Storage.Models.MonitoringSettings"/>
+    /// row. This always reads the default site's row, so it answers the same regardless of
+    /// which site is current.
+    /// </summary>
+    public async Task<bool> IsSharedInfluxConfiguredAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            await using var mainDb = _siteDb.CreateForSite(SiteManagementService.DefaultSiteSlug, isDefault: true);
+            var shared = await mainDb.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            return !string.IsNullOrEmpty(shared?.InfluxDbToken)
+                && !string.IsNullOrEmpty(shared?.InfluxDbUrl);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Whether Live View historic playback is available for the CURRENT site, so a
+    /// speed-test result can offer a deep link into it: monitoring must be enabled for this
+    /// site AND the shared InfluxDB connection must be configured. Mirrors the Monitoring
+    /// page's own readiness gate (<c>_monitoringEnabled &amp;&amp; _influxConfigured</c>).
+    /// </summary>
+    public async Task<bool> IsHistoricPlaybackAvailableAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var settings = await _snmp.GetOrCreateSettingsAsync(ct);
+            return settings.Enabled && await IsSharedInfluxConfiguredAsync(ct);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -546,6 +546,10 @@ h1:focus {
     color: var(--primary-color);
 }
 
+.speedtest-liveview-link {
+    gap: 4px;
+}
+
 .card-header-right {
     display: flex;
     align-items: center;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-data.js
@@ -88,6 +88,23 @@ export function publishScrubberWindow(win) {
     _notify('scrubber-window');
 }
 
+// Restore live-mode playback defaults. Called by the 3D map (the playback
+// authority) at the start of each of its mounts, so state left behind by a
+// previous Live View session - historic mode, a paused flag, a parked
+// scrubber - can't leak into the new one. This module is a singleton that
+// outlives SPA navigations while the map instance itself is rebuilt fresh,
+// so without this every remount inherits whatever the last session left.
+// Notifies so any still-mounted consumer UI syncs to the clean state.
+export function resetPlayback() {
+    _paused = false;
+    _mode = 'live';
+    _scrubberValue = 10000;
+    _scrubberRight = 'Live';
+    _playbackSpeed = 1;
+    _notify('playstate');
+    _notify('scrubber');
+}
+
 // Render local-midnight tick marks onto a scrubber track overlay so multi-day
 // windows have day-boundary orientation. Shared by the 3D scrubber and its 2D
 // mirror. Windows under two days get no ticks; wide windows thin to ~12 ticks.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -3,7 +3,7 @@
 // zero duplicate API calls. GPU-composited canvas for smooth particle animation.
 
 // KEEP IN SYNC: lan-flow-map.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 function demoMask(text) {
     const dm = window.DemoMask;
@@ -274,7 +274,12 @@ class LanFlowMap2D {
     }
 
     async start(){
-        if(flowData.isPaused())flowData.publishPlayState(false,'live');
+        // Standalone (dashboard) mounts have no 3D map to reset stale playback
+        // state a previous Monitoring session left in the shared store, so do it
+        // here. On the Monitoring page the 3D map (the playback authority) has
+        // already reset the store - and may have re-entered historic for a
+        // deep-linked timestamp - so a full mount must never force it back live.
+        if(this._liveOnly&&flowData.isPaused())flowData.publishPlayState(false,'live');
         this._createCanvas();
         const snap=flowData.getSnapshot();
         if(snap){

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -211,6 +211,9 @@ export class LanFlowMap {
         // discovery hint to keep its compact chrome clean (it also hides the
         // scrubber/status). Full Monitoring page leaves it on.
         this._signalHintEnabled = options.signalHint ?? true;
+        // Deep-link entry point (e.g. from a speed-test result): an absolute epoch-ms
+        // instant to open in historic playback, paused. Applied once at the end of start().
+        this._initialAtMs = Number.isFinite(options.initialAt) ? options.initialAt : null;
 
         this._snapshot = null;
         this._deviceScale = 1;          // property-size factor for device radii (set in _layoutNodes)
@@ -513,6 +516,24 @@ export class LanFlowMap {
         await this._loadInitialSpeedTests();
         this._startAnimation();
         this._startPolling();
+        this._applyInitialSeek();
+    }
+
+    // Honor a deep-linked timestamp (options.initialAt) by dropping straight into
+    // historic playback, paused, at that instant. Widens the timeline window first
+    // if the target predates the current span so the instant is reachable rather
+    // than clamping to the left edge (an instant older than retention still clamps).
+    _applyInitialSeek() {
+        const ms = this._initialAtMs;
+        if (!Number.isFinite(ms)) return;
+        this._initialAtMs = null; // one-shot
+        const needed = Date.now() - ms;
+        if (needed > this._scrubSpan) {
+            const preset = flowData.SCRUBBER_PRESETS.find(p => (p.ms ?? Infinity) >= needed)
+                || flowData.SCRUBBER_PRESETS[flowData.SCRUBBER_PRESETS.length - 1];
+            this._setScrubSpan(preset.key);
+        }
+        this.seekTo(ms);
     }
 
     dispose() {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -15,7 +15,7 @@ import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js'
 import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 import { buildBuildings } from './lan-flow-buildings.js?v=1';
 // KEEP IN SYNC: lan-flow-map-2d.js imports the same module. Both must use the same ?v= or they get separate instances.
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 const COLORS = {
     background: 0x202023,
@@ -2647,6 +2647,10 @@ export class LanFlowMap {
     _enterHistoricScrub() {
         this._mode = 'historic';
         this._paused = true;
+        // Mirror the transition into the shared store immediately. The debounced
+        // _onScrubberChange republishes 0-500ms later, but consumers mounting in
+        // that window must not read a stale 'live' state.
+        flowData.publishPlayState(this._paused, this._mode);
         this._syncPlayPauseIcon();
         this._stopHistoricPlayback();
         if (this._panels.modeBadge) {
@@ -4309,6 +4313,11 @@ export async function mount(canvasId, options = {}) {
     }
     const el = document.getElementById(canvasId);
     if (!el) throw new Error(`Canvas #${canvasId} not found`);
+    // The map is the playback authority and mounts before the other Live View
+    // consumers (2D map, WAN chart, port table). Clear playback state a prior
+    // session left in the shared store so every mount starts from Live; a
+    // deep-linked initialAt then re-enters historic through the normal seek path.
+    flowData.resetPlayback();
     _instance = new LanFlowMap(el, options);
     await _instance.start();
     return _instance;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -2067,16 +2067,16 @@ export class LanFlowMap {
         clearTimeout(this._scrubberInputDebounce);
         const pending = this._pendingScrubAt;
         this._pendingScrubAt = null;
-        // Otherwise seed from the exact parked instant when known - requantizing
-        // through the slider value can be minutes off on a wide window. But only
-        // when the thumb still agrees with it; if not, the thumb position is the
-        // user's intent, not the stale instant.
+        // Otherwise seed from the ABSOLUTE parked instant - never the slider-derived
+        // fromValue. The timeline window trails now, so a fixed slider value maps to a
+        // later time as the page sits; seeding from it added the whole sit-duration to
+        // the resume point (park at T, sit 2 min, play started at T+2 min). historicAt
+        // is an absolute Date kept current on every commit path (deep-link, drag,
+        // keyboard scrub), so it never drifts; pending covers an in-flight scrub not yet
+        // committed; fromValue is only a last-resort fallback if neither is set.
         const fromValue = this._scrubberValueToTime(
             Number(this._panels.scrubberRange?.value ?? 500));
-        const stepMs = this._scrubSpan / 10000;
-        this._playbackTime = pending
-            ?? ((this._historicAt && Math.abs(this._historicAt.getTime() - fromValue.getTime()) <= stepMs)
-                ? this._historicAt : fromValue);
+        this._playbackTime = pending ?? this._historicAt ?? fromValue;
         // Publish the seed position immediately instead of waiting for the first
         // 1s tick: consumers re-baseline their playhead on a confirmed seek, and
         // an adopted pending scrub gets its data loaded now rather than a tick late.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -526,6 +526,7 @@ export class LanFlowMap {
     _applyInitialSeek() {
         const ms = this._initialAtMs;
         if (!Number.isFinite(ms)) return;
+        _dbg(`applyInitialSeek ms=${ms} (${new Date(ms).toISOString()})`);
         this._initialAtMs = null; // one-shot
         const needed = Date.now() - ms;
         if (needed > this._scrubSpan) {
@@ -2645,6 +2646,7 @@ export class LanFlowMap {
     // Flip Live -> Historic on the first scrub interaction: land paused with the
     // Historic badge up, and kill any running playback.
     _enterHistoricScrub() {
+        _dbg(`enterHistoricScrub src=${(new Error().stack || '').split('\n').slice(1, 3).join(' | ')}`);
         this._mode = 'historic';
         this._paused = true;
         // Mirror the transition into the shared store immediately. The debounced
@@ -2687,6 +2689,7 @@ export class LanFlowMap {
     // timeline at the instant (or snaps to Live at the right edge) and loads it
     // through the same debounced pipeline as slider/keyboard scrubbing.
     seekTo(ms) {
+        _dbg(`seekTo ms=${ms} (${Number.isFinite(ms) ? new Date(ms).toISOString() : '?'}) src=${(new Error().stack || '').split('\n').slice(1, 4).join(' | ')}`);
         const range = this._panels.scrubberRange;
         if (!range || !Number.isFinite(ms)) return;
         this._stopHistoricPlayback();
@@ -4303,6 +4306,13 @@ function makeRadialBackgroundTexture(width, height) {
     return tex;
 }
 
+// Diagnostic (LiveViewDbg): relay browser-side lifecycle events into the server
+// log via the Monitoring component's DotNet ref. Strip together with the
+// [LiveViewDbg] lines in Monitoring.razor once the deep-link issue is closed.
+export function _dbg(msg) {
+    try { window.__monitoringRef?.invokeMethodAsync('OnMapDebug', 'map: ' + msg).catch(() => {}); } catch { }
+}
+
 // Entry point used by Blazor JS interop.
 let _instance = null;
 
@@ -4313,6 +4323,7 @@ export async function mount(canvasId, options = {}) {
     }
     const el = document.getElementById(canvasId);
     if (!el) throw new Error(`Canvas #${canvasId} not found`);
+    _dbg(`mount opts=${JSON.stringify(options)} module=${import.meta.url} preReset={p:${flowData.isPaused()},m:${flowData.getMode()},v:${flowData.getScrubber().value}}`);
     // The map is the playback authority and mounts before the other Live View
     // consumers (2D map, WAN chart, port table). Clear playback state a prior
     // session left in the shared store so every mount starts from Live; a
@@ -4320,10 +4331,12 @@ export async function mount(canvasId, options = {}) {
     flowData.resetPlayback();
     _instance = new LanFlowMap(el, options);
     await _instance.start();
+    _dbg(`mount done mode=${_instance._mode} paused=${_instance._paused} historicAt=${_instance._historicAt?.toISOString() ?? 'null'}`);
     return _instance;
 }
 
 export function unmount() {
+    _dbg(`unmount hadInstance=${!!_instance}`);
     if (_instance) {
         _instance.dispose();
         _instance = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -526,7 +526,6 @@ export class LanFlowMap {
     _applyInitialSeek() {
         const ms = this._initialAtMs;
         if (!Number.isFinite(ms)) return;
-        _dbg(`applyInitialSeek ms=${ms} (${new Date(ms).toISOString()})`);
         this._initialAtMs = null; // one-shot
         const needed = Date.now() - ms;
         if (needed > this._scrubSpan) {
@@ -2646,7 +2645,6 @@ export class LanFlowMap {
     // Flip Live -> Historic on the first scrub interaction: land paused with the
     // Historic badge up, and kill any running playback.
     _enterHistoricScrub() {
-        _dbg(`enterHistoricScrub src=${(new Error().stack || '').split('\n').slice(1, 3).join(' | ')}`);
         this._mode = 'historic';
         this._paused = true;
         // Mirror the transition into the shared store immediately. The debounced
@@ -2689,7 +2687,6 @@ export class LanFlowMap {
     // timeline at the instant (or snaps to Live at the right edge) and loads it
     // through the same debounced pipeline as slider/keyboard scrubbing.
     seekTo(ms) {
-        _dbg(`seekTo ms=${ms} (${Number.isFinite(ms) ? new Date(ms).toISOString() : '?'}) src=${(new Error().stack || '').split('\n').slice(1, 4).join(' | ')}`);
         const range = this._panels.scrubberRange;
         if (!range || !Number.isFinite(ms)) return;
         this._stopHistoricPlayback();
@@ -4306,13 +4303,6 @@ function makeRadialBackgroundTexture(width, height) {
     return tex;
 }
 
-// Diagnostic (LiveViewDbg): relay browser-side lifecycle events into the server
-// log via the Monitoring component's DotNet ref. Strip together with the
-// [LiveViewDbg] lines in Monitoring.razor once the deep-link issue is closed.
-export function _dbg(msg) {
-    try { window.__monitoringRef?.invokeMethodAsync('OnMapDebug', 'map: ' + msg).catch(() => {}); } catch { }
-}
-
 // Entry point used by Blazor JS interop.
 let _instance = null;
 
@@ -4323,7 +4313,6 @@ export async function mount(canvasId, options = {}) {
     }
     const el = document.getElementById(canvasId);
     if (!el) throw new Error(`Canvas #${canvasId} not found`);
-    _dbg(`mount opts=${JSON.stringify(options)} module=${import.meta.url} preReset={p:${flowData.isPaused()},m:${flowData.getMode()},v:${flowData.getScrubber().value}}`);
     // The map is the playback authority and mounts before the other Live View
     // consumers (2D map, WAN chart, port table). Clear playback state a prior
     // session left in the shared store so every mount starts from Live; a
@@ -4331,12 +4320,10 @@ export async function mount(canvasId, options = {}) {
     flowData.resetPlayback();
     _instance = new LanFlowMap(el, options);
     await _instance.start();
-    _dbg(`mount done mode=${_instance._mode} paused=${_instance._paused} historicAt=${_instance._historicAt?.toISOString() ?? 'null'}`);
     return _instance;
 }
 
 export function unmount() {
-    _dbg(`unmount hadInstance=${!!_instance}`);
     if (_instance) {
         _instance.dispose();
         _instance = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -502,6 +502,7 @@ export function mount(el, mountOpts = {}) {
     // seek/pause push from Blazor can race this mount and be lost (see the
     // matching pull in wan-live-chart.js).
     const mapInst = window.__lanFlowMap?.getInstance?.();
+    window.__lanFlowMap?._dbg?.(`portStats mount-end pull: inst=${!!mapInst} mode=${mapInst?._mode} paused=${mapInst?._paused} at=${(mapInst?._pendingScrubAt ?? mapInst?._historicAt)?.toISOString() ?? 'null'}`);
     if (mapInst && mapInst._mode === 'historic') {
         const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
         if (at) api.seekTime(at.toISOString());

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -490,10 +490,24 @@ export function mount(el, mountOpts = {}) {
     if (Array.isArray(mountOpts.deviceMeta)) {
         for (const d of mountOpts.deviceMeta) if (d && d.mac && d.name) nameOverrides[d.mac] = d.name;
     }
+    // Playback state is module-level and outlives unmount; a paused or historic
+    // state left by a previous session would silently block startPoll() below.
     currentAt = null;
+    paused = false;
     window.__portStatsTable = api;
     loadAndRender();
     startPoll();
+
+    // Converge to the 3D map's (the playback authority's) current state - the
+    // seek/pause push from Blazor can race this mount and be lost (see the
+    // matching pull in wan-live-chart.js).
+    const mapInst = window.__lanFlowMap?.getInstance?.();
+    if (mapInst && mapInst._mode === 'historic') {
+        const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
+        if (at) api.seekTime(at.toISOString());
+    } else if (mapInst && mapInst._paused) {
+        api.pause();
+    }
 }
 
 export const seekTime = (...a) => api.seekTime(...a);

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -502,7 +502,6 @@ export function mount(el, mountOpts = {}) {
     // seek/pause push from Blazor can race this mount and be lost (see the
     // matching pull in wan-live-chart.js).
     const mapInst = window.__lanFlowMap?.getInstance?.();
-    window.__lanFlowMap?._dbg?.(`portStats mount-end pull: inst=${!!mapInst} mode=${mapInst?._mode} paused=${mapInst?._paused} at=${(mapInst?._pendingScrubAt ?? mapInst?._historicAt)?.toISOString() ?? 'null'}`);
     if (mapInst && mapInst._mode === 'historic') {
         const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
         if (at) api.seekTime(at.toISOString());

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -525,11 +525,12 @@ export function resume() {
 // Hovering holds redraws (same as live updateChart) so values can be inspected
 // without the chart shifting under the cursor - EXCEPT briefly after a click on
 // the chart, which must draw its playhead even though the pointer (and so the
-// tooltip) is still over the plot. `force` is for an explicit reposition (a
-// seek): its single draw must land even under the cursor, or a paused seek that
-// arrives mid-hover is swallowed and never retried (the interpolation timer only
-// redraws while playing). The continuous interpolation stays unforced so live
-// hover-inspection during playback is unchanged.
+// tooltip) is still over the plot. `force` bypasses the hover-hold for a discrete
+// paused seek (a deep-link or manual scrub) - its single draw must land even under
+// the cursor, or it's swallowed and never retried while paused. Callers must NOT
+// force during active playback: the per-tick seeks would then redraw through a
+// hover, kicking the user out of tooltip inspection while the background timeline
+// advances - the exact behavior the hover-hold exists to preserve.
 function renderHistoric(at, force = false) {
     if (!chart || buffer.length === 0) return;
     if (!force && Date.now() > clickRenderUntil) {
@@ -635,9 +636,11 @@ export async function seekTime(isoTimestamp) {
         }));
     } catch { return; }
     if (buffer.length === 0) return;
-    // Force: this is the seek's own reposition draw, which must land even if the
-    // pointer is over the plot (paused seeks otherwise never render).
-    renderHistoric(at, true);
+    // Force the reposition draw only for a discrete/paused seek (deep-link, manual
+    // scrub): it must land even under the cursor or it's never retried while paused.
+    // During active playback leave it unforced so a hover still holds the redraw for
+    // inspection while the background timeline (2D/3D maps) keeps advancing.
+    renderHistoric(at, mapPlaybackRate() <= 0);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -498,7 +498,6 @@ export async function mount(containerId, opts) {
     // once at mount completion closes that race: pushes that already fired are
     // recovered here, and pushes still pending find a fully mounted chart.
     const mapInst = window.__lanFlowMap?.getInstance?.();
-    window.__lanFlowMap?._dbg?.(`wanChart mount-end pull: inst=${!!mapInst} mode=${mapInst?._mode} paused=${mapInst?._paused} at=${(mapInst?._pendingScrubAt ?? mapInst?._historicAt)?.toISOString() ?? 'null'}`);
     if (mapInst && mapInst._mode === 'historic') {
         const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
         if (at) await seekTime(at.toISOString());
@@ -582,7 +581,6 @@ function stopHistInterpolation() {
 }
 
 export async function seekTime(isoTimestamp) {
-    window.__lanFlowMap?._dbg?.(`wanChart seekTime ${isoTimestamp} chart=${!!chart} polling=${!!pollTimer}`);
     if (!chart) return;
     seekGen++;
     if (!isoTimestamp) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -525,10 +525,14 @@ export function resume() {
 // Hovering holds redraws (same as live updateChart) so values can be inspected
 // without the chart shifting under the cursor - EXCEPT briefly after a click on
 // the chart, which must draw its playhead even though the pointer (and so the
-// tooltip) is still over the plot.
-function renderHistoric(at) {
+// tooltip) is still over the plot. `force` is for an explicit reposition (a
+// seek): its single draw must land even under the cursor, or a paused seek that
+// arrives mid-hover is swallowed and never retried (the interpolation timer only
+// redraws while playing). The continuous interpolation stays unforced so live
+// hover-inspection during playback is unchanged.
+function renderHistoric(at, force = false) {
     if (!chart || buffer.length === 0) return;
-    if (Date.now() > clickRenderUntil) {
+    if (!force && Date.now() > clickRenderUntil) {
         const el = document.getElementById(elId);
         if (el?.classList.contains('apexcharts-tooltip-active')) return;
     }
@@ -631,7 +635,9 @@ export async function seekTime(isoTimestamp) {
         }));
     } catch { return; }
     if (buffer.length === 0) return;
-    renderHistoric(at);
+    // Force: this is the seek's own reposition draw, which must land even if the
+    // pointer is over the plot (paused seeks otherwise never render).
+    renderHistoric(at, true);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -498,6 +498,7 @@ export async function mount(containerId, opts) {
     // once at mount completion closes that race: pushes that already fired are
     // recovered here, and pushes still pending find a fully mounted chart.
     const mapInst = window.__lanFlowMap?.getInstance?.();
+    window.__lanFlowMap?._dbg?.(`wanChart mount-end pull: inst=${!!mapInst} mode=${mapInst?._mode} paused=${mapInst?._paused} at=${(mapInst?._pendingScrubAt ?? mapInst?._historicAt)?.toISOString() ?? 'null'}`);
     if (mapInst && mapInst._mode === 'historic') {
         const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
         if (at) await seekTime(at.toISOString());
@@ -581,6 +582,7 @@ function stopHistInterpolation() {
 }
 
 export async function seekTime(isoTimestamp) {
+    window.__lanFlowMap?._dbg?.(`wanChart seekTime ${isoTimestamp} chart=${!!chart} polling=${!!pollTimer}`);
     if (!chart) return;
     seekGen++;
     if (!isoTimestamp) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -3,7 +3,7 @@
 // /api/monitoring/live-stats for real-time updates.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import * as flowData from './lan-flow-data.js?v=5';
+import * as flowData from './lan-flow-data.js?v=6';
 
 const HISTORY_MINUTES = 5;
 // Poll faster than the 5s SNMP fast tier so no sample is missed when the two
@@ -490,6 +490,20 @@ export async function mount(containerId, opts) {
         }
     };
     document.addEventListener('visibilitychange', visHandler);
+
+    // Converge to the 3D map's (the playback authority's) current state. This
+    // mount runs concurrently with the map's deep-link/scrub seeks, so the
+    // seekTime push from Blazor's OnMapTimeChanged can land before the chart is
+    // ready and be lost (or be wiped by the live polling started above). Pulling
+    // once at mount completion closes that race: pushes that already fired are
+    // recovered here, and pushes still pending find a fully mounted chart.
+    const mapInst = window.__lanFlowMap?.getInstance?.();
+    if (mapInst && mapInst._mode === 'historic') {
+        const at = mapInst._pendingScrubAt ?? mapInst._historicAt;
+        if (at) await seekTime(at.toISOString());
+    } else if (mapInst && mapInst._paused) {
+        pause();
+    }
 }
 
 export function pause() {


### PR DESCRIPTION
## Summary

On every speed-test result detail view (WAN Speed Test, LAN Speed Test, Client WAN Test, Client Speed Test), the result's date/time is now a link (with the standard external-link icon) that opens Monitoring - Live View in historic playback, paused just before that test.

## Monitoring - Live View

- **Speed-test timestamp deep link** - The date/time on a result detail links to `/monitoring?tab=live&at=<ms>`, opening Live View in historic mode paused at the test. The timeline window widens automatically when the test predates the current scrubber span; timestamps older than retention clamp to the window edge.
- **Per-test landing offset** - Where the playhead lands is computed per test type, because each stamps its timestamp differently: server-initiated LAN device tests and the WAN types are stamped after both directional legs (land at the two-leg start, minus 1s for the inter-leg gap on device tests); the gateway test stamps at its start before the SSH connection (nudged forward past the setup gap); client-initiated iperf3 keeps the first merged run's ingest time (lands ~0.55 of a duration back, just before the traffic starts flowing).
- **Link gating** - The link only shows when historic playback can actually work: Monitoring enabled for the site AND the shared InfluxDB connection configured. A new `MonitoringReadinessService` reads the shared connection from the default site's settings, so managed/agent sites (which inherit the central InfluxDB and have no local token) gate correctly. Monitoring's own Influx state check uses the same service.

## Fixes

- **Maps froze (all-offline or stuck rates) in near-present historic playback** - The per-site singleton map cache fetches a window 5 min *ahead* of its fetch instant, but that ahead portion is empty when fetched (the data isn't written yet). Near the live edge - worsened by an agent-run speed test delaying writes up to ~2 min - the maps reused that stale cached copy and showed every device offline or throughput stuck, while Port Stats (which queries Influx fresh per instant) stayed accurate. Near-present instants now bypass the cache and query fresh; older instants keep the cache, and the online/offline liveness logic is untouched so playback of genuine past outages (upgrades, power cycles) still shows devices going offline. A secondary guard also treats interface-rate presence as a liveness signal alongside device_health, so a single jittered health sample can't dark a device that had traffic.
- **Playback resumed from the wrong time after sitting on the page** - The timeline window trails now, so a fixed scrubber position maps to a later time as the page sits; playback seeded from that window-relative position, adding the sit-duration to the resume point (park at T, wait 2 min, playback started at T+2 min). Playback now seeds from the absolute parked instant, which does not drift; an in-flight scrub and the fallback are preserved.
- **WAN live chart playhead missing on a paused seek** - A paused seek's single render was suppressed when the pointer was over the chart (the hover-hold guard) and never retried, so deep-linking while hovering left the playhead unrendered until play. An explicit paused seek now renders even under the cursor; during active playback the hover-hold is preserved so tooltip inspection still holds while the background timeline advances.
- **Deep link ignored on repeat navigations** - Blazor JS interop resolves an invoke identifier to a function reference once and keeps calling that original closure, so re-eval'ing the mount trampoline with a new `initialAt` was silently ignored: the first deep-link timestamp stayed baked in for the page's lifetime (tab-returns re-seeked to it, later deep links reused it). Per-mount values (`initialAt`, site-scoped `storagePrefix`) are now passed as invoke arguments with stateless bodies; the same fix is applied to the dashboard's map mount.
- **Live View consumers converge on the map's state at mount** - Playback state lives in JS singletons that outlive SPA navigations, and the WAN chart / port table learned of historic seeks only through a one-shot push that could race their async mounts. The 3D map (playback authority, mounted first) resets the shared store each mount; historic transitions publish at the transition instant; the WAN chart and port table pull the map's state once mounted; the port table resets its module-level pause flag (previously it silently blocked polling after a paused session); the 2D map's mount-time force-to-live is now dashboard-only so it can't fight a deep-link seek. Returning to the Live tab always starts at Live.

## Test plan

- [x] Fresh load of `/monitoring?tab=live&at=<ms>`: map, 2D map, WAN chart, and port table all locked historic, paused
- [x] Click a speed-test timestamp link (SPA nav-in); repeat from a different result and confirm the new timestamp is used
- [x] Press play after sitting on a pre-loaded marker: playback starts at the marker, not later
- [x] Hover the WAN chart during historic playback: tooltip inspection holds while the background timeline advances
- [x] Near-present historic playback during/right after agent-run speed tests (verified 2 WAN + 2 AP): maps track Port Stats, no all-offline / stuck rates
- [x] Regression: scrub to a past AP-upgrade window - devices still show offline in playback (genuine-outage feature preserved)
- [x] From historic, press Live, switch tabs and return: everything live; tab away and back while historic returns to Live
- [x] Per-type landing checks (gateway, server device, client iperf3) land sensibly relative to the traffic
- [x] Managed/agent site: link shows and deep link works; Monitoring-disabled or no-InfluxDB site: no link
