### PR TITLE
Live View: don't cache live-edge historic fetches (fixes delayed map throughput)

### DIFF
--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -576,12 +576,18 @@ public class LanFlowMapService
         // was empty when fetched (data not written yet), so serving it there froze the maps
         // while fresh queries (Port Stats) stayed accurate. Refetch when `at` is within the
         // settle window of now so the live edge always reads freshly-written data.
-        var liveEdge = DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
+        var atLiveEdge = at > DateTime.UtcNow - TimeSpan.FromSeconds(HistoricLiveEdgeSettleSeconds);
         var cached = _cache.HistoricData;
-        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || at > liveEdge)
+        if (cached == null || at < cached.From || at > cached.To - TimeSpan.FromSeconds(30) || atLiveEdge)
         {
             cached = await FetchHistoricDataAsync(at, snapshot, gwMac, ct);
-            _cache.HistoricData = cached;
+            // Only promote a fetch to the reusable singleton when it is NOT a live-edge
+            // fetch. A live-edge window's near-present portion is still-arriving/incomplete;
+            // storing it poisons the cache so instants that later age past the settle window
+            // fall inside that stale window and keep reading empty (the "test didn't show for
+            // minutes, then appeared once the window rolled" symptom). Live-edge fetches are
+            // used for this response only and always re-fetched fresh next time.
+            if (!atLiveEdge) _cache.HistoricData = cached;
         }
 
         var ratesByDevice = cached.RatesByDevice;


### PR DESCRIPTION
## Monitoring - Live View

Follow-up to #1039. The live-edge cache bypass added there fixed near-present playback, but it still **stored** the fresh-but-incomplete live-edge window into the per-site singleton cache, which then went stale for later reuse.

- **Live-edge historic fetches no longer poison the map cache** - `GetHistoricUpdateAsync` fetches fresh when the requested instant is within the settle window of now (unchanged), but it no longer promotes that fetch into the reusable singleton. A window fetched mid-relay-lag (e.g. during an agent-run speed test) held stale/empty data for the just-tested instant; once that instant aged past the settle window it fell *inside* the poisoned window and kept reading empty until the window happened to roll over - the "the test didn't show on the 2D/3D map for several minutes, then appeared" symptom (observed on honeybee-home). Live-edge fetches are now used for their own response only; settled (past) fetches still populate the cache as before. No change to the online/offline liveness logic.

## Test plan

- [x] Agent-run speed test, then near-present historic playback right away: maps show throughput (live-edge bypass)
- [x] Re-view that same instant after it ages past ~2.5 min: maps show throughput immediately, no delayed appearance
- [x] Older/past playback (device upgrades, power cycles) unaffected - devices still show offline; cached past windows still reused
