### PR TITLE
Add Disable/Enable toggle to Monitoring Interfaces

### DIFF
--- a/docs/features/2026-07-21-monitoring-interface-disable-enable-design.md
+++ b/docs/features/2026-07-21-monitoring-interface-disable-enable-design.md
@@ -1,0 +1,142 @@
+# Monitoring Interface: Disable / Enable
+
+Status: Design (approved 2026-07-21)
+
+## Summary
+
+Add the ability to Disable (un-deploy) a configured monitoring interface without deleting its configuration, and to Enable it again later.
+A disabled interface has all of its gateway artifacts removed (macvlan, host route, SNAT/DNAT, boot script, cron watchdog), but its row and settings are kept, so it can be restored with a single click.
+This supports the common workflow of pausing an interface during testing and bringing it back later without re-entering it.
+
+## Goals
+
+- Per-interface Disable/Enable toggle (no global switch).
+- A disabled interface stays down across reboots and against the cron watchdog - this must be robust, not merely a UI flag.
+- Reuse the existing deploy/teardown primitives and match the repository's existing patterns (Performance Tweaks, the deployment service, the card UI).
+
+## Non-goals
+
+- No global "pause all" control.
+- No change to CM/ONT/modem polling behaviour (no monitor currently consumes `MonitoringInterface`).
+- No new external ONT provider (tracked separately).
+
+## Background: current architecture
+
+A monitoring interface deploys a macvlan on the WAN port with a stable MAC, a gateway-local IP, a `/32` host route (plus optional SNAT, plus optional alias DNAT for the duplicate-IP case), and a cron watchdog.
+Everything is applied over SSH by `MonitoringInterfaceDeploymentService.DeployAsync(mi)`, which writes an idempotent boot script to `/data/on_boot.d/30-monitoring-iface-<Name>.sh` and runs it.
+Reboot-safety comes from two mechanisms: udm-boot runs the boot script on boot, and the script self-installs a cron watchdog that re-applies after UniFi reprovisioning.
+`RemoveAsync(mi)` performs the gateway teardown only (cron entry, route, macvlan, SNAT/DNAT, boot script) and does not touch the database; the database delete is the separate `Repo.DeleteMonitoringInterfaceAsync(id)`.
+Status is computed on demand by `CheckStatusAsync`; there is no background poller and no persisted status.
+Today there is no enabled/disabled state on the entity (`IsManuallyDeployed` means "the user manages the gateway artifacts by hand" and is unrelated).
+
+## Why a naive flag is not enough
+
+A design review surfaced two correctness problems that rule out "just add a boolean and call the existing RemoveAsync":
+
+1. `RemoveAsync` success is unreliable.
+   It ignores the results of the cron, SNAT, route, macvlan, and boot-script removal steps and only fails on alias-cleanup errors, so a non-aliased interface on an unreachable gateway returns `success = true`.
+   Persisting `Disabled = true` off that would show a paused state while the interface is still deployed.
+
+2. There is a real watchdog race.
+   Removing the cron entry does not stop an already-running watchdog script, which recreates the cron entry and every artifact at its end.
+   The script never reads the database, so a database flag alone cannot pause it.
+
+Therefore Disable needs a gateway-side authority that the script honours, plus a hardened and verified teardown - not just a boolean.
+
+## Design
+
+### 1. Data model
+
+Add `bool Disabled` (default `false`) to `MonitoringInterface`.
+Add an EF Core migration that creates the column with `nullable: false, defaultValue: false`, so existing rows remain enabled, and update the model snapshot.
+Add a migration test seeded from the immediately preceding migration to confirm the default applies to existing rows.
+
+### 2. Gateway-side disabled marker (the core mechanism)
+
+Introduce a per-interface marker file at `/data/monitoring-ifaces.disabled/<Name>`.
+The marker lives in a dedicated directory under `/data`, deliberately not in `on_boot.d`, so udm-boot never executes it.
+Its presence means "do not deploy this interface."
+
+Change the boot-script template so that it checks for the marker in two places: at the very top (before applying any artifact) and again immediately before it (re)installs the cron watchdog.
+If the marker is present the script exits 0 without applying anything and without (re)installing cron.
+Wrap the script's apply section and the teardown in a shared per-interface `flock` (e.g. `/tmp/monitoring-iface-<Name>.lock`), so a teardown and a concurrently-running watchdog cannot interleave.
+
+### 3. Hardened `RemoveAsync`
+
+Check the result of every teardown SSH step (cron, SNAT, route, macvlan, boot script), not only the alias cleanup, and aggregate them into an honest success value with a specific error message on failure.
+After teardown, verify absence (interface, route, cron, and boot script gone) with one probe before reporting success; this verification also catches a watchdog that resurrected artifacts mid-teardown.
+This corrects an existing latent bug and is in scope because Disable builds directly on this primitive.
+
+### 4. Service orchestration
+
+Add `DisableAsync(mi)` and `EnableAsync(mi)` to `MonitoringInterfaceDeploymentService`.
+
+`DisableAsync(mi)`:
+
+1. Write the marker (this guards the teardown against a running watchdog).
+2. Take the flock and run the hardened `RemoveAsync` teardown.
+3. Verify absence.
+4. On success, persist `Disabled = true` via the targeted update (see below).
+   On failure, best-effort remove the marker, surface the error, and leave `Disabled = false`.
+   If the gateway is unreachable the marker write fails first, so Disable reports "gateway unreachable" and changes nothing.
+
+`EnableAsync(mi)`:
+
+1. Persist `Disabled = false`.
+2. Remove the marker.
+3. Run `DeployAsync(mi)` (writes a fresh boot script and cron).
+4. Report success only if `DeployAsync` succeeds; on deploy failure the row stays enabled with the existing "not deployed / needs re-apply" status rather than a fake success.
+
+Order rationale: for Disable, teardown-before-flag means a crash leaves an enabled row that looks "not deployed" (safe) instead of active artifacts hidden behind "Disabled".
+For Enable, flag-before-deploy means a crash cannot leave artifacts up while the UI still says "Disabled".
+A persisted pending/transition state is deliberately avoided; without a reconciliation worker it could get stuck, and strong teardown results plus live verification fit the current on-demand model better.
+
+### 5. `DeployAsync` guard
+
+`DeployAsync` rejects a call on a `Disabled` interface (no-op plus a clear message), so no path can silently deploy a paused row.
+
+### 6. Persistence
+
+Add a targeted `SetDisabledAsync(int id, bool value)` on the repository that updates only the `Disabled` column (and `UpdatedAt`) with an optimistic-concurrency check.
+This avoids `SaveMonitoringInterfaceAsync`, which copies every field from a detached object and could clobber a concurrent edit made in another browser tab after a slow SSH operation.
+
+### 7. UI (`MonitoringInterfacesCard.razor`)
+
+Add a Disable/Enable toggle button in the row action group, following the `RemoveInterface` handler, the `_busyId`/`_busyAction` busy-state, and the `_deploySteps`/`_message` conventions.
+An enabled row shows "Disable" (calls `DisableAsync`); a disabled row shows "Enable" (calls `EnableAsync`).
+`StatusBadge` gains a neutral "Disabled" branch, shown when `mi.Disabled`, distinct from Active (green) and error (red).
+Keep "Edit", "Check status", and "Remove" available for disabled rows; Check status is useful to diagnose leftover artifacts.
+`Snapshot()` must copy `Disabled`, otherwise editing a disabled row would silently save `false`.
+For a disabled row the edit form is save-only (`SaveOnly` must skip old-teardown for an already-disabled row), and "Save & Deploy" is presented as "Save & Enable" (save then `EnableAsync`); the edit form never calls `DeployAsync` on a disabled row.
+Clear the cached `_statuses` entry on every Disable/Enable transition so a stale "Active" badge cannot reappear.
+Hide Disable/Enable for manually-deployed rows (`IsManuallyDeployed == true`); we do not manage those artifacts.
+`SummaryLabel` may show a paused count (for example "4 configured, 1 paused") - optional.
+
+### 8. Queries and uniqueness
+
+Disabled rows keep participating in all uniqueness checks (`Name`, `AliasIp`, `GatewayLocalIp`, and cross-column), so two paused configurations cannot reserve the same gateway artifacts and collide when re-enabled.
+`GetByEffectiveIpAsync` keeps returning disabled rows; callers inspect `Disabled` rather than treating a disabled row as nonexistent.
+
+## Error handling summary
+
+- Disable, gateway unreachable: marker write fails, nothing changes, "gateway unreachable" surfaced, row stays enabled.
+- Disable, teardown step fails: no `Disabled` persisted, marker removed best-effort, specific error surfaced, row stays enabled.
+- Disable, watchdog resurrects mid-teardown: caught by post-teardown verification, treated as a teardown failure.
+- Enable, deploy fails: `Disabled` already cleared, marker removed, row shows "not deployed / needs re-apply", no fake success.
+- Concurrent Enable/Disable from two tabs: targeted `SetDisabledAsync` with optimistic concurrency; the loser gets a concurrency error rather than a clobber.
+
+## Testing
+
+- `DisableAsync`/`EnableAsync` orchestration: flag flips, call order, marker write/remove (gateway SSH and deploy mocked).
+- Teardown-failure paths: non-alias SSH failure and cron/script removal failure both prevent persisting `Disabled` and surface the error.
+- Watchdog exclusion: the script honours the marker at both check points (apply and cron install).
+- Post-teardown verification catches resurrection.
+- Edit: a disabled snapshot round-trips `Disabled`; "Save & Deploy" on a disabled row behaves as "Save & Enable"; `DeployAsync` rejects a disabled row.
+- Manual rows: Disable/Enable are hidden.
+- Enable with a failing deploy: the row stays enabled with no fake success.
+- Concurrency: interleaved Enable/Disable via `SetDisabledAsync` optimistic concurrency.
+- Migration: existing rows default to `Disabled = false` (seeded from the prior migration).
+
+## Open questions
+
+- While an interface is paused, any reachability check or alert against the modem/ONT IP elsewhere in the UI could still fire; no monitor consumes `MonitoringInterface` today, but if a surface does, it should reflect "paused" rather than "unreachable". Decide whether to annotate now or defer.

--- a/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IMonitoringInterfaceRepository.cs
@@ -21,4 +21,10 @@ public interface IMonitoringInterfaceRepository
 
     Task SaveMonitoringInterfaceAsync(MonitoringInterface config, CancellationToken cancellationToken = default);
     Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Flips the Disabled flag on a single row without touching any other field (targeted
+    /// update). Used by Disable/Enable so a paused interface keeps its full config.
+    /// </summary>
+    Task SetDisabledAsync(int id, bool disabled, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721000000_AddMonitoringInterfaceDisabled")]
+    partial class AddMonitoringInterfaceDisabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260721000000_AddMonitoringInterfaceDisabled.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <summary>
+/// Adds MonitoringInterfaces.Disabled: true when the user disabled (un-deployed) an
+/// interface but kept its config for later re-enable. Defaults to false so existing
+/// rows stay deployed.
+/// </summary>
+public partial class AddMonitoringInterfaceDisabled : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<bool>(
+            name: "Disabled",
+            table: "MonitoringInterfaces",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Disabled",
+            table: "MonitoringInterfaces");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringInterface.cs
@@ -89,6 +89,9 @@ public class MonitoringInterface
     /// </summary>
     public bool IsManuallyDeployed { get; set; }
 
+    /// <summary>True when the user disabled (un-deployed) this interface but kept its config for later re-enable.</summary>
+    public bool Disabled { get; set; }
+
     /// <summary>Last deployment/repair error message (null if last action succeeded).</summary>
     [MaxLength(1000)]
     public string? LastError { get; set; }

--- a/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/MonitoringInterfaceRepository.cs
@@ -143,6 +143,7 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
                     existing.SnatEnabled = config.SnatEnabled;
                     existing.WatchdogIntervalMinutes = config.WatchdogIntervalMinutes;
                     existing.IsManuallyDeployed = config.IsManuallyDeployed;
+                    existing.Disabled = config.Disabled;
                     existing.LastError = config.LastError;
                     existing.UpdatedAt = DateTime.UtcNow;
                 }
@@ -167,6 +168,15 @@ public class MonitoringInterfaceRepository : IMonitoringInterfaceRepository
             _logger.LogError(ex, "Failed to save monitoring interface {Name}", config.Name);
             throw;
         }
+    }
+
+    public async Task SetDisabledAsync(int id, bool disabled, CancellationToken cancellationToken = default)
+    {
+        var existing = await _context.MonitoringInterfaces.FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+        if (existing == null) return;
+        existing.Disabled = disabled;
+        existing.UpdatedAt = DateTime.UtcNow;
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     public async Task DeleteMonitoringInterfaceAsync(int id, CancellationToken cancellationToken = default)

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -417,6 +417,7 @@
         AliasIp = mi.AliasIp,
         SnatEnabled = mi.SnatEnabled,
         WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes,
+        IsManuallyDeployed = mi.IsManuallyDeployed,
         Disabled = mi.Disabled
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -73,31 +73,51 @@
                                 <td><code>@mi.GatewayLocalIp/@mi.SubnetPrefix</code></td>
                                 <td>@StatusBadge(mi)</td>
                                 <td>
-                                    <div class="btn-group-wrap">
+                                    <div class="btn-group-wrap mi-row-actions">
                                         <button class="btn btn-secondary btn-sm" @onclick="() => EditInterface(mi)" disabled="@(_busyId != null)">Edit</button>
-                                        <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
-                                            @if (_busyId == mi.Id && _busyAction == "deploy")
-                                            {
-                                                <span class="spinner spinner-sm"></span>
-                                                <span>Deploying...</span>
-                                            }
-                                            else
-                                            {
-                                                <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
-                                            }
-                                        </button>
-                                        <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
-                                        @if (ShowDisableToggle(mi))
+                                        @if (mi.Disabled)
                                         {
-                                            <button class="btn btn-outline-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
-                                                @if (_busyId == mi.Id && (_busyAction == "disable" || _busyAction == "enable"))
+                                            @* Disabled rows expose exactly one forward action - Enable - in the primary
+                                               slot (it redeploys), so Deploy/Re-apply (which would just hit the disabled
+                                               guard) and the separate Disable toggle are both omitted here. *@
+                                            <button class="btn btn-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "enable")
                                                 {
                                                     <span class="spinner spinner-sm"></span>
-                                                    <span>@(mi.Disabled ? "Enabling..." : "Disabling...")</span>
+                                                    <span>Enabling...</span>
                                                 }
                                                 else
                                                 {
-                                                    <span>@(mi.Disabled ? "Enable" : "Disable")</span>
+                                                    <span>Enable</span>
+                                                }
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button class="btn btn-primary btn-sm" @onclick="() => DeployInterface(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "deploy")
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>Deploying...</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>@(IsApplied(mi) ? "Re-apply" : "Deploy")</span>
+                                                }
+                                            </button>
+                                        }
+                                        <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
+                                        @if (ShowDisableToggle(mi) && !mi.Disabled)
+                                        {
+                                            <button class="btn btn-outline-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && _busyAction == "disable")
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>Disabling...</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>Disable</span>
                                                 }
                                             </button>
                                         }

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -878,12 +878,14 @@
         StateHasChanged();
         try
         {
+            var enabledOk = false;
             if (mi.Disabled)
             {
                 var result = await Deploy.EnableAsync(mi);
                 _deploySteps = result.Steps;
                 _message = result.Message;
                 _messageSuccess = result.Success;
+                enabledOk = result.Success;
             }
             else
             {
@@ -896,6 +898,12 @@
             }
             _statuses.Remove(mi.Id);
             await LoadAsync();
+            // A successful Enable just (re)deployed the interface, so refresh its status silently -
+            // otherwise the badge sits at "Unknown" until a manual Check status, even though the
+            // deploy succeeded (mirrors the Deploy button's post-deploy refresh). After a Disable
+            // the badge reads "Disabled" straight from the flag and needs no probe.
+            if (enabledOk)
+                await CheckStatus(mi, silent: true);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -87,6 +87,20 @@
                                             }
                                         </button>
                                         <button class="btn btn-secondary btn-sm" @onclick="() => CheckStatus(mi)" disabled="@(_busyId != null)">Check status</button>
+                                        @if (ShowDisableToggle(mi))
+                                        {
+                                            <button class="btn btn-outline-primary btn-sm" @onclick="() => ToggleDisable(mi)" disabled="@(_busyId != null)">
+                                                @if (_busyId == mi.Id && (_busyAction == "disable" || _busyAction == "enable"))
+                                                {
+                                                    <span class="spinner spinner-sm"></span>
+                                                    <span>@(mi.Disabled ? "Enabling..." : "Disabling...")</span>
+                                                }
+                                                else
+                                                {
+                                                    <span>@(mi.Disabled ? "Enable" : "Disable")</span>
+                                                }
+                                            </button>
+                                        }
                                         <button class="btn btn-danger btn-sm" @onclick="() => RemoveInterface(mi)" disabled="@(_busyId != null)">
                                             @if (_busyId == mi.Id && _busyAction == "remove")
                                             {
@@ -386,7 +400,11 @@
 
     private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
 
-    private static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
+    /// <summary>
+    /// Test-visible (internal, see NetworkOptimizer.Web.csproj InternalsVisibleTo) so the
+    /// Disabled-copy can be verified without a Blazor component-test harness.
+    /// </summary>
+    internal static MonitoringInterface Snapshot(MonitoringInterface mi) => new()
     {
         Id = mi.Id,
         Name = mi.Name,
@@ -398,7 +416,8 @@
         GatewayLocalIp = mi.GatewayLocalIp,
         AliasIp = mi.AliasIp,
         SnatEnabled = mi.SnatEnabled,
-        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes
+        WatchdogIntervalMinutes = mi.WatchdogIntervalMinutes,
+        Disabled = mi.Disabled
     };
 
     // A gateway re-teardown is needed when an edit changes anything the boot script bakes
@@ -515,8 +534,14 @@
     }
 
     private string SummaryLabel()
-        => _interfaces.Count == 0 ? "None configured"
+    {
+        if (_interfaces.Count == 0)
+            return "None configured";
+        var paused = _interfaces.Count(i => i.Disabled);
+        return paused > 0
+            ? $"{_interfaces.Count} configured, {paused} paused"
             : $"{_interfaces.Count} configured";
+    }
 
     private async Task LoadAsync()
     {
@@ -695,7 +720,11 @@
             return;
         }
 
-        var deployResult = await DeployInterfaceReturningResult(saved);
+        // A disabled row that's edited and re-saved should come back enabled: route through
+        // Enable so the paused flag and gateway marker are cleared before redeploying.
+        var deployResult = saved.Disabled
+            ? await EnableInterfaceReturningResult(saved)
+            : await DeployInterfaceReturningResult(saved);
 
         // On a Gate 2 collision, re-enter edit mode on the row we just saved so the user can
         // see and fill in the suggested Alias IP - SaveAndDeploy would otherwise leave the
@@ -760,17 +789,27 @@
         }
     }
 
-    private async Task<MonitoringInterfaceDeploymentService.DeployResult> DeployInterfaceReturningResult(MonitoringInterface mi)
+    private Task<MonitoringInterfaceDeploymentService.DeployResult> DeployInterfaceReturningResult(MonitoringInterface mi)
+        => RunDeployAsync(mi, "deploy", () => Deploy.DeployAsync(mi));
+
+    // "Save & Deploy" on a disabled row means "Save & Enable": Enable clears the paused flag and
+    // marker first, then redeploys - going through DeployAsync directly would hit its disabled
+    // guard and Skip.
+    private Task<MonitoringInterfaceDeploymentService.DeployResult> EnableInterfaceReturningResult(MonitoringInterface mi)
+        => RunDeployAsync(mi, "enable", () => Deploy.EnableAsync(mi));
+
+    private async Task<MonitoringInterfaceDeploymentService.DeployResult> RunDeployAsync(
+        MonitoringInterface mi, string action, Func<Task<MonitoringInterfaceDeploymentService.DeployResult>> operation)
     {
         _busyId = mi.Id;
-        _busyAction = "deploy";
+        _busyAction = action;
         _message = null;
         _deploySteps.Clear();
         DisarmAllForceRemove();
         StateHasChanged();
         try
         {
-            var result = await Deploy.DeployAsync(mi);
+            var result = await operation();
             _deploySteps = result.Steps;
             _message = result.Message;
             _messageSuccess = result.Success;
@@ -787,8 +826,8 @@
         }
         catch (Exception ex)
         {
-            Logger.LogError(ex, "Deploy failed for monitoring interface {Id}", mi.Id);
-            _message = $"Deploy failed: {ex.Message}";
+            Logger.LogError(ex, "{Action} failed for monitoring interface {Id}", action, mi.Id);
+            _message = $"{char.ToUpper(action[0]) + action[1..]} failed: {ex.Message}";
             _messageSuccess = false;
             return new MonitoringInterfaceDeploymentService.DeployResult(
                 false, MonitoringInterfaceDeploymentService.PreflightBlock.GatewayUnreachable, _message, _deploySteps);
@@ -802,6 +841,54 @@
     }
 
     private Task DeployInterface(MonitoringInterface mi) => DeployInterfaceReturningResult(mi);
+
+    /// <summary>
+    /// Toggle a row between disabled (torn down on the gateway, config kept) and enabled
+    /// (redeployed). Mirrors the deploy/remove busy pattern so the button spins and every other
+    /// action is disabled while it runs, then reloads to reflect the new persisted flag.
+    /// </summary>
+    private async Task ToggleDisable(MonitoringInterface mi)
+    {
+        _busyId = mi.Id;
+        _busyAction = mi.Disabled ? "enable" : "disable";
+        _message = null;
+        _deploySteps.Clear();
+        DisarmAllForceRemove();
+        StateHasChanged();
+        try
+        {
+            if (mi.Disabled)
+            {
+                var result = await Deploy.EnableAsync(mi);
+                _deploySteps = result.Steps;
+                _message = result.Message;
+                _messageSuccess = result.Success;
+            }
+            else
+            {
+                var (success, steps) = await Deploy.DisableAsync(mi);
+                _deploySteps = steps;
+                _message = success
+                    ? $"Monitoring interface {mi.Name} disabled. Its config is kept - click Enable to redeploy it."
+                    : $"Couldn't disable {mi.Name}. {(steps.Count > 0 ? steps[^1] : "")}".Trim();
+                _messageSuccess = success;
+            }
+            _statuses.Remove(mi.Id);
+            await LoadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Disable/Enable toggle failed for monitoring interface {Id}", mi.Id);
+            _message = $"Action failed: {ex.Message}";
+            _messageSuccess = false;
+        }
+        finally
+        {
+            _busyId = null;
+            _busyAction = null;
+            StateHasChanged();
+        }
+    }
 
     /// <summary>
     /// What a Remove click should do, given whether this row already had a failed attempt
@@ -913,37 +1000,40 @@
 
     private RenderFragment StatusBadge(MonitoringInterface mi) => builder =>
     {
-        string cls, text;
-        if (!_statuses.TryGetValue(mi.Id, out var s))
-        {
-            cls = "status-disconnected";
-            text = "Unknown";
-        }
-        else if (!s.GatewayReachable)
-        {
-            cls = "status-disconnected";
-            text = "Gateway unreachable";
-        }
-        else if (s.IsFullyApplied(mi))
-        {
-            cls = "status-connected";
-            text = "Active";
-        }
-        else if (s.InterfaceExists || s.BootScriptPresent)
-        {
-            cls = "status-disconnected";
-            text = "Needs re-apply";
-        }
-        else
-        {
-            cls = "status-disconnected";
-            text = "Not deployed";
-        }
+        var (cls, text) = StatusBadgeContent(mi, _statuses.TryGetValue(mi.Id, out var s) ? s : null);
         builder.OpenElement(0, "span");
         builder.AddAttribute(1, "class", $"status-badge {cls}");
         builder.AddContent(2, text);
         builder.CloseElement();
     };
+
+    /// <summary>
+    /// Pure badge decision (class + label) for a row given its last live status (null when never
+    /// probed). Extracted as internal (see NetworkOptimizer.Web.csproj InternalsVisibleTo) so it
+    /// can be unit-tested without a Blazor renderer, mirroring DecideRemoveOutcome. A disabled
+    /// row reads "Disabled" regardless of any stale status - it's paused by the user's choice.
+    /// </summary>
+    internal static (string cls, string text) StatusBadgeContent(
+        MonitoringInterface mi, MonitoringInterfaceDeploymentService.InterfaceStatus? s)
+    {
+        if (mi.Disabled)
+            return ("status-disconnected", "Disabled");
+        if (s == null)
+            return ("status-disconnected", "Unknown");
+        if (!s.GatewayReachable)
+            return ("status-disconnected", "Gateway unreachable");
+        if (s.IsFullyApplied(mi))
+            return ("status-connected", "Active");
+        if (s.InterfaceExists || s.BootScriptPresent)
+            return ("status-disconnected", "Needs re-apply");
+        return ("status-disconnected", "Not deployed");
+    }
+
+    /// <summary>
+    /// Whether the Disable/Enable toggle is shown for a row. Hidden for manually-deployed rows:
+    /// Disable/Enable operate on gateway artifacts this app deploys, not a hand-built config.
+    /// </summary>
+    internal static bool ShowDisableToggle(MonitoringInterface mi) => !mi.IsManuallyDeployed;
 
     private string WanLabelFor(MonitoringInterface mi)
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -418,6 +418,9 @@ public class MonitoringInterfaceDeploymentService
         if (mi.Disabled)
             return new DeployResult(false, PreflightBlock.Skipped, "Interface is disabled; enable it first.", steps);
 
+        // Validate before building any SSH command from mi (boot script, marker path, gates).
+        EnsureShellSafeStrings(mi);
+
         var preflight = await PreflightAsync(mi, ct);
         if (!preflight.Ok)
             return new DeployResult(false, preflight.Block, preflight.Message, steps);
@@ -479,7 +482,12 @@ public class MonitoringInterfaceDeploymentService
         // We are (re)deploying, so this interface must not carry a stale disabled marker - a
         // leftover one (e.g. from a Disable whose marker rollback could not reach the gateway)
         // would make the boot script we write below early-out and silently no-op the deploy.
-        await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null || true");
+        // Check the result: if the marker cannot be cleared the script would bail, so fail
+        // loudly rather than reporting a deploy that did nothing.
+        var markerClear = await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null");
+        if (!markerClear.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable,
+                "Could not clear the disabled marker on the gateway; the boot script would no-op. Retry when the gateway is reachable.", steps);
 
         // Write and run the idempotent boot script.
         var script = GenerateBootScript(mi);
@@ -674,9 +682,19 @@ public class MonitoringInterfaceDeploymentService
     /// </summary>
     public async Task<DeployResult> EnableAsync(MonitoringInterface mi, CancellationToken ct = default)
     {
+        // Validate up front so a corrupt name fails before we mutate DB state or build any SSH
+        // command from it (Codex review: Enable previously skipped this).
+        EnsureShellSafeStrings(mi);
         await _repo.SetDisabledAsync(mi.Id, false);
         mi.Disabled = false;
-        await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null || true");
+        // Clear the marker up front (checked) so Enable un-pauses the interface even if the
+        // deploy below fails. If the marker cannot be cleared the boot script would no-op, so
+        // surface that instead of the unchecked "|| true" the review flagged.
+        var markerClear = await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null");
+        if (!markerClear.success)
+            return new DeployResult(false, PreflightBlock.GatewayUnreachable,
+                "Could not clear the disabled marker on the gateway; retry when it is reachable.",
+                new List<string>());
         return await DeployAsync(mi, ct);
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -3,6 +3,7 @@ using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 using System.Text;
 using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web.Services.Ssh;
@@ -23,6 +24,7 @@ public class MonitoringInterfaceDeploymentService
     private readonly IGatewaySshService _gatewaySsh;
     private readonly IUdmBootService _udmBoot;
     private readonly UniFiConnectionService _connection;
+    private readonly IMonitoringInterfaceRepository _repo;
 
     private const string OnBootDir = "/data/on_boot.d";
 
@@ -42,12 +44,14 @@ public class MonitoringInterfaceDeploymentService
         ILogger<MonitoringInterfaceDeploymentService> logger,
         IGatewaySshService gatewaySsh,
         IUdmBootService udmBoot,
-        UniFiConnectionService connection)
+        UniFiConnectionService connection,
+        IMonitoringInterfaceRepository repo)
     {
         _logger = logger;
         _gatewaySsh = gatewaySsh;
         _udmBoot = udmBoot;
         _connection = connection;
+        _repo = repo;
     }
 
     private static string ScriptName(MonitoringInterface mi) => $"30-monitoring-iface-{mi.Name}.sh";
@@ -408,6 +412,12 @@ public class MonitoringInterfaceDeploymentService
     {
         var steps = new List<string>();
 
+        // A disabled interface must never (re)deploy - Enable clears the flag first (and sets
+        // mi.Disabled=false on the instance it passes here). Guards both the UI path and any
+        // direct caller that hands us a still-disabled row.
+        if (mi.Disabled)
+            return new DeployResult(false, PreflightBlock.Skipped, "Interface is disabled; enable it first.", steps);
+
         var preflight = await PreflightAsync(mi, ct);
         if (!preflight.Ok)
             return new DeployResult(false, preflight.Block, preflight.Message, steps);
@@ -622,6 +632,47 @@ public class MonitoringInterfaceDeploymentService
         }
 
         return (success, steps);
+    }
+
+    /// <summary>
+    /// Disable a monitoring interface: write the gateway marker FIRST (so the cron watchdog and
+    /// a boot run early-out and can't re-apply mid-teardown), then run the hardened+verified
+    /// teardown. Only on a clean teardown is the DB flag set. A teardown failure rolls the marker
+    /// back and leaves the row enabled, so the interface is never left half-paused. The config
+    /// row is kept for later <see cref="EnableAsync"/>.
+    /// </summary>
+    public async Task<(bool success, List<string> steps)> DisableAsync(MonitoringInterface mi)
+    {
+        EnsureShellSafeStrings(mi);
+        var marker = DisabledMarkerPath(mi);
+        var write = await RunAsync($"mkdir -p '{DisabledMarkerDir}' && : > '{marker}'");
+        if (!write.success)
+            return (false, new List<string> { "Could not reach the gateway to disable (marker write failed)." });
+
+        var (removed, steps) = await RemoveAsync(mi);
+        if (!removed)
+        {
+            await RunAsync($"rm -f '{marker}' 2>/dev/null || true");
+            steps.Add("Teardown failed; interface left enabled.");
+            return (false, steps);
+        }
+
+        await _repo.SetDisabledAsync(mi.Id, true);
+        steps.Add("Interface disabled (config kept).");
+        return (true, steps);
+    }
+
+    /// <summary>
+    /// Enable a previously disabled interface: clear the DB flag and remove the gateway marker
+    /// first, then redeploy. A deploy failure does not re-disable the row - the failed
+    /// <see cref="DeployResult"/> is returned as-is so the user sees the real reason.
+    /// </summary>
+    public async Task<DeployResult> EnableAsync(MonitoringInterface mi, CancellationToken ct = default)
+    {
+        await _repo.SetDisabledAsync(mi.Id, false);
+        mi.Disabled = false;
+        await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null || true");
+        return await DeployAsync(mi, ct);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -476,6 +476,11 @@ public class MonitoringInterfaceDeploymentService
                   "boot script sweeping or overwriting a foreign rule in this range undetected.");
         }
 
+        // We are (re)deploying, so this interface must not carry a stale disabled marker - a
+        // leftover one (e.g. from a Disable whose marker rollback could not reach the gateway)
+        // would make the boot script we write below early-out and silently no-op the deploy.
+        await RunAsync($"rm -f '{DisabledMarkerPath(mi)}' 2>/dev/null || true");
+
         // Write and run the idempotent boot script.
         var script = GenerateBootScript(mi);
         var unix = script.Replace("\r\n", "\n").Replace("\r", "\n");

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -532,18 +532,82 @@ public class MonitoringInterfaceDeploymentService
             steps.Add("Alias id is outside the aliasable range - no alias mark/DNAT/policy-route artifacts existed to remove.");
         }
 
+        // Base teardown: guard-check-then-act and capture each result (mirroring the alias
+        // block above), so "nothing to remove" stays a clean success while a genuine removal
+        // failure flips success - rather than the old fire-and-forget "|| true" that swallowed
+        // every failure. Each guard confirms the artifact is present before deleting it, so an
+        // aliased row (no main-table route/SNAT to remove) or a never-fully-deployed one simply
+        // finds nothing and succeeds.
         if (mi.SnatEnabled)
         {
-            await RunAsync($"iptables -w 5 -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null || true");
-            steps.Add("Removed SNAT rule.");
+            var snatDel = await RunAsync(
+                $"if iptables -w 5 -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null; " +
+                $"then iptables -w 5 -t nat -D POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null; fi");
+            if (!snatDel.success)
+            {
+                success = false;
+                steps.Add("WARNING: failed to remove SNAT rule - check the gateway manually.");
+            }
+            else
+            {
+                steps.Add("Removed SNAT rule.");
+            }
         }
 
-        await RunAsync($"ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null || true");
-        await RunAsync($"ip link del {mi.Name} 2>/dev/null || true");
-        steps.Add("Removed route and macvlan interface.");
+        var routeDel = await RunAsync(
+            $"if ip route show {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null | grep -q .; " +
+            $"then ip route del {mi.TargetIp}/32 dev {mi.Name} 2>/dev/null; fi");
+        var linkDel = await RunAsync(
+            $"if ip link show {mi.Name} >/dev/null 2>&1; then ip link del {mi.Name} 2>/dev/null; fi");
+        if (!routeDel.success || !linkDel.success)
+        {
+            success = false;
+            steps.Add("WARNING: failed to remove route/macvlan - check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Removed route and macvlan interface.");
+        }
 
-        await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null || true");
-        steps.Add("Removed boot script.");
+        // rm -f is a no-op success for an absent file; a nonzero here is a real error (e.g. a
+        // read-only /data), so capture it instead of masking it with "|| true".
+        var scriptDel = await RunAsync($"rm -f '{path}' /tmp/netopt-moniface-{mi.Name}.log 2>/dev/null");
+        if (!scriptDel.success)
+        {
+            success = false;
+            steps.Add("WARNING: failed to remove boot script - check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Removed boot script.");
+        }
+
+        // Absence verification: re-probe the interface, main-table route, cron entry, and boot
+        // script. If any is still present after teardown, the cron watchdog may have re-applied
+        // it mid-teardown (a race Disable closes with the marker, Task 4) - flag it rather than
+        // reporting a clean removal. Trailing "true" keeps the SSH exit code tied to reachability,
+        // not to whether a probe matched.
+        var verify = await RunAsync(
+            $"ip link show {mi.Name} >/dev/null 2>&1 && echo IFACE; " +
+            $"ip route show {mi.TargetIp}/32 2>/dev/null | grep -q \"dev {mi.Name}\" && echo ROUTE; " +
+            $"crontab -l 2>/dev/null | grep -qF '{path}' && echo CRON; " +
+            $"test -f '{path}' && echo SCRIPT; " +
+            "true");
+        if (!verify.success)
+        {
+            success = false;
+            steps.Add("WARNING: could not verify teardown (gateway unreachable) - check the gateway manually.");
+        }
+        else if (verify.output.Contains("IFACE") || verify.output.Contains("ROUTE") ||
+                 verify.output.Contains("CRON") || verify.output.Contains("SCRIPT"))
+        {
+            success = false;
+            steps.Add("WARNING: teardown verification failed - artifacts still present (watchdog resurrection?). Check the gateway manually.");
+        }
+        else
+        {
+            steps.Add("Verified teardown: no residual artifacts.");
+        }
 
         return (success, steps);
     }

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -26,6 +26,18 @@ public class MonitoringInterfaceDeploymentService
 
     private const string OnBootDir = "/data/on_boot.d";
 
+    /// <summary>
+    /// Directory (under <c>/data</c>, so it survives reboots and firmware updates like the boot
+    /// scripts) holding one marker file per disabled interface. The boot script and cron
+    /// watchdog early-out when this interface's marker is present, so a disabled interface stays
+    /// torn down without deleting its script. Deliberately NOT under <c>on_boot.d</c> - a file
+    /// there would be executed at boot.
+    /// </summary>
+    public const string DisabledMarkerDir = "/data/monitoring-ifaces.disabled";
+
+    /// <summary>Marker path for a given interface (see <see cref="DisabledMarkerDir"/>).</summary>
+    public static string DisabledMarkerPath(MonitoringInterface mi) => $"{DisabledMarkerDir}/{mi.Name}";
+
     public MonitoringInterfaceDeploymentService(
         ILogger<MonitoringInterfaceDeploymentService> logger,
         IGatewaySshService gatewaySsh,
@@ -841,6 +853,7 @@ MASK=""__MASK__""
 TABLE=""__TABLE__""
 WATCHDOG_MIN=""__WATCHDOG_MIN__""
 SCRIPT=""__SCRIPT_PATH__""
+MARKER=""/data/monitoring-ifaces.disabled/__IFACE__""
 LOG=""/tmp/netopt-moniface-__IFACE__.log""
 
 log() { echo ""$(date '+%Y-%m-%d %H:%M:%S') $1"" >> ""$LOG"" 2>/dev/null; }
@@ -861,11 +874,21 @@ cleanup_marked_rules() {
     rm -f ""$tmp""
 }
 
+# If disabled by the app, do nothing and do not (re)install cron. The marker lets a disabled
+# interface stay torn down across reboots without deleting this script.
+[ -f ""$MARKER"" ] && { log ""disabled marker present, skipping""; exit 0; }
+
 # The physical WAN port must exist; if not (boot race), let the watchdog retry later.
 ip link show ""$WAN_IF"" >/dev/null 2>&1 || { log ""wan $WAN_IF absent, deferring""; exit 0; }
 
 changed=0
 fail=0
+
+# Serialize a manual apply against the cron watchdog tick on a per-interface lock. flock holds
+# fd 9 in the CURRENT shell (not a subshell), so changed/fail set below still reach the final
+# status check; non-blocking, so if another apply already holds the lock we skip this tick.
+exec 9>""/tmp/monitoring-iface-__IFACE__.lock""
+flock -n 9 || { log ""apply already running, skipping""; exit 0; }
 
 # 0. resolve the macvlan parent. With a VLAN, the parent is the subinterface (e.g.
 # eth6.100) so frames are tagged; UniFi creates it for a VLAN WAN, but if it's absent
@@ -960,8 +983,10 @@ if [ ""$SNAT_ENABLED"" = ""1"" ]; then
     fi
 fi
 
-# 5. self-install the cron watchdog (re-applies after reprovision)
-if ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
+# 5. self-install the cron watchdog (re-applies after reprovision). Re-check the marker first:
+# Disable may have written it after the top-of-script check but before we reached here, and we
+# must not reinstall the cron that would immediately re-apply the interface it just tore down.
+if [ ! -f ""$MARKER"" ] && ! crontab -l 2>/dev/null | grep -qF ""$SCRIPT""; then
     (crontab -l 2>/dev/null; echo ""*/$WATCHDOG_MIN * * * * $SCRIPT >/dev/null 2>&1"") | crontab -
     changed=1
 fi

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -622,19 +622,37 @@ public class MonitoringInterfaceDeploymentService
         // it mid-teardown (a race Disable closes with the marker, Task 4) - flag it rather than
         // reporting a clean removal. Trailing "true" keeps the SSH exit code tied to reachability,
         // not to whether a probe matched.
-        var verify = await RunAsync(
+        var verifyProbes =
             $"ip link show {mi.Name} >/dev/null 2>&1 && echo IFACE; " +
             $"ip route show {mi.TargetIp}/32 2>/dev/null | grep -q \"dev {mi.Name}\" && echo ROUTE; " +
             $"crontab -l 2>/dev/null | grep -qF '{path}' && echo CRON; " +
-            $"test -f '{path}' && echo SCRIPT; " +
-            "true");
+            $"test -f '{path}' && echo SCRIPT; ";
+        // Also verify the SNAT rule and (for an aliased row) the mangle mark, nat DNAT, policy
+        // rule, and private route table are gone - a teardown step that silently failed to remove
+        // one of these would otherwise coexist with a "clean" result.
+        if (mi.SnatEnabled)
+            verifyProbes += $"iptables -w 5 -t nat -C POSTROUTING -o {mi.Name} -d {mi.TargetIp} -j SNAT --to-source {mi.GatewayLocalIp} 2>/dev/null && echo SNAT; ";
+        if (mi.AliasIp != null && IsAliasableId(mi.Id))
+        {
+            var vmark = AliasMark(mi.Id);
+            var vtable = AliasTable(mi.Id);
+            verifyProbes +=
+                $"iptables -w 5 -t mangle -C PREROUTING -d {mi.AliasIp} -j MARK --set-xmark {vmark}/{AliasMarkMask} 2>/dev/null && echo AMARK; " +
+                $"iptables -w 5 -t nat -C PREROUTING -m mark --mark {vmark}/{AliasMarkMask} -j DNAT --to-destination {mi.TargetIp} 2>/dev/null && echo ADNAT; " +
+                $"ip rule show 2>/dev/null | grep -qF 'fwmark {vmark}/{AliasMarkMask} lookup {vtable}' && echo ARULE; " +
+                $"ip route show table {vtable} 2>/dev/null | grep -q . && echo ATABLE; ";
+        }
+        var verify = await RunAsync(verifyProbes + "true");
         if (!verify.success)
         {
             success = false;
             steps.Add("WARNING: could not verify teardown (gateway unreachable) - check the gateway manually.");
         }
         else if (verify.output.Contains("IFACE") || verify.output.Contains("ROUTE") ||
-                 verify.output.Contains("CRON") || verify.output.Contains("SCRIPT"))
+                 verify.output.Contains("CRON") || verify.output.Contains("SCRIPT") ||
+                 verify.output.Contains("SNAT") || verify.output.Contains("AMARK") ||
+                 verify.output.Contains("ADNAT") || verify.output.Contains("ARULE") ||
+                 verify.output.Contains("ATABLE"))
         {
             success = false;
             steps.Add("WARNING: teardown verification failed - artifacts still present (watchdog resurrection?). Check the gateway manually.");
@@ -661,6 +679,13 @@ public class MonitoringInterfaceDeploymentService
         var write = await RunAsync($"mkdir -p '{DisabledMarkerDir}' && : > '{marker}'");
         if (!write.success)
             return (false, new List<string> { "Could not reach the gateway to disable (marker write failed)." });
+
+        // Drain any in-flight watchdog apply before tearing down: block on the boot script's
+        // per-interface apply lock so an apply that started before the marker existed finishes and
+        // cannot recreate artifacts after our teardown/verify. New applies already bail at the
+        // marker check, so once the lock is free the teardown runs uncontended. Bounded wait; on
+        // timeout the verification inside RemoveAsync is the safety net.
+        await RunAsync($"flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null || true");
 
         var (removed, steps) = await RemoveAsync(mi);
         if (!removed)

--- a/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInterfaceDeploymentService.cs
@@ -682,10 +682,20 @@ public class MonitoringInterfaceDeploymentService
 
         // Drain any in-flight watchdog apply before tearing down: block on the boot script's
         // per-interface apply lock so an apply that started before the marker existed finishes and
-        // cannot recreate artifacts after our teardown/verify. New applies already bail at the
-        // marker check, so once the lock is free the teardown runs uncontended. Bounded wait; on
-        // timeout the verification inside RemoveAsync is the safety net.
-        await RunAsync($"flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null || true");
+        // cannot recreate artifacts after our teardown. Together with the boot script re-checking
+        // the marker AFTER it acquires this lock, this closes the resurrection race both ways
+        // (apply-already-holds-lock, and apply-takes-lock-after-the-marker). If the drain times
+        // out an apply is stuck holding the lock, so abort instead of tearing down underneath it -
+        // roll the marker back and leave the row enabled to retry.
+        var drain = await RunAsync($"flock -w 30 '/tmp/monitoring-iface-{mi.Name}.lock' true 2>/dev/null");
+        if (!drain.success)
+        {
+            await RunAsync($"rm -f '{marker}' 2>/dev/null || true");
+            return (false, new List<string>
+            {
+                "A gateway apply for this interface is still running (lock not released in time); try disabling again in a moment."
+            });
+        }
 
         var (removed, steps) = await RemoveAsync(mi);
         if (!removed)
@@ -988,6 +998,10 @@ fail=0
 # status check; non-blocking, so if another apply already holds the lock we skip this tick.
 exec 9>""/tmp/monitoring-iface-__IFACE__.lock""
 flock -n 9 || { log ""apply already running, skipping""; exit 0; }
+# Re-check the marker now that we hold the lock: Disable may have written it (and drained the
+# lock) while we were between the top-of-script check and acquiring this lock. Bail before
+# applying anything so a paused apply cannot resurrect artifacts after Disable's teardown.
+[ -f ""$MARKER"" ] && { log ""disabled marker appeared after lock, skipping""; exit 0; }
 
 # 0. resolve the macvlan parent. With a VLAN, the parent is the subinterface (e.g.
 # eth6.100) so frames are tagged; UniFi creates it for a VLAN WAN, but if it's absent

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2241,6 +2241,19 @@ a.btn-sm {
     gap: 0.5rem;
 }
 
+/* Monitoring Interfaces row actions: keep the action buttons on one line by overriding the
+   global .btn min-width and tightening spacing. The table-responsive wrapper provides
+   horizontal scroll on very narrow screens. */
+.mi-row-actions {
+    flex-wrap: nowrap;
+    gap: 0.375rem;
+}
+
+.mi-row-actions .btn {
+    min-width: 0;
+    padding: 0 12px;
+}
+
 .btn-lg {
     height: 44px;
     padding: 0 24px;

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceMigrationTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceMigrationTests.cs
@@ -161,4 +161,16 @@ public class MonitoringInterfaceMigrationTests : IDisposable
                 .WithMessage("*change*");
         }
     }
+
+    [Fact]
+    public void Disabled_DefaultsToFalse_ForExistingAndNewRows()
+    {
+        using var context = CreateContext();
+        MigrationSafety.MigrateWithFriendlyErrors(context);
+        context.Database.ExecuteSqlRaw(
+            "INSERT INTO MonitoringInterfaces (Name, WanIfName, TargetIp, SubnetPrefix, GatewayLocalIp, SnatEnabled, WatchdogIntervalMinutes, IsManuallyDeployed, CreatedAt, UpdatedAt) " +
+            "VALUES ('modem0','eth4','192.168.100.1',24,'192.168.100.2',1,5,0,'2026-01-01','2026-01-01');");
+        var disabled = context.Database.SqlQueryRaw<bool>("SELECT Disabled FROM MonitoringInterfaces WHERE Name='modem0'").AsEnumerable().Single();
+        disabled.Should().BeFalse();
+    }
 }

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInterfaceRepositoryTests.cs
@@ -163,4 +163,29 @@ public class MonitoringInterfaceRepositoryTests : IDisposable
         byTarget!.Name.Should().Be("ont0");
         byAlias!.Name.Should().Be("starlink0");
     }
+
+    [Fact]
+    public async Task SetDisabledAsync_TogglesFlagAndBumpsUpdatedAt()
+    {
+        var mi = Valid("modem0", "eth4", "192.168.100.1", "192.168.100.2");
+        await _repository.SaveMonitoringInterfaceAsync(mi);
+        var before = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!.UpdatedAt;
+        await _repository.SetDisabledAsync(mi.Id, true);
+        var after = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!;
+        after.Disabled.Should().BeTrue();
+        after.UpdatedAt.Should().BeOnOrAfter(before);
+        after.TargetIp.Should().Be(mi.TargetIp);
+    }
+
+    [Fact]
+    public async Task SaveMonitoringInterfaceAsync_PreservesDisabledOnEdit()
+    {
+        var mi = Valid("modem0", "eth4", "192.168.100.1", "192.168.100.2");
+        await _repository.SaveMonitoringInterfaceAsync(mi);
+        await _repository.SetDisabledAsync(mi.Id, true);
+        var edit = (await _repository.GetMonitoringInterfaceAsync(mi.Id))!;
+        edit.WatchdogIntervalMinutes = 7;
+        await _repository.SaveMonitoringInterfaceAsync(edit);
+        (await _repository.GetMonitoringInterfaceAsync(mi.Id))!.Disabled.Should().BeTrue();
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -678,6 +678,41 @@ public class MonitoringInterfaceDeploymentServiceTests
     }
 
     [Fact]
+    public async Task RemoveAsync_NonAliased_AllTeardownStepsSucceedAndNothingLingers_ReportsSuccess()
+    {
+        // Happy path: every teardown command succeeds and the absence verification finds no
+        // residual artifacts (empty probe output) - Remove reports success with no WARNING.
+        var mi = Valid();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeTrue();
+        steps.Should().NotContain(s => s.Contains("WARNING"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_NonAliased_RouteDeleteFails_ReportsFailureWithWarning()
+    {
+        // A genuine base-teardown failure (the guarded route delete returns nonzero) must flip
+        // success to false and surface a WARNING step - not be swallowed by fire-and-forget.
+        var mi = Valid();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("ip route del") ? (false, "route del failed") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("WARNING") && s.Contains("route"));
+    }
+
+    [Fact]
     public async Task CheckStatusAsync_AliasedRowWithOutOfRangeId_ReportsAliasFlagsAbsentWithoutThrowing()
     {
         var mi = ValidAliased(id: MonitoringInterfaceDeploymentService.MaxAliasableId + 1);

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -829,6 +829,24 @@ public class MonitoringInterfaceDeploymentServiceTests
     }
 
     [Fact]
+    public async Task EnableAsync_UnsafeName_ThrowsBeforeTouchingGatewayOrDb()
+    {
+        // Enable must validate up front like Disable/Remove (Codex review): a name that fails
+        // shell-safety has to throw before any SSH command or DB write, not later in DeployAsync.
+        var mi = Valid();
+        mi.Id = 5;
+        mi.Name = "bad name"; // the space fails the shell-safe regex
+        var ssh = new Mock<IGatewaySshService>();
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.EnableAsync(mi));
+
+        ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+        repo.Verify(r => r.SetDisabledAsync(It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task CheckStatusAsync_AliasedRowWithOutOfRangeId_ReportsAliasFlagsAbsentWithoutThrowing()
     {
         var mi = ValidAliased(id: MonitoringInterfaceDeploymentService.MaxAliasableId + 1);

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
+using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web.Services;
@@ -13,8 +14,10 @@ public class MonitoringInterfaceDeploymentServiceTests
 {
     // RemoveAsync/CheckStatusAsync only depend on IGatewaySshService (UniFiConnectionService is
     // only touched by PreflightAsync's UniFi-overlap gate, which these tests never exercise).
-    private static MonitoringInterfaceDeploymentService BuildService(Mock<IGatewaySshService> ssh)
-        => new(Mock.Of<ILogger<MonitoringInterfaceDeploymentService>>(), ssh.Object, Mock.Of<IUdmBootService>(), null!);
+    private static MonitoringInterfaceDeploymentService BuildService(
+        Mock<IGatewaySshService> ssh, Mock<IMonitoringInterfaceRepository>? repo = null)
+        => new(Mock.Of<ILogger<MonitoringInterfaceDeploymentService>>(), ssh.Object, Mock.Of<IUdmBootService>(),
+            null!, (repo ?? new Mock<IMonitoringInterfaceRepository>()).Object);
     private static MonitoringInterface Valid(int? vlan = null) => new()
     {
         Name = "modem0",
@@ -606,6 +609,100 @@ public class MonitoringInterfaceDeploymentServiceTests
         // "already applied" on every watchdog run and never get migrated off its phantom route.
         var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid());
         script.Should().Contain("grep \"inet $LOCAL_IP/$PREFIX \" | grep -q noprefixroute");
+    }
+
+    [Fact]
+    public async Task DisableAsync_WritesMarkerBeforeTeardownAndFlagsDisabledOnSuccess()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, steps) = await service.DisableAsync(mi);
+
+        success.Should().BeTrue();
+        // The marker must be written first - before any teardown command - so the cron watchdog
+        // cannot re-apply the interface between teardown steps.
+        commands.Should().NotBeEmpty();
+        commands[0].Should().Contain(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi));
+        commands[0].Should().Contain(": >");
+        var firstTeardown = commands.FindIndex(c => c.Contains("crontab"));
+        firstTeardown.Should().BeGreaterThan(0);
+        // On a clean teardown the DB flag is set.
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DisableAsync_TeardownFails_LeavesEnabledAndRemovesMarker()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("ip route del") ? (false, "err") : (true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, _) = await service.DisableAsync(mi);
+
+        success.Should().BeFalse();
+        // A failed teardown must NOT flag the row disabled, and must roll the marker back so the
+        // interface isn't left half-paused (marker present but artifacts still up).
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+    }
+
+    [Fact]
+    public async Task EnableAsync_ClearsFlagAndMarkerThenDeploys_NoReDisableOnDeployFailure()
+    {
+        var mi = Valid();
+        mi.Id = 5;
+        mi.Disabled = true;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var result = await service.EnableAsync(mi);
+
+        // Enable clears the flag and marker up front, then deploys. A deploy failure (no real
+        // gateway behind the mocks) must NOT silently re-disable - the row stays enabled and the
+        // failed DeployResult surfaces.
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, false, It.IsAny<CancellationToken>()), Times.Once);
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+        mi.Disabled.Should().BeFalse();
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task DeployAsync_DisabledInterface_ReturnsSkippedWithoutTouchingGateway()
+    {
+        var mi = Valid();
+        mi.Disabled = true;
+        var ssh = new Mock<IGatewaySshService>();
+        var service = BuildService(ssh);
+
+        var result = await service.DeployAsync(mi);
+
+        result.Success.Should().BeFalse();
+        result.Block.Should().Be(MonitoringInterfaceDeploymentService.PreflightBlock.Skipped);
+        ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -847,6 +847,44 @@ public class MonitoringInterfaceDeploymentServiceTests
     }
 
     [Fact]
+    public async Task DisableAsync_DrainsApplyLockBeforeTeardown()
+    {
+        // Watchdog-resurrection guard: after writing the marker, Disable blocks on the boot
+        // script's per-interface apply lock so an in-flight apply finishes before teardown.
+        var mi = Valid();
+        mi.Id = 8;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((true, ""));
+        var service = BuildService(ssh, new Mock<IMonitoringInterfaceRepository>());
+
+        await service.DisableAsync(mi);
+
+        commands.Should().Contain(c => c.Contains("flock -w 30") && c.Contains($"/tmp/monitoring-iface-{mi.Name}.lock"));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_VerificationFindsResidualSnat_ReportsFailure()
+    {
+        // Every teardown command "succeeds", but the absence verification still finds the SNAT
+        // rule present (a silently-failed removal or a watchdog resurrection) - Remove must flip
+        // success and warn rather than reporting a clean teardown.
+        var mi = Valid(); // SnatEnabled defaults to true, so the verify includes the SNAT probe
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("echo IFACE") ? (true, "SNAT\n") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("verification failed"));
+    }
+
+    [Fact]
     public async Task CheckStatusAsync_AliasedRowWithOutOfRangeId_ReportsAliasFlagsAbsentWithoutThrowing()
     {
         var mi = ValidAliased(id: MonitoringInterfaceDeploymentService.MaxAliasableId + 1);

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -866,6 +866,48 @@ public class MonitoringInterfaceDeploymentServiceTests
     }
 
     [Fact]
+    public async Task DisableAsync_DrainTimesOut_AbortsAndRollsBackMarker()
+    {
+        // If an in-flight apply will not release the lock in time, Disable must abort (not tear
+        // down underneath it), roll the marker back, and leave the row enabled.
+        var mi = Valid();
+        mi.Id = 9;
+        var commands = new List<string>();
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => commands.Add(cmd))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("flock -w 30") ? (false, "") : (true, ""));
+        var repo = new Mock<IMonitoringInterfaceRepository>();
+        var service = BuildService(ssh, repo);
+
+        var (success, _) = await service.DisableAsync(mi);
+
+        success.Should().BeFalse();
+        repo.Verify(r => r.SetDisabledAsync(mi.Id, true, It.IsAny<CancellationToken>()), Times.Never);
+        commands.Should().Contain(c => c.Contains("rm -f") &&
+            c.Contains(MonitoringInterfaceDeploymentService.DisabledMarkerPath(mi)));
+    }
+
+    [Fact]
+    public async Task RemoveAsync_VerificationFindsResidualAliasDnat_ReportsFailure()
+    {
+        // Aliased teardown "succeeds" per-command, but verification finds the DNAT rule still
+        // present - Remove must flip success and warn (covers the alias probes added to verify).
+        var mi = ValidAliased(id: 9);
+        var ssh = new Mock<IGatewaySshService>();
+        ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string cmd, TimeSpan? _, CancellationToken _) =>
+                cmd.Contains("echo IFACE") ? (true, "ADNAT\n") : (true, ""));
+        var service = BuildService(ssh);
+
+        var (success, steps) = await service.RemoveAsync(mi);
+
+        success.Should().BeFalse();
+        steps.Should().Contain(s => s.Contains("verification failed"));
+    }
+
+    [Fact]
     public async Task RemoveAsync_VerificationFindsResidualSnat_ReportsFailure()
     {
         // Every teardown command "succeeds", but the absence verification still finds the SNAT

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfaceDeploymentServiceTests.cs
@@ -608,6 +608,25 @@ public class MonitoringInterfaceDeploymentServiceTests
         script.Should().Contain("grep \"inet $LOCAL_IP/$PREFIX \" | grep -q noprefixroute");
     }
 
+    [Fact]
+    public void BootScript_HonoursDisabledMarkerAndLocksApply()
+    {
+        var script = MonitoringInterfaceDeploymentService.GenerateBootScript(Valid());
+
+        // Marker var + early-out before doing any work, so a disabled interface's boot script
+        // and cron watchdog become inert without needing to be deleted.
+        script.Should().Contain("MARKER=\"/data/monitoring-ifaces.disabled/modem0\"");
+        script.Should().Contain("[ -f \"$MARKER\" ] && { log \"disabled marker present, skipping\"; exit 0; }");
+
+        // Re-check the marker immediately before (re)installing the cron watchdog, closing the
+        // race where Disable writes the marker after the top check but before cron install.
+        script.Should().Contain("if [ ! -f \"$MARKER\" ] && ! crontab -l 2>/dev/null | grep -qF \"$SCRIPT\"; then");
+
+        // Per-interface flock serializes a manual apply against the cron watchdog tick.
+        script.Should().Contain("flock -n 9");
+        script.Should().Contain("/tmp/monitoring-iface-modem0.lock");
+    }
+
     private static NetworkInfo UniFiNet(string name, string subnet, bool wan = false, bool enabled = true) => new()
     {
         Name = name,

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
@@ -140,4 +140,26 @@ public class MonitoringInterfacesCardTests
 
         card._forceRemoveArmed.Should().BeEmpty();
     }
+
+    [Fact]
+    public void Snapshot_CopiesIsManuallyDeployedAndDisabled()
+    {
+        // Codex review: Snapshot omitting IsManuallyDeployed made editing a manually-deployed
+        // row silently flip it to app-managed (its hidden Disable/Enable toggle then reappeared).
+        var mi = new MonitoringInterface
+        {
+            Id = 3,
+            Name = "modem0",
+            WanIfName = "eth1",
+            TargetIp = "192.168.100.1",
+            GatewayLocalIp = "192.168.100.2",
+            IsManuallyDeployed = true,
+            Disabled = true,
+        };
+
+        var snap = MonitoringInterfacesCard.Snapshot(mi);
+
+        snap.IsManuallyDeployed.Should().BeTrue();
+        snap.Disabled.Should().BeTrue();
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MonitoringInterfacesCardTests.cs
@@ -1,5 +1,7 @@
 using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Web.Components.Shared;
+using NetworkOptimizer.Web.Services;
 using Xunit;
 
 namespace NetworkOptimizer.Web.Tests;
@@ -65,6 +67,60 @@ public class MonitoringInterfacesCardTests
         outcome.Arm.Should().BeFalse();
         outcome.Success.Should().BeFalse();
         outcome.Message.Should().Contain("may remain").And.Contain("manual cleanup");
+    }
+
+    [Fact]
+    public void StatusBadgeContent_DisabledRow_ShowsDisabledRegardlessOfLiveStatus()
+    {
+        // A disabled interface reads "Disabled" no matter what the last live probe found - even
+        // a fully-applied status (a probe taken before Disable finished) must not override it.
+        var mi = new MonitoringInterface { Name = "modem0", Disabled = true };
+        var fullyApplied = new MonitoringInterfaceDeploymentService.InterfaceStatus
+        {
+            GatewayReachable = true,
+            InterfaceExists = true,
+            LocalIpAssigned = true,
+            RoutePresent = true,
+            SnatPresent = true,
+            WatchdogCronPresent = true,
+            BootScriptPresent = true,
+        };
+
+        var withStatus = MonitoringInterfacesCard.StatusBadgeContent(mi, fullyApplied);
+        withStatus.text.Should().Be("Disabled");
+        withStatus.cls.Should().Contain("status-disconnected");
+
+        MonitoringInterfacesCard.StatusBadgeContent(mi, null).text.Should().Be("Disabled");
+    }
+
+    [Fact]
+    public void StatusBadgeContent_EnabledRow_KeepsStatusDrivenLabels()
+    {
+        // Regression guard: a non-disabled row keeps the existing status-driven labels.
+        var mi = new MonitoringInterface { Name = "modem0" };
+        MonitoringInterfacesCard.StatusBadgeContent(mi, null).text.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public void Snapshot_CopiesDisabledFlag()
+    {
+        var mi = new MonitoringInterface { Name = "modem0", TargetIp = "192.168.100.1", Disabled = true };
+
+        var copy = MonitoringInterfacesCard.Snapshot(mi);
+
+        copy.Disabled.Should().BeTrue();
+        copy.TargetIp.Should().Be("192.168.100.1");
+    }
+
+    [Fact]
+    public void ShowDisableToggle_HiddenForManuallyDeployedRows()
+    {
+        // Disable/Enable tears down and redeploys gateway artifacts we own; a manually-deployed
+        // row is the user's own hand-built config, so the toggle must not appear for it.
+        MonitoringInterfacesCard.ShowDisableToggle(new MonitoringInterface { IsManuallyDeployed = false })
+            .Should().BeTrue();
+        MonitoringInterfacesCard.ShowDisableToggle(new MonitoringInterface { IsManuallyDeployed = true })
+            .Should().BeFalse();
     }
 
     [Fact]


### PR DESCRIPTION
Adds a per-interface Disable/Enable toggle to Monitoring Interfaces: un-deploy an interface (tear down the macvlan/route/SNAT + boot script + cron watchdog) while keeping its saved config, then bring it back with one click. As discussed on Discord - a power-user convenience for pausing an interface during testing.

## Behaviour
- New `bool Disabled` on `MonitoringInterface` (+ migration, default false, existing rows stay deployed).
- Disable tears down all gateway artifacts and keeps the row; Enable redeploys.
- Stays down across reboots and against the cron watchdog via a gateway-side marker (`/data/monitoring-ifaces.disabled/<Name>`) the boot/watchdog script honours - checked at the top, again after it takes its apply lock, and before installing cron. Disable drains that lock before teardown, so an in-flight apply cannot resurrect artifacts.
- Reuses `DeployAsync`/`RemoveAsync`; mirrors the Performance Tweaks enable/disable pattern.

## UI
- Enabled: Edit / Re-apply / Check status / Disable / Remove. Disabled: Enable takes the primary slot, a "Disabled" badge, Check status + Remove stay. Manually-deployed rows do not get the toggle. Scoped CSS keeps the row on one line.

## Hardening (also fixes an existing latent bug)
- `RemoveAsync` now checks the result of every teardown step and verifies absence (iface/route/cron/script/SNAT + alias mark/DNAT/policy-route), instead of the previous fire-and-forget `|| true` that swallowed failures.

## Deliberately left out (your call)
- Optimistic concurrency on the toggle (no RowVersion today; a known limitation for a single-admin tool).
- Annotating reachability checks while an interface is paused.

Tested live on my own gateway across all four monitoring interfaces. Full test suite green. Design note in `docs/features/`.
