### PR TITLE
feat(cm): one-click Disable/Enable toggle for Cable Modem Device Monitoring

### DIFF
--- a/src/NetworkOptimizer.Storage/Interfaces/ICmRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/ICmRepository.cs
@@ -12,4 +12,20 @@ public interface ICmRepository
     Task<CmConfiguration?> GetCmConfigurationAsync(int id, CancellationToken cancellationToken = default);
     Task SaveCmConfigurationAsync(CmConfiguration config, CancellationToken cancellationToken = default);
     Task DeleteCmConfigurationAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Toggle only the <see cref="CmConfiguration.Enabled"/> flag of one config (the
+    /// row-level Disable/Enable button), without touching the rest of the entity. Bumps
+    /// UpdatedAt; when disabling, clears the stale LastError so a paused row does not keep
+    /// showing an old poll failure. No-op if the id does not exist.
+    /// </summary>
+    Task SetCmEnabledAsync(int id, bool enabled, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persist a poll outcome for one config, updating only LastPolled (when provided),
+    /// LastError, and UpdatedAt - never Enabled. Skips (and returns false) when the config
+    /// was disabled meanwhile, so an in-flight poll can neither resurrect a paused CM nor
+    /// overwrite its frozen state. Returns true when the result was persisted.
+    /// </summary>
+    Task<bool> UpdateCmPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Repositories/CmRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/CmRepository.cs
@@ -126,4 +126,52 @@ public class CmRepository : ICmRepository
             throw;
         }
     }
+
+    public async Task SetCmEnabledAsync(int id, bool enabled, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.CmConfigurations.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+            if (config == null)
+                return;
+
+            config.Enabled = enabled;
+            config.UpdatedAt = DateTime.UtcNow;
+            if (!enabled)
+                config.LastError = null;
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Set CM configuration {Id} Enabled={Enabled}", id, enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set Enabled on CM configuration {Id}", id);
+            throw;
+        }
+    }
+
+    public async Task<bool> UpdateCmPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.CmConfigurations.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+            // Never resurrect or overwrite a config that was disabled while the poll was
+            // in flight - its frozen state (and cleared LastError) must stand.
+            if (config == null || !config.Enabled)
+                return false;
+
+            if (lastPolled.HasValue)
+                config.LastPolled = lastPolled.Value;
+            config.LastError = lastError;
+            config.UpdatedAt = DateTime.UtcNow;
+
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update CM poll result for {Id}", id);
+            throw;
+        }
+    }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1343,6 +1343,16 @@
                                                 <span>Test</span>
                                             }
                                         </button>
+                                        <button class="btn @(cm.Enabled ? "btn-secondary" : "btn-primary") btn-sm" @onclick="() => ToggleCmEnabled(cm)" disabled="@(_cmTogglingId != null)">
+                                            @if (_cmTogglingId == cm.Id)
+                                            {
+                                                <span class="spinner"></span>
+                                            }
+                                            else
+                                            {
+                                                <span>@(cm.Enabled ? "Disable" : "Enable")</span>
+                                            }
+                                        </button>
                                         <button class="btn btn-danger btn-sm" @onclick="() => DeleteCm(cm.Id)">Delete</button>
                                     </div>
                                 </td>
@@ -3990,6 +4000,7 @@
     private string? _cmTestResult;
     private string _cmTestResultClass = "info";
     private int? _cmTestingId;
+    private int? _cmTogglingId;
     private string? _cmTestedHost;
     private string _cmStatus = "Inactive";
 
@@ -5685,6 +5696,27 @@
         finally
         {
             _cmTestingId = null;
+            StateHasChanged();
+        }
+    }
+
+    private async Task ToggleCmEnabled(CmConfiguration config)
+    {
+        _cmTogglingId = config.Id;
+        StateHasChanged();
+        try
+        {
+            await CmMonitorService.SetCmEnabledAsync(config.Id, !config.Enabled);
+            await LoadCmSettings();
+        }
+        catch (Exception ex)
+        {
+            _cmTestResult = $"Error: {ex.Message}";
+            _cmTestResultClass = "danger";
+        }
+        finally
+        {
+            _cmTogglingId = null;
             StateHasChanged();
         }
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -159,6 +159,18 @@ public sealed class CableModemMonitorService : IDisposable
     }
 
     /// <summary>
+    /// Enable or disable polling for one cable modem (the Settings row Disable/Enable toggle).
+    /// Disabled configs are skipped by the poll loop (GetEnabledCmConfigurationsAsync)
+    /// while their configuration is retained.
+    /// </summary>
+    public async Task SetCmEnabledAsync(int id, bool enabled)
+    {
+        using var scope = CreateSiteScope();
+        var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
+        await repo.SetCmEnabledAsync(id, enabled);
+    }
+
+    /// <summary>
     /// Test connectivity to a cable modem using the configured provider.
     /// </summary>
     public async Task<(bool Success, string Message)> ProbeAsync(CmConfiguration config)
@@ -238,9 +250,11 @@ public sealed class CableModemMonitorService : IDisposable
 
             if (stats != null)
             {
-                _statsCache[config.Id] = stats;
-                await UpdateConfigSuccessAsync(config.Id);
-                WriteToInflux(config, stats);
+                if (await UpdateConfigSuccessAsync(config.Id))
+                {
+                    _statsCache[config.Id] = stats;
+                    WriteToInflux(config, stats);
+                }
             }
             else
             {
@@ -296,44 +310,33 @@ public sealed class CableModemMonitorService : IDisposable
         };
     }
 
-    private async Task UpdateConfigSuccessAsync(int id)
+    private async Task<bool> UpdateConfigSuccessAsync(int id)
     {
         try
         {
             using var scope = CreateSiteScope();
             var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
-            var config = await repo.GetCmConfigurationAsync(id);
-            if (config != null)
-            {
-                config.LastPolled = DateTime.UtcNow;
-                config.LastError = null;
-                config.UpdatedAt = DateTime.UtcNow;
-                await repo.SaveCmConfigurationAsync(config);
-            }
+            return await repo.UpdateCmPollResultAsync(id, DateTime.UtcNow, null);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update CM config {Id} after successful poll", id);
+            return false;
         }
     }
 
-    private async Task UpdateConfigErrorAsync(int id, string error)
+    private async Task<bool> UpdateConfigErrorAsync(int id, string error)
     {
         try
         {
             using var scope = CreateSiteScope();
             var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
-            var config = await repo.GetCmConfigurationAsync(id);
-            if (config != null)
-            {
-                config.LastError = error.Length > 1000 ? error[..1000] : error;
-                config.UpdatedAt = DateTime.UtcNow;
-                await repo.SaveCmConfigurationAsync(config);
-            }
+            return await repo.UpdateCmPollResultAsync(id, null, error.Length > 1000 ? error[..1000] : error);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update CM config {Id} after error", id);
+            return false;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -168,6 +168,16 @@ public sealed class CableModemMonitorService : IDisposable
         using var scope = CreateSiteScope();
         var repo = scope.ServiceProvider.GetRequiredService<ICmRepository>();
         await repo.SetCmEnabledAsync(id, enabled);
+
+        if (!enabled)
+        {
+            // Drop the correctable/uncorrectable running totals (as DeleteCmAsync does) so
+            // the first poll after re-enabling starts a fresh delta. Otherwise the errors
+            // accumulated by the modem while paused land in one poll as a huge spike and
+            // can trip the uncorrectables alert the moment the CM is resumed.
+            _previousTotalCorrectables.TryRemove(id, out _);
+            _previousTotalUncorrectables.TryRemove(id, out _);
+        }
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Storage.Tests/CmRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/CmRepositoryTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Repositories;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+public class CmRepositoryTests : IDisposable
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly CmRepository _repository;
+
+    public CmRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new NetworkOptimizerDbContext(options);
+        var logger = new Mock<ILogger<CmRepository>>();
+        _repository = new CmRepository(_context, logger.Object);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task GetEnabledCmConfigurationsAsync_ReturnsOnlyEnabled()
+    {
+        _context.CmConfigurations.AddRange(
+            new CmConfiguration { Name = "Live CM", Host = "192.168.100.1", Enabled = true },
+            new CmConfiguration { Name = "Paused CM", Host = "192.168.100.2", Enabled = false });
+        await _context.SaveChangesAsync();
+
+        var results = await _repository.GetEnabledCmConfigurationsAsync();
+
+        results.Should().ContainSingle().Which.Name.Should().Be("Live CM");
+    }
+
+    [Fact]
+    public async Task SetCmEnabledAsync_Disable_SetsFlagFalseAndClearsLastError()
+    {
+        var cm = new CmConfiguration
+        {
+            Name = "CM1000", Host = "192.168.100.1", Enabled = true,
+            LastError = "timeout after 10s", LastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+        };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetCmEnabledAsync(cm.Id, false);
+
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull("a paused CM should not keep showing a stale poll error");
+        reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+            "LastPolled is history and is preserved");
+    }
+
+    [Fact]
+    public async Task SetCmEnabledAsync_Enable_SetsFlagTrueAndLeavesLastErrorForNextPoll()
+    {
+        var cm = new CmConfiguration
+        {
+            Name = "S33", Host = "192.168.100.1", Enabled = false, LastError = "was unreachable",
+        };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetCmEnabledAsync(cm.Id, true);
+
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.Enabled.Should().BeTrue();
+        reloaded.LastError.Should().Be("was unreachable",
+            "re-enabling does not fabricate a healthy state; the next poll overwrites LastError");
+    }
+
+    [Fact]
+    public async Task SetCmEnabledAsync_BumpsUpdatedAt()
+    {
+        var cm = new CmConfiguration
+        {
+            Name = "CM", Host = "192.168.100.1", Enabled = true,
+            UpdatedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetCmEnabledAsync(cm.Id, false);
+
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.UpdatedAt.Should().BeAfter(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task SetCmEnabledAsync_UnknownId_DoesNotThrow()
+    {
+        var act = async () => await _repository.SetCmEnabledAsync(9999, false);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task UpdateCmPollResultAsync_EnabledConfig_WritesResultAndReturnsTrue()
+    {
+        var cm = new CmConfiguration { Name = "CM", Host = "192.168.100.1", Enabled = true };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+        var when = new DateTime(2026, 7, 22, 9, 0, 0, DateTimeKind.Utc);
+
+        var persisted = await _repository.UpdateCmPollResultAsync(cm.Id, when, null);
+
+        persisted.Should().BeTrue();
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.LastPolled.Should().Be(when);
+        reloaded.LastError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateCmPollResultAsync_ErrorPath_SetsErrorWithoutAdvancingLastPolled()
+    {
+        var lastSuccess = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var cm = new CmConfiguration { Name = "CM", Host = "192.168.100.1", Enabled = true, LastPolled = lastSuccess };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        var persisted = await _repository.UpdateCmPollResultAsync(cm.Id, lastPolled: null, "boom");
+
+        persisted.Should().BeTrue();
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.LastError.Should().Be("boom");
+        reloaded.LastPolled.Should().Be(lastSuccess, "an error must not advance LastPolled, which tracks the last success");
+    }
+
+    [Fact]
+    public async Task UpdateCmPollResultAsync_ConfigDisabledMidPoll_DoesNotResurrectOrOverwrite()
+    {
+        // Regression: an in-flight poll finishing after the user clicked Disable must not
+        // re-enable the CM or rewrite the LastError that Disable cleared.
+        var cm = new CmConfiguration
+        {
+            Name = "CM1000", Host = "192.168.100.1", Enabled = true, LastError = "timeout",
+            LastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+        };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetCmEnabledAsync(cm.Id, false);            // user pauses it
+        var persisted = await _repository.UpdateCmPollResultAsync(     // late poll result lands
+            cm.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "timeout again");
+
+        persisted.Should().BeFalse();
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused CM");
+        reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
+        reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateCmPollResultAsync_UnknownId_ReturnsFalse()
+    {
+        (await _repository.UpdateCmPollResultAsync(9999, DateTime.UtcNow, null)).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Adds the same one-click row-level **Disable/Enable** toggle to Cable Modem Device Monitoring that #1044 adds for ONT - "same shape and UI".

### What
- A per-row **Disable / Enable** button in the CM settings table (busy spinner, buttons disabled during a toggle). The existing Enabled/Disabled badge flips after the action.
- Disabling pauses polling and clears the stale `LastError` so a paused row stops showing an old failure; the configuration is retained (no delete needed for dead/unreachable modems that otherwise spam poll errors every cycle).

### How (mirrors #1044)
- `ICmRepository.SetCmEnabledAsync` flips only `Enabled` (+ `UpdatedAt`, clears `LastError` on disable); no full-entity round-trip / no password re-encrypt.
- `ICmRepository.UpdateCmPollResultAsync` is a guarded poll-result write: it updates only `LastPolled`/`LastError`/`UpdatedAt` (never `Enabled`) and returns `false` when the config was disabled mid-poll, so an in-flight poll cannot resurrect or overwrite a paused modem. `PollSingleAsync` now persists the result **before** the stats-cache / InfluxDB / alert writes and gates them on that guard.
- Small related fix: disabling a modem now drops its correctable/uncorrectable running totals (as `DeleteCmAsync` already does), so re-enabling after a pause starts a fresh delta instead of charting the whole paused interval as one spike.

### Tests
New `CmRepositoryTests` (toggle, poll-result guard, mid-poll-disable regression). Full `NetworkOptimizer.Storage.Tests` green (160/160) and the solution builds clean.

Independent, off `dev`; companion PR does the same for Cellular. Pattern reference: #1044.
