### PR TITLE
feat(cellular): one-click Disable/Enable toggle for Cellular Modem Device Monitoring

### DIFF
--- a/src/NetworkOptimizer.Storage/Interfaces/IModemRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IModemRepository.cs
@@ -12,4 +12,20 @@ public interface IModemRepository
     Task<ModemConfiguration?> GetModemConfigurationAsync(int id, CancellationToken cancellationToken = default);
     Task SaveModemConfigurationAsync(ModemConfiguration config, CancellationToken cancellationToken = default);
     Task DeleteModemConfigurationAsync(int id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Toggle only the <see cref="ModemConfiguration.Enabled"/> flag of one config (the
+    /// row-level Disable/Enable button), without touching the rest of the entity. Bumps
+    /// UpdatedAt; when disabling, clears the stale LastError so a paused row does not keep
+    /// showing an old poll failure. No-op if the id does not exist.
+    /// </summary>
+    Task SetModemEnabledAsync(int id, bool enabled, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Persist a poll outcome for one config, updating only LastPolled (when provided),
+    /// LastError, and UpdatedAt - never Enabled. Skips (and returns false) when the config
+    /// was disabled meanwhile, so an in-flight poll can neither resurrect a paused modem nor
+    /// overwrite its frozen state. Returns true when the result was persisted.
+    /// </summary>
+    Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
@@ -154,4 +154,52 @@ public class ModemRepository : IModemRepository
             throw;
         }
     }
+
+    public async Task SetModemEnabledAsync(int id, bool enabled, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.ModemConfigurations.FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+            if (config == null)
+                return;
+
+            config.Enabled = enabled;
+            config.UpdatedAt = DateTime.UtcNow;
+            if (!enabled)
+                config.LastError = null;
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Set modem configuration {Id} Enabled={Enabled}", id, enabled);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set Enabled on modem configuration {Id}", id);
+            throw;
+        }
+    }
+
+    public async Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _context.ModemConfigurations.FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+            // Never resurrect or overwrite a config that was disabled while the poll was
+            // in flight - its frozen state (and cleared LastError) must stand.
+            if (config == null || !config.Enabled)
+                return false;
+
+            if (lastPolled.HasValue)
+                config.LastPolled = lastPolled.Value;
+            config.LastError = lastError;
+            config.UpdatedAt = DateTime.UtcNow;
+
+            await _context.SaveChangesAsync(cancellationToken);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update modem poll result for {Id}", id);
+            throw;
+        }
+    }
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1104,6 +1104,16 @@
                                     <div class="btn-group-wrap">
                                         <button class="btn btn-secondary btn-sm" @onclick="() => EditModem(modem)">Edit</button>
                                         <button class="btn btn-secondary btn-sm" @onclick="() => TestModemConnection(modem)">Refresh</button>
+                                        <button class="btn @(modem.Enabled ? "btn-secondary" : "btn-primary") btn-sm" @onclick="() => ToggleModemEnabled(modem)" disabled="@(_modemTogglingId != null)">
+                                            @if (_modemTogglingId == modem.Id)
+                                            {
+                                                <span class="spinner"></span>
+                                            }
+                                            else
+                                            {
+                                                <span>@(modem.Enabled ? "Disable" : "Enable")</span>
+                                            }
+                                        </button>
                                         <button class="btn btn-danger btn-sm" @onclick="() => DeleteModem(modem)">Delete</button>
                                     </div>
                                 </td>
@@ -3974,6 +3984,7 @@
     private string probeResult = "";
     private string probeResultClass = "";
     private string modemStatus = "Unknown";
+    private int? _modemTogglingId;
     private bool savingModem = false;
     private string modemMessage = "";
     private string modemMessageClass = "";
@@ -5541,6 +5552,27 @@
             modemMessageClass = "danger";
         }
         StateHasChanged();
+    }
+
+    private async Task ToggleModemEnabled(ModemConfiguration modem)
+    {
+        _modemTogglingId = modem.Id;
+        StateHasChanged();
+        try
+        {
+            await ModemService.SetModemEnabledAsync(modem.Id, !modem.Enabled);
+            await LoadModemConfigs();
+        }
+        catch (Exception ex)
+        {
+            modemMessage = $"Error: {ex.Message}";
+            modemMessageClass = "danger";
+        }
+        finally
+        {
+            _modemTogglingId = null;
+            StateHasChanged();
+        }
     }
 
     private async Task TestModemConnection(ModemConfiguration modem)

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -261,20 +261,21 @@ public class CellularModemService : ICellularModemService
 
             if (stats != null)
             {
-                await UpdateModemConfigAsync(modem.Id, null, success: true);
-
-                lock (_lock)
+                if (await UpdateModemConfigAsync(modem.Id, null, success: true))
                 {
-                    _lastStats = stats;
-                    _statsCache[modem.Id] = stats;
+                    lock (_lock)
+                    {
+                        _lastStats = stats;
+                        _statsCache[modem.Id] = stats;
+                    }
+
+                    // Write to InfluxDB for time-series charting
+                    WriteCellularToInflux(modem, stats);
+
+                    _ = _alertEvaluator.EvaluateAsync(
+                        modem.Id, modem.Name,
+                        stats.SignalQuality, stats.NetworkMode, stats.IsRoaming);
                 }
-
-                // Write to InfluxDB for time-series charting
-                WriteCellularToInflux(modem, stats);
-
-                _ = _alertEvaluator.EvaluateAsync(
-                    modem.Id, modem.Name,
-                    stats.SignalQuality, stats.NetworkMode, stats.IsRoaming);
 
                 return (true, $"Modem polled successfully. RSRP: {stats.Lte?.Rsrp ?? stats.Nr5g?.Rsrp}dBm");
             }
@@ -300,6 +301,18 @@ public class CellularModemService : ICellularModemService
         using var scope = CreateSiteScope();
         var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
         return await repository.GetModemConfigurationsAsync();
+    }
+
+    /// <summary>
+    /// Enable or disable polling for one modem (the Settings row Disable/Enable toggle).
+    /// Disabled configs are skipped by the poll loop (GetEnabledModemConfigurationsAsync)
+    /// while their configuration is retained.
+    /// </summary>
+    public async Task SetModemEnabledAsync(int id, bool enabled)
+    {
+        using var scope = CreateSiteScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
+        await repository.SetModemEnabledAsync(id, enabled);
     }
 
     /// <summary>
@@ -395,26 +408,19 @@ public class CellularModemService : ICellularModemService
         }
     }
 
-    private async Task UpdateModemConfigAsync(int modemId, string? error, bool success)
+    private async Task<bool> UpdateModemConfigAsync(int modemId, string? error, bool success)
     {
         try
         {
             using var scope = CreateSiteScope();
             var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
-
-            var config = await repository.GetModemConfigurationAsync(modemId);
-            if (config != null)
-            {
-                if (success)
-                    config.LastPolled = DateTime.UtcNow;
-                config.LastError = error;
-                config.UpdatedAt = DateTime.UtcNow;
-                await repository.SaveModemConfigurationAsync(config);
-            }
+            return await repository.UpdateModemPollResultAsync(
+                modemId, success ? DateTime.UtcNow : (DateTime?)null, error);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update modem config after poll");
+            return false;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/ICellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/ICellularModemService.cs
@@ -52,6 +52,13 @@ public interface ICellularModemService : IDisposable
     Task<List<ModemConfiguration>> GetModemsAsync();
 
     /// <summary>
+    /// Enable or disable polling for one modem while retaining its configuration.
+    /// </summary>
+    /// <param name="id">The modem configuration ID.</param>
+    /// <param name="enabled">Whether polling is enabled.</param>
+    Task SetModemEnabledAsync(int id, bool enabled);
+
+    /// <summary>
     /// Add or update a modem configuration.
     /// </summary>
     /// <param name="config">The modem configuration to save.</param>

--- a/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
@@ -96,4 +96,128 @@ public class ModemRepositoryTests : IDisposable
         var deleted = await _context.ModemConfigurations.FindAsync(id);
         deleted.Should().BeNull();
     }
+
+    [Fact]
+    public async Task SetModemEnabledAsync_Disable_SetsFlagFalseAndClearsLastError()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "UniFi 5G Max", Host = "192.168.1.1", Enabled = true,
+            LastError = "timeout after 10s", LastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetModemEnabledAsync(modem.Id, false);
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull("a paused modem should not keep showing a stale poll error");
+        reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+            "LastPolled is history and is preserved");
+    }
+
+    [Fact]
+    public async Task SetModemEnabledAsync_Enable_SetsFlagTrueAndLeavesLastErrorForNextPoll()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "LTE Backup Pro", Host = "192.168.1.2", Enabled = false, LastError = "was unreachable",
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetModemEnabledAsync(modem.Id, true);
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.Enabled.Should().BeTrue();
+        reloaded.LastError.Should().Be("was unreachable",
+            "re-enabling does not fabricate a healthy state; the next poll overwrites LastError");
+    }
+
+    [Fact]
+    public async Task SetModemEnabledAsync_BumpsUpdatedAt()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "Modem", Host = "192.168.1.1", Enabled = true,
+            UpdatedAt = new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetModemEnabledAsync(modem.Id, false);
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.UpdatedAt.Should().BeAfter(new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task SetModemEnabledAsync_UnknownId_DoesNotThrow()
+    {
+        var act = async () => await _repository.SetModemEnabledAsync(9999, false);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_EnabledConfig_WritesResultAndReturnsTrue()
+    {
+        var modem = new ModemConfiguration { Name = "Modem", Host = "192.168.1.1", Enabled = true };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+        var when = new DateTime(2026, 7, 22, 9, 0, 0, DateTimeKind.Utc);
+
+        var persisted = await _repository.UpdateModemPollResultAsync(modem.Id, when, null);
+
+        persisted.Should().BeTrue();
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.LastPolled.Should().Be(when);
+        reloaded.LastError.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_ErrorPath_SetsErrorWithoutAdvancingLastPolled()
+    {
+        var lastSuccess = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var modem = new ModemConfiguration { Name = "Modem", Host = "192.168.1.1", Enabled = true, LastPolled = lastSuccess };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        var persisted = await _repository.UpdateModemPollResultAsync(modem.Id, lastPolled: null, "boom");
+
+        persisted.Should().BeTrue();
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.LastError.Should().Be("boom");
+        reloaded.LastPolled.Should().Be(lastSuccess, "an error must not advance LastPolled, which tracks the last success");
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_ConfigDisabledMidPoll_DoesNotResurrectOrOverwrite()
+    {
+        // Regression: an in-flight poll finishing after the user clicked Disable must not
+        // re-enable the modem or rewrite the LastError that Disable cleared.
+        var modem = new ModemConfiguration
+        {
+            Name = "UniFi 5G Max", Host = "192.168.1.1", Enabled = true, LastError = "timeout",
+            LastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc),
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.SetModemEnabledAsync(modem.Id, false);            // user pauses it
+        var persisted = await _repository.UpdateModemPollResultAsync(       // late poll result lands
+            modem.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "timeout again");
+
+        persisted.Should().BeFalse();
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused modem");
+        reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
+        reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_UnknownId_ReturnsFalse()
+    {
+        (await _repository.UpdateModemPollResultAsync(9999, DateTime.UtcNow, null)).Should().BeFalse();
+    }
 }


### PR DESCRIPTION
Adds the same one-click row-level **Disable/Enable** toggle to Cellular Modem Device Monitoring that #1044 adds for ONT - "same shape and UI".

### What
- A per-row **Disable / Enable** button in the "Configured Modems" table (busy spinner, buttons disabled during a toggle). The existing Enabled/Disabled badge flips after the action.
- Disabling pauses polling and clears the stale `LastError` so a paused row stops showing an old failure; the configuration is retained.

### How (mirrors #1044)
- `IModemRepository.SetModemEnabledAsync` flips only `Enabled` (+ `UpdatedAt`, clears `LastError` on disable). Also surfaced on `ICellularModemService`.
- `IModemRepository.UpdateModemPollResultAsync` is a guarded poll-result write: updates only `LastPolled`/`LastError`/`UpdatedAt` (never `Enabled`) and returns `false` when the config was disabled mid-poll. `PollModemAsync` gates the stats-cache, InfluxDB write, and alert evaluation on that guard so a paused modem neither caches, charts, nor alerts.

### Tests
`ModemRepositoryTests` extended (toggle, poll-result guard, mid-poll-disable regression). Full `NetworkOptimizer.Storage.Tests` green (159/159) and the solution builds clean.

Independent, off `dev`; companion PR does the same for Cable Modem. Pattern reference: #1044.
