### PR TITLE
fix(monitoring): harden ONT/CM/Cellular Disable/Enable toggle (review follow-ups)

### DIFF
--- a/src/NetworkOptimizer.Storage/Repositories/CmRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/CmRepository.cs
@@ -84,7 +84,6 @@ public class CmRepository : ICmRepository
                     existing.Username = config.Username;
                     existing.Password = config.Password;
                     existing.StatusPagePath = config.StatusPagePath;
-                    existing.Enabled = config.Enabled;
                     existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
                     existing.LastPolled = config.LastPolled;
                     existing.LastError = config.LastError;
@@ -154,19 +153,20 @@ public class CmRepository : ICmRepository
     {
         try
         {
-            var config = await _context.CmConfigurations.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
-            // Never resurrect or overwrite a config that was disabled while the poll was
-            // in flight - its frozen state (and cleared LastError) must stand.
-            if (config == null || !config.Enabled)
-                return false;
-
+            var now = DateTime.UtcNow;
+            int rows;
             if (lastPolled.HasValue)
-                config.LastPolled = lastPolled.Value;
-            config.LastError = lastError;
-            config.UpdatedAt = DateTime.UtcNow;
-
-            await _context.SaveChangesAsync(cancellationToken);
-            return true;
+                rows = await _context.CmConfigurations.Where(c => c.Id == id && c.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c.LastPolled, lastPolled.Value)
+                        .SetProperty(c => c.LastError, lastError)
+                        .SetProperty(c => c.UpdatedAt, now), cancellationToken);
+            else
+                rows = await _context.CmConfigurations.Where(c => c.Id == id && c.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c.LastError, lastError)
+                        .SetProperty(c => c.UpdatedAt, now), cancellationToken);
+            return rows > 0;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
@@ -107,7 +107,6 @@ public class ModemRepository : IModemRepository
                     existing.ModemType = config.ModemType;
                     existing.QmiDevice = config.QmiDevice;
                     existing.Provider = config.Provider;
-                    existing.Enabled = config.Enabled;
                     existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
                     existing.LastPolled = config.LastPolled;
                     existing.LastError = config.LastError;
@@ -182,19 +181,20 @@ public class ModemRepository : IModemRepository
     {
         try
         {
-            var config = await _context.ModemConfigurations.FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
-            // Never resurrect or overwrite a config that was disabled while the poll was
-            // in flight - its frozen state (and cleared LastError) must stand.
-            if (config == null || !config.Enabled)
-                return false;
-
+            var now = DateTime.UtcNow;
+            int rows;
             if (lastPolled.HasValue)
-                config.LastPolled = lastPolled.Value;
-            config.LastError = lastError;
-            config.UpdatedAt = DateTime.UtcNow;
-
-            await _context.SaveChangesAsync(cancellationToken);
-            return true;
+                rows = await _context.ModemConfigurations.Where(m => m.Id == id && m.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.LastPolled, lastPolled.Value)
+                        .SetProperty(m => m.LastError, lastError)
+                        .SetProperty(m => m.UpdatedAt, now), cancellationToken);
+            else
+                rows = await _context.ModemConfigurations.Where(m => m.Id == id && m.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(m => m.LastError, lastError)
+                        .SetProperty(m => m.UpdatedAt, now), cancellationToken);
+            return rows > 0;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Storage/Repositories/OntRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/OntRepository.cs
@@ -85,7 +85,6 @@ public class OntRepository : IOntRepository
                     existing.Password = config.Password;
                     existing.PrivateKeyPath = config.PrivateKeyPath;
                     existing.AttachedSfpId = config.AttachedSfpId;
-                    existing.Enabled = config.Enabled;
                     existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
                     existing.LastPolled = config.LastPolled;
                     existing.LastError = config.LastError;
@@ -155,19 +154,20 @@ public class OntRepository : IOntRepository
     {
         try
         {
-            var config = await _context.OntConfigurations.FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
-            // Never resurrect or overwrite a config that was disabled while the poll was
-            // in flight - its frozen state (and cleared LastError) must stand.
-            if (config == null || !config.Enabled)
-                return false;
-
+            var now = DateTime.UtcNow;
+            int rows;
             if (lastPolled.HasValue)
-                config.LastPolled = lastPolled.Value;
-            config.LastError = lastError;
-            config.UpdatedAt = DateTime.UtcNow;
-
-            await _context.SaveChangesAsync(cancellationToken);
-            return true;
+                rows = await _context.OntConfigurations.Where(o => o.Id == id && o.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(o => o.LastPolled, lastPolled.Value)
+                        .SetProperty(o => o.LastError, lastError)
+                        .SetProperty(o => o.UpdatedAt, now), cancellationToken);
+            else
+                rows = await _context.OntConfigurations.Where(o => o.Id == id && o.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(o => o.LastError, lastError)
+                        .SetProperty(o => o.UpdatedAt, now), cancellationToken);
+            return rows > 0;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Storage/Repositories/StarlinkRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/StarlinkRepository.cs
@@ -81,7 +81,6 @@ public class StarlinkRepository : IStarlinkRepository
                     existing.Provider = config.Provider;
                     existing.Host = config.Host;
                     existing.Port = config.Port;
-                    existing.Enabled = config.Enabled;
                     existing.PollingIntervalSeconds = config.PollingIntervalSeconds;
                     existing.LastPolled = config.LastPolled;
                     existing.LastError = config.LastError;
@@ -132,19 +131,24 @@ public class StarlinkRepository : IStarlinkRepository
     {
         try
         {
-            var config = await _context.StarlinkConfigurations.FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
             // Never resurrect or overwrite a config that was disabled while the poll was
-            // in flight - its frozen state (and cleared LastError) must stand.
-            if (config == null || !config.Enabled)
-                return false;
-
+            // in flight - its frozen state (and cleared LastError) must stand. Check and
+            // write in one conditional statement so a Disable committing in between
+            // cannot slip through.
+            var now = DateTime.UtcNow;
+            int rows;
             if (lastPolled.HasValue)
-                config.LastPolled = lastPolled.Value;
-            config.LastError = lastError;
-            config.UpdatedAt = DateTime.UtcNow;
-
-            await _context.SaveChangesAsync(cancellationToken);
-            return true;
+                rows = await _context.StarlinkConfigurations.Where(c => c.Id == id && c.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c.LastPolled, lastPolled.Value)
+                        .SetProperty(c => c.LastError, lastError)
+                        .SetProperty(c => c.UpdatedAt, now), cancellationToken);
+            else
+                rows = await _context.StarlinkConfigurations.Where(c => c.Id == id && c.Enabled)
+                    .ExecuteUpdateAsync(s => s
+                        .SetProperty(c => c.LastError, lastError)
+                        .SetProperty(c => c.UpdatedAt, now), cancellationToken);
+            return rows > 0;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1825,13 +1825,6 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" @bind="_editingStarlink.Enabled" />
-                            <span>Enable polling</span>
-                        </label>
-                    </div>
-
                     <div class="action-buttons">
                         <button class="btn btn-primary" @onclick="SaveStarlink" disabled="@_savingStarlink">
                             @if (_savingStarlink)

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1236,12 +1236,6 @@
                             }
                         }
 
-                        <div class="form-group">
-                            <label class="checkbox-label">
-                                <input type="checkbox" @bind="editingModem.Enabled" />
-                                <span>Enable polling</span>
-                            </label>
-                        </div>
                     }
 
                     <div class="action-buttons">
@@ -1436,13 +1430,6 @@
                             <label class="form-label">Polling Interval (sec)</label>
                             <input type="number" class="form-control" @bind="_editingCm.PollingIntervalSeconds" min="60" max="3600" />
                         </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" @bind="_editingCm.Enabled" />
-                            <span>Enable polling</span>
-                        </label>
                     </div>
 
                     <div class="action-buttons">
@@ -1661,13 +1648,6 @@
                             <label class="form-label">Polling Interval (sec)</label>
                             <input type="number" class="form-control" @bind="_editingOnt.PollingIntervalSeconds" min="60" max="3600" />
                         </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="checkbox-label">
-                            <input type="checkbox" @bind="_editingOnt.Enabled" />
-                            <span>Enable polling</span>
-                        </label>
                     </div>
 
                     <div class="action-buttons">

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -505,7 +505,7 @@
                 {
                     modemStats = cachedStats;
                 }
-                else
+                else if (modem.Enabled)
                 {
                     // No cached stats - do initial poll
                     var (success, _) = await ModemService.PollModemAsync(modem);
@@ -580,7 +580,7 @@
             modemStats = cached;
             StateHasChanged();
 
-            if (cached == null)
+            if (cached == null && modem.Enabled)
             {
                 // No cached stats - try polling, but don't block paging
                 var (success, _) = await ModemService.PollModemAsync(modem);

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -110,6 +110,11 @@ public sealed class CableModemMonitorService : IDisposable
             _logger.LogWarning("PollCmAsync called for unknown CM config {Id}", cmId);
             return;
         }
+        if (!config.Enabled)
+        {
+            _logger.LogDebug("PollCmAsync skipped for disabled CM config {Id}", cmId);
+            return;
+        }
 
         await PollSingleAsync(config);
     }
@@ -331,7 +336,7 @@ public sealed class CableModemMonitorService : IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update CM config {Id} after successful poll", id);
-            return false;
+            throw;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -257,6 +257,14 @@ public class CellularModemService : ICellularModemService
     {
         try
         {
+            using (var scope = CreateSiteScope())
+            {
+                var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
+                var current = await repository.GetModemConfigurationAsync(modem.Id);
+                if (current == null || !current.Enabled)
+                    return (false, "Modem is disabled - enable it to resume polling.");
+            }
+
             var stats = await ExecutePollAsync(modem);
 
             if (stats != null)
@@ -420,7 +428,7 @@ public class CellularModemService : ICellularModemService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update modem config after poll");
-            return false;
+            throw;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -131,6 +131,11 @@ public class OntMonitorService : IDisposable
             _logger.LogWarning("Cannot poll ONT {Id}: configuration not found", ontId);
             return null;
         }
+        if (!config.Enabled)
+        {
+            _logger.LogDebug("Cannot poll ONT {Id}: configuration is disabled", ontId);
+            return null;
+        }
 
         return await PollSingleAsync(config, repository, await ResolveThresholdsAsync(scope));
     }

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -112,6 +112,11 @@ public sealed class StarlinkMonitorService : IDisposable
             _logger.LogWarning("PollStarlinkAsync called for unknown Starlink config {Id}", id);
             return;
         }
+        if (!config.Enabled)
+        {
+            _logger.LogDebug("PollStarlinkAsync skipped for disabled Starlink config {Id}", id);
+            return;
+        }
 
         await PollSingleAsync(config);
     }
@@ -318,6 +323,8 @@ public sealed class StarlinkMonitorService : IDisposable
     /// <summary>
     /// Guarded success write - returns false (and persists nothing) when the config was
     /// disabled while the poll was in flight, so callers can skip caching/Influx too.
+    /// A write failure is rethrown rather than reported as that same false, so it
+    /// surfaces on the poll error path instead of silently dropping valid stats.
     /// </summary>
     private async Task<bool> UpdateConfigSuccessAsync(int id)
     {
@@ -330,7 +337,7 @@ public sealed class StarlinkMonitorService : IDisposable
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to update Starlink config {Id} after successful poll", id);
-            return false;
+            throw;
         }
     }
 

--- a/tests/NetworkOptimizer.Storage.Tests/CmRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/CmRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -10,21 +11,31 @@ namespace NetworkOptimizer.Storage.Tests;
 
 public class CmRepositoryTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly NetworkOptimizerDbContext _context;
     private readonly CmRepository _repository;
 
     public CmRepositoryTests()
     {
+        // SQLite in-memory (not the EF InMemory provider): UpdateCmPollResultAsync uses
+        // ExecuteUpdate for an atomic guarded write, which only a relational provider supports.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
         var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
 
         _context = new NetworkOptimizerDbContext(options);
+        _context.Database.EnsureCreated();
         var logger = new Mock<ILogger<CmRepository>>();
         _repository = new CmRepository(_context, logger.Object);
     }
 
-    public void Dispose() => _context.Dispose();
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
 
     [Fact]
     public async Task GetEnabledCmConfigurationsAsync_ReturnsOnlyEnabled()
@@ -37,6 +48,27 @@ public class CmRepositoryTests : IDisposable
         var results = await _repository.GetEnabledCmConfigurationsAsync();
 
         results.Should().ContainSingle().Which.Name.Should().Be("Live CM");
+    }
+
+    [Fact]
+    public async Task SaveCmConfigurationAsync_ExistingConfig_PreservesDatabaseEnabledValue()
+    {
+        var cm = new CmConfiguration
+        {
+            Name = "Paused CM", Host = "192.168.100.1", Enabled = false,
+        };
+        _context.CmConfigurations.Add(cm);
+        await _context.SaveChangesAsync();
+
+        await _repository.SaveCmConfigurationAsync(new CmConfiguration
+        {
+            Id = cm.Id, Name = "Edited CM", Host = cm.Host, Enabled = true,
+        });
+
+        _context.ChangeTracker.Clear();
+        var reloaded = await _repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.Name.Should().Be("Edited CM");
+        reloaded.Enabled.Should().BeFalse("only SetCmEnabledAsync may change Enabled on an existing CM");
     }
 
     [Fact]
@@ -155,6 +187,38 @@ public class CmRepositoryTests : IDisposable
         reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused CM");
         reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
         reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateCmPollResultAsync_SqliteDisabledBeforeLateResult_AtomicallySkipsUpdate()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new NetworkOptimizerDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+        var repository = new CmRepository(context, new Mock<ILogger<CmRepository>>().Object);
+        var lastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var cm = new CmConfiguration
+        {
+            Name = "CM", Host = "192.168.100.1", Enabled = true, LastPolled = lastPolled,
+        };
+        context.CmConfigurations.Add(cm);
+        await context.SaveChangesAsync();
+
+        await repository.SetCmEnabledAsync(cm.Id, false);
+        context.ChangeTracker.Clear();
+        var persisted = await repository.UpdateCmPollResultAsync(
+            cm.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "late");
+
+        persisted.Should().BeFalse();
+        context.ChangeTracker.Clear();
+        var reloaded = await repository.GetCmConfigurationAsync(cm.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull();
+        reloaded.LastPolled.Should().Be(lastPolled);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -10,16 +11,22 @@ namespace NetworkOptimizer.Storage.Tests;
 
 public class ModemRepositoryTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly NetworkOptimizerDbContext _context;
     private readonly ModemRepository _repository;
 
     public ModemRepositoryTests()
     {
+        // SQLite in-memory (not the EF InMemory provider): UpdateModemPollResultAsync uses
+        // ExecuteUpdate for an atomic guarded write, which only a relational provider supports.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
         var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
 
         _context = new NetworkOptimizerDbContext(options);
+        _context.Database.EnsureCreated();
         var logger = new Mock<ILogger<ModemRepository>>();
         _repository = new ModemRepository(_context, logger.Object);
     }
@@ -27,6 +34,7 @@ public class ModemRepositoryTests : IDisposable
     public void Dispose()
     {
         _context.Dispose();
+        _connection.Dispose();
     }
 
     [Fact]
@@ -81,6 +89,27 @@ public class ModemRepositoryTests : IDisposable
 
         var saved = await _context.ModemConfigurations.FirstOrDefaultAsync(m => m.Name == "New Modem");
         saved.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SaveModemConfigurationAsync_ExistingConfig_PreservesDatabaseEnabledValue()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "Paused Modem", Host = "192.168.1.1", Enabled = false,
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.SaveModemConfigurationAsync(new ModemConfiguration
+        {
+            Id = modem.Id, Name = "Edited Modem", Host = modem.Host, Enabled = true,
+        });
+
+        _context.ChangeTracker.Clear();
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.Name.Should().Be("Edited Modem");
+        reloaded.Enabled.Should().BeFalse("only SetModemEnabledAsync may change Enabled on an existing modem");
     }
 
     [Fact]
@@ -213,6 +242,38 @@ public class ModemRepositoryTests : IDisposable
         reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused modem");
         reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
         reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_SqliteDisabledBeforeLateResult_AtomicallySkipsUpdate()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new NetworkOptimizerDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+        var repository = new ModemRepository(context, new Mock<ILogger<ModemRepository>>().Object);
+        var lastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var modem = new ModemConfiguration
+        {
+            Name = "Modem", Host = "192.168.1.1", Enabled = true, LastPolled = lastPolled,
+        };
+        context.ModemConfigurations.Add(modem);
+        await context.SaveChangesAsync();
+
+        await repository.SetModemEnabledAsync(modem.Id, false);
+        context.ChangeTracker.Clear();
+        var persisted = await repository.UpdateModemPollResultAsync(
+            modem.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "late");
+
+        persisted.Should().BeFalse();
+        context.ChangeTracker.Clear();
+        var reloaded = await repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull();
+        reloaded.LastPolled.Should().Be(lastPolled);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/OntRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/OntRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -10,21 +11,31 @@ namespace NetworkOptimizer.Storage.Tests;
 
 public class OntRepositoryTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly NetworkOptimizerDbContext _context;
     private readonly OntRepository _repository;
 
     public OntRepositoryTests()
     {
+        // SQLite in-memory (not the EF InMemory provider): UpdateOntPollResultAsync uses
+        // ExecuteUpdate for an atomic guarded write, which only a relational provider supports.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
         var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
 
         _context = new NetworkOptimizerDbContext(options);
+        _context.Database.EnsureCreated();
         var logger = new Mock<ILogger<OntRepository>>();
         _repository = new OntRepository(_context, logger.Object);
     }
 
-    public void Dispose() => _context.Dispose();
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
 
     [Fact]
     public async Task GetEnabledOntConfigurationsAsync_ReturnsOnlyEnabled()
@@ -37,6 +48,27 @@ public class OntRepositoryTests : IDisposable
         var results = await _repository.GetEnabledOntConfigurationsAsync();
 
         results.Should().ContainSingle().Which.Name.Should().Be("Live ONT");
+    }
+
+    [Fact]
+    public async Task SaveOntConfigurationAsync_ExistingConfig_PreservesDatabaseEnabledValue()
+    {
+        var ont = new OntConfiguration
+        {
+            Name = "Paused ONT", Host = "192.168.1.1", Enabled = false,
+        };
+        _context.OntConfigurations.Add(ont);
+        await _context.SaveChangesAsync();
+
+        await _repository.SaveOntConfigurationAsync(new OntConfiguration
+        {
+            Id = ont.Id, Name = "Edited ONT", Host = ont.Host, Enabled = true,
+        });
+
+        _context.ChangeTracker.Clear();
+        var reloaded = await _repository.GetOntConfigurationAsync(ont.Id);
+        reloaded!.Name.Should().Be("Edited ONT");
+        reloaded.Enabled.Should().BeFalse("only SetOntEnabledAsync may change Enabled on an existing ONT");
     }
 
     [Fact]
@@ -155,6 +187,38 @@ public class OntRepositoryTests : IDisposable
         reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused ONT");
         reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
         reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateOntPollResultAsync_SqliteDisabledBeforeLateResult_AtomicallySkipsUpdate()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new NetworkOptimizerDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+        var repository = new OntRepository(context, new Mock<ILogger<OntRepository>>().Object);
+        var lastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var ont = new OntConfiguration
+        {
+            Name = "ONT", Host = "192.168.1.1", Enabled = true, LastPolled = lastPolled,
+        };
+        context.OntConfigurations.Add(ont);
+        await context.SaveChangesAsync();
+
+        await repository.SetOntEnabledAsync(ont.Id, false);
+        context.ChangeTracker.Clear();
+        var persisted = await repository.UpdateOntPollResultAsync(
+            ont.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "late");
+
+        persisted.Should().BeFalse();
+        context.ChangeTracker.Clear();
+        var reloaded = await repository.GetOntConfigurationAsync(ont.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull();
+        reloaded.LastPolled.Should().Be(lastPolled);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/StarlinkRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/StarlinkRepositoryTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -10,21 +11,31 @@ namespace NetworkOptimizer.Storage.Tests;
 
 public class StarlinkRepositoryTests : IDisposable
 {
+    private readonly SqliteConnection _connection;
     private readonly NetworkOptimizerDbContext _context;
     private readonly StarlinkRepository _repository;
 
     public StarlinkRepositoryTests()
     {
+        // SQLite in-memory (not the EF InMemory provider): UpdateStarlinkPollResultAsync uses
+        // ExecuteUpdate for an atomic guarded write, which only a relational provider supports.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
         var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
-            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .UseSqlite(_connection)
             .Options;
 
         _context = new NetworkOptimizerDbContext(options);
+        _context.Database.EnsureCreated();
         var logger = new Mock<ILogger<StarlinkRepository>>();
         _repository = new StarlinkRepository(_context, logger.Object);
     }
 
-    public void Dispose() => _context.Dispose();
+    public void Dispose()
+    {
+        _context.Dispose();
+        _connection.Dispose();
+    }
 
     [Fact]
     public async Task GetEnabledStarlinkConfigurationsAsync_ReturnsOnlyEnabled()
@@ -37,6 +48,27 @@ public class StarlinkRepositoryTests : IDisposable
         var results = await _repository.GetEnabledStarlinkConfigurationsAsync();
 
         results.Should().ContainSingle().Which.Name.Should().Be("Live Dish");
+    }
+
+    [Fact]
+    public async Task SaveStarlinkConfigurationAsync_ExistingConfig_PreservesDatabaseEnabledValue()
+    {
+        var terminal = new StarlinkConfiguration
+        {
+            Name = "Paused Dish", Host = "192.168.100.1", Enabled = false,
+        };
+        _context.StarlinkConfigurations.Add(terminal);
+        await _context.SaveChangesAsync();
+
+        await _repository.SaveStarlinkConfigurationAsync(new StarlinkConfiguration
+        {
+            Id = terminal.Id, Name = "Edited Dish", Host = terminal.Host, Enabled = true,
+        });
+
+        _context.ChangeTracker.Clear();
+        var reloaded = await _repository.GetStarlinkConfigurationAsync(terminal.Id);
+        reloaded!.Name.Should().Be("Edited Dish");
+        reloaded.Enabled.Should().BeFalse("only SetStarlinkEnabledAsync may change Enabled on an existing terminal");
     }
 
     [Fact]
@@ -155,6 +187,38 @@ public class StarlinkRepositoryTests : IDisposable
         reloaded!.Enabled.Should().BeFalse("the late poll must not re-enable a paused terminal");
         reloaded.LastError.Should().BeNull("the late poll must not overwrite the LastError that Disable cleared");
         reloaded.LastPolled.Should().Be(new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public async Task UpdateStarlinkPollResultAsync_SqliteDisabledBeforeLateResult_AtomicallySkipsUpdate()
+    {
+        await using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseSqlite(connection)
+            .Options;
+        await using var context = new NetworkOptimizerDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+        var repository = new StarlinkRepository(context, new Mock<ILogger<StarlinkRepository>>().Object);
+        var lastPolled = new DateTime(2026, 7, 22, 8, 0, 0, DateTimeKind.Utc);
+        var terminal = new StarlinkConfiguration
+        {
+            Name = "Roof", Host = "192.168.100.1", Enabled = true, LastPolled = lastPolled,
+        };
+        context.StarlinkConfigurations.Add(terminal);
+        await context.SaveChangesAsync();
+
+        await repository.SetStarlinkEnabledAsync(terminal.Id, false);
+        context.ChangeTracker.Clear();
+        var persisted = await repository.UpdateStarlinkPollResultAsync(
+            terminal.Id, new DateTime(2026, 7, 22, 8, 5, 0, DateTimeKind.Utc), "late");
+
+        persisted.Should().BeFalse();
+        context.ChangeTracker.Clear();
+        var reloaded = await repository.GetStarlinkConfigurationAsync(terminal.Id);
+        reloaded!.Enabled.Should().BeFalse();
+        reloaded.LastError.Should().BeNull();
+        reloaded.LastPolled.Should().Be(lastPolled);
     }
 
     [Fact]


### PR DESCRIPTION
Pattern-wide robustness follow-ups to the device-monitoring Disable/Enable toggle (#1044 ONT, #1046 CM, #1047 Cellular), applied across all three device types. From an adversarial review of the toggle; two of these (#1, #4) were flagged as good catches.

### #1 - Make the anti-resurrection guard atomic
`UpdateXxxPollResultAsync` read `Enabled` and then called `SaveChanges` separately - a TOCTOU where a `Disable` committing in between let an in-flight poll still overwrite the paused row's frozen `LastError`/`LastPolled`. It now does a single conditional `ExecuteUpdate(...).Where(x => x.Id == id && x.Enabled)` (returns `rows > 0`), so the check and the write are one atomic statement. Repo tests moved from the EF **InMemory** provider to **SQLite in-memory** (InMemory can't execute `ExecuteUpdate`), plus a relational mid-poll-disable regression per type.

### #2 - Don't contact / falsely report a disabled device on the manual + dashboard paths
The public poll entry points fetched the device before the guard ran, so refreshing a disabled device still hit the network - and Cellular returned `(true, "polled successfully")` while nothing persisted. `PollCmAsync`, `PollModemAsync`, and the ONT manual poll now short-circuit when the config is disabled (Cellular returns a clear "modem is disabled" message), and the CM/Cellular/ONT stats panels skip auto-polling a disabled config. The non-persisting **Test/Probe** buttons are unchanged.

### #3 - One control for enable/disable (UX change)
Each edit form still had its own **"Enable polling" checkbox**, competing with the new row toggle - open the edit form, toggle the row off, click Update, and the stale form value re-enabled it. Removed that checkbox from the **ONT/CM/Cellular** edit forms (the row Disable/Enable button is now the single control) and stopped `SaveXxxConfigurationAsync` from writing `Enabled` on update, so `SetXxxEnabledAsync` is the sole writer. **Starlink's edit form is untouched** (it has no toggle). New tests assert Save preserves the DB `Enabled` value.

### #4 - A persistence exception is no longer mistaken for "disabled"
The CM/Cellular poll success helpers caught every repository exception and returned `false` - the same value the guard uses for a disabled row - so a transient DB write failure on an *enabled* device silently dropped valid stats (and Cellular reported success). They now rethrow, so a real failure surfaces via the poll error path; `false` only ever means "disabled" (matching how ONT already behaved).

### Tests
`NetworkOptimizer.Storage.Tests` 183/183 and `NetworkOptimizer.Web.Tests` 933/933 green; solution builds clean (0 warnings).

Off `dev` after #1044/#1046/#1047 merged.
