### PR TITLE
Monitoring - ISP Health: category filter pills for Path & Congestion Events

### DIFF
--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -289,7 +289,7 @@
         setInterval(function() {
             // Clean up orphaned tippy instances (elements that no longer have data-tooltip but still have _tippy)
             // This happens when Blazor reuses elements and removes the data-tooltip attribute
-            document.querySelectorAll('.path-connector, .wireless-icon').forEach(function(el) {
+            document.querySelectorAll('.path-connector, .wireless-icon, .isp-event-badge').forEach(function(el) {
                 if (el._tippy && !el.hasAttribute('data-tooltip')) {
                     el._tippy.destroy();
                 }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -639,12 +639,13 @@ else
             else
             {
                 <div class="isp-event-timeline">
-                    @foreach (var entry in timeline)
+                    @foreach (var (entry, i) in timeline.Select((e, i) => (e, i)))
                     {
                         @* Keyed so filter/report re-renders never reuse a badge span across entries -
                            Tippy caches its content per node, so attribute-swapped reuse shows a stale
-                           tooltip (e.g. a congestion tooltip on a Path shift badge). *@
-                        <div class="isp-event-item" @key="entry">
+                           tooltip (e.g. a congestion tooltip on a Path shift badge). The index is part
+                           of the key because records compare by value and duplicate keys throw. *@
+                        <div class="isp-event-item" @key="(entry, i)">
                             <span class="isp-event-badge @entry.BadgeClass" data-tooltip="@entry.BadgeTooltip">@entry.Badge</span>
                             <span class="isp-event-time">@EventTimeLabel(entry.Time)</span>
                             <span class="isp-event-text">@entry.Text</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -622,9 +622,9 @@ else
         <div class="card-header isp-events-header">
             <h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2>
             <div class="time-range-selector isp-event-filter">
-                <button class="time-btn evt-congestion @(_showCongestion ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Congestion)">Congestion</button>
-                <button class="time-btn evt-shift @(_showShifts ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Shift)">Path shifts</button>
-                <button class="time-btn evt-change @(_showChanges ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Change)">Path changes</button>
+                <button class="time-btn evt-congestion @(_visibleEventCats.Contains(EventCategory.Congestion) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Congestion)">Congestion</button>
+                <button class="time-btn evt-shift @(_visibleEventCats.Contains(EventCategory.Shift) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Shift)">Path shifts</button>
+                <button class="time-btn evt-change @(_visibleEventCats.Contains(EventCategory.Change) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Change)">Path changes</button>
             </div>
         </div>
         <div class="card-body">
@@ -641,7 +641,10 @@ else
                 <div class="isp-event-timeline">
                     @foreach (var entry in timeline)
                     {
-                        <div class="isp-event-item">
+                        @* Keyed so filter/report re-renders never reuse a badge span across entries -
+                           Tippy caches its content per node, so attribute-swapped reuse shows a stale
+                           tooltip (e.g. a congestion tooltip on a Path shift badge). *@
+                        <div class="isp-event-item" @key="entry">
                             <span class="isp-event-badge @entry.BadgeClass" data-tooltip="@entry.BadgeTooltip">@entry.Badge</span>
                             <span class="isp-event-time">@EventTimeLabel(entry.Time)</span>
                             <span class="isp-event-text">@entry.Text</span>
@@ -721,10 +724,12 @@ else
     private System.Threading.Timer? _ageTimer;
 
     // Path & Congestion Events category filters (display-only - scoring is untouched). All on by
-    // default; the hidden set persists per site in localStorage as a comma list.
-    private bool _showCongestion = true;
-    private bool _showShifts = true;
-    private bool _showChanges = true;
+    // default; the hidden set persists per site in localStorage as a comma list. Click semantics
+    // match the LAN flow map band chips: all on -> click solos that category, only-it-on -> click
+    // restores all, otherwise a plain toggle.
+    private static readonly EventCategory[] AllEventCategories =
+        { EventCategory.Congestion, EventCategory.Shift, EventCategory.Change };
+    private HashSet<EventCategory> _visibleEventCats = new(AllEventCategories);
     private const string EventFilterBaseKey = "isp-health-event-filters";
 
     // Date/time filter. Never persisted: OnInitializedAsync starts on the live window (the effective
@@ -1045,10 +1050,10 @@ else
             catch { /* persistence is best-effort */ }
             if (!string.IsNullOrEmpty(hidden))
             {
-                _showCongestion = !hidden.Contains("congestion");
-                _showShifts = !hidden.Contains("shift");
-                _showChanges = !hidden.Contains("change");
-                if (!_showCongestion || !_showShifts || !_showChanges) StateHasChanged();
+                if (hidden.Contains("congestion")) _visibleEventCats.Remove(EventCategory.Congestion);
+                if (hidden.Contains("shift")) _visibleEventCats.Remove(EventCategory.Shift);
+                if (hidden.Contains("change")) _visibleEventCats.Remove(EventCategory.Change);
+                if (_visibleEventCats.Count < AllEventCategories.Length) StateHasChanged();
             }
         }
         if (_scrollChartAfterRender)
@@ -1203,36 +1208,32 @@ else
     private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null,
         EventCategory Category = EventCategory.Congestion, string? BadgeTooltip = null);
 
-    private bool CategoryVisible(TimelineEntry e) => e.Category switch
-    {
-        EventCategory.Shift => _showShifts,
-        EventCategory.Change => _showChanges,
-        _ => _showCongestion,
-    };
+    private bool CategoryVisible(TimelineEntry e) => _visibleEventCats.Contains(e.Category);
 
     // Hidden categories as the chart's annotation type names, as a JS array literal for the
     // mount/setHiddenTypes calls.
     private string HiddenChartTypesJson()
     {
         var hidden = new List<string>();
-        if (!_showCongestion) hidden.Add("'congestion'");
-        if (!_showShifts) hidden.Add("'path-shift'");
-        if (!_showChanges) hidden.Add("'unreachable'");
+        if (!_visibleEventCats.Contains(EventCategory.Congestion)) hidden.Add("'congestion'");
+        if (!_visibleEventCats.Contains(EventCategory.Shift)) hidden.Add("'path-shift'");
+        if (!_visibleEventCats.Contains(EventCategory.Change)) hidden.Add("'unreachable'");
         return "[" + string.Join(",", hidden) + "]";
     }
 
     private async Task ToggleEventFilterAsync(EventCategory cat)
     {
-        switch (cat)
-        {
-            case EventCategory.Congestion: _showCongestion = !_showCongestion; break;
-            case EventCategory.Shift: _showShifts = !_showShifts; break;
-            case EventCategory.Change: _showChanges = !_showChanges; break;
-        }
+        if (_visibleEventCats.Count == AllEventCategories.Length)
+            _visibleEventCats = new HashSet<EventCategory> { cat };
+        else if (_visibleEventCats.Count == 1 && _visibleEventCats.Contains(cat))
+            _visibleEventCats = new HashSet<EventCategory>(AllEventCategories);
+        else if (!_visibleEventCats.Remove(cat))
+            _visibleEventCats.Add(cat);
+
         var hidden = new List<string>();
-        if (!_showCongestion) hidden.Add("congestion");
-        if (!_showShifts) hidden.Add("shift");
-        if (!_showChanges) hidden.Add("change");
+        if (!_visibleEventCats.Contains(EventCategory.Congestion)) hidden.Add("congestion");
+        if (!_visibleEventCats.Contains(EventCategory.Shift)) hidden.Add("shift");
+        if (!_visibleEventCats.Contains(EventCategory.Change)) hidden.Add("change");
         try { await JS.InvokeVoidAsync("localStorage.setItem", SiteCtx.ScopeStorageKey(EventFilterBaseKey), string.Join(",", hidden)); }
         catch { /* persistence is best-effort */ }
         if (_chartMounted)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -621,9 +621,9 @@ else
         <div class="card-header isp-events-header">
             <h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2>
             <div class="time-range-selector isp-event-filter">
-                <button class="time-btn evt-congestion @(_visibleEventCats.Contains(EventCategory.Congestion) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Congestion)">Congestion</button>
-                <button class="time-btn evt-shift @(_visibleEventCats.Contains(EventCategory.Shift) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Shift)">Path shifts</button>
-                <button class="time-btn evt-change @(_visibleEventCats.Contains(EventCategory.Change) ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Change)">Path changes</button>
+                <button class="time-btn evt-congestion @(_visibleEventCats.Contains(EventCategory.Congestion) ? "active" : "")" @onclick="e => ToggleEventFilterAsync(EventCategory.Congestion, e)">Congestion</button>
+                <button class="time-btn evt-shift @(_visibleEventCats.Contains(EventCategory.Shift) ? "active" : "")" @onclick="e => ToggleEventFilterAsync(EventCategory.Shift, e)">Path shifts</button>
+                <button class="time-btn evt-change @(_visibleEventCats.Contains(EventCategory.Change) ? "active" : "")" @onclick="e => ToggleEventFilterAsync(EventCategory.Change, e)">Path changes</button>
             </div>
         </div>
         <div class="card-body">
@@ -1206,9 +1206,16 @@ else
         return "[" + string.Join(",", hidden) + "]";
     }
 
-    private async Task ToggleEventFilterAsync(EventCategory cat)
+    // Ctrl+Click (Cmd+Click on macOS) bypasses the solo/restore semantics and just toggles the one
+    // category, so a single category can be hidden straight from the all-on state.
+    private async Task ToggleEventFilterAsync(EventCategory cat, MouseEventArgs e)
     {
-        if (_visibleEventCats.Count == AllEventCategories.Length)
+        if (e.CtrlKey || e.MetaKey)
+        {
+            if (!_visibleEventCats.Remove(cat))
+                _visibleEventCats.Add(cat);
+        }
+        else if (_visibleEventCats.Count == AllEventCategories.Length)
             _visibleEventCats = new HashSet<EventCategory> { cat };
         else if (_visibleEventCats.Count == 1 && _visibleEventCats.Contains(cat))
             _visibleEventCats = new HashSet<EventCategory>(AllEventCategories);

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -642,7 +642,7 @@ else
                     @foreach (var entry in timeline)
                     {
                         <div class="isp-event-item">
-                            <span class="isp-event-badge @entry.BadgeClass">@entry.Badge</span>
+                            <span class="isp-event-badge @entry.BadgeClass" data-tooltip="@entry.BadgeTooltip">@entry.Badge</span>
                             <span class="isp-event-time">@EventTimeLabel(entry.Time)</span>
                             <span class="isp-event-text">@entry.Text</span>
                         </div>
@@ -1201,7 +1201,7 @@ else
     private enum EventCategory { Congestion, Shift, Change }
 
     private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null,
-        EventCategory Category = EventCategory.Congestion);
+        EventCategory Category = EventCategory.Congestion, string? BadgeTooltip = null);
 
     private bool CategoryVisible(TimelineEntry e) => e.Category switch
     {
@@ -1273,22 +1273,25 @@ else
                 && evt.BottleneckHopIp != null
                 ? " and the hops beyond" : "";
             var lead = $"{span} of elevated latency and jitter on {where}{beyond}{load} ({mag}).";
-            var (badge, badgeClass, text) = evt.Disposition switch
+            var (badge, badgeClass, text, tip) = evt.Disposition switch
             {
                 CongestionDisposition.SelfInflicted => ("Loaded Latency", "isp-event-badge-congestion-soft",
-                    $"{lead} Everything slowed together under load, so the limit was your access link, not one hop - bufferbloat or a congested shared-access network."),
+                    $"{lead} Everything slowed together under load, so the limit was your access link, not one hop - bufferbloat or a congested shared-access network.",
+                    (string?)"Latency rose under your own WAN load - likely your access link, not ISP congestion. Shown dimmed."),
                 CongestionDisposition.ControlPlaneNoise => ("Congestion", "isp-event-badge-congestion-soft",
-                    $"{lead} Its next hop stayed clean, so this is the hop's own ICMP handling, not a forwarding bottleneck."),
+                    $"{lead} Its next hop stayed clean, so this is the hop's own ICMP handling, not a forwarding bottleneck.",
+                    "This hop deprioritized ping replies while forwarding stayed clean - not confirmed as real congestion. Shown dimmed."),
                 CongestionDisposition.Unverifiable => ("Congestion", "isp-event-badge-congestion-soft",
-                    $"{lead}"),
+                    $"{lead}",
+                    "Seen on one path and couldn't be cross-checked, so it's unconfirmed. Shown dimmed."),
                 _ when evt.ConfirmedBySibling => ("Congestion", "isp-event-badge-congestion",
-                    $"{lead}"),
+                    $"{lead}", null),
                 _ when evt.LoadCoincident && evt.CleanParallelPaths > 0 => ("Congestion", "isp-event-badge-congestion",
-                    $"{lead} {evt.CleanParallelPaths} other monitored paths stayed clean under the same load, so it was this hop's own capacity, not your access link."),
+                    $"{lead} {evt.CleanParallelPaths} other monitored paths stayed clean under the same load, so it was this hop's own capacity, not your access link.", null),
                 _ => ("Congestion", "isp-event-badge-congestion",
-                    $"{lead}")
+                    $"{lead}", null)
             };
-            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text, evt.End));
+            entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text, evt.End, BadgeTooltip: tip));
         }
         foreach (var shift in r.PathShifts)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -7,6 +7,7 @@
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NetworkOptimizer.Web.Services.PullToRefreshState PtrState
+@inject SiteContextService SiteCtx
 
 @* Date/time filter (left) + Refresh. The live/cached view (the effective auto-computed window, which
    auto-fallback may have reduced below the configured target) is the only state where Refresh is
@@ -618,12 +619,22 @@ else
     }
 
     <div class="card isp-health-card">
-        <div class="card-header"><h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2></div>
+        <div class="card-header isp-events-header">
+            <h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2>
+            <div class="time-range-selector isp-event-filter">
+                <button class="time-btn evt-congestion @(_showCongestion ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Congestion)">Congestion</button>
+                <button class="time-btn evt-shift @(_showShifts ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Shift)">Path shifts</button>
+                <button class="time-btn evt-change @(_showChanges ? "active" : "")" @onclick="() => ToggleEventFilterAsync(EventCategory.Change)">Path changes</button>
+            </div>
+        </div>
         <div class="card-body">
-            @{ var timeline = EventTimeline(r).Where(InZoomWindow).ToList(); }
+            @{
+                var allEvents = EventTimeline(r).Where(InZoomWindow).ToList();
+                var timeline = allEvents.Where(CategoryVisible).ToList();
+            }
             @if (timeline.Count == 0)
             {
-                <p class="page-description">@(IsZoomed ? "No congestion events or path shifts in this range. Reset the chart zoom to see the full window." : "No congestion events or path shifts detected in the window.")</p>
+                <p class="page-description">@(allEvents.Count > 0 ? "All events in this range are hidden by the filters above." : IsZoomed ? "No congestion events or path shifts in this range. Reset the chart zoom to see the full window." : "No congestion events or path shifts detected in the window.")</p>
             }
             else
             {
@@ -708,6 +719,13 @@ else
     private bool _autoReloading;
     private bool _showAllIspHops;
     private System.Threading.Timer? _ageTimer;
+
+    // Path & Congestion Events category filters (display-only - scoring is untouched). All on by
+    // default; the hidden set persists per site in localStorage as a comma list.
+    private bool _showCongestion = true;
+    private bool _showShifts = true;
+    private bool _showChanges = true;
+    private const string EventFilterBaseKey = "isp-health-event-filters";
 
     // Date/time filter. Never persisted: OnInitializedAsync starts on the live window (the effective
     // auto-computed window, which auto-fallback may have reduced below the configured target), so
@@ -1018,6 +1036,21 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            // Restore the per-site event-category filters before the chart mounts (the chart only
+            // mounts once a report has rendered, which is always after this first render).
+            string? hidden = null;
+            try { hidden = await JS.InvokeAsync<string>("localStorage.getItem", SiteCtx.ScopeStorageKey(EventFilterBaseKey)); }
+            catch { /* persistence is best-effort */ }
+            if (!string.IsNullOrEmpty(hidden))
+            {
+                _showCongestion = !hidden.Contains("congestion");
+                _showShifts = !hidden.Contains("shift");
+                _showChanges = !hidden.Contains("change");
+                if (!_showCongestion || !_showShifts || !_showChanges) StateHasChanged();
+            }
+        }
         if (_scrollChartAfterRender)
         {
             _scrollChartAfterRender = false;
@@ -1062,7 +1095,7 @@ else
             _selfRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("eval",
                 $"(async () => {{ const m = await import('{VersionedJs("/js/isp-health-charts.js")}'); " +
-                $"window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart', {fromArg}, {toArg}); }})();");
+                $"window.__ispHealthCharts = m; await m.mount('isp-health-asn-chart', {fromArg}, {toArg}, {HiddenChartTypesJson()}); }})();");
             // Hand the chart a callback so its drag-zoom can filter the events list to the visible window.
             await JS.InvokeVoidAsync("__ispHealthCharts.setDotNetRef", _selfRef);
         }
@@ -1165,7 +1198,49 @@ else
             ? $"zoomed: {_zoomFrom!.Value.ToLocalTime():MMM d, HH:mm} to {_zoomTo!.Value.ToLocalTime():MMM d, HH:mm}"
             : WindowLabel(r);
 
-    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null);
+    private enum EventCategory { Congestion, Shift, Change }
+
+    private record TimelineEntry(DateTime Time, string Badge, string BadgeClass, string Text, DateTime? End = null,
+        EventCategory Category = EventCategory.Congestion);
+
+    private bool CategoryVisible(TimelineEntry e) => e.Category switch
+    {
+        EventCategory.Shift => _showShifts,
+        EventCategory.Change => _showChanges,
+        _ => _showCongestion,
+    };
+
+    // Hidden categories as the chart's annotation type names, as a JS array literal for the
+    // mount/setHiddenTypes calls.
+    private string HiddenChartTypesJson()
+    {
+        var hidden = new List<string>();
+        if (!_showCongestion) hidden.Add("'congestion'");
+        if (!_showShifts) hidden.Add("'path-shift'");
+        if (!_showChanges) hidden.Add("'unreachable'");
+        return "[" + string.Join(",", hidden) + "]";
+    }
+
+    private async Task ToggleEventFilterAsync(EventCategory cat)
+    {
+        switch (cat)
+        {
+            case EventCategory.Congestion: _showCongestion = !_showCongestion; break;
+            case EventCategory.Shift: _showShifts = !_showShifts; break;
+            case EventCategory.Change: _showChanges = !_showChanges; break;
+        }
+        var hidden = new List<string>();
+        if (!_showCongestion) hidden.Add("congestion");
+        if (!_showShifts) hidden.Add("shift");
+        if (!_showChanges) hidden.Add("change");
+        try { await JS.InvokeVoidAsync("localStorage.setItem", SiteCtx.ScopeStorageKey(EventFilterBaseKey), string.Join(",", hidden)); }
+        catch { /* persistence is best-effort */ }
+        if (_chartMounted)
+        {
+            try { await JS.InvokeVoidAsync("eval", $"window.__ispHealthCharts?.setHiddenTypes?.({HiddenChartTypesJson()});"); }
+            catch { /* chart not mounted yet */ }
+        }
+    }
 
     private static IEnumerable<TimelineEntry> EventTimeline(IspHealthReport r)
     {
@@ -1200,17 +1275,17 @@ else
             var lead = $"{span} of elevated latency and jitter on {where}{beyond}{load} ({mag}).";
             var (badge, badgeClass, text) = evt.Disposition switch
             {
-                CongestionDisposition.SelfInflicted => ("Loaded Latency", "isp-event-badge-info",
+                CongestionDisposition.SelfInflicted => ("Loaded Latency", "isp-event-badge-congestion-soft",
                     $"{lead} Everything slowed together under load, so the limit was your access link, not one hop - bufferbloat or a congested shared-access network."),
-                CongestionDisposition.ControlPlaneNoise => ("Congestion", "isp-event-badge-info",
+                CongestionDisposition.ControlPlaneNoise => ("Congestion", "isp-event-badge-congestion-soft",
                     $"{lead} Its next hop stayed clean, so this is the hop's own ICMP handling, not a forwarding bottleneck."),
-                CongestionDisposition.Unverifiable => ("Congestion", "isp-event-badge-info",
+                CongestionDisposition.Unverifiable => ("Congestion", "isp-event-badge-congestion-soft",
                     $"{lead}"),
-                _ when evt.ConfirmedBySibling => ("Congestion", "isp-event-badge-warning",
+                _ when evt.ConfirmedBySibling => ("Congestion", "isp-event-badge-congestion",
                     $"{lead}"),
-                _ when evt.LoadCoincident && evt.CleanParallelPaths > 0 => ("Congestion", "isp-event-badge-warning",
+                _ when evt.LoadCoincident && evt.CleanParallelPaths > 0 => ("Congestion", "isp-event-badge-congestion",
                     $"{lead} {evt.CleanParallelPaths} other monitored paths stayed clean under the same load, so it was this hop's own capacity, not your access link."),
-                _ => ("Congestion", "isp-event-badge-warning",
+                _ => ("Congestion", "isp-event-badge-congestion",
                     $"{lead}")
             };
             entries.Add(new TimelineEntry(evt.Start, badge, badgeClass, text, evt.End));
@@ -1222,15 +1297,16 @@ else
             {
                 var span = shift.UnreachableEnd.HasValue ? FormatDuration(shift.UnreachableEnd.Value - shift.Time) : "the window";
                 var hops = shift.CorrelatedTargetCount > 1 ? $" ({shift.CorrelatedTargetCount} monitored hops)" : "";
-                entries.Add(new TimelineEntry(shift.Time, "Path change", "isp-event-badge-info",
+                entries.Add(new TimelineEntry(shift.Time, "Path change", "isp-event-badge-change",
                     $"{where} went fully unreachable for {span}{hops} - a routing (BGP) change, not access-layer loss. Excluded from the Packet Loss factor; still counted against {where}'s own network grade.",
-                    shift.UnreachableEnd));
+                    shift.UnreachableEnd, EventCategory.Change));
                 continue;
             }
             var direction = shift.Direction == PathShiftDirection.Up ? "up" : "down";
             var correlated = shift.CorrelatedTargetCount > 1 ? $", seen on {shift.CorrelatedTargetCount} paths" : "";
-            entries.Add(new TimelineEntry(shift.Time, "Path shift", "isp-event-badge-info",
-                $"RTT stepped {direction} {Math.Abs(shift.DeltaMs):0.#} ms on {where} ({shift.BeforeMedianMs:0.#} to {shift.AfterMedianMs:0.#} ms){correlated}. BGP or transport fabric change."));
+            entries.Add(new TimelineEntry(shift.Time, "Path shift", "isp-event-badge-shift",
+                $"RTT stepped {direction} {Math.Abs(shift.DeltaMs):0.#} ms on {where} ({shift.BeforeMedianMs:0.#} to {shift.AfterMedianMs:0.#} ms){correlated}. BGP or transport fabric change.",
+                Category: EventCategory.Shift));
         }
         return entries.OrderBy(e => e.Time);
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -7,7 +7,6 @@
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NetworkOptimizer.Web.Services.PullToRefreshState PtrState
-@inject SiteContextService SiteCtx
 
 @* Date/time filter (left) + Refresh. The live/cached view (the effective auto-computed window, which
    auto-fallback may have reduced below the configured target) is the only state where Refresh is
@@ -725,13 +724,13 @@ else
     private System.Threading.Timer? _ageTimer;
 
     // Path & Congestion Events category filters (display-only - scoring is untouched). All on by
-    // default; the hidden set persists per site in localStorage as a comma list. Click semantics
-    // match the LAN flow map band chips: all on -> click solos that category, only-it-on -> click
-    // restores all, otherwise a plain toggle.
+    // default and deliberately NOT persisted, like the date/time filter above: a saved filter would
+    // silently suppress new events on the next visit. Click semantics match the LAN flow map band
+    // chips: all on -> click solos that category, only-it-on -> click restores all, otherwise a
+    // plain toggle.
     private static readonly EventCategory[] AllEventCategories =
         { EventCategory.Congestion, EventCategory.Shift, EventCategory.Change };
     private HashSet<EventCategory> _visibleEventCats = new(AllEventCategories);
-    private const string EventFilterBaseKey = "isp-health-event-filters";
 
     // Date/time filter. Never persisted: OnInitializedAsync starts on the live window (the effective
     // auto-computed window, which auto-fallback may have reduced below the configured target), so
@@ -1042,21 +1041,6 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (firstRender)
-        {
-            // Restore the per-site event-category filters before the chart mounts (the chart only
-            // mounts once a report has rendered, which is always after this first render).
-            string? hidden = null;
-            try { hidden = await JS.InvokeAsync<string>("localStorage.getItem", SiteCtx.ScopeStorageKey(EventFilterBaseKey)); }
-            catch { /* persistence is best-effort */ }
-            if (!string.IsNullOrEmpty(hidden))
-            {
-                if (hidden.Contains("congestion")) _visibleEventCats.Remove(EventCategory.Congestion);
-                if (hidden.Contains("shift")) _visibleEventCats.Remove(EventCategory.Shift);
-                if (hidden.Contains("change")) _visibleEventCats.Remove(EventCategory.Change);
-                if (_visibleEventCats.Count < AllEventCategories.Length) StateHasChanged();
-            }
-        }
         if (_scrollChartAfterRender)
         {
             _scrollChartAfterRender = false;
@@ -1231,12 +1215,6 @@ else
         else if (!_visibleEventCats.Remove(cat))
             _visibleEventCats.Add(cat);
 
-        var hidden = new List<string>();
-        if (!_visibleEventCats.Contains(EventCategory.Congestion)) hidden.Add("congestion");
-        if (!_visibleEventCats.Contains(EventCategory.Shift)) hidden.Add("shift");
-        if (!_visibleEventCats.Contains(EventCategory.Change)) hidden.Add("change");
-        try { await JS.InvokeVoidAsync("localStorage.setItem", SiteCtx.ScopeStorageKey(EventFilterBaseKey), string.Join(",", hidden)); }
-        catch { /* persistence is best-effort */ }
         if (_chartMounted)
         {
             try { await JS.InvokeVoidAsync("eval", $"window.__ispHealthCharts?.setHiddenTypes?.({HiddenChartTypesJson()});"); }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17002,6 +17002,10 @@ a.isp-health-hero-speed:hover {
     white-space: nowrap;
 }
 
+.isp-event-badge[data-tooltip] {
+    cursor: help;
+}
+
 .isp-event-badge-warning {
     color: var(--warning-color);
     background: rgba(245, 158, 11, 0.15);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17017,6 +17017,46 @@ a.isp-health-hero-speed:hover {
     background: rgba(238, 99, 104, 0.15);
 }
 
+.isp-event-badge-congestion {
+    color: var(--warning-color);
+    background: rgba(245, 158, 11, 0.15);
+}
+
+.isp-event-badge-congestion-soft {
+    color: rgba(231, 150, 19, 0.7);
+    background: rgba(245, 158, 11, 0.08);
+}
+
+.isp-event-badge-shift {
+    color: var(--info-color);
+    background: rgba(59, 130, 246, 0.15);
+}
+
+.isp-event-badge-change {
+    color: #a78bfa;
+    background: rgba(167, 139, 250, 0.15);
+}
+
+.isp-events-header {
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.isp-event-filter .time-btn.active.evt-congestion {
+    color: var(--warning-color);
+    background: rgba(245, 158, 11, 0.15);
+}
+
+.isp-event-filter .time-btn.active.evt-shift {
+    color: var(--info-color);
+    background: rgba(59, 130, 246, 0.15);
+}
+
+.isp-event-filter .time-btn.active.evt-change {
+    color: #a78bfa;
+    background: rgba(167, 139, 250, 0.15);
+}
+
 .isp-event-time {
     font-size: 0.78rem;
     font-weight: 600;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17000,6 +17000,7 @@ a.isp-health-hero-speed:hover {
     text-transform: uppercase;
     letter-spacing: 0.04em;
     white-space: nowrap;
+    cursor: default;
 }
 
 .isp-event-badge[data-tooltip] {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17023,7 +17023,7 @@ a.isp-health-hero-speed:hover {
 }
 
 .isp-event-badge-congestion-soft {
-    color: rgba(231, 150, 19, 0.7);
+    color: rgba(231, 150, 19, 0.5);
     background: rgba(245, 158, 11, 0.08);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -15,6 +15,9 @@ let isZoomed = false;
 let dotNetRef = null;
 // null = default 48 h cached view; { from, to } ISO strings = a filter-selected window.
 let win = null;
+// Event annotation types hidden by the panel's category filter pills; display-only.
+let hiddenTypes = new Set();
+let lastEvents = [];
 
 function buildOpts() {
     return {
@@ -108,6 +111,7 @@ function buildOpts() {
 function buildAnnotations(events) {
     const xaxis = [];
     for (const e of events) {
+        if (hiddenTypes.has(e.type)) continue;
         if (e.type === 'congestion') {
             xaxis.push({
                 x: new Date(e.start).getTime(),
@@ -123,11 +127,11 @@ function buildAnnotations(events) {
             xaxis.push({
                 x: new Date(e.start).getTime(),
                 x2: e.end ? new Date(e.end).getTime() : undefined,
-                fillColor: '#4797ff',
+                fillColor: '#a78bfa',
                 opacity: 0.12,
                 label: {
                     text: e.label,
-                    style: { color: '#ededef', background: '#1e3a5f', fontSize: '10px' },
+                    style: { color: '#ededef', background: '#581c87', fontSize: '10px' },
                 },
             });
         } else {
@@ -184,7 +188,8 @@ async function loadAndUpdate() {
             data: (a.points || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
         }));
 
-        chart.updateOptions({ annotations: buildAnnotations(json.events || []) }, false, false);
+        lastEvents = json.events || [];
+        chart.updateOptions({ annotations: buildAnnotations(lastEvents) }, false, false);
         // Preserve the user's drag-zoom; a series refresh while zoomed would snap back
         if (!isZoomed) chart.updateSeries(series, false);
     } catch (e) {
@@ -192,10 +197,11 @@ async function loadAndUpdate() {
     }
 }
 
-export async function mount(elId, fromISO = null, toISO = null) {
+export async function mount(elId, fromISO = null, toISO = null, hidden = null) {
     const el = document.getElementById(elId);
     if (!el) return;
     win = (fromISO && toISO) ? { from: fromISO, to: toISO } : null;
+    hiddenTypes = new Set(hidden || []);
 
     resetBtn = document.createElement('button');
     resetBtn.type = 'button';
@@ -230,6 +236,13 @@ export function setDotNetRef(ref) {
     dotNetRef = ref;
 }
 
+// Re-render event annotations with the given types hidden (display-only category filter);
+// no refetch, the last-loaded events are re-applied.
+export function setHiddenTypes(types) {
+    hiddenTypes = new Set(types || []);
+    if (chart) chart.updateOptions({ annotations: buildAnnotations(lastEvents) }, false, false);
+}
+
 export function scrollChartIntoView() {
     document.getElementById('isp-health-asn-chart')?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 }
@@ -241,5 +254,7 @@ export function unmount() {
     isZoomed = false;
     dotNetRef = null;
     win = null;
+    hiddenTypes = new Set();
+    lastEvents = [];
     if (chart) { chart.destroy(); chart = null; }
 }


### PR DESCRIPTION
## Monitoring - ISP Health

- **Path & Congestion Events** - a three-pill category filter (Congestion / Path shifts / Path changes) in the card header. Standard chip semantics: all on by default, first click solos a category, clicking the last active pill restores all, otherwise a plain toggle. Session-only by design, like the tab's date/time filter - a persisted filter would silently suppress new events on the next visit. Display-only; scoring is untouched.
- Filtering applies to both the events list and the **Per-Network RTT** chart annotations (congestion shading, path-shift lines, unreachable spans), with no refetch on toggle.
- Event badges recolored to match their pill: congestion amber, path shifts blue, path changes purple. Unconfirmed congestion (Loaded Latency, ICMP control-plane noise, unverifiable) renders as a dimmer shade of the same amber and carries a tooltip explaining why it's dimmed; confirmed congestion stays full intensity. Badges show a help cursor only when they carry a tooltip.
- The chart's unreachable annotations went blue to purple to agree with the Path changes pill.

## Fixes

- **Stale event-badge tooltips** - Blazor reusing timeline DOM nodes across re-renders could leave one entry's tooltip on another (wrong text, missing help cursor). Timeline items are now keyed, and event badges joined the periodic orphaned-tooltip sweep.
