### PR TITLE
sfp-sgmiiplus: retry the boot-time 2.5G mode set instead of only warning

### DIFF
--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/19-sfp-sgmiiplus-eth5.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/19-sfp-sgmiiplus-eth5.sh
@@ -8,9 +8,13 @@
 # within the timeout, the module loads anyway — this handles SFPs that are
 # hard-locked at 2.5G and can't establish a 1G link without the host matching.
 #
-# UniFi OS 5.1.27 can fail to commit the first boot-time mode set. The script
-# retries up to three times, restoring stock SGMII 1G between attempts, and
-# verifies that the 312.5 MHz clock holds past one SSDK MAC-sync cycle.
+# The boot-time mode set does not always commit: uniphy2 can stay at 125 MHz
+# even though insmod succeeded, and early in boot a set that did commit can
+# still be reverted up to ~35s later. Which boots are affected is timing-
+# dependent, so a given firmware and SFP can boot cleanly and fail on the next
+# try. The script retries up to five times, restoring stock SGMII 1G between
+# attempts, and verifies that the 312.5 MHz clock holds for 45s before
+# declaring success.
 #
 # The module bypasses the SSDK's SFP EEPROM validation by calling the uniphy
 # mode set function directly. The SSDK's MAC sync polling loop re-reads the
@@ -31,7 +35,8 @@ MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
 CLOCK_PATH="/sys/kernel/debug/clk/uniphy2_gcc_tx_clk/clk_rate"
 IFACE="eth5"
 CARRIER_TIMEOUT=90
-MAX_ATTEMPTS=3
+MAX_ATTEMPTS=5
+HOLD_SECS=45
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
@@ -113,18 +118,24 @@ while [ $attempt -le $MAX_ATTEMPTS ]; do
 
     # Clock is the success criterion, not carrier, so no-link 2.5G SFPs work.
     if [ "${AFTER_CLOCK}" = "312500000" ]; then
-        log "Clock reached 312500000 Hz; verifying it holds past a sync cycle"
-        sleep 15
-        AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
-        log "Clock rate after hold: ${AFTER_CLOCK} Hz"
+        log "Clock reached 312500000 Hz; verifying it holds for ${HOLD_SECS}s"
+        held=0
+        while [ $held -lt $HOLD_SECS ]; do
+            sleep 5
+            held=$((held + 5))
+            AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+            if [ "${AFTER_CLOCK}" != "312500000" ]; then
+                break
+            fi
+        done
 
         if [ "${AFTER_CLOCK}" = "312500000" ]; then
-            log "Verified: uniphy2 running at 312.5 MHz (SGMII+ 2.5G) and held past a sync cycle"
+            log "Verified: uniphy2 running at 312.5 MHz (SGMII+ 2.5G) and held for ${HOLD_SECS}s"
             verified=1
             break
         fi
 
-        log "WARNING: Attempt ${attempt} hold expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+        log "WARNING: Attempt ${attempt} clock reverted to ${AFTER_CLOCK} Hz after ${held}s of holding"
     else
         log "WARNING: Attempt ${attempt} expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
     fi

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/19-sfp-sgmiiplus-eth5.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/19-sfp-sgmiiplus-eth5.sh
@@ -8,14 +8,17 @@
 # within the timeout, the module loads anyway — this handles SFPs that are
 # hard-locked at 2.5G and can't establish a 1G link without the host matching.
 #
+# UniFi OS 5.1.27 can fail to commit the first boot-time mode set. The script
+# retries up to three times, restoring stock SGMII 1G between attempts, and
+# verifies that the 312.5 MHz clock holds past one SSDK MAC-sync cycle.
+#
 # The module bypasses the SSDK's SFP EEPROM validation by calling the uniphy
 # mode set function directly. The SSDK's MAC sync polling loop re-reads the
-# SFP EEPROM every ~12s and would revert the 2.5G change. The module excludes
-# eth5 from the polling loop's port bitmap and restarts it — the loop continues
-# to run for all other ports, so eth6 link recovery is unaffected.
+# SFP EEPROM every ~12s and would revert the 2.5G change. The module (v3+)
+# excludes eth5 from the polling loop's port bitmap and restarts it — the loop
+# continues to run for all other ports, so eth6 link recovery is unaffected.
 #
 # WARNING: This targets eth5 / Port 6 (the 1st SFP+ port) ONLY.
-# For eth6 / Port 7, use 20-sfp-sgmiiplus.sh instead.
 #
 # Target: UCG-Fiber / UXG-Fiber (IPQ9574, kernel 5.4.213-ui-ipq9574)
 # Requires: qca-ssdk.ko loaded, module pre-deployed to /data/sfp-sgmiiplus/
@@ -28,6 +31,7 @@ MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
 CLOCK_PATH="/sys/kernel/debug/clk/uniphy2_gcc_tx_clk/clk_rate"
 IFACE="eth5"
 CARRIER_TIMEOUT=90
+MAX_ATTEMPTS=3
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
@@ -73,9 +77,7 @@ if [ "$carrier" != "1" ]; then
     log "${IFACE} no carrier after ${CARRIER_TIMEOUT}s — loading module anyway (SFP may be hard-locked at 2.5G)"
 fi
 
-# ─── Load module ───
-
-log "Loading ${MODULE_NAME}..."
+# ─── Load and verify module ───
 
 BEFORE_CLOCK=""
 if [ -f "${CLOCK_PATH}" ]; then
@@ -83,29 +85,95 @@ if [ -f "${CLOCK_PATH}" ]; then
     log "Clock rate before: ${BEFORE_CLOCK} Hz"
 fi
 
-insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
-RET=$?
+attempt=1
+verified=0
 
-if [ ${RET} -ne 0 ]; then
-    log "ERROR: insmod failed with exit code ${RET}"
-    exit 1
-fi
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+    log "Loading ${MODULE_NAME} (attempt ${attempt}/${MAX_ATTEMPTS})..."
 
-# Give the mode set sequence time to complete (~300ms PLL relock + calibration)
-sleep 1
+    insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
+    RET=$?
 
-# ─── Verify ───
-
-if [ -f "${CLOCK_PATH}" ]; then
-    AFTER_CLOCK=$(cat "${CLOCK_PATH}")
-    log "Clock rate after: ${AFTER_CLOCK} Hz"
-    if [ "${AFTER_CLOCK}" = "312500000" ]; then
-        log "Verified: uniphy2 running at 312.5 MHz (SGMII+ 2.5G)"
-    else
-        log "WARNING: Expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    if [ ${RET} -ne 0 ]; then
+        log "ERROR: insmod failed with exit code ${RET}"
+        exit 1
     fi
-else
-    log "WARNING: ${CLOCK_PATH} not found, cannot verify clock rate"
+
+    # Give the mode set sequence time to complete (~300ms PLL relock + calibration)
+    sleep 1
+
+    if [ ! -f "${CLOCK_PATH}" ]; then
+        log "WARNING: ${CLOCK_PATH} not found, cannot verify clock rate"
+        verified=1
+        break
+    fi
+
+    AFTER_CLOCK=$(cat "${CLOCK_PATH}")
+    log "Clock rate after attempt ${attempt}: ${AFTER_CLOCK} Hz"
+
+    # Clock is the success criterion, not carrier, so no-link 2.5G SFPs work.
+    if [ "${AFTER_CLOCK}" = "312500000" ]; then
+        log "Clock reached 312500000 Hz; verifying it holds past a sync cycle"
+        sleep 15
+        AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+        log "Clock rate after hold: ${AFTER_CLOCK} Hz"
+
+        if [ "${AFTER_CLOCK}" = "312500000" ]; then
+            log "Verified: uniphy2 running at 312.5 MHz (SGMII+ 2.5G) and held past a sync cycle"
+            verified=1
+            break
+        fi
+
+        log "WARNING: Attempt ${attempt} hold expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    else
+        log "WARNING: Attempt ${attempt} expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    fi
+
+    log "Removing ${MODULE_NAME} to restore stock SGMII 1G before retry"
+    rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
+    RET=$?
+
+    if [ ${RET} -ne 0 ]; then
+        log "ERROR: rmmod failed with exit code ${RET}"
+        exit 1
+    fi
+
+    elapsed=0
+    carrier=""
+    while [ $elapsed -lt 30 ]; do
+        carrier=$(cat /sys/class/net/${IFACE}/carrier 2>/dev/null)
+        if [ "$carrier" = "1" ]; then
+            log "${IFACE} stock 1G carrier recovered after ${elapsed}s"
+            break
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    if [ "$carrier" != "1" ]; then
+        log "WARNING: ${IFACE} stock 1G carrier did not recover after 30s; continuing anyway"
+    fi
+
+    if [ $attempt -lt $MAX_ATTEMPTS ]; then
+        backoff=$((attempt * 5))
+        log "Retrying after ${backoff}s backoff"
+        sleep $backoff
+    fi
+
+    attempt=$((attempt + 1))
+done
+
+if [ $verified -ne 1 ]; then
+    if lsmod | grep -q "${MODULE_NAME}"; then
+        rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
+        RET=$?
+        if [ ${RET} -ne 0 ]; then
+            log "ERROR: final rmmod failed with exit code ${RET}"
+            exit 1
+        fi
+    fi
+    log "ERROR: 2.5G mode did not stick after ${MAX_ATTEMPTS} attempts; ${IFACE} was left in stock SGMII 1G state so the link still works at 1G"
+    exit 1
 fi
 
 if lsmod | grep -q "${MODULE_NAME}"; then

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/20-sfp-sgmiiplus.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/20-sfp-sgmiiplus.sh
@@ -8,6 +8,10 @@
 # within the timeout, the module loads anyway — this handles SFPs that are
 # hard-locked at 2.5G and can't establish a 1G link without the host matching.
 #
+# UniFi OS 5.1.27 can fail to commit the first boot-time mode set. The script
+# retries up to three times, restoring stock SGMII 1G between attempts, and
+# verifies that the 312.5 MHz clock holds past one SSDK MAC-sync cycle.
+#
 # The module bypasses the SSDK's SFP EEPROM validation by calling the uniphy
 # mode set function directly. The SSDK's MAC sync polling loop re-reads the
 # SFP EEPROM every ~12s and would revert the 2.5G change. The module (v3+)
@@ -27,6 +31,7 @@ MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
 CLOCK_PATH="/sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate"
 IFACE="eth6"
 CARRIER_TIMEOUT=90
+MAX_ATTEMPTS=3
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
@@ -72,9 +77,7 @@ if [ "$carrier" != "1" ]; then
     log "${IFACE} no carrier after ${CARRIER_TIMEOUT}s — loading module anyway (SFP may be hard-locked at 2.5G)"
 fi
 
-# ─── Load module ───
-
-log "Loading ${MODULE_NAME}..."
+# ─── Load and verify module ───
 
 BEFORE_CLOCK=""
 if [ -f "${CLOCK_PATH}" ]; then
@@ -82,29 +85,95 @@ if [ -f "${CLOCK_PATH}" ]; then
     log "Clock rate before: ${BEFORE_CLOCK} Hz"
 fi
 
-insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
-RET=$?
+attempt=1
+verified=0
 
-if [ ${RET} -ne 0 ]; then
-    log "ERROR: insmod failed with exit code ${RET}"
-    exit 1
-fi
+while [ $attempt -le $MAX_ATTEMPTS ]; do
+    log "Loading ${MODULE_NAME} (attempt ${attempt}/${MAX_ATTEMPTS})..."
 
-# Give the mode set sequence time to complete (~300ms PLL relock + calibration)
-sleep 1
+    insmod "${MODULE_FILE}" 2>> "${LOG_FILE}"
+    RET=$?
 
-# ─── Verify ───
-
-if [ -f "${CLOCK_PATH}" ]; then
-    AFTER_CLOCK=$(cat "${CLOCK_PATH}")
-    log "Clock rate after: ${AFTER_CLOCK} Hz"
-    if [ "${AFTER_CLOCK}" = "312500000" ]; then
-        log "Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G)"
-    else
-        log "WARNING: Expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    if [ ${RET} -ne 0 ]; then
+        log "ERROR: insmod failed with exit code ${RET}"
+        exit 1
     fi
-else
-    log "WARNING: ${CLOCK_PATH} not found, cannot verify clock rate"
+
+    # Give the mode set sequence time to complete (~300ms PLL relock + calibration)
+    sleep 1
+
+    if [ ! -f "${CLOCK_PATH}" ]; then
+        log "WARNING: ${CLOCK_PATH} not found, cannot verify clock rate"
+        verified=1
+        break
+    fi
+
+    AFTER_CLOCK=$(cat "${CLOCK_PATH}")
+    log "Clock rate after attempt ${attempt}: ${AFTER_CLOCK} Hz"
+
+    # Clock is the success criterion, not carrier, so no-link 2.5G SFPs work.
+    if [ "${AFTER_CLOCK}" = "312500000" ]; then
+        log "Clock reached 312500000 Hz; verifying it holds past a sync cycle"
+        sleep 15
+        AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+        log "Clock rate after hold: ${AFTER_CLOCK} Hz"
+
+        if [ "${AFTER_CLOCK}" = "312500000" ]; then
+            log "Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G) and held past a sync cycle"
+            verified=1
+            break
+        fi
+
+        log "WARNING: Attempt ${attempt} hold expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    else
+        log "WARNING: Attempt ${attempt} expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+    fi
+
+    log "Removing ${MODULE_NAME} to restore stock SGMII 1G before retry"
+    rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
+    RET=$?
+
+    if [ ${RET} -ne 0 ]; then
+        log "ERROR: rmmod failed with exit code ${RET}"
+        exit 1
+    fi
+
+    elapsed=0
+    carrier=""
+    while [ $elapsed -lt 30 ]; do
+        carrier=$(cat /sys/class/net/${IFACE}/carrier 2>/dev/null)
+        if [ "$carrier" = "1" ]; then
+            log "${IFACE} stock 1G carrier recovered after ${elapsed}s"
+            break
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+
+    if [ "$carrier" != "1" ]; then
+        log "WARNING: ${IFACE} stock 1G carrier did not recover after 30s; continuing anyway"
+    fi
+
+    if [ $attempt -lt $MAX_ATTEMPTS ]; then
+        backoff=$((attempt * 5))
+        log "Retrying after ${backoff}s backoff"
+        sleep $backoff
+    fi
+
+    attempt=$((attempt + 1))
+done
+
+if [ $verified -ne 1 ]; then
+    if lsmod | grep -q "${MODULE_NAME}"; then
+        rmmod "${MODULE_NAME}" 2>> "${LOG_FILE}"
+        RET=$?
+        if [ ${RET} -ne 0 ]; then
+            log "ERROR: final rmmod failed with exit code ${RET}"
+            exit 1
+        fi
+    fi
+    log "ERROR: 2.5G mode did not stick after ${MAX_ATTEMPTS} attempts; ${IFACE} was left in stock SGMII 1G state so the link still works at 1G"
+    exit 1
 fi
 
 if lsmod | grep -q "${MODULE_NAME}"; then

--- a/src/NetworkOptimizer.Web/Resources/PerfTweaks/20-sfp-sgmiiplus.sh
+++ b/src/NetworkOptimizer.Web/Resources/PerfTweaks/20-sfp-sgmiiplus.sh
@@ -8,9 +8,13 @@
 # within the timeout, the module loads anyway — this handles SFPs that are
 # hard-locked at 2.5G and can't establish a 1G link without the host matching.
 #
-# UniFi OS 5.1.27 can fail to commit the first boot-time mode set. The script
-# retries up to three times, restoring stock SGMII 1G between attempts, and
-# verifies that the 312.5 MHz clock holds past one SSDK MAC-sync cycle.
+# The boot-time mode set does not always commit: uniphy1 can stay at 125 MHz
+# even though insmod succeeded, and early in boot a set that did commit can
+# still be reverted up to ~35s later. Which boots are affected is timing-
+# dependent, so a given firmware and SFP can boot cleanly and fail on the next
+# try. The script retries up to five times, restoring stock SGMII 1G between
+# attempts, and verifies that the 312.5 MHz clock holds for 45s before
+# declaring success.
 #
 # The module bypasses the SSDK's SFP EEPROM validation by calling the uniphy
 # mode set function directly. The SSDK's MAC sync polling loop re-reads the
@@ -31,7 +35,8 @@ MODULE_FILE="${MODULE_DIR}/${MODULE_NAME}.ko"
 CLOCK_PATH="/sys/kernel/debug/clk/uniphy1_gcc_tx_clk/clk_rate"
 IFACE="eth6"
 CARRIER_TIMEOUT=90
-MAX_ATTEMPTS=3
+MAX_ATTEMPTS=5
+HOLD_SECS=45
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') - $1" >> "${LOG_FILE}"
@@ -113,18 +118,24 @@ while [ $attempt -le $MAX_ATTEMPTS ]; do
 
     # Clock is the success criterion, not carrier, so no-link 2.5G SFPs work.
     if [ "${AFTER_CLOCK}" = "312500000" ]; then
-        log "Clock reached 312500000 Hz; verifying it holds past a sync cycle"
-        sleep 15
-        AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
-        log "Clock rate after hold: ${AFTER_CLOCK} Hz"
+        log "Clock reached 312500000 Hz; verifying it holds for ${HOLD_SECS}s"
+        held=0
+        while [ $held -lt $HOLD_SECS ]; do
+            sleep 5
+            held=$((held + 5))
+            AFTER_CLOCK=$(cat "${CLOCK_PATH}" 2>/dev/null)
+            if [ "${AFTER_CLOCK}" != "312500000" ]; then
+                break
+            fi
+        done
 
         if [ "${AFTER_CLOCK}" = "312500000" ]; then
-            log "Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G) and held past a sync cycle"
+            log "Verified: uniphy1 running at 312.5 MHz (SGMII+ 2.5G) and held for ${HOLD_SECS}s"
             verified=1
             break
         fi
 
-        log "WARNING: Attempt ${attempt} hold expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
+        log "WARNING: Attempt ${attempt} clock reverted to ${AFTER_CLOCK} Hz after ${held}s of holding"
     else
         log "WARNING: Attempt ${attempt} expected 312500000 Hz, got ${AFTER_CLOCK} Hz"
     fi


### PR DESCRIPTION
Fixes #1052.

On UniFi OS 5.1.27 the first boot-time uniphy mode set can fail to commit: the module loads cleanly and logs success, but the uniphy clock stays at 125 MHz and the port stays NO-CARRIER against an SFP that has switched to 2.5G. The scripts already detect this (clock readback) but only log a WARNING. A manual `rmmod` + `insmod` on the same boot reliably fixes it - full evidence in the issue.

### Change

Both `20-sfp-sgmiiplus.sh` and `19-sfp-sgmiiplus-eth5.sh` (kept textually parallel) turn the single post-insmod clock check into a bounded recovery loop:

- verify the clock reads 312500000 Hz **and holds past one ~12s SSDK MAC-sync cycle** - a single read 1s after insmod only proves a momentary state
- on mismatch: `rmmod` to restore stock SGMII 1G, wait up to 30s for the stock 1G link to recover (continue on timeout - the SFP may be absent or unable to link at 1G), back off 5s/10s, retry; 3 attempts total
- if all attempts fail: remove the module, log a clear ERROR, exit non-zero - the port is left in stock SGMII 1G state so the WAN still works at 1G instead of staying dead

The success criterion is deliberately clock-only (not carrier) so the module still loads for SFPs that are hard-locked at 2.5G and cannot establish a 1G link (existing documented behavior). Behavior with an unreadable debugfs clock path is unchanged from today. The retry is bounded on purpose: if something on the host actively re-asserts 1G, an unbounded loop would flap the WAN forever.

No C# changes needed - `PerfTweaksDeploymentService` compares script hashes, so existing deployments will show as update-available and redeploy the new script as usual.

### Testing

- `sh -n` clean on both scripts; scripts stay strict busybox/POSIX sh.
- Harness test with shimmed `insmod`/`rmmod`/`lsmod` and file-backed clock/carrier: (a) attempt 1 fails, attempt 2 commits -> success path with hold verification, exit 0; (b) all attempts fail -> module removed, port left stock, exit 1. Both logs behave as intended.
- Live evidence for the recovery sequence itself (rmmod -> stock 1G relink -> insmod -> 312.5 MHz held, link 2500 Full, PPPoE back) verified manually on my UCG-Fiber on 5.1.27.
- The remaining open question is whether the retry also commits at boot time (my manual fix ran later in uptime). I hit the failure on every reboot, so I will reboot with the patched script and report back on the issue.
