### PR TITLE
Security Audit: resolve UniFi domain-group destinations

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallGroupHelper.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallGroupHelper.cs
@@ -4,11 +4,35 @@ using NetworkOptimizer.UniFi.Models;
 namespace NetworkOptimizer.Audit.Analyzers;
 
 /// <summary>
-/// Shared helper for resolving firewall group references (port groups and address groups)
+/// Shared helper for resolving firewall group references (port, address, and domain groups)
 /// and checking port specifications.
 /// </summary>
 public static class FirewallGroupHelper
 {
+    /// <summary>
+    /// Resolve a domain group ID to its web domains.
+    /// </summary>
+    public static List<string>? ResolveDomainGroup(
+        string groupId,
+        Dictionary<string, UniFiFirewallGroup>? firewallGroups,
+        ILogger? logger = null)
+    {
+        if (firewallGroups == null || !firewallGroups.TryGetValue(groupId, out var group))
+        {
+            logger?.LogDebug("Domain group {GroupId} not found in loaded groups", groupId);
+            return null;
+        }
+
+        if (group.GroupType != "domain-group")
+        {
+            logger?.LogWarning("Group {GroupId} ({GroupName}) is type '{GroupType}', expected domain-group",
+                groupId, group.Name, group.GroupType);
+            return null;
+        }
+
+        return group.GroupMembers?.Count > 0 ? group.GroupMembers.ToList() : null;
+    }
+
     /// <summary>
     /// Resolve a port group ID to a comma-separated port string (e.g., "53,80,443" or "4001-4003")
     /// </summary>

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -22,7 +22,7 @@ public class FirewallRuleAnalyzer
     }
 
     /// <summary>
-    /// Set firewall groups for flattening port_group_id and ip_group_id references.
+    /// Set firewall groups for flattening port_group_id, ip_group_id, and web_group_id references.
     /// Call this before ExtractFirewallPolicies to enable group resolution.
     /// </summary>
     public void SetFirewallGroups(IEnumerable<UniFiFirewallGroup>? groups)
@@ -1231,6 +1231,9 @@ public class FirewallRuleAnalyzer
 
         var destTarget = rule.DestinationMatchingTarget?.ToUpperInvariant();
         var protocol = rule.Protocol?.ToLowerInvariant() ?? "all";
+
+        if (destTarget == "WEB" && rule.HasUnresolvedDestinationDomainGroup)
+            return false;
 
         // Check for HTTP/HTTPS app IDs - these are always broad web access
         if (rule.AppIds != null && rule.AppIds.Any(id =>

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleParser.cs
@@ -8,7 +8,7 @@ namespace NetworkOptimizer.Audit.Analyzers;
 
 /// <summary>
 /// Parses firewall rules from UniFi API responses.
-/// Supports flattening of port lists (port groups) and IP lists (address groups)
+/// Supports flattening of port lists, IP lists, and web domains from firewall groups
 /// when firewall groups are provided.
 /// </summary>
 public class FirewallRuleParser
@@ -37,7 +37,7 @@ public class FirewallRuleParser
     }
 
     /// <summary>
-    /// Set firewall groups for flattening port_group_id and ip_group_id references.
+    /// Set firewall groups for flattening port_group_id, ip_group_id, and web_group_id references.
     /// Call this before ExtractFirewallPolicies to enable group resolution.
     /// </summary>
     public void SetFirewallGroups(IEnumerable<UniFiFirewallGroup>? groups)
@@ -256,6 +256,7 @@ public class FirewallRuleParser
         bool destMatchOppositeIps = false;
         bool destMatchOppositeNetworks = false;
         bool destMatchOppositePorts = false;
+        bool hasUnresolvedDestDomainGroup = false;
         bool hasUnresolvedDestPortGroup = false;
         if (policy.TryGetProperty("destination", out var dest) && dest.ValueKind == JsonValueKind.Object)
         {
@@ -308,8 +309,28 @@ public class FirewallRuleParser
                     .ToList();
             }
 
-            // Flatten IP group reference (matching_target_type == "OBJECT" with ip_group_id)
             var matchingTargetType = dest.GetStringOrNull("matching_target_type");
+            var webGroupId = dest.GetStringOrNull("web_group_id");
+            if (matchingTargetType == "OBJECT" && !string.IsNullOrEmpty(webGroupId))
+            {
+                var groupDomains = ResolveDomainGroup(webGroupId);
+                if (groupDomains != null && groupDomains.Count > 0)
+                {
+                    webDomains = webDomains == null
+                        ? groupDomains
+                        : webDomains.Concat(groupDomains).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+                    _logger.LogDebug("Flattened destination domain group {GroupId} to {Count} domains for rule {RuleName}",
+                        webGroupId, groupDomains.Count, name);
+                }
+                else
+                {
+                    hasUnresolvedDestDomainGroup = true;
+                    _logger.LogWarning("Failed to resolve destination domain group {GroupId} for rule {RuleName}",
+                        webGroupId, name);
+                }
+            }
+
+            // Flatten IP group reference (matching_target_type == "OBJECT" with ip_group_id)
             var ipGroupId = dest.GetStringOrNull("ip_group_id");
             if (matchingTargetType == "OBJECT" && !string.IsNullOrEmpty(ipGroupId))
             {
@@ -377,6 +398,7 @@ public class FirewallRuleParser
             DestinationMatchOppositeIps = destMatchOppositeIps,
             DestinationMatchOppositeNetworks = destMatchOppositeNetworks,
             DestinationMatchOppositePorts = destMatchOppositePorts,
+            HasUnresolvedDestinationDomainGroup = hasUnresolvedDestDomainGroup,
             HasUnresolvedDestinationPortGroup = hasUnresolvedDestPortGroup,
             // Connection state matching
             ConnectionStateType = connectionStateType,
@@ -728,6 +750,12 @@ public class FirewallRuleParser
     /// </summary>
     private List<string>? ResolveAddressGroup(string groupId)
         => FirewallGroupHelper.ResolveAddressGroup(groupId, _firewallGroups, _logger);
+
+    /// <summary>
+    /// Resolve a domain group ID to a list of web domains.
+    /// </summary>
+    private List<string>? ResolveDomainGroup(string groupId)
+        => FirewallGroupHelper.ResolveDomainGroup(groupId, _firewallGroups, _logger);
 
     /// <summary>
     /// Resolve a port group ID to a comma-separated port string (e.g., "53,80,443" or "4001-4003")

--- a/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
+++ b/src/NetworkOptimizer.Audit/Models/FirewallRule.cs
@@ -156,6 +156,11 @@ public class FirewallRule
     public List<string>? DestinationNetworkIds { get; init; }
 
     /// <summary>
+    /// True when a destination web_group_id was present but its domain-group members could not be resolved.
+    /// </summary>
+    public bool HasUnresolvedDestinationDomainGroup { get; init; }
+
+    /// <summary>
     /// ICMP type name (ANY, ECHO_REQUEST, etc.) - for ICMP protocol
     /// </summary>
     public string? IcmpTypename { get; init; }

--- a/src/NetworkOptimizer.UniFi/Models/UniFiFirewallGroup.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiFirewallGroup.cs
@@ -4,7 +4,7 @@ namespace NetworkOptimizer.UniFi.Models;
 
 /// <summary>
 /// Response from GET /api/s/{site}/rest/firewallgroup
-/// Represents a firewall group (address group, port group, IPv6 group)
+/// Represents a firewall group (address, IPv6 address, port, or domain group)
 /// </summary>
 public class UniFiFirewallGroup
 {
@@ -18,7 +18,7 @@ public class UniFiFirewallGroup
     public string Name { get; set; } = string.Empty;
 
     [JsonPropertyName("group_type")]
-    public string GroupType { get; set; } = string.Empty; // "address-group", "ipv6-address-group", "port-group"
+    public string GroupType { get; set; } = string.Empty; // "address-group", "ipv6-address-group", "port-group", "domain-group"
 
     [JsonPropertyName("group_members")]
     public List<string> GroupMembers { get; set; } = new();

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallGroupHelperTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallGroupHelperTests.cs
@@ -11,6 +11,51 @@ public class FirewallGroupHelperTests
 {
     private readonly Mock<ILogger> _loggerMock = new();
 
+    #region ResolveDomainGroup Tests
+
+    [Fact]
+    public void ResolveDomainGroup_ValidDomainGroup_ReturnsDomains()
+    {
+        var groups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["group1"] = new UniFiFirewallGroup
+            {
+                Id = "group1",
+                Name = "DoH Providers",
+                GroupType = "domain-group",
+                GroupMembers = new List<string> { "dns.google", "cloudflare-dns.com" }
+            }
+        };
+
+        var result = FirewallGroupHelper.ResolveDomainGroup("group1", groups, _loggerMock.Object);
+
+        result.Should().BeEquivalentTo("dns.google", "cloudflare-dns.com");
+    }
+
+    [Theory]
+    [InlineData("address-group")]
+    [InlineData("ipv6-address-group")]
+    [InlineData("port-group")]
+    public void ResolveDomainGroup_NonDomainGroup_ReturnsNull(string groupType)
+    {
+        var groups = new Dictionary<string, UniFiFirewallGroup>
+        {
+            ["group1"] = new UniFiFirewallGroup
+            {
+                Id = "group1",
+                Name = "Other Object",
+                GroupType = groupType,
+                GroupMembers = new List<string> { "192.0.2.1" }
+            }
+        };
+
+        var result = FirewallGroupHelper.ResolveDomainGroup("group1", groups, _loggerMock.Object);
+
+        result.Should().BeNull();
+    }
+
+    #endregion
+
     #region IncludesPort Tests
 
     [Theory]

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -6481,6 +6482,123 @@ public class FirewallRuleAnalyzerTests
         var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, null);
 
         issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_DomainGroupBackedManagementHttps_NoIssue()
+    {
+        const string managementZoneId = "management-zone";
+        const string externalZoneId = "external-zone";
+        var domainGroup = new UniFiFirewallGroup
+        {
+            Id = "group-unifi-cloud",
+            Name = "UniFi Cloud and AFC Domains",
+            GroupType = "domain-group",
+            GroupMembers = new List<string> { "ui.com", "afcapi.qcs.qualcomm.com" }
+        };
+        _analyzer.SetFirewallGroups(new[] { domainGroup });
+        var policies = JsonDocument.Parse(@"[{
+            ""_id"": ""allow-management-ui"",
+            ""name"": ""Allow Management to External UI/AFC HTTPS"",
+            ""enabled"": true,
+            ""action"": ""ALLOW"",
+            ""protocol"": ""tcp"",
+            ""source"": {
+                ""zone_id"": ""management-zone"",
+                ""matching_target"": ""ANY""
+            },
+            ""destination"": {
+                ""web_matching_type"": ""CUSTOM"",
+                ""web_domains"": [],
+                ""web_group_id"": ""group-unifi-cloud"",
+                ""zone_id"": ""external-zone"",
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""port_matching_type"": ""SPECIFIC"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: managementZoneId)
+        };
+
+        var rules = _analyzer.ExtractFirewallPolicies(policies);
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, externalZoneId);
+
+        rules.Should().ContainSingle().Which.WebDomains.Should().BeEquivalentTo(domainGroup.GroupMembers);
+        issues.Should().NotContain(issue => issue.Type == "INTERNET_BLOCK_BYPASSED");
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_UnresolvedDomainGroup_NoIssue()
+    {
+        const string externalZoneId = "external-zone";
+        var policies = JsonDocument.Parse(@"[{
+            ""_id"": ""allow-unresolved-web-object"",
+            ""name"": ""Allow unresolved domain object"",
+            ""enabled"": true,
+            ""action"": ""ALLOW"",
+            ""protocol"": ""tcp"",
+            ""source"": {
+                ""matching_target"": ""NETWORK"",
+                ""network_ids"": [""mgmt-net""]
+            },
+            ""destination"": {
+                ""web_domains"": [],
+                ""web_group_id"": ""missing-domain-group"",
+                ""zone_id"": ""external-zone"",
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
+        };
+
+        var rules = _analyzer.ExtractFirewallPolicies(policies);
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, externalZoneId);
+
+        rules.Should().ContainSingle().Which.Should().Match<FirewallRule>(rule =>
+            rule.DestinationMatchingTarget == "WEB" &&
+            rule.HasUnresolvedDestinationDomainGroup);
+        issues.Should().NotContain(issue => issue.Type == "INTERNET_BLOCK_BYPASSED");
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_EmptyWebTargetWithoutObject_ReturnsIssue()
+    {
+        const string externalZoneId = "external-zone";
+        var policies = JsonDocument.Parse(@"[{
+            ""_id"": ""allow-empty-web-target"",
+            ""name"": ""Allow empty web target"",
+            ""enabled"": true,
+            ""action"": ""ALLOW"",
+            ""protocol"": ""tcp"",
+            ""source"": {
+                ""matching_target"": ""NETWORK"",
+                ""network_ids"": [""mgmt-net""]
+            },
+            ""destination"": {
+                ""web_domains"": [],
+                ""zone_id"": ""external-zone"",
+                ""matching_target"": ""WEB"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
+        };
+
+        var rules = _analyzer.ExtractFirewallPolicies(policies);
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, externalZoneId);
+
+        rules.Should().ContainSingle().Which.HasUnresolvedDestinationDomainGroup.Should().BeFalse();
+        issues.Should().ContainSingle(issue => issue.Type == "INTERNET_BLOCK_BYPASSED");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleParserTests.cs
@@ -1175,6 +1175,72 @@ public class FirewallRuleParserTests
     #region Firewall Group Flattening Tests
 
     [Fact]
+    public void ParseFirewallPolicy_DestinationDomainGroupReference_FlattensToWebDomains()
+    {
+        var domainGroup = new UniFiFirewallGroup
+        {
+            Id = "group-doh",
+            Name = "DoH Providers",
+            GroupType = "domain-group",
+            GroupMembers = new List<string>
+            {
+                "cloudflare-dns.com", "dns.google", "dns.quad9.net", "doh.opendns.com"
+            }
+        };
+        _parser.SetFirewallGroups(new[] { domainGroup });
+
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""block-doh"",
+            ""destination"": {
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""web_matching_type"": ""CUSTOM"",
+                ""web_domains"": [],
+                ""web_group_id"": ""group-doh"",
+                ""port_matching_type"": ""SPECIFIC"",
+                ""port"": ""443""
+            }
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallPolicy(json);
+
+        rule.Should().NotBeNull();
+        rule!.DestinationMatchingTarget.Should().Be("WEB");
+        rule.WebDomains.Should().BeEquivalentTo(domainGroup.GroupMembers);
+        rule.HasUnresolvedDestinationDomainGroup.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ParseFirewallPolicy_DestinationWebGroupReferencesAddressGroup_DoesNotUseAddressesAsDomains()
+    {
+        var addressGroup = new UniFiFirewallGroup
+        {
+            Id = "group-addresses",
+            Name = "External DNS IPs",
+            GroupType = "address-group",
+            GroupMembers = new List<string> { "1.1.1.1", "8.8.8.8" }
+        };
+        _parser.SetFirewallGroups(new[] { addressGroup });
+
+        var json = JsonDocument.Parse(@"{
+            ""_id"": ""wrong-object-type"",
+            ""destination"": {
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""web_group_id"": ""group-addresses""
+            }
+        }").RootElement;
+
+        var rule = _parser.ParseFirewallPolicy(json);
+
+        rule.Should().NotBeNull();
+        rule!.DestinationMatchingTarget.Should().Be("WEB");
+        rule.WebDomains.Should().BeNull();
+        rule.DestinationIps.Should().BeNull();
+        rule.HasUnresolvedDestinationDomainGroup.Should().BeTrue();
+    }
+
+    [Fact]
     public void ParseFirewallPolicy_DestinationPortGroupReference_FlattensToPortString()
     {
         // Arrange - Set up a port group (DNS port 53)

--- a/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Dns/DnsSecurityAnalyzerTests.cs
@@ -445,6 +445,104 @@ public class DnsSecurityAnalyzerTests : IDisposable
     }
 
     [Fact]
+    public async Task Analyze_WithDomainGroupBackedDohTcp443Block_DetectsRule()
+    {
+        var domainGroup = new UniFiFirewallGroup
+        {
+            Id = "group-doh",
+            Name = "DoH Providers",
+            GroupType = "domain-group",
+            GroupMembers = new List<string>
+            {
+                "cloudflare-dns.com", "dns.google", "dns.quad9.net", "doh.opendns.com"
+            }
+        };
+        var firewall = JsonDocument.Parse(@"[{
+            ""name"": ""Block Internal to External DoH v4"",
+            ""enabled"": true,
+            ""action"": ""BLOCK"",
+            ""protocol"": ""tcp"",
+            ""destination"": {
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""web_matching_type"": ""CUSTOM"",
+                ""web_domains"": [],
+                ""web_group_id"": ""group-doh"",
+                ""port_matching_type"": ""SPECIFIC"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall, new List<UniFiFirewallGroup> { domainGroup }));
+
+        result.HasDohBlockRule.Should().BeTrue();
+        result.DohRuleName.Should().Be("Block Internal to External DoH v4");
+        result.DohBlockedDomains.Should().BeEquivalentTo(domainGroup.GroupMembers);
+    }
+
+    [Fact]
+    public async Task Analyze_WithIncompleteDomainGroupBackedDohBlock_DoesNotDetect()
+    {
+        var domainGroup = new UniFiFirewallGroup
+        {
+            Id = "group-doh",
+            Name = "Incomplete DoH Providers",
+            GroupType = "domain-group",
+            GroupMembers = new List<string> { "cloudflare-dns.com", "dns.google", "dns.quad9.net" }
+        };
+        var firewall = JsonDocument.Parse(@"[{
+            ""name"": ""Partial DoH Block"",
+            ""enabled"": true,
+            ""action"": ""BLOCK"",
+            ""protocol"": ""tcp"",
+            ""destination"": {
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""web_domains"": [],
+                ""web_group_id"": ""group-doh"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall, new List<UniFiFirewallGroup> { domainGroup }));
+
+        result.HasDohBlockRule.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Analyze_WithDomainGroupBackedUdp443Block_DoesNotDetectTcpDohBlock()
+    {
+        var domainGroup = new UniFiFirewallGroup
+        {
+            Id = "group-doh",
+            Name = "DoH Providers",
+            GroupType = "domain-group",
+            GroupMembers = new List<string>
+            {
+                "cloudflare-dns.com", "dns.google", "dns.quad9.net", "doh.opendns.com"
+            }
+        };
+        var firewall = JsonDocument.Parse(@"[{
+            ""name"": ""Block DoH3 Only"",
+            ""enabled"": true,
+            ""action"": ""BLOCK"",
+            ""protocol"": ""udp"",
+            ""destination"": {
+                ""matching_target"": ""WEB"",
+                ""matching_target_type"": ""OBJECT"",
+                ""web_domains"": [],
+                ""web_group_id"": ""group-doh"",
+                ""port"": ""443""
+            }
+        }]").RootElement;
+
+        var result = await _analyzer.AnalyzeAsync(null, ParseFirewallRules(firewall, new List<UniFiFirewallGroup> { domainGroup }));
+
+        result.HasDohBlockRule.Should().BeFalse();
+        result.HasDoh3BlockRule.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task Analyze_WithDohBlockRule_MissingRequiredProvider_DoesNotDetect()
     {
         // Only 3 of 4 required providers (missing OpenDNS) - should not get credit


### PR DESCRIPTION
Fixes #1062.

## Security Audit

- **Native domain groups resolved** - zone-policy `web_group_id` references now resolve `domain-group` members into the rule’s web domains while preserving the `WEB` destination target.
- **DoH coverage restored** - domain-group-backed TCP/443 blocks receive credit only when they cover all required DoH providers.
- **Internet bypass false positives removed** - domain-restricted Management HTTPS allows are no longer treated as broad external access.
- **Failure handling remains conservative** - missing groups retain their object-backed restriction without receiving DNS coverage, while address and port groups cannot be interpreted as domains.

The implementation was verified against the live UniFi `WEB`/`OBJECT` policy shape and includes coverage for inline domains, resolved and unresolved domain groups, incorrect object types, incomplete provider coverage, and broad WEB rules without an object reference.

## Validation

- `dotnet test tests/NetworkOptimizer.Audit.Tests/NetworkOptimizer.Audit.Tests.csproj --no-restore`
- All 3,460 Audit tests pass