### PR TITLE
An externally supplied credential key is never silently replaced

### DIFF
--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -893,6 +893,8 @@ Create the key once, out of band, before first start:
 head -c 64 /dev/urandom > credential_key && chmod 600 credential_key
 ```
 
+With `NO_CREDENTIAL_KEY_FILE` set, the key is read and never generated: if the file is missing, unreadable, or empty, Network Optimizer **refuses to start** rather than minting a replacement. That is deliberate - a fresh key would start cleanly and leave every stored secret undecryptable. If you want the key generated for you, leave the variable unset and let it live in the data directory.
+
 Now a leak of the data volume no longer includes the key. **Migration note:** to switch an *existing* install to `NO_CREDENTIAL_KEY_FILE`, copy the current `data/.credential_key` bytes into the new location first - a fresh key cannot decrypt already-stored secrets.
 
 **Config exports are secret too.** A `.nopt` config export bundles the credential key so the imported backup can decrypt its own secrets, and its file-level encryption is light obfuscation rather than a real barrier. So treat `.nopt` files exactly like the data volume - they effectively contain your stored credentials. Store and transfer them accordingly.

--- a/src/NetworkOptimizer.Storage/Services/CredentialProtectionService.cs
+++ b/src/NetworkOptimizer.Storage/Services/CredentialProtectionService.cs
@@ -1,4 +1,4 @@
-using System.Security.Cryptography;
+﻿using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
 
@@ -124,21 +124,22 @@ public class CredentialProtectionService : ICredentialProtectionService
         // volume - so a leak or backup of the data volume does not also hand over the
         // key. When unset, the key lives beside the database in the data directory,
         // which then must be treated as secret material (see DEPLOYMENT.md).
-        // WARNING: pointing an EXISTING install at a new/empty path generates a fresh
-        // key and makes previously-stored secrets undecryptable; move the existing
-        // .credential_key contents to the new path first.
+        // WARNING: pointing an EXISTING install at a new/empty path makes
+        // previously-stored secrets undecryptable; move the existing .credential_key
+        // contents to the new path first.
         var overridePath = Environment.GetEnvironmentVariable("NO_CREDENTIAL_KEY_FILE");
+        if (!string.IsNullOrWhiteSpace(overridePath))
+            return ReadSuppliedKey(overridePath.Trim());
+
         // In Docker, default to /app/data; otherwise use LocalApplicationData.
         var isDocker = string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true", StringComparison.OrdinalIgnoreCase);
-        var keyFilePath = !string.IsNullOrWhiteSpace(overridePath)
-            ? overridePath.Trim()
-            : isDocker
-                ? "/app/data/.credential_key"
-                : Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "NetworkOptimizer",
-                    ".credential_key"
-                );
+        var keyFilePath = isDocker
+            ? "/app/data/.credential_key"
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "NetworkOptimizer",
+                ".credential_key"
+            );
 
         try
         {
@@ -184,5 +185,51 @@ public class CredentialProtectionService : ICredentialProtectionService
             var fallback = Environment.MachineName + KeyPurpose + Environment.UserName;
             return Encoding.UTF8.GetBytes(fallback.PadRight(64, 'X'));
         }
+    }
+
+    /// <summary>
+    /// Reads a key the operator supplied through NO_CREDENTIAL_KEY_FILE. Throws rather than
+    /// generating or falling back, because setting that variable is a statement that the key is
+    /// managed OUTSIDE this application - so a missing file means the supply failed, not that a key
+    /// is wanted.
+    ///
+    /// Generating one instead is silent and looks like nothing happened: the app starts, every
+    /// stored ENC: value is undecryptable against the new key, and anything saved afterwards is
+    /// encrypted under it - leaving a mixture that restoring the real key only half repairs. The
+    /// same is true of the machine-name fallback further up, which in a container derives from the
+    /// container id and so differs on every recreate.
+    ///
+    /// That is an edge case when the path is a file sitting on the host, and routine when the key is
+    /// fetched from a vault at every boot: an unreachable vault, a flapped tunnel, or losing a
+    /// start-order race all land here. Refusing to start is recoverable in a way that quietly
+    /// re-keying is not.
+    /// </summary>
+    private static byte[] ReadSuppliedKey(string keyFilePath)
+    {
+        byte[] key;
+        try
+        {
+            key = File.ReadAllBytes(keyFilePath);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"NO_CREDENTIAL_KEY_FILE is set to '{keyFilePath}', which could not be read. The " +
+                "credential key is supplied externally, so no key is generated to replace it - " +
+                "doing that would make every stored secret undecryptable. Fix the file or unset " +
+                "NO_CREDENTIAL_KEY_FILE to let the key live in the data directory.", ex);
+        }
+
+        // A zero-length file is a half-finished write, not a key. Length is otherwise not policed:
+        // an operator's own key material has always been taken as-is, whatever its size.
+        if (key.Length == 0)
+        {
+            throw new InvalidOperationException(
+                $"NO_CREDENTIAL_KEY_FILE is set to '{keyFilePath}', which is empty. That is an " +
+                "incomplete write rather than a key; using it would make every stored secret " +
+                "undecryptable.");
+        }
+
+        return key;
     }
 }

--- a/tests/NetworkOptimizer.Storage.Tests/CredentialProtectionServiceTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/CredentialProtectionServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using NetworkOptimizer.Storage.Services;
 using Xunit;
 
@@ -327,6 +327,86 @@ public class CredentialProtectionServiceTests : IDisposable
 
         // Assert
         act.Should().NotThrow();
+    }
+
+    #endregion
+
+    #region NO_CREDENTIAL_KEY_FILE Tests
+
+    // These live in this class deliberately: NO_CREDENTIAL_KEY_FILE is process-wide, and the only
+    // other place a CredentialProtectionService is constructed is this class's own constructor.
+    // xUnit runs tests within a class sequentially, so nothing can observe the variable while set.
+
+    /// <summary>Sets the variable for the duration of an action, then puts it back.</summary>
+    private static void WithKeyFile(string? path, Action act)
+    {
+        var original = Environment.GetEnvironmentVariable("NO_CREDENTIAL_KEY_FILE");
+        Environment.SetEnvironmentVariable("NO_CREDENTIAL_KEY_FILE", path);
+        try { act(); }
+        finally { Environment.SetEnvironmentVariable("NO_CREDENTIAL_KEY_FILE", original); }
+    }
+
+    [Fact]
+    public void SuppliedKey_ThatIsMissing_RefusesToStart()
+    {
+        // The failure this exists to prevent: generating a replacement key here starts cleanly and
+        // leaves every stored secret undecryptable. Routine once the key is fetched from a vault at
+        // boot, where an unreachable vault lands exactly here.
+        var missing = Path.Combine(_tempKeyDir, "never_written");
+
+        WithKeyFile(missing, () =>
+        {
+            var act = () => new CredentialProtectionService();
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*could not be read*");
+            File.Exists(missing).Should().BeFalse("an externally supplied key is never generated here");
+        });
+    }
+
+    [Fact]
+    public void SuppliedKey_ThatIsEmpty_RefusesToStart()
+    {
+        // A half-finished write, not a key.
+        var empty = Path.Combine(_tempKeyDir, "empty_key");
+        File.WriteAllBytes(empty, Array.Empty<byte>());
+
+        WithKeyFile(empty, () =>
+        {
+            var act = () => new CredentialProtectionService();
+
+            act.Should().Throw<InvalidOperationException>().WithMessage("*is empty*");
+        });
+    }
+
+    [Fact]
+    public void SuppliedKey_IsUsedAsGiven_AndNotRewritten()
+    {
+        var supplied = Path.Combine(_tempKeyDir, "supplied_key");
+        var bytes = new byte[64];
+        for (var i = 0; i < bytes.Length; i++)
+            bytes[i] = (byte)i;
+        File.WriteAllBytes(supplied, bytes);
+
+        WithKeyFile(supplied, () =>
+        {
+            var service = new CredentialProtectionService();
+
+            service.Decrypt(service.Encrypt("secret")).Should().Be("secret");
+            File.ReadAllBytes(supplied).Should().Equal(bytes, "the supplied key is read, never rewritten");
+        });
+    }
+
+    [Fact]
+    public void SuppliedKey_ThatIsBlank_FallsBackToTheDataDirectory()
+    {
+        // Whitespace is treated as unset, so an empty value in a compose file does not become a
+        // path that then fails to read.
+        WithKeyFile("   ", () =>
+        {
+            var act = () => new CredentialProtectionService();
+
+            act.Should().NotThrow();
+        });
     }
 
     #endregion


### PR DESCRIPTION
## UniFi Console Connection

- **A supplied credential key is never silently replaced** - Setting `NO_CREDENTIAL_KEY_FILE` says the credential key is managed outside the app. If the file was missing, we generated a fresh random key, wrote it, and started normally - every stored secret then undecryptable, anything saved afterwards encrypted under the new key, and nothing in the logs saying so. An unreadable file was worse: the `catch` treated it as "no key yet" and derived one from `MachineName + KeyPurpose + UserName`, which in a container comes from the container id and so differs on every recreate. Now the file is read and nothing else - a missing, unreadable, or zero-length file refuses to start, naming the path and saying to unset the variable if the key is meant to live in the data directory.

- **Documented it** - the `NO_CREDENTIAL_KEY_FILE` section of the Deployment Guide offered the variable as a way to move the key off the data volume and said nothing about absence, which is now the difference between starting and refusing to.

## Why now

Both failures are edge cases while the path is a file sitting on the host, which is what the variable was written for. They stop being edge cases the moment the key is fetched from a vault at boot rather than stored beside the app - an unreachable vault, a flapped tunnel, or losing a start-order race all land in exactly this path, and each one quietly re-keys the install. Refusing to start is recoverable in a way that quietly re-keying is not.

## Scope

The unset path is completely untouched, so every existing install behaves exactly as before, including generating the key on first run. Whitespace still counts as unset, so a blank value in a compose file does not become a path that then fails to read. Length is otherwise not policed - an operator's own key material has always been taken as-is at whatever size.

## Verification

- 0 build warnings, 13/13 test projects green
- Four new tests in `CredentialProtectionServiceTests`: missing refuses and writes nothing, empty refuses, a supplied key is used as given and not rewritten, blank falls back to the data directory
- Confirmed they catch the regression: reverting the service file alone leaves the build clean and fails two of them
- The tests live in that class deliberately - `NO_CREDENTIAL_KEY_FILE` is process-wide, and that class holds the only other place a `CredentialProtectionService` is constructed, so xUnit's within-class ordering keeps anything from observing the variable while set
