### PR TITLE
Monitoring: switches that offset their ifXTable index no longer report zero traffic

### DIFF
--- a/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
+++ b/src/NetworkOptimizer.Monitoring/NetworkOptimizer.Monitoring.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="NetworkOptimizer.Monitoring.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\NetworkOptimizer.Core\NetworkOptimizer.Core.csproj" />
   </ItemGroup>
 

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -624,8 +624,10 @@ public class SnmpPoller : ISnmpPoller
             highSpeedByIdx.Count > 0 ? highSpeedByIdx.Keys
                 : nameByIdx.Count > 0 ? nameByIdx.Keys
                 : aliasByIdx.Keys);
+        // Debug rather than Information: this is a fixed property of the device, and the slow
+        // tier re-derives it on every metadata refresh, so anything louder repeats all day.
         if (ifXOffset != 0)
-            _logger.LogInformation(
+            _logger.LogDebug(
                 "Device {Ip} publishes ifXTable at ifIndex offset {Offset}; rebasing onto the ifTable index space so HC counters resolve per port.",
                 ip, ifXOffset);
 
@@ -875,7 +877,8 @@ public class SnmpPoller : ISnmpPoller
     ///
     /// Detection is deliberately narrow so a conforming device can never be reindexed: the two
     /// index sets must be the same size, share no index at all, and line up under a single
-    /// constant. Any overlap means the tables already agree and the answer is 0.
+    /// constant. Anything else - including a uniform shift whose ranges still overlap - is
+    /// refused and returns 0, leaving the lookups exactly as they were.
     /// </summary>
     internal static long DetectIfXTableIndexOffset(
         IEnumerable<string> ifTableIndexes, IEnumerable<string> ifXTableIndexes)

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -365,17 +365,21 @@ public class SnmpPoller : ISnmpPoller
                 outBcast32 = await BulkWalkAsync(ip, UniFiOids.IfOutBroadcastPkts);
             }
 
-            var hcInOctetsByIdx = IndexByIfIndex(hcInOctets, UniFiOids.IfHCInOctets);
-            var hcOutOctetsByIdx = IndexByIfIndex(hcOutOctets, UniFiOids.IfHCOutOctets);
+            // Rebase every ifXTable lookup onto the ifTable index space the loop below addresses
+            // by. Off a conforming device the offset is 0 and each call hands the dictionary
+            // straight back. The 32-bit counters are ifTable already and are left alone.
+            var ifXOffset = meta.IfXTableIndexOffset;
+            var hcInOctetsByIdx = RebaseByOffset(IndexByIfIndex(hcInOctets, UniFiOids.IfHCInOctets), ifXOffset);
+            var hcOutOctetsByIdx = RebaseByOffset(IndexByIfIndex(hcOutOctets, UniFiOids.IfHCOutOctets), ifXOffset);
             var inOctets32ByIdx = needFallback ? IndexByIfIndex(inOctets32!, UniFiOids.IfInOctets) : null;
             var outOctets32ByIdx = needFallback ? IndexByIfIndex(outOctets32!, UniFiOids.IfOutOctets) : null;
 
-            var hcInUcastByIdx = IndexByIfIndex(hcInUcast, UniFiOids.IfHCInUcastPkts);
-            var hcOutUcastByIdx = IndexByIfIndex(hcOutUcast, UniFiOids.IfHCOutUcastPkts);
-            var hcInMcastByIdx = IndexByIfIndex(hcInMcast, UniFiOids.IfHCInMulticastPkts);
-            var hcOutMcastByIdx = IndexByIfIndex(hcOutMcast, UniFiOids.IfHCOutMulticastPkts);
-            var hcInBcastByIdx = IndexByIfIndex(hcInBcast, UniFiOids.IfHCInBroadcastPkts);
-            var hcOutBcastByIdx = IndexByIfIndex(hcOutBcast, UniFiOids.IfHCOutBroadcastPkts);
+            var hcInUcastByIdx = RebaseByOffset(IndexByIfIndex(hcInUcast, UniFiOids.IfHCInUcastPkts), ifXOffset);
+            var hcOutUcastByIdx = RebaseByOffset(IndexByIfIndex(hcOutUcast, UniFiOids.IfHCOutUcastPkts), ifXOffset);
+            var hcInMcastByIdx = RebaseByOffset(IndexByIfIndex(hcInMcast, UniFiOids.IfHCInMulticastPkts), ifXOffset);
+            var hcOutMcastByIdx = RebaseByOffset(IndexByIfIndex(hcOutMcast, UniFiOids.IfHCOutMulticastPkts), ifXOffset);
+            var hcInBcastByIdx = RebaseByOffset(IndexByIfIndex(hcInBcast, UniFiOids.IfHCInBroadcastPkts), ifXOffset);
+            var hcOutBcastByIdx = RebaseByOffset(IndexByIfIndex(hcOutBcast, UniFiOids.IfHCOutBroadcastPkts), ifXOffset);
             var inUcast32ByIdx = needPktFallback ? IndexByIfIndex(inUcast32!, UniFiOids.IfInUcastPkts) : null;
             var outUcast32ByIdx = needPktFallback ? IndexByIfIndex(outUcast32!, UniFiOids.IfOutUcastPkts) : null;
             var inMcast32ByIdx = needPktFallback ? IndexByIfIndex(inMcast32!, UniFiOids.IfInMulticastPkts) : null;
@@ -607,18 +611,37 @@ public class SnmpPoller : ISnmpPoller
         var adminStatusWalk = await BulkWalkAsync(ip, UniFiOids.IfAdminStatus);
         var lastChangeWalk = await BulkWalkAsync(ip, UniFiOids.IfLastChange);
 
+        var descrByIdx = IndexByIfIndex(descrWalk, UniFiOids.IfDescr);
+        var nameByIdx = IndexByIfIndex(nameWalk, UniFiOids.IfName);
+        var aliasByIdx = IndexByIfIndex(aliasWalk, UniFiOids.IfAlias);
+        var highSpeedByIdx = IndexByIfIndex(highSpeedWalk, UniFiOids.IfHighSpeed);
+
+        // ifName, ifAlias, ifHighSpeed and the ifHC* counters are all ifXTable, so they share
+        // one index space and one detection settles the lot. The counters are walked per poll
+        // and rebased there from the offset cached here alongside the metadata.
+        var ifXOffset = DetectIfXTableIndexOffset(
+            descrByIdx.Keys,
+            highSpeedByIdx.Count > 0 ? highSpeedByIdx.Keys
+                : nameByIdx.Count > 0 ? nameByIdx.Keys
+                : aliasByIdx.Keys);
+        if (ifXOffset != 0)
+            _logger.LogInformation(
+                "Device {Ip} publishes ifXTable at ifIndex offset {Offset}; rebasing onto the ifTable index space so HC counters resolve per port.",
+                ip, ifXOffset);
+
         return new InterfaceMetadataCache
         {
-            DescrByIdx = IndexByIfIndex(descrWalk, UniFiOids.IfDescr),
-            NameByIdx = IndexByIfIndex(nameWalk, UniFiOids.IfName),
-            AliasByIdx = IndexByIfIndex(aliasWalk, UniFiOids.IfAlias),
+            DescrByIdx = descrByIdx,
+            NameByIdx = RebaseByOffset(nameByIdx, ifXOffset),
+            AliasByIdx = RebaseByOffset(aliasByIdx, ifXOffset),
             TypeByIdx = IndexByIfIndex(typeWalk, UniFiOids.IfType),
             MtuByIdx = IndexByIfIndex(mtuWalk, UniFiOids.IfMtu),
             SpeedByIdx = IndexByIfIndex(speedWalk, UniFiOids.IfSpeed),
-            HighSpeedByIdx = IndexByIfIndex(highSpeedWalk, UniFiOids.IfHighSpeed),
+            HighSpeedByIdx = RebaseByOffset(highSpeedByIdx, ifXOffset),
             PhysAddrByIdx = IndexByIfIndex(physAddrWalk, UniFiOids.IfPhysAddress),
             AdminByIdx = IndexByIfIndex(adminStatusWalk, UniFiOids.IfAdminStatus),
             LastChangeByIdx = IndexByIfIndex(lastChangeWalk, UniFiOids.IfLastChange),
+            IfXTableIndexOffset = ifXOffset,
         };
     }
 
@@ -838,6 +861,66 @@ public class SnmpPoller : ISnmpPoller
         return dict;
     }
 
+    /// <summary>
+    /// The constant ifIndex offset at which a device publishes ifXTable, or 0 when it agrees
+    /// with ifTable as RFC 2863 requires.
+    ///
+    /// A US-8 returns ifDescr and the 32-bit counters on 1..8 while every ifXTable row -
+    /// ifName, ifAlias, ifHighSpeed and the ifHC* counters - sits at 1000001..1000008 (#1067).
+    /// It is firmware-dependent, not model-dependent: another US-8 on the same site indexes
+    /// both tables the same way, so this keys off the data shape and never off a model string.
+    /// Nothing downstream expects that split, so every HC lookup keyed by the ifDescr index
+    /// missed and each port read as a zero counter. Zero counters never move, so no interface
+    /// ever produced a rate and the switch was dropped from polling altogether.
+    ///
+    /// Detection is deliberately narrow so a conforming device can never be reindexed: the two
+    /// index sets must be the same size, share no index at all, and line up under a single
+    /// constant. Any overlap means the tables already agree and the answer is 0.
+    /// </summary>
+    internal static long DetectIfXTableIndexOffset(
+        IEnumerable<string> ifTableIndexes, IEnumerable<string> ifXTableIndexes)
+    {
+        var baseIdx = ParseSortedIndexes(ifTableIndexes);
+        var extIdx = ParseSortedIndexes(ifXTableIndexes);
+        if (baseIdx.Count == 0 || baseIdx.Count != extIdx.Count) return 0;
+
+        var offset = extIdx[0] - baseIdx[0];
+        if (offset == 0) return 0;
+        for (int i = 1; i < baseIdx.Count; i++)
+            if (extIdx[i] - baseIdx[i] != offset) return 0;
+
+        // A uniform offset alone is not enough: two disjoint-looking runs could still overlap
+        // (1..8 against 5..12 shifts by 4 and shares half its indexes), and rebasing those
+        // would corrupt a device whose tables were fine.
+        var baseSet = new HashSet<long>(baseIdx);
+        foreach (var idx in extIdx)
+            if (baseSet.Contains(idx)) return 0;
+
+        return offset;
+    }
+
+    private static List<long> ParseSortedIndexes(IEnumerable<string> indexes)
+    {
+        var parsed = new List<long>();
+        foreach (var idx in indexes)
+            if (long.TryParse(idx, out var value)) parsed.Add(value);
+        parsed.Sort();
+        return parsed;
+    }
+
+    /// <summary>
+    /// Rekeys an ifXTable lookup onto the ifTable index space so callers can address it by the
+    /// ifDescr index like every other table. A zero offset returns the dictionary untouched.
+    /// </summary>
+    private static Dictionary<string, string> RebaseByOffset(Dictionary<string, string> byIdx, long offset)
+    {
+        if (offset == 0 || byIdx.Count == 0) return byIdx;
+        var rebased = new Dictionary<string, string>(byIdx.Count);
+        foreach (var (idx, value) in byIdx)
+            if (long.TryParse(idx, out var parsed)) rebased[(parsed - offset).ToString()] = value;
+        return rebased;
+    }
+
     private static readonly System.Text.RegularExpressions.Regex EthNRegex = new(@"^eth\d+", System.Text.RegularExpressions.RegexOptions.Compiled);
 
     internal static string ResolveIfName(string? ifAlias, string? ifName)
@@ -983,6 +1066,13 @@ internal sealed class InterfaceMetadataCache
     public Dictionary<string, string> MtuByIdx { get; init; } = new();
     public Dictionary<string, string> SpeedByIdx { get; init; } = new();
     public Dictionary<string, string> HighSpeedByIdx { get; init; } = new();
+
+    /// <summary>
+    /// Constant ifIndex offset this device publishes ifXTable at, or 0 when it shares ifTable's
+    /// index space. The ifXTable dictionaries above are already rebased; the per-poll ifHC*
+    /// counter walks are rebased against this. See SnmpPoller.DetectIfXTableIndexOffset.
+    /// </summary>
+    public long IfXTableIndexOffset { get; init; }
     public Dictionary<string, string> PhysAddrByIdx { get; init; } = new();
     public Dictionary<string, string> AdminByIdx { get; init; } = new();
     public Dictionary<string, string> LastChangeByIdx { get; init; } = new();

--- a/tests/NetworkOptimizer.Monitoring.Tests/IfXTableIndexOffsetTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/IfXTableIndexOffsetTests.cs
@@ -1,0 +1,100 @@
+using NetworkOptimizer.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Monitoring.Tests;
+
+/// <summary>
+/// ifXTable is required to share ifTable's ifIndex, but some UniFi switches publish it on its
+/// own index space - a US-8 returns ifDescr on 1..8 with every ifXTable row at 1000001..1000008
+/// (#1067). These cover the detection that joins the two back up, and the far more important
+/// property that a conforming device is never touched.
+/// </summary>
+public class IfXTableIndexOffsetTests
+{
+    private static string[] Range(int first, int count) =>
+        Enumerable.Range(first, count).Select(i => i.ToString()).ToArray();
+
+    [Fact]
+    public void DetectsTheOffsetAUsEightPublishes()
+    {
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(Range(1, 8), Range(1_000_001, 8));
+
+        Assert.Equal(1_000_000, offset);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenTheTablesAlreadyAgree()
+    {
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(Range(1, 8), Range(1, 8));
+
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenAnyIndexIsSharedBetweenTheTables()
+    {
+        // 1..8 against 5..12 is a uniform +4 shift, but the two overlap on 5..8. Rebasing that
+        // would move real rows onto other ports, so a uniform offset alone must not be enough.
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(Range(1, 8), Range(5, 8));
+
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenTheShiftIsNotUniform()
+    {
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(
+            new[] { "1", "2", "3" },
+            new[] { "1000001", "1000002", "2000003" });
+
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenTheTablesDifferInSize()
+    {
+        // A device that simply omits ifXTable rows for some interfaces is sparse, not offset,
+        // and the per-index lookups already handle a miss.
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(Range(1, 8), Range(1_000_001, 6));
+
+        Assert.Equal(0, offset);
+    }
+
+    [Fact]
+    public void ReturnsZeroWhenEitherTableIsEmpty()
+    {
+        Assert.Equal(0, SnmpPoller.DetectIfXTableIndexOffset(Array.Empty<string>(), Range(1_000_001, 8)));
+        Assert.Equal(0, SnmpPoller.DetectIfXTableIndexOffset(Range(1, 8), Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void IgnoresIndexesThatAreNotNumeric()
+    {
+        // A malformed walk should fall out as "no offset" rather than throw mid-poll.
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(
+            new[] { "1", "not-an-index", "3" },
+            new[] { "1000001", "1000003" });
+
+        Assert.Equal(1_000_000, offset);
+    }
+
+    [Fact]
+    public void HandlesUnsortedWalkOrder()
+    {
+        // BulkWalk order is the device's business, and the offset must not depend on it.
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(
+            new[] { "3", "1", "2" },
+            new[] { "1000002", "1000003", "1000001" });
+
+        Assert.Equal(1_000_000, offset);
+    }
+
+    [Fact]
+    public void DetectsANegativeOffset()
+    {
+        // Nothing says the extension table has to sit above ifTable; the join is the same.
+        var offset = SnmpPoller.DetectIfXTableIndexOffset(Range(1_000_001, 8), Range(1, 8));
+
+        Assert.Equal(-1_000_000, offset);
+    }
+}


### PR DESCRIPTION
Some UniFi switches publish ifXTable on a different ifIndex space than ifTable. A US-8 returns `ifDescr` and the 32-bit counters on `1..8`, while `ifName`, `ifAlias`, `ifHighSpeed` and every `ifHC*` counter sit at `1000001..1000008`. RFC 2863 has the two tables share an index, and every lookup here assumed that.

The result was that the 64-bit counters were fetched successfully and then never found. Because the HC walk returned a full set of rows the device never looked sparse, so the 32-bit fallback never engaged, and the build loop looked up ifDescr's indices in a dictionary keyed a million higher. Every port read as a zero counter.

## Monitoring

- **Device Stats** - Ports on affected switches report real throughput instead of a flat zero. `ifHighSpeed` resolves for the first time too, so those ports show their negotiated link speed rather than reading as unknown-speed links, and their names now come from `ifName` / `ifAlias` instead of falling back to `ifDescr`.
- **Setup** - Affected switches stay in SNMP polling. Zero counters never advance, so no interface ever produced a rate and the switch was excluded after five polls, taking its CPU, memory and temperature collection down with it for the exclusion window.

## How the offset is found

Detection reads the walks, never a model string. The reporter has a second US-8 that indexes both tables identically, so this is firmware behaviour and no SKU check would have caught it.

The rule is deliberately narrow, so a conforming device can never be reindexed. The two index sets must be the same size, share no index at all, and line up under a single constant. Anything else is refused and the lookups are left exactly as they were. Sharing any index disqualifies the match, which stops a uniform-looking shift such as `1..8` against `5..12` from moving rows onto the wrong ports.

Off a conforming device the offset is zero and every rebase call hands the dictionary straight back, so there is no behaviour change and no extra allocation.

## Notes

- The counter fix lives in `NetworkOptimizer.Monitoring`, which compiles into the on-site agent, so an agent monitoring an affected switch needs updating to pick it up. `LatestAgentVersion` is deliberately left alone: this is the only agent-relevant change and prompting the whole fleet for it would be noise.
- Reported with `snmpwalk` captures in #1067, thanks @jimstrang.

Closes #1067