### PR TITLE
Monitoring - ISP Health: partial-loss detection reads every internet destination

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -674,12 +674,13 @@ else
                                 var shapeExpanded = _expandedOutageShapes.Contains(outage.Start);
                                 var hiddenCount = tiers.Count - OutageShapeEdgeRows * 2;
                                 <div class="isp-outage-shape">
-                                    @if (collapsible)
+                                    @* The fault line is the only way in; the toggle exists only as the way
+                                       back down, sitting right above the rows. *@
+                                    @if (collapsible && shapeExpanded)
                                     {
-                                        <div class="isp-outage-shape-toggle @(shapeExpanded ? "expanded" : "")">
-                                            <button type="button" aria-expanded="@shapeExpanded" @onclick="() => ToggleOutageShape(outage.Start)">
-                                                @(shapeExpanded ? "Collapse" : $"Show all {tiers.Count} targets")
-                                                <span class="isp-outage-fault-chevron">@(shapeExpanded ? "▲" : "▼")</span>
+                                        <div class="isp-outage-shape-toggle">
+                                            <button type="button" aria-expanded="true" @onclick="() => ToggleOutageShape(outage.Start)">
+                                                Collapse <span class="isp-outage-fault-chevron">▲</span>
                                             </button>
                                         </div>
                                     }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -636,33 +636,80 @@ else
                                     </SiteOperatorOnly>
                                 }
                             </div>
-                            @if (outage.Tiers.Any(t => t.WentDark))
+                            @{
+                                var shapeDark = outage.Tiers.Any(t => t.WentDark);
+                            }
+                            @if (shapeDark || (outage.IsPartial && outage.Tiers.Count > 0))
                             {
-                                <div class="isp-outage-shape">
-                                    @foreach (var tier in outage.Tiers)
-                                    {
-                                        <div class="isp-outage-hop">
+                                RenderFragment<OutageTierState> hopRow;
+                                if (shapeDark)
+                                {
+                                    hopRow = tier =>
+                                        @<div class="isp-outage-hop">
                                             <span class="isp-outage-hop-name" data-tooltip="@OutageHopTooltip(tier)">@tier.Name</span>
                                             <div class="isp-outage-hop-track">
                                                 <div class="isp-outage-hop-dark" style="width: @(OutageHopDarkPercent(outage, tier).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
                                             </div>
                                             <span class="isp-outage-hop-status @(tier.WentDark ? "" : "isp-outage-hop-up")">@OutageHopStatus(tier)</span>
-                                        </div>
-                                    }
-                                </div>
-                            }
-                            else if (outage.IsPartial && outage.Tiers.Count > 0)
-                            {
-                                <div class="isp-outage-shape">
-                                    @foreach (var tier in outage.Tiers)
-                                    {
-                                        <div class="isp-outage-hop">
+                                        </div>;
+                                }
+                                else
+                                {
+                                    hopRow = tier =>
+                                        @<div class="isp-outage-hop">
                                             <span class="isp-outage-hop-name">@tier.Name</span>
                                             <div class="isp-outage-hop-track">
                                                 <div class="isp-outage-hop-loss" style="width: @(tier.PeakLossPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
                                             </div>
                                             <span class="isp-outage-hop-status">peak @tier.PeakLossPct.ToString("0")% loss</span>
+                                        </div>;
+                                }
+                                @* Long waterfalls collapse to the first and last three rows - the ends carry the
+                                   story (where the break sat, what stayed reachable) - with the hidden middle
+                                   drawn as a clickable fault line. Both the middle rows and the fault line sit in
+                                   expand-wrappers with opposite states so one grows as the other collapses; the
+                                   negative top margin cancels the parent flex gap around whichever is at 0fr. *@
+                                var tiers = outage.Tiers;
+                                var collapsible = tiers.Count > OutageShapeCollapseThreshold;
+                                var shapeExpanded = _expandedOutageShapes.Contains(outage.Start);
+                                var hiddenCount = tiers.Count - OutageShapeEdgeRows * 2;
+                                <div class="isp-outage-shape">
+                                    @if (collapsible)
+                                    {
+                                        <div class="isp-outage-shape-toggle">
+                                            <button type="button" aria-expanded="@shapeExpanded" @onclick="() => ToggleOutageShape(outage.Start)">
+                                                @(shapeExpanded ? "Collapse" : $"Show all {tiers.Count} targets")
+                                                <span class="isp-outage-fault-chevron">@(shapeExpanded ? "▲" : "▼")</span>
+                                            </button>
                                         </div>
+                                    }
+                                    @foreach (var tier in collapsible ? tiers.Take(OutageShapeEdgeRows) : tiers)
+                                    {
+                                        @hopRow(tier)
+                                    }
+                                    @if (collapsible)
+                                    {
+                                        <div class="expand-wrapper isp-outage-seam @(shapeExpanded ? "" : "expanded")">
+                                            <div class="expand-content">
+                                                <button type="button" class="isp-outage-fault" aria-expanded="false" @onclick="() => ToggleOutageShape(outage.Start)">
+                                                    <span class="isp-outage-fault-pill">@hiddenCount more targets <span class="isp-outage-fault-chevron">▼</span></span>
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div class="expand-wrapper isp-outage-seam @(shapeExpanded ? "expanded" : "")">
+                                            <div class="expand-content">
+                                                <div class="isp-outage-shape-middle">
+                                                    @foreach (var tier in tiers.Skip(OutageShapeEdgeRows).Take(hiddenCount))
+                                                    {
+                                                        @hopRow(tier)
+                                                    }
+                                                </div>
+                                            </div>
+                                        </div>
+                                        @foreach (var tier in tiers.Skip(tiers.Count - OutageShapeEdgeRows))
+                                        {
+                                            @hopRow(tier)
+                                        }
                                     }
                                 </div>
                             }
@@ -1089,6 +1136,20 @@ else
     // reads as if it didn't register.
     private readonly HashSet<DateTime> _ackPending = new();
     private string AckLockClass => _ackPending.Count > 0 ? "isp-outage-ack-locked" : "";
+
+    // A waterfall with more targets than this collapses to its first and last
+    // OutageShapeEdgeRows rows with the hidden middle drawn as a fault line.
+    private const int OutageShapeCollapseThreshold = 6;
+    private const int OutageShapeEdgeRows = 3;
+
+    // Keyed by outage onset (stable across recomputes, same key the ack flow uses),
+    // so an expanded waterfall stays open through report refreshes.
+    private readonly HashSet<DateTime> _expandedOutageShapes = new();
+
+    private void ToggleOutageShape(DateTime outageStartUtc)
+    {
+        if (!_expandedOutageShapes.Remove(outageStartUtc)) _expandedOutageShapes.Add(outageStartUtc);
+    }
 
     /// <summary>Marks an outage "that was me" (user-caused, excluded from scoring) and reloads
     /// the report for the current window so the score and findings drop it.</summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -676,7 +676,7 @@ else
                                 <div class="isp-outage-shape">
                                     @if (collapsible)
                                     {
-                                        <div class="isp-outage-shape-toggle">
+                                        <div class="isp-outage-shape-toggle @(shapeExpanded ? "expanded" : "")">
                                             <button type="button" aria-expanded="@shapeExpanded" @onclick="() => ToggleOutageShape(outage.Start)">
                                                 @(shapeExpanded ? "Collapse" : $"Show all {tiers.Count} targets")
                                                 <span class="isp-outage-fault-chevron">@(shapeExpanded ? "▲" : "▼")</span>
@@ -1139,7 +1139,9 @@ else
 
     // A waterfall with more targets than this collapses to its first and last
     // OutageShapeEdgeRows rows with the hidden middle drawn as a fault line.
-    private const int OutageShapeCollapseThreshold = 6;
+    // Seven shows all seven: collapsing to six would hide a single row, and a
+    // one-row fault line is sillier than the row itself.
+    private const int OutageShapeCollapseThreshold = 7;
     private const int OutageShapeEdgeRows = 3;
 
     // Keyed by outage onset (stable across recomputes, same key the ack flow uses),

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -983,6 +983,16 @@ public class IspHealthService
                 0, gatewaySamples, Groupable: false, AsnLabel: null, IsGateway: true)
             : null;
         var baseDepth = gatewayHop != null ? 1 : 0;
+        // Both hop lists share every access and transit row, and the sort keys are pure functions of
+        // the series - MedianRtt copies and sorts each one's RTTs, which is not free on a long
+        // window and the compute already runs against a time budget. Derive each series' keys once.
+        var sortKeys = new Dictionary<AsnSeries, (int HopNumber, double Rtt)>();
+        (int HopNumber, double Rtt) SortKey(AsnSeries s)
+        {
+            if (!sortKeys.TryGetValue(s, out var k))
+                sortKeys[s] = k = (ClusterHopNumber(s), MedianRtt(s));
+            return k;
+        }
         List<OutageDetector.Hop> BuildHops(IEnumerable<(AsnSeries Series, bool Groupable, string? AsnLabel, bool IsInternet)> sources)
         {
             var ordered = sources
@@ -994,8 +1004,8 @@ public class IspHealthService
                     x.Series.AsnNumber,
                     Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
                     Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
-                    HopNumber = ClusterHopNumber(x.Series),
-                    Rtt = MedianRtt(x.Series)
+                    HopNumber = SortKey(x.Series).HopNumber,
+                    Rtt = SortKey(x.Series).Rtt
                 })
                 .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
                 .ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -512,6 +512,10 @@ public class IspHealthService
         // Onsets of outages the user marked "that was me", stamped onto the detected events
         // below (tolerance-matched; a recompute can shift a boundary by a bucket).
         List<DateTime> ackedOutageStarts;
+        // The WAN this report grades, in MonitoringTarget.WanInterface's namespace (the UniFi WAN
+        // name, "wan"/"wan2" - NOT the data-path ifname GetPrimaryWanInterfaceAsync returns). Used
+        // to keep another WAN's internet destinations out of the partial-loss breadth pool.
+        string? primaryWanKey;
         await using (var db = await CreateSiteDbAsync(ct))
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
@@ -526,6 +530,13 @@ public class IspHealthService
                 .OrderBy(c => string.Equals(c.WanInterface, "wan", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
                 .FirstOrDefault(c => c.AccessTechnology != AccessTechnology.Unknown);
             technology = primaryContext?.AccessTechnology ?? settings.AccessTechnology;
+            // Same wan-first ordering, but the interface NAME and without the access-technology
+            // filter: a WAN whose technology was never set still owns its targets. Falls back to
+            // "wan" so a site with no discovery context yet still scopes to the conventional primary.
+            primaryWanKey = wanContexts
+                .OrderBy(c => string.Equals(c.WanInterface, "wan", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .Select(c => c.WanInterface)
+                .FirstOrDefault(w => !string.IsNullOrEmpty(w)) ?? "wan";
 
             targets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
@@ -902,6 +913,27 @@ public class IspHealthService
                 .OrderBy(MedianRtt))
             .Take(2)
             .ToList();
+        // Every internet destination on the WAN being graded - the partial pass's breadth evidence.
+        // Null WanInterface is INCLUDED: the tracer stamps only what it discovers, so a hand-added
+        // destination has none, and dropping those would quietly shrink the pool on exactly the
+        // installs that curated it. Only a target explicitly bound to a DIFFERENT WAN is excluded,
+        // so a failover link's destinations can't manufacture breadth for the primary. (The rest of
+        // ISP Health is still primary-WAN-only by assumption rather than by filter - see TODO.md
+        // "Multi-WAN Support (ISP Health & NMS)".)
+        var breadthInternet = targets
+            .Where(t => t.TargetType == MonitoringTargetType.InternetService
+                && internetSeriesExt.ContainsKey(t.TargetId)
+                && (string.IsNullOrEmpty(t.WanInterface)
+                    || string.Equals(t.WanInterface, primaryWanKey, StringComparison.OrdinalIgnoreCase)))
+            .Select(t => new AsnSeries
+            {
+                AsnNumber = t.AsnNumber ?? 0,
+                AsnName = t.Name,
+                TargetIds = { t.TargetId },
+                Samples = internetSeriesExt[t.TargetId],
+                HopIps = { t.Address }
+            })
+            .ToList();
         // Each waterfall row is labeled by its ASN. Access ISP and Transit can both be the same
         // ASN (e.g. AT&T is both the access network and a transit hop), so a transit row whose ASN
         // also appears in the access layer is suffixed " Transit" to disambiguate it.
@@ -926,7 +958,7 @@ public class IspHealthService
         //    access hop's own outage timing shows; the detector re-collapses shared signatures.
         //  - Transit kept as the per-ASN RTT clusters (the Per-Network RTT grouping), untouched.
         //  - Internet trimmed to two rows (displayInternet).
-        var outageSources = ispTargets
+        var accessAndTransitSources = ispTargets
             .Where(t => ispSeriesExt.ContainsKey(t.TargetId))
             .Select(t => (Series: new AsnSeries
             {
@@ -937,20 +969,13 @@ public class IspHealthService
                 HopIps = { t.Address }
             }, Groupable: true, AsnLabel: AsnNameCleanup.Clean(t.AsnName) ?? accessAsnName, IsInternet: false))
             .Concat(transitChart.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)TransitLabel(s), IsInternet: false)))
-            .Concat(displayInternet.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)null, IsInternet: true)));
-        var orderedWanHops = outageSources
-            .Select(x => new
-            {
-                x.Groupable,
-                x.AsnLabel,
-                x.IsInternet,
-                Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
-                Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
-                HopNumber = ClusterHopNumber(x.Series),
-                Rtt = MedianRtt(x.Series)
-            })
-            .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
             .ToList();
+        (AsnSeries Series, bool Groupable, string? AsnLabel, bool IsInternet) AsInternetRow(AsnSeries s) =>
+            (Series: s, Groupable: false, AsnLabel: (string?)null, IsInternet: true);
+        var outageSources = accessAndTransitSources.Concat(displayInternet.Select(AsInternetRow));
+        // Same rows, but with EVERY internet destination instead of the two display ones - the
+        // partial pass's breadth evidence (see below).
+        var partialSources = accessAndTransitSources.Concat(breadthInternet.Select(AsInternetRow));
         // The LAN gateway is the nearest hop (Depth 0) when monitored; WAN hops shift one deeper.
         // Its loss lets the detector tell a LAN/gateway outage from a WAN outage. Absent => unchanged.
         var gatewayHop = gatewaySamples.Count > 0
@@ -958,22 +983,46 @@ public class IspHealthService
                 0, gatewaySamples, Groupable: false, AsnLabel: null, IsGateway: true)
             : null;
         var baseDepth = gatewayHop != null ? 1 : 0;
-        // Rows without a persisted hop number sorted to the end above - that Depth is a sort
-        // position, not a path position, so they carry KnownPosition: false and never anchor
-        // the detector's "break upstream of X" attribution (e.g. a hostname-based ISP target
-        // the discovery traces never mapped). Internet endpoint rows are likewise flagged so
-        // a destination can never be named as the hop the break sat beyond.
-        var outageHops = (gatewayHop != null ? new[] { gatewayHop } : Array.Empty<OutageDetector.Hop>())
-            .Concat(orderedWanHops.Select((x, i) =>
-                new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel,
-                    KnownPosition: x.HopNumber != int.MaxValue, IsInternet: x.IsInternet)))
-            .ToList();
+        List<OutageDetector.Hop> BuildHops(IEnumerable<(AsnSeries Series, bool Groupable, string? AsnLabel, bool IsInternet)> sources)
+        {
+            var ordered = sources
+                .Select(x => new
+                {
+                    x.Groupable,
+                    x.AsnLabel,
+                    x.IsInternet,
+                    x.Series.AsnNumber,
+                    Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
+                    Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
+                    HopNumber = ClusterHopNumber(x.Series),
+                    Rtt = MedianRtt(x.Series)
+                })
+                .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
+                .ToList();
+            // Rows without a persisted hop number sorted to the end above - that Depth is a sort
+            // position, not a path position, so they carry KnownPosition: false and never anchor
+            // the detector's "break upstream of X" attribution (e.g. a hostname-based ISP target
+            // the discovery traces never mapped). Internet endpoint rows are likewise flagged so
+            // a destination can never be named as the hop the break sat beyond.
+            return (gatewayHop != null ? new[] { gatewayHop } : Array.Empty<OutageDetector.Hop>())
+                .Concat(ordered.Select((x, i) =>
+                    new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel,
+                        KnownPosition: x.HopNumber != int.MaxValue, IsInternet: x.IsInternet,
+                        AsnNumber: x.AsnNumber)))
+                .ToList();
+        }
+        var outageHops = BuildHops(outageSources);
         ct.ThrowIfCancellationRequested();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
         // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
         // across the full set of monitored hops, excluding windows already flagged as blackouts.
+        // Unlike the blackout pass - whose trigger is every internet target and whose HOPS are only
+        // the shape - the partial pass reads breadth off the hop list itself, so it must see every
+        // internet destination or the gate is judged on two rows. Trimming to the display pair let
+        // an identical event trip at one site and not another purely because the first happened to
+        // monitor one more transit hop (so its ASN split into one more RTT cluster).
         var partialDisruptions = OutageDetector.DetectPartial(
-            outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
+            BuildHops(partialSources), outages.Select(o => (o.Start, o.End)).ToList(), _options);
         outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
         // Drop events that ended at or before the window start: the lead-in reach-back only exists to
         // capture an outage that STRADDLES the window start (its recovery is in-window), so an event

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -28,8 +28,13 @@ public static class OutageDetector
     /// endpoint rows (destinations reached over diverse paths, not points on THE path) - they trigger
     /// and shape outages but likewise never anchor attribution: "break upstream of a destination"
     /// says nothing.
+    /// <paramref name="AsnNumber"/> is the row's real ASN, used ONLY by the partial pass's
+    /// independence gate. It is deliberately separate from <paramref name="AsnLabel"/>: internet rows
+    /// keep a null AsnLabel so each destination still shows its own name ("AWS us-west-1"), but
+    /// several regional endpoints of one provider must not read as several independent networks.
+    /// Zero means unattributed, and such a row falls back to counting as its own network.
     /// </summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null, bool IsGateway = false, bool KnownPosition = true, bool IsInternet = false);
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null, bool IsGateway = false, bool KnownPosition = true, bool IsInternet = false, int AsnNumber = 0);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -140,7 +145,7 @@ public static class OutageDetector
         bool BucketQualifies(DateTime t)
         {
             var degraded = pool.Where(h => hopBuckets[h].TryGetValue(t, out var l) && l.Count > 0 && l[0] >= partialPct).ToList();
-            var asns = degraded.Select(h => h.AsnLabel ?? h.Name).Distinct().Count();
+            var asns = degraded.Select(NetworkKey).Distinct().Count();
             return degraded.Count >= options.OutagePartialMinTargets && asns >= options.OutagePartialMinAsns;
         }
 
@@ -179,6 +184,17 @@ public static class OutageDetector
         }
         return events;
     }
+
+    /// <summary>
+    /// The network a hop counts as for the partial pass's independence gate. Prefers the real ASN
+    /// so several endpoints of one provider (a cloud's regional destinations, all reached over that
+    /// provider's own network) count once - the gate asks how many INDEPENDENT networks degraded,
+    /// and the display label can't answer that: internet rows deliberately carry a null AsnLabel so
+    /// each destination still shows its own name. Unattributed rows (ASN 0) fall back to the label,
+    /// counting as their own network, which is the safe reading when we can't prove otherwise.
+    /// </summary>
+    private static string NetworkKey(Hop h) =>
+        h.AsnNumber > 0 ? $"AS{h.AsnNumber}" : h.AsnLabel ?? h.Name;
 
     private static OutageEvent BuildPartialEvent(
         DateTime start, DateTime end,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -186,15 +186,18 @@ public static class OutageDetector
     }
 
     /// <summary>
-    /// The network a hop counts as for the partial pass's independence gate. Prefers the real ASN
-    /// so several endpoints of one provider (a cloud's regional destinations, all reached over that
-    /// provider's own network) count once - the gate asks how many INDEPENDENT networks degraded,
-    /// and the display label can't answer that: internet rows deliberately carry a null AsnLabel so
-    /// each destination still shows its own name. Unattributed rows (ASN 0) fall back to the label,
-    /// counting as their own network, which is the safe reading when we can't prove otherwise.
+    /// The network a hop counts as for the partial pass's independence gate, which asks how many
+    /// INDEPENDENT networks degraded together. A row that HAS an <see cref="Hop.AsnLabel"/> is
+    /// already grouped at ASN level by that label, and the label is the corrected one (hand-added
+    /// access hops are mapped onto the access ISP's canonical ASN even when their own address
+    /// resolves elsewhere or not at all) - so the label wins there, and one ISP's hops count once
+    /// however their per-target ASN attribution turned out. Only internet rows lack a label, by
+    /// design, so each destination shows its own name; those key on the real ASN so several
+    /// regional endpoints of one provider, all reached over that provider's network, count once.
+    /// An unattributed destination falls back to its name - its own network, the safe reading.
     /// </summary>
     private static string NetworkKey(Hop h) =>
-        h.AsnNumber > 0 ? $"AS{h.AsnNumber}" : h.AsnLabel ?? h.Name;
+        h.AsnLabel ?? (h.AsnNumber > 0 ? $"AS{h.AsnNumber}" : h.Name);
 
     private static OutageEvent BuildPartialEvent(
         DateTime start, DateTime end,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17762,7 +17762,6 @@ a.isp-health-hero-speed:hover {
 }
 
 .isp-outage {
-    position: relative;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -17900,33 +17899,13 @@ a.isp-outage-ack:hover {
     color: var(--success-color);
 }
 
-/* Legend-style toggle straddling the outage block's top border. */
 .isp-outage-shape-toggle {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    transform: translate(-50%, -55%);
-    z-index: 1;
+    display: flex;
+    justify-content: center;
 }
 
 .isp-outage-shape-toggle button {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    padding: 0.14rem 0.65rem;
-    border: 1px solid var(--border-color);
-    border-radius: 999px;
-    background: var(--bg-tertiary);
-    color: var(--text-muted);
-    font-size: 0.72rem;
-    white-space: nowrap;
     cursor: pointer;
-    transition: color 0.15s ease, border-color 0.15s ease;
-}
-
-.isp-outage-shape-toggle button:hover {
-    color: var(--text-secondary);
-    border-color: var(--text-muted);
 }
 
 /* Cancels the shape's flex gap around a seam wrapper so the 0fr state adds no
@@ -17989,7 +17968,8 @@ a.isp-outage-ack:hover {
     opacity: 0.6;
 }
 
-.isp-outage-fault-pill {
+.isp-outage-fault-pill,
+.isp-outage-shape-toggle button {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
@@ -18003,7 +17983,8 @@ a.isp-outage-ack:hover {
     transition: color 0.15s ease, border-color 0.15s ease;
 }
 
-.isp-outage-fault:hover .isp-outage-fault-pill {
+.isp-outage-fault:hover .isp-outage-fault-pill,
+.isp-outage-shape-toggle button:hover {
     color: var(--text-primary);
     border-color: var(--text-muted);
 }
@@ -18035,19 +18016,6 @@ a.isp-outage-ack:hover {
 
     .isp-outage-head .isp-outage-ack {
         margin-left: auto;
-    }
-
-    /* On mobile the fault line is the expand affordance; the toggle appears only
-       once expanded, in flow above the rows, as the way back down. */
-    .isp-outage-shape-toggle:not(.expanded) {
-        display: none;
-    }
-
-    .isp-outage-shape-toggle.expanded {
-        position: static;
-        transform: none;
-        display: flex;
-        justify-content: center;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17762,6 +17762,7 @@ a.isp-health-hero-speed:hover {
 }
 
 .isp-outage {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -17899,28 +17900,33 @@ a.isp-outage-ack:hover {
     color: var(--success-color);
 }
 
+/* Legend-style toggle straddling the outage block's top border. */
 .isp-outage-shape-toggle {
-    display: flex;
-    justify-content: center;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%, -55%);
+    z-index: 1;
 }
 
 .isp-outage-shape-toggle button {
     display: inline-flex;
     align-items: center;
     gap: 0.35rem;
-    padding: 0.12rem 0.6rem;
-    border: none;
+    padding: 0.14rem 0.65rem;
+    border: 1px solid var(--border-color);
     border-radius: 999px;
-    background: none;
+    background: var(--bg-tertiary);
     color: var(--text-muted);
     font-size: 0.72rem;
+    white-space: nowrap;
     cursor: pointer;
-    transition: color 0.15s ease, background 0.15s ease;
+    transition: color 0.15s ease, border-color 0.15s ease;
 }
 
 .isp-outage-shape-toggle button:hover {
     color: var(--text-secondary);
-    background: var(--bg-tertiary);
+    border-color: var(--text-muted);
 }
 
 /* Cancels the shape's flex gap around a seam wrapper so the 0fr state adds no
@@ -17988,9 +17994,9 @@ a.isp-outage-ack:hover {
     align-items: center;
     gap: 0.4rem;
     padding: 0.16rem 0.7rem;
-    border: 1px solid var(--bg-tertiary);
+    border: 1px solid var(--border-color);
     border-radius: 999px;
-    background: var(--bg-tertiary);
+    background: var(--bg-card);
     color: var(--text-secondary);
     font-size: 0.72rem;
     white-space: nowrap;
@@ -18029,6 +18035,19 @@ a.isp-outage-ack:hover {
 
     .isp-outage-head .isp-outage-ack {
         margin-left: auto;
+    }
+
+    /* On mobile the fault line is the expand affordance; the toggle appears only
+       once expanded, in flow above the rows, as the way back down. */
+    .isp-outage-shape-toggle:not(.expanded) {
+        display: none;
+    }
+
+    .isp-outage-shape-toggle.expanded {
+        position: static;
+        transform: none;
+        display: flex;
+        justify-content: center;
     }
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17899,6 +17899,114 @@ a.isp-outage-ack:hover {
     color: var(--success-color);
 }
 
+.isp-outage-shape-toggle {
+    display: flex;
+    justify-content: center;
+}
+
+.isp-outage-shape-toggle button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.12rem 0.6rem;
+    border: none;
+    border-radius: 999px;
+    background: none;
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    cursor: pointer;
+    transition: color 0.15s ease, background 0.15s ease;
+}
+
+.isp-outage-shape-toggle button:hover {
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+}
+
+/* Cancels the shape's flex gap around a seam wrapper so the 0fr state adds no
+   phantom spacing; the visible child restores the gap itself (margin/padding-top). */
+.isp-outage-seam {
+    margin-top: -0.45rem;
+}
+
+.isp-outage-shape-middle {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding-top: 0.45rem;
+}
+
+.isp-outage-fault {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0.45rem;
+    padding: 0.2rem 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+}
+
+/* The hidden middle reads as a fault: two dashed strands sheared 4px out of line,
+   fading toward the card edges, meeting the count pill at the break. */
+.isp-outage-fault::before,
+.isp-outage-fault::after {
+    content: "";
+    position: absolute;
+    height: 2px;
+    opacity: 0.35;
+    transition: opacity 0.15s ease;
+}
+
+.isp-outage-fault::before {
+    left: 0;
+    right: calc(50% + 4.75rem);
+    top: calc(50% - 3px);
+    background: repeating-linear-gradient(90deg, var(--text-muted) 0 7px, transparent 7px 13px);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 45%);
+    mask-image: linear-gradient(90deg, transparent, #000 45%);
+}
+
+.isp-outage-fault::after {
+    left: calc(50% + 4.75rem);
+    right: 0;
+    top: calc(50% + 1px);
+    background: repeating-linear-gradient(270deg, var(--text-muted) 0 7px, transparent 7px 13px);
+    -webkit-mask-image: linear-gradient(270deg, transparent, #000 45%);
+    mask-image: linear-gradient(270deg, transparent, #000 45%);
+}
+
+.isp-outage-fault:hover::before,
+.isp-outage-fault:hover::after {
+    opacity: 0.6;
+}
+
+.isp-outage-fault-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.16rem 0.7rem;
+    border: 1px solid var(--bg-tertiary);
+    border-radius: 999px;
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.isp-outage-fault:hover .isp-outage-fault-pill {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+}
+
+.isp-outage-fault-chevron {
+    font-size: 0.55rem;
+    line-height: 1;
+}
+
 @media (max-width: 768px) {
     .isp-outage-hop {
         grid-template-columns: 1fr auto;

--- a/tests/NetworkOptimizer.Web.Tests/AgentConnectionAlertMonitorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentConnectionAlertMonitorTests.cs
@@ -7,8 +7,8 @@ namespace NetworkOptimizer.Web.Tests;
 public class AgentConnectionAlertMonitorTests
 {
     [Theory]
-    [InlineData("Falkor", "Agent \"Falkor\"")]
-    [InlineData("Honeybee Home", "Agent \"Honeybee Home\"")]
+    [InlineData("Beacon", "Agent \"Beacon\"")]
+    [InlineData("North Office", "Agent \"North Office\"")]
     public void AgentLabel_DistinctiveName_KeepsQuotedName(string name, string expected)
         => AgentConnectionAlertMonitor.AgentLabel(name).Should().Be(expected);
 

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -352,6 +352,29 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Access_hops_of_one_isp_count_once_even_when_their_own_asn_attribution_differs()
+    {
+        // A hand-added access hop resolves to no ASN of its own while its auto-discovered siblings
+        // carry the ISP's - they are one network regardless, and the shared label already says so.
+        // Keying independence on the per-target ASN would read this ISP as two networks and let one
+        // access tier's bad minute clear a gate that exists to require several.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("hop-a", 0, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("hop-b", 1, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("hop-c", 2, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            // Same ISP, no ASN of its own - must not read as a second independent network.
+            new OutageDetector.Hop("hop-d", 3, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 0),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
     public void Internet_destinations_supply_the_breadth_a_thin_transit_layer_cannot()
     {
         // A thin path: one access ISP, a transit layer that collapses to two rows of one ASN, and a

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -330,6 +330,59 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Regional_endpoints_of_one_provider_are_not_independent_networks()
+    {
+        // Four destinations, one provider: a cloud's regional endpoints are reached over that
+        // provider's own network, so they degrade together for one reason. Internet rows carry a
+        // null AsnLabel (each shows its own name), so counting labels would read this as four
+        // independent networks and clear the breadth gate on a single provider's bad day.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AWS us-east-1", 0, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-east-2", 1, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-west-1", 2, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-west-2", 3, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Internet_destinations_supply_the_breadth_a_thin_transit_layer_cannot()
+    {
+        // A thin path: one access ISP, a transit layer that collapses to two rows of one ASN, and a
+        // path event hitting destinations everywhere. Transit + the one canonical resolver is three
+        // rows - under the gate - so the event only surfaces because the other monitored
+        // destinations are in the pool. Four distinct networks degrade here.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Access ISP", 0, LossSeries(ds, de, 0), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("Level 3 (lag-101)", 1, LossSeries(ds, de, 60), AsnLabel: "Level 3", AsnNumber: 3356),
+            new OutageDetector.Hop("Level 3 (ae25)", 2, LossSeries(ds, de, 60), AsnLabel: "Level 3", AsnNumber: 3356),
+            new OutageDetector.Hop("Google", 3, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 15169),
+            new OutageDetector.Hop("Cloudflare", 4, LossSeries(ds, de, 0), IsInternet: true, AsnNumber: 13335),
+            new OutageDetector.Hop("Akamai", 5, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 20940),
+            new OutageDetector.Hop("Quad9", 6, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 19281),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        events[0].IsPartial.Should().BeTrue();
+        // The access tier stayed clean and every degraded row sits beyond it, so the break is
+        // upstream - and no destination may be named as the hop it sat beyond.
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("Access ISP");
+        events[0].Tiers.Select(t => t.Name).Should().NotContain("Cloudflare");
+    }
+
+    [Fact]
     public void Olt_blip_at_onset_then_recovery_still_reads_upstream_and_leads_the_waterfall()
     {
         var internet1 = Series(0, (OutStart, OutEnd, 100));


### PR DESCRIPTION
## Monitoring - ISP Health

- **Partial-loss disruptions now weigh every internet destination** - A partial-loss disruption is flagged when enough independent targets degrade together in the same short window. That breadth test was reading only the two resolver rows the outage waterfall puts on screen, so it was judged on the access hops, the transit groups, and two destinations. Whether an event got caught therefore turned on how a site's transit hops happened to group by latency rather than on how broad the event actually was: two sites on the same access network saw one identical event and only one of them reported it, while seven of the quiet site's destinations sat at 80-100% loss without ever counting. Detection now reads all of them. The waterfall still shows its two resolver rows, and blackout detection is unchanged.

- **Coincident loss counts per network, not per target** - Several regional endpoints of one cloud provider are reached over that provider's own network and degrade together for one reason, so they now count once toward the "independent networks" test rather than reading as several unrelated networks. Access hops belonging to one ISP likewise count once, however each individual hop's ASN lookup happened to resolve.

- **Breadth is measured against the WAN being graded** - A target explicitly bound to a different WAN no longer contributes, so a failover link cannot supply breadth for the link being scored. Targets with no WAN recorded still count, since hand-added ones never get stamped with a WAN.

- **Partial-loss rows count against every monitored path** - The targets figure on a partial-loss row is now measured against all monitored paths instead of a trimmed subset. The denominator is larger, so a genuinely narrow event now reads as narrow, and that breadth feeds the event's severity: partial-loss events that touched few paths score a little softer than before.

- **Long outage waterfalls collapse to a fault line** - With every destination in play, one event can carry a dozen-plus target rows. A waterfall with eight or more targets now collapses to its first and last three - the ends carry the story (where the break sat, what stayed reachable) - and the hidden middle is drawn as a fault line: two dashed strands sheared out of line, meeting a pill with the hidden-target count. Clicking the fault line expands the full list in place with the app's usual expand animation, and a **Collapse** control above the rows folds it back. An expanded waterfall stays open across report refreshes; seven targets or fewer render exactly as before.
