### PR TITLE
Monitoring - Live View: Port Statistics renders on multi-device sites; tab-scoped filter clear

### DIFF
--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -54,6 +54,7 @@ let lastDevices = [];       // raw devices from the most recent fetch
 let pendingSelect = null;   // mac to isolate once data arrives
 
 let currentAt = null;       // ISO timestamp for historic playback, null = live
+let sanitized = false;      // degenerate persisted filter dropped once per mount
 let pollTimer = null;
 let fetchController = null;
 let seekDebounce = null;
@@ -396,10 +397,27 @@ async function fetchData() {
     }
 }
 
+// A persisted filter that hides EVERY device of a tab is degenerate - typically it
+// isolated a device that no longer exists - and below two devices the chip row never
+// renders, so there is no way out of it in the UI. Disregard it once, at first data
+// arrival: mid-session an all-hidden tab can be a deliberate ctrl-click state, and the
+// live poll must not yank it away. Only this site's devices are touched - the storage
+// key is origin-wide, and another site's saved filter is not ours to prune.
+function dropDegenerateFilter() {
+    for (const isAps of [false, true]) {
+        const devs = lastDevices.filter(d => isApDevice(d) === isAps);
+        if (devs.length && devs.every(d => visibility[d.mac] === false)) {
+            for (const d of devs) delete visibility[d.mac];
+            savePrefs();
+        }
+    }
+}
+
 async function loadAndRender() {
     const data = await fetchData();
     if (!data) return;
     lastDevices = data.devices || [];
+    if (!sanitized) { sanitized = true; dropDegenerateFilter(); }
     rebuildMeta(tabDevices());
     if (pendingSelect) {
         const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
@@ -511,6 +529,7 @@ export function mount(el, mountOpts = {}) {
     // state left by a previous session would silently block startPoll() below.
     currentAt = null;
     paused = false;
+    sanitized = false;
     window.__portStatsTable = api;
     loadAndRender();
     startPoll();

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -206,8 +206,10 @@ function renderTabs() {
     if (!tabsEl) return;
     const hasAps = lastDevices.some(isApDevice);
     const hasInfra = lastDevices.some(d => !isApDevice(d));
-    // Only worth splitting when both classes are present.
-    if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; return; }
+    // Only worth splitting when both classes are present. Hidden, not just emptied:
+    // a blank .time-range-selector still paints its pill background as a dark dot.
+    if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; tabsEl.style.display = 'none'; return; }
+    tabsEl.style.display = '';
     const tabs = [['infra', 'Gateways & Switches'], ['aps', 'APs']];
     tabsEl.innerHTML = tabs.map(([k, label]) =>
         `<button class="time-btn ${activeTab === k ? 'active' : ''}" data-tab="${k}">${label}</button>`).join('');

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -303,7 +303,8 @@ function renderBadges() {
     }
 
     // Last: the chip rebuild above wipes the row, so the reset is re-added after it.
-    renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; renderBadges(); renderTable(); }, 'Clear filter');
+    renderFilterReset(badgesEl, isFiltered(visibility),
+        () => { visibility = {}; savePrefs(); renderBadges(); renderTableNow(); }, 'Clear filter');
 }
 
 function renderTableNow(showAll) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -3,7 +3,7 @@
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
 import { renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { renderFilterReset } from './chart-filter.js?v=4';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }
@@ -270,6 +270,14 @@ function rebuildMeta(devices) {
     });
 }
 
+// Release only the tab in view (Gateways & Switches vs APs) from the filter:
+// deviceMeta is per-tab, and entries for the other tab's devices are that tab's
+// own filter state, kept intact.
+function clearTabFilter() {
+    for (const d of deviceMeta) delete visibility[d.mac];
+    savePrefs();
+}
+
 function renderBadges() {
     if (!badgesEl) return;
     if (deviceMeta.length <= 1) { badgesEl.innerHTML = ''; return; }
@@ -292,7 +300,7 @@ function renderBadges() {
                 const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
                 const onlyThis = visibility[mac] !== false
                     && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
-                if (onlyThis) visibility = {};
+                if (onlyThis) for (const d of deviceMeta) delete visibility[d.mac];
                 else if (allVis) deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac);
                 else visibility[mac] = visibility[mac] === false;
             }
@@ -303,8 +311,10 @@ function renderBadges() {
     }
 
     // Last: the chip rebuild above wipes the row, so the reset is re-added after it.
-    renderFilterReset(badgesEl, isFiltered(visibility),
-        () => { visibility = {}; savePrefs(); renderBadges(); renderTableNow(); }, 'Clear filter');
+    // Tab-scoped on both sides (deviceMeta holds only the tab in view): a filter
+    // parked on the other tab neither summons the control here nor is cleared by it.
+    renderFilterReset(badgesEl, deviceMeta.some(d => visibility[d.mac] === false),
+        () => { clearTabFilter(); renderBadges(); renderTableNow(); }, 'Clear filter');
 }
 
 function renderTableNow(showAll) {
@@ -324,7 +334,7 @@ function renderTableNow(showAll) {
             meta: () => deviceMeta,
             key: 'mac',
             visibility: () => visibility,
-            resetVisibility: () => { visibility = {}; },
+            resetVisibility: clearTabFilter,
             // Hide filtered devices entirely (showAllRows=false), not grey them out,
             // matching the pill behaviour; re-enable via the pills.
             onChanged: () => { savePrefs(); renderBadges(); renderTableNow(false); },


### PR DESCRIPTION
## Monitoring - Live View

- **Port Statistics** renders again on multi-device sites - the shared clear-filter control's rollout referenced a variable this module doesn't have, so the chip-row render crashed before the table could draw. Single-device sites skipped the broken path entirely, which is why only they kept working, and why filtering down to one device blanked the card too.

- **Clear filter** now works on the Port Statistics chip row and is scoped to the tab in view (**Gateways & Switches** vs **APs**): the control appears only when the current tab has hidden devices, clearing releases only those, and un-isolating a device via its chip no longer unhides the other tab's devices either.

- A saved filter that hides every device of a tab - typically one that isolated a device that no longer exists - is disregarded on load. Previously it could leave the card permanently empty: below two devices the chip row never renders, so nothing in the UI could release it.

- No more stray dark dot on sites with only one device class - the empty tab strip still painted its pill background; it's hidden when there's nothing to switch between.
