### PR TITLE
Security Audit: scope internet bypass findings to external traffic

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -1158,6 +1158,17 @@ public class FirewallRuleAnalyzer
                 if (!rule.Enabled || rule.Predefined || !rule.ActionType.IsAllowAction())
                     continue;
 
+                // Return-only rules cannot initiate internet connections, even when
+                // their protocol or port would otherwise look like broad web access.
+                if (!rule.AllowsNewConnections())
+                {
+                    _logger.LogDebug(
+                        "Internet bypass: rule '{Rule}' cannot initiate new connections (connectionStateType={ConnectionStateType}, connectionStates={ConnectionStates})",
+                        rule.Name, rule.ConnectionStateType,
+                        rule.ConnectionStates != null ? string.Join(",", rule.ConnectionStates) : "none");
+                    continue;
+                }
+
                 if (!rule.AppliesToSourceNetwork(network))
                 {
                     _logger.LogDebug("Internet bypass: rule '{Rule}' does not apply to network '{Network}' (srcTarget={SrcTarget}, srcZone={SrcZone}, netZone={NetZone})",
@@ -1231,6 +1242,15 @@ public class FirewallRuleAnalyzer
 
         var destTarget = rule.DestinationMatchingTarget?.ToUpperInvariant();
         var protocol = rule.Protocol?.ToLowerInvariant() ?? "all";
+
+        // When zone information is available, a rule explicitly targeting a
+        // non-external zone cannot provide internet access.
+        if (!string.IsNullOrEmpty(externalZoneId) &&
+            !string.IsNullOrEmpty(rule.DestinationZoneId) &&
+            !string.Equals(rule.DestinationZoneId, externalZoneId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
 
         if (destTarget == "WEB" && rule.HasUnresolvedDestinationDomainGroup)
             return false;

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -6456,6 +6456,134 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void CheckInternetDisabledBroadAllow_ReturnOnlyHttpsRule_NoIssue()
+    {
+        // Parse the live zone-policy shape end to end. User-created return rules
+        // cannot create new connections, so they cannot bypass an internet restriction.
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var ruleJson = JsonDocument.Parse(@"{
+            ""_id"": ""allow-management-return"",
+            ""name"": ""Allow Management to Internal Return"",
+            ""action"": ""ALLOW"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""connection_state_type"": ""RESPOND_ONLY"",
+            ""connection_states"": [],
+            ""source"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""management-zone""
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""internal-zone""
+            }
+        }").RootElement;
+        var rule = _analyzer.ParseFirewallPolicy(ruleJson)!;
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(new List<FirewallRule> { rule }, networks, "external-zone");
+
+        rule.AllowsNewConnections().Should().BeFalse();
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_LegacyReturnOnlyHttpsRule_NoIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false)
+        };
+        var ruleJson = JsonDocument.Parse(@"{
+            ""_id"": ""allow-management-return"",
+            ""name"": ""Allow Management HTTPS Return"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""tcp"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_network_id"": ""mgmt-net"",
+            ""dst_port"": ""443"",
+            ""state_new"": false,
+            ""state_established"": true,
+            ""state_related"": true,
+            ""state_invalid"": false
+        }").RootElement;
+        var rule = new FirewallRuleParser(_parserLoggerMock.Object).ParseFirewallRule(ruleJson)!;
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(new List<FirewallRule> { rule }, networks, null);
+
+        rule.AllowsNewConnections().Should().BeFalse();
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_InternalZoneHttpsAllow_NoIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-management-internal-https",
+                Name = "Allow Management to Internal HTTPS",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                DestinationPort = "443",
+                ConnectionStateType = "ALL",
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "management-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = "internal-zone"
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, "external-zone");
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_ExternalZoneCustomWithNew_ReturnsIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-management-external-https",
+                Name = "Allow Management to External HTTPS",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                DestinationPort = "443",
+                ConnectionStateType = "CUSTOM",
+                ConnectionStates = new List<string> { "NEW", "ESTABLISHED" },
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "management-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = "external-zone"
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, "external-zone");
+
+        issues.Should().ContainSingle(issue => issue.Type == IssueTypes.InternetBlockBypassed);
+    }
+
+    [Fact]
     public void CheckInternetDisabledBroadAllow_SpecificDomains_NoIssue()
     {
         // Rules with specific WebDomains (like UniFi cloud access) should NOT trigger


### PR DESCRIPTION
Fixes #1074.

## Security Audit

- **Return-only rules excluded** - user-created `RESPOND_ONLY` rules and legacy `CUSTOM` rules limited to `ESTABLISHED`/`RELATED` are no longer classified as Internet access bypasses because they cannot initiate new connections.
- **Internal destinations respected** - HTTPS and application-based allows explicitly targeting a non-external zone are no longer treated as broad Internet access.
- **True bypasses preserved** - external-zone rules that allow `NEW` connections continue to report `INTERNET_BLOCK_BYPASSED`.
- **Diagnostic context added** - Debug logging records the connection-state details when a return-only rule is excluded.

This completes the return-rule handling introduced by #1019 in the separate `CheckInternetDisabledBroadAllow` path. The fix is independent of the domain-group resolution added in #1062.

Coverage includes parsed modern `RESPOND_ONLY` policies, legacy `ESTABLISHED`/`RELATED` rules, internal-zone HTTPS allows, and external-zone `CUSTOM` rules containing `NEW`.

## Validation

- `dotnet test tests/NetworkOptimizer.Audit.Tests/NetworkOptimizer.Audit.Tests.csproj --no-restore --filter 'FullyQualifiedName~FirewallRuleAnalyzerTests'`
- 294 Firewall Rule Analyzer tests pass
- `dotnet test tests/NetworkOptimizer.Audit.Tests/NetworkOptimizer.Audit.Tests.csproj --no-restore`
- All 3,464 Audit tests pass