### PR TITLE
v2.5.1 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -1158,6 +1158,17 @@ public class FirewallRuleAnalyzer
                 if (!rule.Enabled || rule.Predefined || !rule.ActionType.IsAllowAction())
                     continue;
 
+                // Return-only rules cannot initiate internet connections, even when
+                // their protocol or port would otherwise look like broad web access.
+                if (!rule.AllowsNewConnections())
+                {
+                    _logger.LogDebug(
+                        "Internet bypass: rule '{Rule}' cannot initiate new connections (connectionStateType={ConnectionStateType}, connectionStates={ConnectionStates})",
+                        rule.Name, rule.ConnectionStateType,
+                        rule.ConnectionStates != null ? string.Join(",", rule.ConnectionStates) : "none");
+                    continue;
+                }
+
                 if (!rule.AppliesToSourceNetwork(network))
                 {
                     _logger.LogDebug("Internet bypass: rule '{Rule}' does not apply to network '{Network}' (srcTarget={SrcTarget}, srcZone={SrcZone}, netZone={NetZone})",
@@ -1231,6 +1242,15 @@ public class FirewallRuleAnalyzer
 
         var destTarget = rule.DestinationMatchingTarget?.ToUpperInvariant();
         var protocol = rule.Protocol?.ToLowerInvariant() ?? "all";
+
+        // When zone information is available, a rule explicitly targeting a
+        // non-external zone cannot provide internet access.
+        if (!string.IsNullOrEmpty(externalZoneId) &&
+            !string.IsNullOrEmpty(rule.DestinationZoneId) &&
+            !string.Equals(rule.DestinationZoneId, externalZoneId, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
 
         if (destTarget == "WEB" && rule.HasUnresolvedDestinationDomainGroup)
             return false;

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -1158,13 +1158,6 @@ public class FirewallRuleAnalyzer
                 if (!rule.Enabled || rule.Predefined || !rule.ActionType.IsAllowAction())
                     continue;
 
-                if (!rule.AllowsNewConnections())
-                {
-                    _logger.LogDebug("Internet bypass: rule '{Rule}' only allows return traffic (connectionStateType={StateType}), cannot bypass internet block",
-                        rule.Name, rule.ConnectionStateType);
-                    continue;
-                }
-
                 if (!rule.AppliesToSourceNetwork(network))
                 {
                     _logger.LogDebug("Internet bypass: rule '{Rule}' does not apply to network '{Network}' (srcTarget={SrcTarget}, srcZone={SrcZone}, netZone={NetZone})",

--- a/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/FirewallRuleAnalyzer.cs
@@ -1158,6 +1158,13 @@ public class FirewallRuleAnalyzer
                 if (!rule.Enabled || rule.Predefined || !rule.ActionType.IsAllowAction())
                     continue;
 
+                if (!rule.AllowsNewConnections())
+                {
+                    _logger.LogDebug("Internet bypass: rule '{Rule}' only allows return traffic (connectionStateType={StateType}), cannot bypass internet block",
+                        rule.Name, rule.ConnectionStateType);
+                    continue;
+                }
+
                 if (!rule.AppliesToSourceNetwork(network))
                 {
                     _logger.LogDebug("Internet bypass: rule '{Rule}' does not apply to network '{Network}' (srcTarget={SrcTarget}, srcZone={SrcZone}, netZone={NetZone})",

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -636,33 +636,81 @@ else
                                     </SiteOperatorOnly>
                                 }
                             </div>
-                            @if (outage.Tiers.Any(t => t.WentDark))
+                            @{
+                                var shapeDark = outage.Tiers.Any(t => t.WentDark);
+                            }
+                            @if (shapeDark || (outage.IsPartial && outage.Tiers.Count > 0))
                             {
-                                <div class="isp-outage-shape">
-                                    @foreach (var tier in outage.Tiers)
-                                    {
-                                        <div class="isp-outage-hop">
+                                RenderFragment<OutageTierState> hopRow;
+                                if (shapeDark)
+                                {
+                                    hopRow = tier =>
+                                        @<div class="isp-outage-hop">
                                             <span class="isp-outage-hop-name" data-tooltip="@OutageHopTooltip(tier)">@tier.Name</span>
                                             <div class="isp-outage-hop-track">
                                                 <div class="isp-outage-hop-dark" style="width: @(OutageHopDarkPercent(outage, tier).ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
                                             </div>
                                             <span class="isp-outage-hop-status @(tier.WentDark ? "" : "isp-outage-hop-up")">@OutageHopStatus(tier)</span>
-                                        </div>
-                                    }
-                                </div>
-                            }
-                            else if (outage.IsPartial && outage.Tiers.Count > 0)
-                            {
-                                <div class="isp-outage-shape">
-                                    @foreach (var tier in outage.Tiers)
-                                    {
-                                        <div class="isp-outage-hop">
+                                        </div>;
+                                }
+                                else
+                                {
+                                    hopRow = tier =>
+                                        @<div class="isp-outage-hop">
                                             <span class="isp-outage-hop-name">@tier.Name</span>
                                             <div class="isp-outage-hop-track">
                                                 <div class="isp-outage-hop-loss" style="width: @(tier.PeakLossPct.ToString("0.#", System.Globalization.CultureInfo.InvariantCulture))%"></div>
                                             </div>
                                             <span class="isp-outage-hop-status">peak @tier.PeakLossPct.ToString("0")% loss</span>
+                                        </div>;
+                                }
+                                @* Long waterfalls collapse to the first and last three rows - the ends carry the
+                                   story (where the break sat, what stayed reachable) - with the hidden middle
+                                   drawn as a clickable fault line. Both the middle rows and the fault line sit in
+                                   expand-wrappers with opposite states so one grows as the other collapses; the
+                                   negative top margin cancels the parent flex gap around whichever is at 0fr. *@
+                                var tiers = outage.Tiers;
+                                var collapsible = tiers.Count > OutageShapeCollapseThreshold;
+                                var shapeExpanded = _expandedOutageShapes.Contains(outage.Start);
+                                var hiddenCount = tiers.Count - OutageShapeEdgeRows * 2;
+                                <div class="isp-outage-shape">
+                                    @* The fault line is the only way in; the toggle exists only as the way
+                                       back down, sitting right above the rows. *@
+                                    @if (collapsible && shapeExpanded)
+                                    {
+                                        <div class="isp-outage-shape-toggle">
+                                            <button type="button" aria-expanded="true" @onclick="() => ToggleOutageShape(outage.Start)">
+                                                Collapse <span class="isp-outage-fault-chevron">▲</span>
+                                            </button>
                                         </div>
+                                    }
+                                    @foreach (var tier in collapsible ? tiers.Take(OutageShapeEdgeRows) : tiers)
+                                    {
+                                        @hopRow(tier)
+                                    }
+                                    @if (collapsible)
+                                    {
+                                        <div class="expand-wrapper isp-outage-seam @(shapeExpanded ? "" : "expanded")">
+                                            <div class="expand-content">
+                                                <button type="button" class="isp-outage-fault" aria-expanded="false" @onclick="() => ToggleOutageShape(outage.Start)">
+                                                    <span class="isp-outage-fault-pill">@hiddenCount more targets <span class="isp-outage-fault-chevron">▼</span></span>
+                                                </button>
+                                            </div>
+                                        </div>
+                                        <div class="expand-wrapper isp-outage-seam @(shapeExpanded ? "expanded" : "")">
+                                            <div class="expand-content">
+                                                <div class="isp-outage-shape-middle">
+                                                    @foreach (var tier in tiers.Skip(OutageShapeEdgeRows).Take(hiddenCount))
+                                                    {
+                                                        @hopRow(tier)
+                                                    }
+                                                </div>
+                                            </div>
+                                        </div>
+                                        @foreach (var tier in tiers.Skip(tiers.Count - OutageShapeEdgeRows))
+                                        {
+                                            @hopRow(tier)
+                                        }
                                     }
                                 </div>
                             }
@@ -1089,6 +1137,22 @@ else
     // reads as if it didn't register.
     private readonly HashSet<DateTime> _ackPending = new();
     private string AckLockClass => _ackPending.Count > 0 ? "isp-outage-ack-locked" : "";
+
+    // A waterfall with more targets than this collapses to its first and last
+    // OutageShapeEdgeRows rows with the hidden middle drawn as a fault line.
+    // Seven shows all seven: collapsing to six would hide a single row, and a
+    // one-row fault line is sillier than the row itself.
+    private const int OutageShapeCollapseThreshold = 7;
+    private const int OutageShapeEdgeRows = 3;
+
+    // Keyed by outage onset (stable across recomputes, same key the ack flow uses),
+    // so an expanded waterfall stays open through report refreshes.
+    private readonly HashSet<DateTime> _expandedOutageShapes = new();
+
+    private void ToggleOutageShape(DateTime outageStartUtc)
+    {
+        if (!_expandedOutageShapes.Remove(outageStartUtc)) _expandedOutageShapes.Add(outageStartUtc);
+    }
 
     /// <summary>Marks an outage "that was me" (user-caused, excluded from scoring) and reloads
     /// the report for the current window so the score and findings drop it.</summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -512,6 +512,10 @@ public class IspHealthService
         // Onsets of outages the user marked "that was me", stamped onto the detected events
         // below (tolerance-matched; a recompute can shift a boundary by a bucket).
         List<DateTime> ackedOutageStarts;
+        // The WAN this report grades, in MonitoringTarget.WanInterface's namespace (the UniFi WAN
+        // name, "wan"/"wan2" - NOT the data-path ifname GetPrimaryWanInterfaceAsync returns). Used
+        // to keep another WAN's internet destinations out of the partial-loss breadth pool.
+        string? primaryWanKey;
         await using (var db = await CreateSiteDbAsync(ct))
         {
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
@@ -526,6 +530,13 @@ public class IspHealthService
                 .OrderBy(c => string.Equals(c.WanInterface, "wan", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
                 .FirstOrDefault(c => c.AccessTechnology != AccessTechnology.Unknown);
             technology = primaryContext?.AccessTechnology ?? settings.AccessTechnology;
+            // Same wan-first ordering, but the interface NAME and without the access-technology
+            // filter: a WAN whose technology was never set still owns its targets. Falls back to
+            // "wan" so a site with no discovery context yet still scopes to the conventional primary.
+            primaryWanKey = wanContexts
+                .OrderBy(c => string.Equals(c.WanInterface, "wan", StringComparison.OrdinalIgnoreCase) ? 0 : 1)
+                .Select(c => c.WanInterface)
+                .FirstOrDefault(w => !string.IsNullOrEmpty(w)) ?? "wan";
 
             targets = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.Enabled && (t.TargetType == MonitoringTargetType.AccessIsp
@@ -902,6 +913,27 @@ public class IspHealthService
                 .OrderBy(MedianRtt))
             .Take(2)
             .ToList();
+        // Every internet destination on the WAN being graded - the partial pass's breadth evidence.
+        // Null WanInterface is INCLUDED: the tracer stamps only what it discovers, so a hand-added
+        // destination has none, and dropping those would quietly shrink the pool on exactly the
+        // installs that curated it. Only a target explicitly bound to a DIFFERENT WAN is excluded,
+        // so a failover link's destinations can't manufacture breadth for the primary. (The rest of
+        // ISP Health is still primary-WAN-only by assumption rather than by filter - see TODO.md
+        // "Multi-WAN Support (ISP Health & NMS)".)
+        var breadthInternet = targets
+            .Where(t => t.TargetType == MonitoringTargetType.InternetService
+                && internetSeriesExt.ContainsKey(t.TargetId)
+                && (string.IsNullOrEmpty(t.WanInterface)
+                    || string.Equals(t.WanInterface, primaryWanKey, StringComparison.OrdinalIgnoreCase)))
+            .Select(t => new AsnSeries
+            {
+                AsnNumber = t.AsnNumber ?? 0,
+                AsnName = t.Name,
+                TargetIds = { t.TargetId },
+                Samples = internetSeriesExt[t.TargetId],
+                HopIps = { t.Address }
+            })
+            .ToList();
         // Each waterfall row is labeled by its ASN. Access ISP and Transit can both be the same
         // ASN (e.g. AT&T is both the access network and a transit hop), so a transit row whose ASN
         // also appears in the access layer is suffixed " Transit" to disambiguate it.
@@ -926,7 +958,7 @@ public class IspHealthService
         //    access hop's own outage timing shows; the detector re-collapses shared signatures.
         //  - Transit kept as the per-ASN RTT clusters (the Per-Network RTT grouping), untouched.
         //  - Internet trimmed to two rows (displayInternet).
-        var outageSources = ispTargets
+        var accessAndTransitSources = ispTargets
             .Where(t => ispSeriesExt.ContainsKey(t.TargetId))
             .Select(t => (Series: new AsnSeries
             {
@@ -937,20 +969,13 @@ public class IspHealthService
                 HopIps = { t.Address }
             }, Groupable: true, AsnLabel: AsnNameCleanup.Clean(t.AsnName) ?? accessAsnName, IsInternet: false))
             .Concat(transitChart.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)TransitLabel(s), IsInternet: false)))
-            .Concat(displayInternet.Select(s => (Series: s, Groupable: false, AsnLabel: (string?)null, IsInternet: true)));
-        var orderedWanHops = outageSources
-            .Select(x => new
-            {
-                x.Groupable,
-                x.AsnLabel,
-                x.IsInternet,
-                Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
-                Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
-                HopNumber = ClusterHopNumber(x.Series),
-                Rtt = MedianRtt(x.Series)
-            })
-            .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
             .ToList();
+        (AsnSeries Series, bool Groupable, string? AsnLabel, bool IsInternet) AsInternetRow(AsnSeries s) =>
+            (Series: s, Groupable: false, AsnLabel: (string?)null, IsInternet: true);
+        var outageSources = accessAndTransitSources.Concat(displayInternet.Select(AsInternetRow));
+        // Same rows, but with EVERY internet destination instead of the two display ones - the
+        // partial pass's breadth evidence (see below).
+        var partialSources = accessAndTransitSources.Concat(breadthInternet.Select(AsInternetRow));
         // The LAN gateway is the nearest hop (Depth 0) when monitored; WAN hops shift one deeper.
         // Its loss lets the detector tell a LAN/gateway outage from a WAN outage. Absent => unchanged.
         var gatewayHop = gatewaySamples.Count > 0
@@ -958,22 +983,56 @@ public class IspHealthService
                 0, gatewaySamples, Groupable: false, AsnLabel: null, IsGateway: true)
             : null;
         var baseDepth = gatewayHop != null ? 1 : 0;
-        // Rows without a persisted hop number sorted to the end above - that Depth is a sort
-        // position, not a path position, so they carry KnownPosition: false and never anchor
-        // the detector's "break upstream of X" attribution (e.g. a hostname-based ISP target
-        // the discovery traces never mapped). Internet endpoint rows are likewise flagged so
-        // a destination can never be named as the hop the break sat beyond.
-        var outageHops = (gatewayHop != null ? new[] { gatewayHop } : Array.Empty<OutageDetector.Hop>())
-            .Concat(orderedWanHops.Select((x, i) =>
-                new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel,
-                    KnownPosition: x.HopNumber != int.MaxValue, IsInternet: x.IsInternet)))
-            .ToList();
+        // Both hop lists share every access and transit row, and the sort keys are pure functions of
+        // the series - MedianRtt copies and sorts each one's RTTs, which is not free on a long
+        // window and the compute already runs against a time budget. Derive each series' keys once.
+        var sortKeys = new Dictionary<AsnSeries, (int HopNumber, double Rtt)>();
+        (int HopNumber, double Rtt) SortKey(AsnSeries s)
+        {
+            if (!sortKeys.TryGetValue(s, out var k))
+                sortKeys[s] = k = (ClusterHopNumber(s), MedianRtt(s));
+            return k;
+        }
+        List<OutageDetector.Hop> BuildHops(IEnumerable<(AsnSeries Series, bool Groupable, string? AsnLabel, bool IsInternet)> sources)
+        {
+            var ordered = sources
+                .Select(x => new
+                {
+                    x.Groupable,
+                    x.AsnLabel,
+                    x.IsInternet,
+                    x.Series.AsnNumber,
+                    Name = x.Series.AsnName ?? x.Series.TargetIds.FirstOrDefault() ?? "hop",
+                    Series = (IReadOnlyList<LatencySample>)x.Series.Samples,
+                    HopNumber = SortKey(x.Series).HopNumber,
+                    Rtt = SortKey(x.Series).Rtt
+                })
+                .OrderBy(x => x.HopNumber).ThenBy(x => x.Rtt)
+                .ToList();
+            // Rows without a persisted hop number sorted to the end above - that Depth is a sort
+            // position, not a path position, so they carry KnownPosition: false and never anchor
+            // the detector's "break upstream of X" attribution (e.g. a hostname-based ISP target
+            // the discovery traces never mapped). Internet endpoint rows are likewise flagged so
+            // a destination can never be named as the hop the break sat beyond.
+            return (gatewayHop != null ? new[] { gatewayHop } : Array.Empty<OutageDetector.Hop>())
+                .Concat(ordered.Select((x, i) =>
+                    new OutageDetector.Hop(x.Name, baseDepth + i, x.Series, x.Groupable, x.AsnLabel,
+                        KnownPosition: x.HopNumber != int.MaxValue, IsInternet: x.IsInternet,
+                        AsnNumber: x.AsnNumber)))
+                .ToList();
+        }
+        var outageHops = BuildHops(outageSources);
         ct.ThrowIfCancellationRequested();
         var outages = OutageDetector.Detect(internetTriggerTargets, outageHops, _options);
         // Second pass: coincident partial-loss disruptions (the path getting lossy but not dark)
         // across the full set of monitored hops, excluding windows already flagged as blackouts.
+        // Unlike the blackout pass - whose trigger is every internet target and whose HOPS are only
+        // the shape - the partial pass reads breadth off the hop list itself, so it must see every
+        // internet destination or the gate is judged on two rows. Trimming to the display pair let
+        // an identical event trip at one site and not another purely because the first happened to
+        // monitor one more transit hop (so its ASN split into one more RTT cluster).
         var partialDisruptions = OutageDetector.DetectPartial(
-            outageHops, outages.Select(o => (o.Start, o.End)).ToList(), _options);
+            BuildHops(partialSources), outages.Select(o => (o.Start, o.End)).ToList(), _options);
         outages = outages.Concat(partialDisruptions).OrderBy(o => o.Start).ToList();
         // Drop events that ended at or before the window start: the lead-in reach-back only exists to
         // capture an outage that STRADDLES the window start (its recovery is in-window), so an event

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -28,8 +28,13 @@ public static class OutageDetector
     /// endpoint rows (destinations reached over diverse paths, not points on THE path) - they trigger
     /// and shape outages but likewise never anchor attribution: "break upstream of a destination"
     /// says nothing.
+    /// <paramref name="AsnNumber"/> is the row's real ASN, used ONLY by the partial pass's
+    /// independence gate. It is deliberately separate from <paramref name="AsnLabel"/>: internet rows
+    /// keep a null AsnLabel so each destination still shows its own name ("AWS us-west-1"), but
+    /// several regional endpoints of one provider must not read as several independent networks.
+    /// Zero means unattributed, and such a row falls back to counting as its own network.
     /// </summary>
-    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null, bool IsGateway = false, bool KnownPosition = true, bool IsInternet = false);
+    public sealed record Hop(string Name, int Depth, IReadOnlyList<LatencySample> Series, bool Groupable = false, string? AsnLabel = null, bool IsGateway = false, bool KnownPosition = true, bool IsInternet = false, int AsnNumber = 0);
 
     /// <param name="triggerTargets">The internet/destination loss series whose near-total loss defines an outage.</param>
     /// <param name="hops">Every monitored hop, ordered by distance (Depth ascending = nearest first), for the shape.</param>
@@ -140,7 +145,7 @@ public static class OutageDetector
         bool BucketQualifies(DateTime t)
         {
             var degraded = pool.Where(h => hopBuckets[h].TryGetValue(t, out var l) && l.Count > 0 && l[0] >= partialPct).ToList();
-            var asns = degraded.Select(h => h.AsnLabel ?? h.Name).Distinct().Count();
+            var asns = degraded.Select(NetworkKey).Distinct().Count();
             return degraded.Count >= options.OutagePartialMinTargets && asns >= options.OutagePartialMinAsns;
         }
 
@@ -179,6 +184,20 @@ public static class OutageDetector
         }
         return events;
     }
+
+    /// <summary>
+    /// The network a hop counts as for the partial pass's independence gate, which asks how many
+    /// INDEPENDENT networks degraded together. A row that HAS an <see cref="Hop.AsnLabel"/> is
+    /// already grouped at ASN level by that label, and the label is the corrected one (hand-added
+    /// access hops are mapped onto the access ISP's canonical ASN even when their own address
+    /// resolves elsewhere or not at all) - so the label wins there, and one ISP's hops count once
+    /// however their per-target ASN attribution turned out. Only internet rows lack a label, by
+    /// design, so each destination shows its own name; those key on the real ASN so several
+    /// regional endpoints of one provider, all reached over that provider's network, count once.
+    /// An unattributed destination falls back to its name - its own network, the safe reading.
+    /// </summary>
+    private static string NetworkKey(Hop h) =>
+        h.AsnLabel ?? (h.AsnNumber > 0 ? $"AS{h.AsnNumber}" : h.Name);
 
     private static OutageEvent BuildPartialEvent(
         DateTime start, DateTime end,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17899,6 +17899,101 @@ a.isp-outage-ack:hover {
     color: var(--success-color);
 }
 
+.isp-outage-shape-toggle {
+    display: flex;
+    justify-content: center;
+}
+
+.isp-outage-shape-toggle button {
+    cursor: pointer;
+}
+
+/* Cancels the shape's flex gap around a seam wrapper so the 0fr state adds no
+   phantom spacing; the visible child restores the gap itself (margin/padding-top). */
+.isp-outage-seam {
+    margin-top: -0.45rem;
+}
+
+.isp-outage-shape-middle {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    padding-top: 0.45rem;
+}
+
+.isp-outage-fault {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    margin-top: 0.45rem;
+    padding: 0.2rem 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+}
+
+/* The hidden middle reads as a fault: two dashed strands sheared 4px out of line,
+   fading toward the card edges, meeting the count pill at the break. */
+.isp-outage-fault::before,
+.isp-outage-fault::after {
+    content: "";
+    position: absolute;
+    height: 2px;
+    opacity: 0.35;
+    transition: opacity 0.15s ease;
+}
+
+.isp-outage-fault::before {
+    left: 0;
+    right: calc(50% + 4.75rem);
+    top: calc(50% - 3px);
+    background: repeating-linear-gradient(90deg, var(--text-muted) 0 7px, transparent 7px 13px);
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 45%);
+    mask-image: linear-gradient(90deg, transparent, #000 45%);
+}
+
+.isp-outage-fault::after {
+    left: calc(50% + 4.75rem);
+    right: 0;
+    top: calc(50% + 1px);
+    background: repeating-linear-gradient(270deg, var(--text-muted) 0 7px, transparent 7px 13px);
+    -webkit-mask-image: linear-gradient(270deg, transparent, #000 45%);
+    mask-image: linear-gradient(270deg, transparent, #000 45%);
+}
+
+.isp-outage-fault:hover::before,
+.isp-outage-fault:hover::after {
+    opacity: 0.6;
+}
+
+.isp-outage-fault-pill,
+.isp-outage-shape-toggle button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.16rem 0.7rem;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-card);
+    color: var(--text-secondary);
+    font-size: 0.72rem;
+    white-space: nowrap;
+    transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.isp-outage-fault:hover .isp-outage-fault-pill,
+.isp-outage-shape-toggle button:hover {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+}
+
+.isp-outage-fault-chevron {
+    font-size: 0.55rem;
+    line-height: 1;
+}
+
 @media (max-width: 768px) {
     .isp-outage-hop {
         grid-template-columns: 1fr auto;

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -3,7 +3,7 @@
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
 import { renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { renderFilterReset } from './chart-filter.js?v=4';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }
@@ -54,6 +54,7 @@ let lastDevices = [];       // raw devices from the most recent fetch
 let pendingSelect = null;   // mac to isolate once data arrives
 
 let currentAt = null;       // ISO timestamp for historic playback, null = live
+let sanitized = false;      // degenerate persisted filter dropped once per mount
 let pollTimer = null;
 let fetchController = null;
 let seekDebounce = null;
@@ -206,8 +207,10 @@ function renderTabs() {
     if (!tabsEl) return;
     const hasAps = lastDevices.some(isApDevice);
     const hasInfra = lastDevices.some(d => !isApDevice(d));
-    // Only worth splitting when both classes are present.
-    if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; return; }
+    // Only worth splitting when both classes are present. Hidden, not just emptied:
+    // a blank .time-range-selector still paints its pill background as a dark dot.
+    if (!(hasAps && hasInfra)) { tabsEl.innerHTML = ''; tabsEl.style.display = 'none'; return; }
+    tabsEl.style.display = '';
     const tabs = [['infra', 'Gateways & Switches'], ['aps', 'APs']];
     tabsEl.innerHTML = tabs.map(([k, label]) =>
         `<button class="time-btn ${activeTab === k ? 'active' : ''}" data-tab="${k}">${label}</button>`).join('');
@@ -270,6 +273,14 @@ function rebuildMeta(devices) {
     });
 }
 
+// Release only the tab in view (Gateways & Switches vs APs) from the filter:
+// deviceMeta is per-tab, and entries for the other tab's devices are that tab's
+// own filter state, kept intact.
+function clearTabFilter() {
+    for (const d of deviceMeta) delete visibility[d.mac];
+    savePrefs();
+}
+
 function renderBadges() {
     if (!badgesEl) return;
     if (deviceMeta.length <= 1) { badgesEl.innerHTML = ''; return; }
@@ -292,7 +303,7 @@ function renderBadges() {
                 const allVis = deviceMeta.every(d => visibility[d.mac] !== false);
                 const onlyThis = visibility[mac] !== false
                     && deviceMeta.filter(d => d.mac !== mac).every(d => visibility[d.mac] === false);
-                if (onlyThis) visibility = {};
+                if (onlyThis) for (const d of deviceMeta) delete visibility[d.mac];
                 else if (allVis) deviceMeta.forEach(d => visibility[d.mac] = d.mac === mac);
                 else visibility[mac] = visibility[mac] === false;
             }
@@ -303,7 +314,10 @@ function renderBadges() {
     }
 
     // Last: the chip rebuild above wipes the row, so the reset is re-added after it.
-    renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; renderBadges(); renderTable(); }, 'Clear filter');
+    // Tab-scoped on both sides (deviceMeta holds only the tab in view): a filter
+    // parked on the other tab neither summons the control here nor is cleared by it.
+    renderFilterReset(badgesEl, deviceMeta.some(d => visibility[d.mac] === false),
+        () => { clearTabFilter(); renderBadges(); renderTableNow(); }, 'Clear filter');
 }
 
 function renderTableNow(showAll) {
@@ -323,7 +337,7 @@ function renderTableNow(showAll) {
             meta: () => deviceMeta,
             key: 'mac',
             visibility: () => visibility,
-            resetVisibility: () => { visibility = {}; },
+            resetVisibility: clearTabFilter,
             // Hide filtered devices entirely (showAllRows=false), not grey them out,
             // matching the pill behaviour; re-enable via the pills.
             onChanged: () => { savePrefs(); renderBadges(); renderTableNow(false); },
@@ -383,10 +397,27 @@ async function fetchData() {
     }
 }
 
+// A persisted filter that hides EVERY device of a tab is degenerate - typically it
+// isolated a device that no longer exists - and below two devices the chip row never
+// renders, so there is no way out of it in the UI. Disregard it once, at first data
+// arrival: mid-session an all-hidden tab can be a deliberate ctrl-click state, and the
+// live poll must not yank it away. Only this site's devices are touched - the storage
+// key is origin-wide, and another site's saved filter is not ours to prune.
+function dropDegenerateFilter() {
+    for (const isAps of [false, true]) {
+        const devs = lastDevices.filter(d => isApDevice(d) === isAps);
+        if (devs.length && devs.every(d => visibility[d.mac] === false)) {
+            for (const d of devs) delete visibility[d.mac];
+            savePrefs();
+        }
+    }
+}
+
 async function loadAndRender() {
     const data = await fetchData();
     if (!data) return;
     lastDevices = data.devices || [];
+    if (!sanitized) { sanitized = true; dropDegenerateFilter(); }
     rebuildMeta(tabDevices());
     if (pendingSelect) {
         const match = deviceMeta.find(d => d.mac.toLowerCase() === pendingSelect.toLowerCase());
@@ -498,6 +529,7 @@ export function mount(el, mountOpts = {}) {
     // state left by a previous session would silently block startPoll() below.
     currentAt = null;
     paused = false;
+    sanitized = false;
     window.__portStatsTable = api;
     loadAndRender();
     startPoll();

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -6456,6 +6456,134 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void CheckInternetDisabledBroadAllow_ReturnOnlyHttpsRule_NoIssue()
+    {
+        // Parse the live zone-policy shape end to end. User-created return rules
+        // cannot create new connections, so they cannot bypass an internet restriction.
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var ruleJson = JsonDocument.Parse(@"{
+            ""_id"": ""allow-management-return"",
+            ""name"": ""Allow Management to Internal Return"",
+            ""action"": ""ALLOW"",
+            ""enabled"": true,
+            ""protocol"": ""all"",
+            ""connection_state_type"": ""RESPOND_ONLY"",
+            ""connection_states"": [],
+            ""source"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""management-zone""
+            },
+            ""destination"": {
+                ""matching_target"": ""ANY"",
+                ""zone_id"": ""internal-zone""
+            }
+        }").RootElement;
+        var rule = _analyzer.ParseFirewallPolicy(ruleJson)!;
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(new List<FirewallRule> { rule }, networks, "external-zone");
+
+        rule.AllowsNewConnections().Should().BeFalse();
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_LegacyReturnOnlyHttpsRule_NoIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false)
+        };
+        var ruleJson = JsonDocument.Parse(@"{
+            ""_id"": ""allow-management-return"",
+            ""name"": ""Allow Management HTTPS Return"",
+            ""action"": ""accept"",
+            ""enabled"": true,
+            ""protocol"": ""tcp"",
+            ""ruleset"": ""LAN_IN"",
+            ""src_network_id"": ""mgmt-net"",
+            ""dst_port"": ""443"",
+            ""state_new"": false,
+            ""state_established"": true,
+            ""state_related"": true,
+            ""state_invalid"": false
+        }").RootElement;
+        var rule = new FirewallRuleParser(_parserLoggerMock.Object).ParseFirewallRule(ruleJson)!;
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(new List<FirewallRule> { rule }, networks, null);
+
+        rule.AllowsNewConnections().Should().BeFalse();
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_InternalZoneHttpsAllow_NoIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-management-internal-https",
+                Name = "Allow Management to Internal HTTPS",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                DestinationPort = "443",
+                ConnectionStateType = "ALL",
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "management-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = "internal-zone"
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, "external-zone");
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_ExternalZoneCustomWithNew_ReturnsIssue()
+    {
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net",
+                internetAccessEnabled: false, firewallZoneId: "management-zone")
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-management-external-https",
+                Name = "Allow Management to External HTTPS",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                DestinationPort = "443",
+                ConnectionStateType = "CUSTOM",
+                ConnectionStates = new List<string> { "NEW", "ESTABLISHED" },
+                SourceMatchingTarget = "ANY",
+                SourceZoneId = "management-zone",
+                DestinationMatchingTarget = "ANY",
+                DestinationZoneId = "external-zone"
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, "external-zone");
+
+        issues.Should().ContainSingle(issue => issue.Type == IssueTypes.InternetBlockBypassed);
+    }
+
+    [Fact]
     public void CheckInternetDisabledBroadAllow_SpecificDomains_NoIssue()
     {
         // Rules with specific WebDomains (like UniFi cloud access) should NOT trigger

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -6064,6 +6064,68 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
+    public void CheckInternetDisabledBroadAllow_RespondOnlyReturnRule_NoIssue()
+    {
+        // A RESPOND_ONLY rule only permits replies to established sessions - it cannot
+        // initiate NEW connections, so it cannot bypass the internet block (issue #1074)
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-return",
+                Name = "Allow Management to Internal Return",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                SourceMatchingTarget = "NETWORK",
+                SourceNetworkIds = new List<string> { "mgmt-net" },
+                DestinationMatchingTarget = "ANY",
+                DestinationPort = "443",
+                ConnectionStateType = "RESPOND_ONLY"
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, null);
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckInternetDisabledBroadAllow_LegacyEstablishedRelatedRule_NoIssue()
+    {
+        // Legacy CUSTOM state list of ESTABLISHED/RELATED is return-only traffic too
+        var networks = new List<NetworkInfo>
+        {
+            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
+        };
+        var rules = new List<FirewallRule>
+        {
+            new FirewallRule
+            {
+                Id = "allow-return-legacy",
+                Name = "Allow Return Traffic Legacy",
+                Action = "ALLOW",
+                Enabled = true,
+                Protocol = "tcp",
+                SourceMatchingTarget = "NETWORK",
+                SourceNetworkIds = new List<string> { "mgmt-net" },
+                DestinationMatchingTarget = "ANY",
+                DestinationPort = "443",
+                ConnectionStateType = "CUSTOM",
+                ConnectionStates = new List<string> { "ESTABLISHED", "RELATED" }
+            }
+        };
+
+        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, null);
+
+        issues.Should().BeEmpty();
+    }
+
+    [Fact]
     public void CheckInternetDisabledBroadAllow_Port80_Udp_NoIssue()
     {
         // Port 80 with UDP only is NOT HTTP - HTTP requires TCP

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/FirewallRuleAnalyzerTests.cs
@@ -6064,68 +6064,6 @@ public class FirewallRuleAnalyzerTests
     }
 
     [Fact]
-    public void CheckInternetDisabledBroadAllow_RespondOnlyReturnRule_NoIssue()
-    {
-        // A RESPOND_ONLY rule only permits replies to established sessions - it cannot
-        // initiate NEW connections, so it cannot bypass the internet block (issue #1074)
-        var networks = new List<NetworkInfo>
-        {
-            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
-        };
-        var rules = new List<FirewallRule>
-        {
-            new FirewallRule
-            {
-                Id = "allow-return",
-                Name = "Allow Management to Internal Return",
-                Action = "ALLOW",
-                Enabled = true,
-                Protocol = "tcp",
-                SourceMatchingTarget = "NETWORK",
-                SourceNetworkIds = new List<string> { "mgmt-net" },
-                DestinationMatchingTarget = "ANY",
-                DestinationPort = "443",
-                ConnectionStateType = "RESPOND_ONLY"
-            }
-        };
-
-        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, null);
-
-        issues.Should().BeEmpty();
-    }
-
-    [Fact]
-    public void CheckInternetDisabledBroadAllow_LegacyEstablishedRelatedRule_NoIssue()
-    {
-        // Legacy CUSTOM state list of ESTABLISHED/RELATED is return-only traffic too
-        var networks = new List<NetworkInfo>
-        {
-            CreateNetwork("Management", NetworkPurpose.Management, id: "mgmt-net", internetAccessEnabled: false)
-        };
-        var rules = new List<FirewallRule>
-        {
-            new FirewallRule
-            {
-                Id = "allow-return-legacy",
-                Name = "Allow Return Traffic Legacy",
-                Action = "ALLOW",
-                Enabled = true,
-                Protocol = "tcp",
-                SourceMatchingTarget = "NETWORK",
-                SourceNetworkIds = new List<string> { "mgmt-net" },
-                DestinationMatchingTarget = "ANY",
-                DestinationPort = "443",
-                ConnectionStateType = "CUSTOM",
-                ConnectionStates = new List<string> { "ESTABLISHED", "RELATED" }
-            }
-        };
-
-        var issues = _analyzer.CheckInternetDisabledBroadAllow(rules, networks, null);
-
-        issues.Should().BeEmpty();
-    }
-
-    [Fact]
     public void CheckInternetDisabledBroadAllow_Port80_Udp_NoIssue()
     {
         // Port 80 with UDP only is NOT HTTP - HTTP requires TCP

--- a/tests/NetworkOptimizer.Web.Tests/AgentConnectionAlertMonitorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentConnectionAlertMonitorTests.cs
@@ -7,8 +7,8 @@ namespace NetworkOptimizer.Web.Tests;
 public class AgentConnectionAlertMonitorTests
 {
     [Theory]
-    [InlineData("Falkor", "Agent \"Falkor\"")]
-    [InlineData("Honeybee Home", "Agent \"Honeybee Home\"")]
+    [InlineData("Beacon", "Agent \"Beacon\"")]
+    [InlineData("North Office", "Agent \"North Office\"")]
     public void AgentLabel_DistinctiveName_KeepsQuotedName(string name, string expected)
         => AgentConnectionAlertMonitor.AgentLabel(name).Should().Be(expected);
 

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/OutageDetectorTests.cs
@@ -330,6 +330,82 @@ public class OutageDetectorTests
     }
 
     [Fact]
+    public void Regional_endpoints_of_one_provider_are_not_independent_networks()
+    {
+        // Four destinations, one provider: a cloud's regional endpoints are reached over that
+        // provider's own network, so they degrade together for one reason. Internet rows carry a
+        // null AsnLabel (each shows its own name), so counting labels would read this as four
+        // independent networks and clear the breadth gate on a single provider's bad day.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("AWS us-east-1", 0, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-east-2", 1, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-west-1", 2, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+            new OutageDetector.Hop("AWS us-west-2", 3, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 16509),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Access_hops_of_one_isp_count_once_even_when_their_own_asn_attribution_differs()
+    {
+        // A hand-added access hop resolves to no ASN of its own while its auto-discovered siblings
+        // carry the ISP's - they are one network regardless, and the shared label already says so.
+        // Keying independence on the per-target ASN would read this ISP as two networks and let one
+        // access tier's bad minute clear a gate that exists to require several.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("hop-a", 0, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("hop-b", 1, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("hop-c", 2, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            // Same ISP, no ASN of its own - must not read as a second independent network.
+            new OutageDetector.Hop("hop-d", 3, LossSeries(ds, de, 60), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 0),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Internet_destinations_supply_the_breadth_a_thin_transit_layer_cannot()
+    {
+        // A thin path: one access ISP, a transit layer that collapses to two rows of one ASN, and a
+        // path event hitting destinations everywhere. Transit + the one canonical resolver is three
+        // rows - under the gate - so the event only surfaces because the other monitored
+        // destinations are in the pool. Four distinct networks degrade here.
+        var ds = OutStart;
+        var de = OutStart.AddMinutes(10);
+        var hops = new[]
+        {
+            new OutageDetector.Hop("Access ISP", 0, LossSeries(ds, de, 0), Groupable: true, AsnLabel: "Access ISP", AsnNumber: 64500),
+            new OutageDetector.Hop("Level 3 (lag-101)", 1, LossSeries(ds, de, 60), AsnLabel: "Level 3", AsnNumber: 3356),
+            new OutageDetector.Hop("Level 3 (ae25)", 2, LossSeries(ds, de, 60), AsnLabel: "Level 3", AsnNumber: 3356),
+            new OutageDetector.Hop("Google", 3, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 15169),
+            new OutageDetector.Hop("Cloudflare", 4, LossSeries(ds, de, 0), IsInternet: true, AsnNumber: 13335),
+            new OutageDetector.Hop("Akamai", 5, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 20940),
+            new OutageDetector.Hop("Quad9", 6, LossSeries(ds, de, 60), IsInternet: true, AsnNumber: 19281),
+        };
+
+        var events = OutageDetector.DetectPartial(hops, NoDarkWindows, Options);
+
+        events.Should().ContainSingle();
+        events[0].IsPartial.Should().BeTrue();
+        // The access tier stayed clean and every degraded row sits beyond it, so the break is
+        // upstream - and no destination may be named as the hop it sat beyond.
+        events[0].Scope.Should().Be(OutageScope.Upstream);
+        events[0].LastReachableHop.Should().Be("Access ISP");
+        events[0].Tiers.Select(t => t.Name).Should().NotContain("Cloudflare");
+    }
+
+    [Fact]
     public void Olt_blip_at_onset_then_recovery_still_reads_upstream_and_leads_the_waterfall()
     {
         var internet1 = Series(0, (OutStart, OutEnd, 100));


### PR DESCRIPTION
Three fixes since v2.5.0.

- **Monitoring - Live View** - The **Port Statistics** table renders on multi-device sites again. The device filter is now tab-scoped (**Gateways & Switches** vs **APs**) on both the pills and the **Clear filter** control, and a stale persisted filter that hid every device of a tab is dropped on load instead of leaving the table blank with no way out. (#1075)
- **Monitoring - ISP Health** - Partial-loss detection now reads every monitored internet destination rather than the two displayed rows, so an identical event is judged on the same breadth evidence at every site - and independence is counted per network, so several regional endpoints of one provider no longer read as several independent networks. Long outage waterfalls collapse to their first and last three rows with the hidden middle drawn as an expandable fault line. (#1073)
- **Security Audit** - The **Firewall: Internet Block Bypassed** check no longer flags allow rules that cannot initiate new connections (RESPOND_ONLY and legacy ESTABLISHED/RELATED return rules), and rules explicitly targeting a non-external zone are no longer treated as broad internet access. (#1076, thanks @jimstrang for the fix and the detailed report in #1074)