### PR TITLE
Agent: survive and self-heal a wedged async socket engine

### DIFF
--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -520,8 +520,13 @@ ExecStop=${NGINX_BIN} -s quit -c ${INSTALL_DIR}/nginx-speedtest.conf
 Restart=always
 RestartSec=5
 
+# Enabling under the AGENT's .wants (not multi-user's): BindsTo above stops
+# nginx with the agent but never starts it again, so hook the start side to the
+# agent too - every agent start (boot, deploys, manual restarts, the async-I/O
+# watchdog's self-restart) relights nginx. Lives here in the nginx unit so the
+# dependency only exists on installs that actually include the speed test.
 [Install]
-WantedBy=multi-user.target
+WantedBy=netopt-agent.service
 UNIT
 
         # If the first test fails only because an enforcing AppArmor profile denies
@@ -537,7 +542,10 @@ UNIT
             # Enable now, but START it below, after the agent unit is installed and
             # running - nginx BindsTo the agent, so starting it before the agent exists
             # would immediately stop it again.
-            systemctl enable --quiet netopt-speedtest-nginx.service
+            # reenable (not enable): converges upgrade re-runs onto the current
+            # WantedBy - enable alone would leave a stale multi-user.target.wants
+            # symlink from installs made before nginx was wanted by the agent.
+            systemctl reenable --quiet netopt-speedtest-nginx.service
             START_SPEEDTEST_NGINX=1
             ok "LAN speed test ready on port 3000 (starts with the agent)"
         else
@@ -555,12 +563,6 @@ cat > "/etc/systemd/system/${SERVICE_NAME}.service" <<UNIT
 Description=Network Optimizer Agent (${SERVICE_NAME})
 After=network-online.target
 Wants=network-online.target
-# The speed test nginx BindsTo this unit, so it stops whenever the agent stops -
-# but BindsTo alone never starts it again. Wanting it from here relights it on
-# every agent start (deploys, manual restarts, and the async-I/O watchdog's
-# self-restart). Harmless when the speed test isn't installed: a missing Wants
-# target is simply ignored.
-Wants=netopt-speedtest-nginx.service
 
 [Service]
 Type=simple

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -555,6 +555,12 @@ cat > "/etc/systemd/system/${SERVICE_NAME}.service" <<UNIT
 Description=Network Optimizer Agent (${SERVICE_NAME})
 After=network-online.target
 Wants=network-online.target
+# The speed test nginx BindsTo this unit, so it stops whenever the agent stops -
+# but BindsTo alone never starts it again. Wanting it from here relights it on
+# every agent start (deploys, manual restarts, and the async-I/O watchdog's
+# self-restart). Harmless when the speed test isn't installed: a missing Wants
+# target is simply ignored.
+Wants=netopt-speedtest-nginx.service
 
 [Service]
 Type=simple

--- a/src/NetworkOptimizer.Agent/AsyncIoWatchdog.cs
+++ b/src/NetworkOptimizer.Agent/AsyncIoWatchdog.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NetworkOptimizer.Agent;
+
+/// <summary>
+/// Self-heal for a wedged .NET async socket engine, seen on a UniFi gateway's
+/// vendor kernel (2026-07-30): epoll_wait slept through a wakeup, so every
+/// async socket completion stopped being delivered while the kernel kept
+/// completing the underlying work. Timers, sync I/O, and child processes all
+/// keep running, so the agent looks alive while the tunnel, heartbeats, and
+/// probe pipe reads starve forever on connects the kernel already finished.
+///
+/// Detection is a loopback canary: an async connect to our own listener on
+/// 127.0.0.1. That connect cannot time out for network reasons, so several
+/// consecutive in-process timeouts prove the engine is dead - a real WAN or
+/// server outage never trips it. The engine's event loop is process-global,
+/// so the only remedy is a process restart: the watchdog persists the result
+/// backlog and exits non-zero for the unit's Restart=always to relaunch.
+/// </summary>
+public static class AsyncIoWatchdog
+{
+    /// <summary>Consecutive canary failures before declaring the engine dead.</summary>
+    public const int FailuresBeforeRestart = 3;
+
+    /// <summary>EX_SOFTWARE: distinguishes a watchdog restart from a crash in journal/systemd status.</summary>
+    public const int ExitCode = 70;
+
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan CanaryTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Runs for the life of the process. <paramref name="persistState"/> is
+    /// invoked (best-effort) right before the restart exit; it must use only
+    /// sync I/O, since async I/O is exactly what is broken at that point.
+    /// </summary>
+    public static async Task RunAsync(Action persistState, CancellationToken ct)
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(FailuresBeforeRestart + 1);
+        var endpoint = (IPEndPoint)listener.LocalEndPoint!;
+
+        var failures = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(Interval, ct);
+
+            var completed = await CanaryConnectAsync(endpoint, ct);
+            DrainBacklog(listener);
+            if (ct.IsCancellationRequested)
+                return;
+            if (completed)
+            {
+                failures = 0;
+                continue;
+            }
+
+            failures++;
+            Console.Error.WriteLine(
+                $"Async I/O canary: loopback connect did not complete in {CanaryTimeout.TotalSeconds:0}s ({failures}/{FailuresBeforeRestart})");
+            if (failures < FailuresBeforeRestart)
+                continue;
+
+            Console.Error.WriteLine(
+                "Async socket engine is wedged (the kernel completes loopback connects this process never observes); " +
+                "exiting so systemd relaunches the agent");
+            try
+            {
+                persistState();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"State persist before watchdog restart failed: {ex.Message}");
+            }
+            Environment.Exit(ExitCode);
+        }
+    }
+
+    /// <summary>
+    /// True when the async connect COMPLETED - success or failure both prove
+    /// the engine is delivering completions. False only when nothing arrived
+    /// within the timeout, which on loopback means the delivery path is dead.
+    /// </summary>
+    private static async Task<bool> CanaryConnectAsync(IPEndPoint endpoint, CancellationToken ct)
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        Task connect;
+        try
+        {
+            connect = socket.ConnectAsync(endpoint);
+        }
+        catch
+        {
+            socket.Dispose();
+            return true;
+        }
+
+        var winner = await Task.WhenAny(connect, Task.Delay(CanaryTimeout, ct));
+        if (winner == connect)
+        {
+            try { await connect; } catch { }
+            socket.Dispose();
+            return true;
+        }
+
+        // Timed out (or shutdown cancelled the delay - the caller re-checks ct).
+        // Observe the completion that may never fire, and close the kernel-side
+        // connection so it doesn't linger.
+        _ = connect.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+        socket.Dispose();
+        return false;
+    }
+
+    /// <summary>
+    /// Accepts and discards the canary's connections on the SYNC path, which
+    /// works even when the async engine is dead - otherwise kernel-established
+    /// canary connects would fill the listen backlog and fail future canaries
+    /// for the wrong reason.
+    /// </summary>
+    private static void DrainBacklog(Socket listener)
+    {
+        try
+        {
+            while (listener.Poll(0, SelectMode.SelectRead))
+                listener.Accept().Dispose();
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/NetworkOptimizer.Agent/ProbeRunner.cs
+++ b/src/NetworkOptimizer.Agent/ProbeRunner.cs
@@ -24,6 +24,10 @@ public sealed class ProbeRunner
     private readonly LocalProbeExecutor _executor = new(NullLogger<LocalProbeExecutor>.Instance);
     private readonly ConcurrentDictionary<string, DateTime> _lastProbed = new();
     private readonly ConcurrentDictionary<string, Task> _inFlight = new();
+    // Deliberately never disposed: in-flight probes release their slot after
+    // RunAsync exits on shutdown, and Release on a disposed semaphore throws
+    // into tasks nobody awaits. Process teardown reclaims it.
+    private readonly SemaphoreSlim _concurrency = new(4);
     private volatile IReadOnlyList<ProbeTargetSpec> _targets = [];
 
     /// <summary>
@@ -65,7 +69,6 @@ public sealed class ProbeRunner
         try { await Task.Delay(TimeSpan.FromSeconds(20), ct); }
         catch (OperationCanceledException) { return; }
 
-        using var concurrency = new SemaphoreSlim(4);
         while (!ct.IsCancellationRequested)
         {
             var now = DateTime.UtcNow;
@@ -78,7 +81,7 @@ public sealed class ProbeRunner
             {
                 if (!IsDue(target, now) || _inFlight.ContainsKey(target.TargetId))
                     continue;
-                var probe = ProbeAsync(target, concurrency, ct);
+                var probe = ProbeAsync(target, ct);
                 _inFlight[target.TargetId] = probe;
                 _ = probe.ContinueWith(_ => _inFlight.TryRemove(target.TargetId, out Task? _),
                     TaskScheduler.Default);
@@ -93,9 +96,9 @@ public sealed class ProbeRunner
         return !_lastProbed.TryGetValue(spec.TargetId, out var last) || now - last >= interval;
     }
 
-    private async Task ProbeAsync(ProbeTargetSpec spec, SemaphoreSlim concurrency, CancellationToken ct)
+    private async Task ProbeAsync(ProbeTargetSpec spec, CancellationToken ct)
     {
-        await concurrency.WaitAsync(ct);
+        await _concurrency.WaitAsync(ct);
         try
         {
             _lastProbed[spec.TargetId] = DateTime.UtcNow;
@@ -151,7 +154,7 @@ public sealed class ProbeRunner
         }
         finally
         {
-            concurrency.Release();
+            _concurrency.Release();
         }
     }
 }

--- a/src/NetworkOptimizer.Agent/ProbeRunner.cs
+++ b/src/NetworkOptimizer.Agent/ProbeRunner.cs
@@ -23,7 +23,17 @@ public sealed class ProbeRunner
     private readonly string? _defaultSourceIp;
     private readonly LocalProbeExecutor _executor = new(NullLogger<LocalProbeExecutor>.Instance);
     private readonly ConcurrentDictionary<string, DateTime> _lastProbed = new();
+    private readonly ConcurrentDictionary<string, Task> _inFlight = new();
     private volatile IReadOnlyList<ProbeTargetSpec> _targets = [];
+
+    /// <summary>
+    /// Hard wall-clock cap on one probe. The executor's own overall cap is
+    /// ~11 s worst case (20 pings at 0.2 s + 2 s timeout + margin), so anything
+    /// past this is a hung await, not a slow network - the probe's concurrency
+    /// slot is reclaimed and no result is recorded (a gap is honest; fabricated
+    /// loss is not).
+    /// </summary>
+    private static readonly TimeSpan ProbeDeadline = TimeSpan.FromSeconds(30);
 
     /// <param name="defaultSourceIp">
     /// Source address every probe binds to unless the target spec carries its
@@ -59,9 +69,20 @@ public sealed class ProbeRunner
         while (!ct.IsCancellationRequested)
         {
             var now = DateTime.UtcNow;
-            var due = _targets.Where(t => IsDue(t, now)).ToList();
-            if (due.Count > 0)
-                await Task.WhenAll(due.Select(t => ProbeAsync(t, concurrency, ct)));
+            // Fire-and-track, never await-all: the tick must keep scheduling
+            // even if one probe hangs (a wedged async engine once froze the
+            // whole scheduler through a WhenAll here, taking every target dark
+            // instead of just the stuck one). _inFlight keeps a slow or hung
+            // target from stacking duplicate probes.
+            foreach (var target in _targets)
+            {
+                if (!IsDue(target, now) || _inFlight.ContainsKey(target.TargetId))
+                    continue;
+                var probe = ProbeAsync(target, concurrency, ct);
+                _inFlight[target.TargetId] = probe;
+                _ = probe.ContinueWith(_ => _inFlight.TryRemove(target.TargetId, out Task? _),
+                    TaskScheduler.Default);
+            }
             await Task.Delay(TimeSpan.FromSeconds(2), ct);
         }
     }
@@ -88,11 +109,21 @@ public sealed class ProbeRunner
                 spec.Port > 0 ? spec.Port : null,
                 string.IsNullOrEmpty(spec.SourceIp) ? _defaultSourceIp : spec.SourceIp);
 
-            var ping = await _executor.PingAsync(
+            var pingTask = _executor.PingAsync(
                 target,
                 count: Math.Max(3, Math.Min(spec.PingCount, 20)),
                 perPingTimeout: TimeSpan.FromSeconds(2),
                 ct: ct);
+            var winner = await Task.WhenAny(pingTask, Task.Delay(ProbeDeadline, ct));
+            if (winner != pingTask)
+            {
+                _ = pingTask.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+                if (!ct.IsCancellationRequested)
+                    Console.Error.WriteLine(
+                        $"Probe {spec.TargetId} did not complete within {ProbeDeadline.TotalSeconds:0}s; dropping this sample");
+                return;
+            }
+            var ping = await pingTask;
             if (ct.IsCancellationRequested) return;
 
             var result = new ProbeResult

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -234,10 +234,14 @@ if (!string.IsNullOrEmpty(config.TunnelUrl))
     snmpRunner = new SnmpRunner(resultBuffer.Enqueue);
     probeTask = probeRunner.RunAsync(cts.Token);
     snmpTask = snmpRunner.RunAsync(cts.Token);
-    // Restart-based self-heal for a wedged async socket engine (the unit ships
-    // Restart=always); spools the backlog first so the restart is lossless.
-    watchdogTask = AsyncIoWatchdog.RunAsync(SaveSpool, cts.Token);
 }
+
+// Restart-based self-heal for a wedged async socket engine (every install
+// mode restarts the agent on exit); spools the backlog first so the restart
+// is lossless. Deliberately outside the tunnel block: heartbeat-only agents
+// die of the same wedge (async HTTP) and need the same cure - without a
+// buffer the spool callback is a no-op.
+watchdogTask = AsyncIoWatchdog.RunAsync(SaveSpool, cts.Token);
 
 // Prefer the persistent gRPC tunnel; REST heartbeats keep the agent visible as
 // Online whenever the tunnel is unavailable (tunnel disabled server-side, an

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -197,13 +197,46 @@ ProbeRunner? probeRunner = null;
 SnmpRunner? snmpRunner = null;
 Task? probeTask = null;
 Task? snmpTask = null;
+Task? watchdogTask = null;
+var spoolPath = Path.Combine(
+    Path.GetDirectoryName(Path.GetFullPath(configPath)) ?? ".", "result-spool.bin");
+
+// Best-effort spool of the unacked backlog for the next process to replay.
+// Called on graceful shutdown and by the async-I/O watchdog right before its
+// restart exit, so restarts don't cost the outage data the buffer exists for.
+void SaveSpool()
+{
+    if (resultBuffer is not { Count: > 0 })
+        return;
+    var count = resultBuffer.Count;
+    resultBuffer.SaveTo(spoolPath);
+    Console.WriteLine($"Spooled {count} unsent result message(s) for the next start");
+}
+
 if (!string.IsNullOrEmpty(config.TunnelUrl))
 {
     resultBuffer = new ResultBuffer();
+    if (File.Exists(spoolPath))
+    {
+        try
+        {
+            var restored = resultBuffer.LoadFrom(spoolPath);
+            if (restored > 0)
+                Console.WriteLine($"Restored {restored} spooled result message(s) from the previous run");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Result spool restore failed: {ex.Message}");
+        }
+        try { File.Delete(spoolPath); } catch { }
+    }
     probeRunner = new ProbeRunner(resultBuffer.Enqueue, config.ProbeSourceIp);
     snmpRunner = new SnmpRunner(resultBuffer.Enqueue);
     probeTask = probeRunner.RunAsync(cts.Token);
     snmpTask = snmpRunner.RunAsync(cts.Token);
+    // Restart-based self-heal for a wedged async socket engine (the unit ships
+    // Restart=always); spools the backlog first so the restart is lossless.
+    watchdogTask = AsyncIoWatchdog.RunAsync(SaveSpool, cts.Token);
 }
 
 // Prefer the persistent gRPC tunnel; REST heartbeats keep the agent visible as
@@ -304,6 +337,19 @@ if (probeTask != null)
 if (snmpTask != null)
 {
     try { await snmpTask; } catch (OperationCanceledException) { }
+}
+if (watchdogTask != null)
+{
+    try { await watchdogTask; } catch (OperationCanceledException) { }
+}
+
+try
+{
+    SaveSpool();
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Result spool save failed: {ex.Message}");
 }
 
 Console.WriteLine("Agent stopped");

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -209,8 +209,11 @@ public sealed class ResultBuffer
                     restored++;
                 }
             }
-            catch (InvalidProtocolBufferException)
+            catch (Exception ex) when (ex is InvalidProtocolBufferException or ArgumentOutOfRangeException)
             {
+                // Truncated tail or corrupt bytes (crash mid-write, bit rot):
+                // keep the clean prefix. ArgumentOutOfRange covers a corrupt
+                // varint decoding to ticks outside DateTime's range.
             }
             EvictLocked();
         }

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -1,3 +1,5 @@
+using Google.Protobuf;
+
 namespace NetworkOptimizer.AgentProtocol;
 
 /// <summary>
@@ -148,6 +150,73 @@ public sealed class ResultBuffer
                 _entries.RemoveFirst();
             }
         }
+    }
+
+    /// <summary>Spool file header: identifies the format and its version.</summary>
+    private const uint SpoolMagic = 0x4E4F5350; // "NOSP"
+    private const int SpoolVersion = 1;
+
+    /// <summary>
+    /// Writes every buffered (unacked) message with its enqueue time to
+    /// <paramref name="path"/>, replacing any existing file, so a restart
+    /// (deliberate stop, update, or watchdog-forced) keeps the outage backlog
+    /// instead of losing it with the process. Deliberately synchronous file
+    /// I/O: the async-engine watchdog calls this while async I/O is wedged.
+    /// </summary>
+    public void SaveTo(string path)
+    {
+        lock (_lock)
+        {
+            using var file = new FileStream(path, FileMode.Create, FileAccess.Write);
+            var output = new CodedOutputStream(file);
+            output.WriteFixed32(SpoolMagic);
+            output.WriteInt32(SpoolVersion);
+            foreach (var entry in _entries)
+            {
+                output.WriteInt64(entry.EnqueuedUtc.Ticks);
+                output.WriteMessage(entry.Message);
+            }
+            output.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Appends the messages spooled by <see cref="SaveTo"/>, preserving their
+    /// original enqueue times so the age cap still applies, then re-applies the
+    /// caps. A truncated or corrupt spool (crash mid-write) keeps whatever
+    /// decoded cleanly. Returns the number of messages restored.
+    /// </summary>
+    public int LoadFrom(string path)
+    {
+        using var file = File.OpenRead(path);
+        var input = new CodedInputStream(file);
+        var restored = 0;
+        lock (_lock)
+        {
+            try
+            {
+                if (input.ReadFixed32() != SpoolMagic || input.ReadInt32() != SpoolVersion)
+                    return 0;
+                while (!input.IsAtEnd)
+                {
+                    var enqueuedTicks = input.ReadInt64();
+                    var message = new AgentMessage();
+                    input.ReadMessage(message);
+                    var entry = new Entry(++_nextSeq, message,
+                        new DateTime(enqueuedTicks, DateTimeKind.Utc), message.CalculateSize());
+                    _entries.AddLast(entry);
+                    _bytes += entry.SizeBytes;
+                    restored++;
+                }
+            }
+            catch (InvalidProtocolBufferException)
+            {
+            }
+            EvictLocked();
+        }
+        if (restored > 0)
+            _available.Release();
+        return restored;
     }
 
     private SendFrame? BuildUnsentFrameLocked(long afterSeq, int maxSamples)

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -191,11 +191,17 @@ public class LocalProbeExecutor : IProbeExecutor
             }
             var stdout = await SafeReadAsync(stdoutTask);
             Observe(stderrTask);
+            if (stdout is null)
+                throw new ProbeOutputTimeoutException(
+                    $"ping output read for {target.Address} did not complete within {OutputReadGrace.TotalSeconds:0}s");
 
             var parsed = PingOutputParser.Parse(stdout, target, Vantage, safeCount);
             return parsed;
         }
-        catch (Exception ex)
+        // Output-timeout means async completion delivery is broken, and the managed
+        // Ping path depends on the same machinery - falling back would hang or
+        // fabricate. Let it propagate; callers drop the sample.
+        catch (Exception ex) when (ex is not ProbeOutputTimeoutException)
         {
             _logger.LogDebug(ex, "Native ping invocation failed; falling back to managed Ping");
             return await ManagedPingAsync(target, count, timeout, ct);
@@ -415,8 +421,11 @@ public class LocalProbeExecutor : IProbeExecutor
                 // a hard error.
                 try { proc.Kill(entireProcessTree: true); } catch { }
             }
-            var stdout = stdoutTask.IsCompletedSuccessfully ? stdoutTask.Result : await SafeReadAsync(stdoutTask);
-            var stderr = stderrTask.IsCompletedSuccessfully ? stderrTask.Result : await SafeReadAsync(stderrTask);
+            // A never-completing read degrades to empty here on purpose: a partial or
+            // absent traceroute parses to Reached=false - an honest failure, unlike
+            // ping where empty output would fabricate a loss percentage.
+            var stdout = stdoutTask.IsCompletedSuccessfully ? stdoutTask.Result : (await SafeReadAsync(stdoutTask) ?? string.Empty);
+            var stderr = stderrTask.IsCompletedSuccessfully ? stderrTask.Result : (await SafeReadAsync(stderrTask) ?? string.Empty);
 
             var output = string.IsNullOrWhiteSpace(stdout) ? stderr : stdout;
             return TracerouteOutputParser.Parse(output, target, Vantage, target.Mode);
@@ -449,13 +458,15 @@ public class LocalProbeExecutor : IProbeExecutor
     /// </summary>
     private static readonly TimeSpan OutputReadGrace = TimeSpan.FromSeconds(5);
 
-    private static async Task<string> SafeReadAsync(Task<string> readTask)
+    private static async Task<string?> SafeReadAsync(Task<string> readTask)
     {
         var winner = await Task.WhenAny(readTask, Task.Delay(OutputReadGrace));
         if (winner != readTask)
         {
+            // Never completed: the output is UNKNOWN, not empty - callers must
+            // treat null as "drop this sample", never parse it as a result.
             Observe(readTask);
-            return string.Empty;
+            return null;
         }
         try { return await readTask; }
         catch { return string.Empty; }

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -190,6 +190,7 @@ public class LocalProbeExecutor : IProbeExecutor
                 try { proc.Kill(entireProcessTree: true); } catch { }
             }
             var stdout = await SafeReadAsync(stdoutTask);
+            Observe(stderrTask);
 
             var parsed = PingOutputParser.Parse(stdout, target, Vantage, safeCount);
             return parsed;
@@ -440,11 +441,29 @@ public class LocalProbeExecutor : IProbeExecutor
         }
     }
 
+    /// <summary>
+    /// Grace period for collecting a finished/killed child's redirected output.
+    /// The pipe normally closes with the child, completing the read instantly;
+    /// the bound exists because a pipe read whose completion is never delivered
+    /// (wedged async engine) would otherwise hang its caller forever.
+    /// </summary>
+    private static readonly TimeSpan OutputReadGrace = TimeSpan.FromSeconds(5);
+
     private static async Task<string> SafeReadAsync(Task<string> readTask)
     {
+        var winner = await Task.WhenAny(readTask, Task.Delay(OutputReadGrace));
+        if (winner != readTask)
+        {
+            Observe(readTask);
+            return string.Empty;
+        }
         try { return await readTask; }
         catch { return string.Empty; }
     }
+
+    /// <summary>Observes a possibly never-completing task's fault so it can't surface as unobserved.</summary>
+    private static void Observe(Task task) =>
+        _ = task.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
 
     private async Task<PingProbeResult> TcpPingAsync(ProbeTarget target, int count, TimeSpan timeout, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Monitoring/Probes/ProbeOutputTimeoutException.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/ProbeOutputTimeoutException.cs
@@ -1,0 +1,16 @@
+namespace NetworkOptimizer.Monitoring.Probes;
+
+/// <summary>
+/// Thrown when a probe child process's redirected output read never completes
+/// within the grace period: the child has exited (or been killed) but the
+/// pipe-read completion was never delivered (wedged async engine). The probe
+/// has NO trustworthy outcome, so callers must drop the sample entirely -
+/// parsing the missing output as empty would fabricate a 100% loss result,
+/// planting false outages in monitoring data and the alert evaluators.
+/// </summary>
+public sealed class ProbeOutputTimeoutException : IOException
+{
+    public ProbeOutputTimeoutException(string message) : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -149,6 +149,12 @@ public class AgentProbeResultSink
     /// </summary>
     public void OnAgentDisconnected(AgentTunnelConnection connection)
     {
+        // A strike only means "empty enumeration" if the NEXT one is its true
+        // consecutive sibling. Across a disconnect the next enumeration comes
+        // from a fresh reconnect - exactly the transient-empty condition the
+        // two-strike guard exists for - so a held-over strike would fast-track
+        // the disable on the first sighting. Start clean.
+        _snmpEmptyEnumerations.TryRemove($"{connection.SiteSlug}:{connection.AgentId}", out _);
         _ = Task.Run(async () =>
         {
             try

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -229,6 +229,22 @@ public class AgentProbeResultSink
         {
             var isDefault = connection.SiteSlug == SiteManagementService.DefaultSiteSlug;
             await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault);
+
+            // Disabled monitoring stops probing everywhere: every server-side
+            // collection tier (latency included) gates on MonitoringSettings.Enabled
+            // via ShouldRunNowAsync, so mirror that for agent sites. Push an empty
+            // replacement set - the agent stops probing instead of burning cycles
+            // on results the sink would only discard. Absent settings mean
+            // monitoring was never set up: same treatment, matching the server.
+            var monitoringSettings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            if (monitoringSettings is not { Enabled: true })
+            {
+                connection.TrySend(new ServerMessage { ProbeConfig = new ProbeConfig() });
+                _logger.LogDebug("Monitoring disabled for site {Slug}; pushed empty probe config to agent {Id}",
+                    connection.SiteSlug, connection.AgentId);
+                return;
+            }
+
             var targets = await db.MonitoringTargets
                 .AsNoTracking()
                 .Where(t => t.Enabled)

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -60,6 +60,14 @@ public class AgentProbeResultSink
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _consoleFetchGate = new();
     private static readonly TimeSpan ConsoleCacheTtl = TimeSpan.FromSeconds(60);
 
+    // Agents (site slug + agent id) whose last SNMP push enumeration found zero
+    // SNMP-enabled devices. One empty sighting is not proof (a just-reconnected
+    // console reports an empty/partial device list for its first moments); only
+    // a second consecutive one is adopted as a real disable. Keyed per agent so
+    // one agent's transient empty can't fast-track a disable to a sibling agent
+    // on the same site. See PushSnmpConfigAsync.
+    private readonly ConcurrentDictionary<string, bool> _snmpEmptyEnumerations = new();
+
     // Samples older than this skip the alert state machines. Agents replay
     // their store-and-forward backlog after a tunnel outage; feeding an
     // hours-old down→up sequence through the evaluators would fire and resolve
@@ -427,15 +435,40 @@ public class AgentProbeResultSink
                     }
                 }
 
-                // Console is up but the site genuinely has no SNMP-enabled devices.
                 if (config.Devices.Count == 0)
+                {
+                    // Console is up but enumerated no SNMP-enabled devices. One
+                    // sighting is not proof the site really has none: a console
+                    // that just reconnected (server restart, tunnel bounce)
+                    // reports an empty/partial device list for its first
+                    // moments, and disabling on that stopped the agent's SNMP
+                    // polling until the next refresh cycle - a ~60 s data gap
+                    // per server restart, seen live on an agent site 2026-07-30.
+                    // Skip the push (the agent keeps its last-known-good config)
+                    // and adopt the disable only when a second consecutive
+                    // enumeration agrees.
+                    if (_snmpEmptyEnumerations.TryAdd($"{connection.SiteSlug}:{connection.AgentId}", true))
+                    {
+                        _logger.LogDebug(
+                            "SNMP push for site {Slug}: console enumerated no SNMP-enabled devices; keeping agent {Id}'s last config until a second enumeration confirms",
+                            connection.SiteSlug, connection.AgentId);
+                        return;
+                    }
                     config.Enabled = false;
+                }
+                else
+                {
+                    _snmpEmptyEnumerations.TryRemove($"{connection.SiteSlug}:{connection.AgentId}", out _);
+                }
             }
 
             connection.TrySend(new ServerMessage { SnmpConfig = config });
             if (config.Enabled)
                 _logger.LogInformation("Pushed SNMP config with {Count} device(s) to agent {Id} (site {Slug})",
                     config.Devices.Count, connection.AgentId, connection.SiteSlug);
+            else
+                _logger.LogDebug("Pushed disabled SNMP config to agent {Id} (site {Slug})",
+                    connection.AgentId, connection.SiteSlug);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
+++ b/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
@@ -22,7 +22,7 @@ public static class AppVersionInfo
     /// "Update agent" callout for enrolled agents reporting an older version
     /// than this, and over-bumping nags agents into pointless upgrades.
     /// </summary>
-    public const string LatestAgentVersion = "2.2.0";
+    public const string LatestAgentVersion = "2.5.2";
 
     /// <summary>Full informational version (e.g. "1.4.2" or "0.0.0-alpha.0.12").</summary>
     public static string Informational { get; }

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -366,6 +366,34 @@ public class ResultBufferTests
     }
 
     [Fact]
+    public void SpoolLoadSurvivesHostileTicks()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            using (var file = File.Create(path))
+            {
+                // Valid header, then ticks beyond DateTime's range - a corrupt
+                // varint must not take LoadFrom down.
+                var output = new Google.Protobuf.CodedOutputStream(file);
+                output.WriteFixed32(0x4E4F5350);
+                output.WriteInt32(1);
+                output.WriteInt64(long.MaxValue);
+                output.WriteMessage(ProbeMessage("hostile"));
+                output.Flush();
+            }
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(0);
+            buffer.Count.Should().Be(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public void SpoolLoadIgnoresUnrecognizedFile()
     {
         var path = TempSpoolPath();

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -265,4 +265,121 @@ public class ResultBufferTests
             indices.Should().BeInAscendingOrder();
         }
     }
+
+    private static string TempSpoolPath() =>
+        Path.Combine(Path.GetTempPath(), $"no-spool-test-{Guid.NewGuid():N}.bin");
+
+    [Fact]
+    public async Task SpoolRoundTripPreservesMessagesAndOrder()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("a"));
+            source.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+            source.Enqueue(ProbeMessage("b"));
+            source.SaveTo(path);
+
+            var restored = new ResultBuffer();
+            restored.LoadFrom(path).Should().Be(3);
+            restored.Count.Should().Be(3);
+            restored.ApproxBytes.Should().Be(source.ApproxBytes);
+
+            (await NextAsync(restored)).ProbeResults.Results[0].TargetId.Should().Be("a");
+            (await NextAsync(restored)).PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+            (await NextAsync(restored)).ProbeResults.Results[0].TargetId.Should().Be("b");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadAppendsAfterExistingEntries()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("spooled"));
+            source.SaveTo(path);
+
+            var buffer = new ResultBuffer();
+            buffer.Enqueue(ProbeMessage("live"));
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadAppliesAgeCapFromOriginalEnqueueTimes()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("stale"));
+            source.SaveTo(path);
+
+            // Everything in the spool is older than the age cap, so a load
+            // into a short-max-age buffer restores then immediately evicts.
+            var buffer = new ResultBuffer(maxAge: TimeSpan.Zero);
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(0);
+            buffer.DroppedTotal.Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadKeepsCleanPrefixOfTruncatedFile()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("first"));
+            source.Enqueue(ProbeMessage("second"));
+            source.SaveTo(path);
+
+            // Chop mid-way through the last message, as a crash mid-write would.
+            var bytes = File.ReadAllBytes(path);
+            File.WriteAllBytes(path, bytes[..(bytes.Length - 5)]);
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadIgnoresUnrecognizedFile()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            File.WriteAllBytes(path, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(0);
+            buffer.Count.Should().Be(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }


### PR DESCRIPTION
## Incident

The logicl-hq UDR7 agent went dark for 3 hours on 2026-07-30 while its process stayed alive. A full-process dump plus packet captures pinned the root cause: the gateway's vendor kernel lost an epoll wakeup, freezing .NET's `SocketAsyncEngine` event loop. Async socket completions stopped being delivered while the kernel kept completing the work - tunnel reconnects "timed out" on TCP connects that finished in 45 ms, heartbeats timed out, and probe stdout pipe reads hung forever. SNMP polling (sync UDP) sailed through untouched. The dump's async stacks showed four probes hung in `SafeReadAsync`, a fifth queued on the semaphore, and the scheduler frozen in `Task.WhenAll` - the entire probe stream went dark from one class of hung await.

A ptrace attach (dump collection) knocked the engine loose and the agent recovered on its own, confirming the state was a lost wakeup, not corruption - and that a process restart is a full cure.

## Changes

- **`AsyncIoWatchdog` (new)** - loopback connect canary every 60 s. A connect to our own 127.0.0.1 listener cannot time out for network reasons, so three consecutive in-process timeouts prove the async engine is dead; the watchdog spools the result backlog and exits 70 for the unit's `Restart=always` to relaunch (all three installers - gateway, native, Docker - already restart on exit). Runs in every agent mode, including heartbeat-only agents without a tunnel - the same wedge kills async HTTP. Real WAN or server outages never trip it: during those, async completions still arrive (as failures), which counts as healthy.
- **`ResultBuffer.SaveTo`/`LoadFrom`** - spools the unacked backlog to disk across restarts (sync file I/O on purpose; original enqueue times preserved so the 12 h age cap still applies; a truncated or corrupt spool - including out-of-range ticks - keeps its clean prefix). Saved on graceful shutdown and watchdog exit, restored and deleted on startup. Watchdog restarts, deploys, and updates no longer lose buffered outage data.
- **`ProbeRunner`** - the 2 s scheduler tick now fires-and-tracks probes instead of `WhenAll`-ing them, so one hung probe can only take its own target dark, never all of them; an in-flight guard prevents duplicate stacking; a 30 s per-probe hard deadline reclaims the concurrency slot and drops the sample without recording fabricated loss. The concurrency semaphore is a never-disposed field so in-flight probes can't release against a disposed instance at shutdown.
- **`LocalProbeExecutor`** - a child-output read that never completes within the 5 s grace (wedged async engine) now throws `ProbeOutputTimeoutException` and the sample is dropped by every caller - a gap, never fabricated 100% loss (parsing the missing output as empty would have produced `Sent=N, Received=0`). The exception is excluded from the managed-Ping fallback, which rides the same broken machinery. Traceroute deliberately keeps the empty-string degrade: partial output parses to `Reached=false`, an honest failure. Ping stderr reader faults are observed. Also hardens the server-side probe path, which shares this code.
- **`AgentProbeResultSink` - SNMP disable-race fix (found during live testing)** - on tunnel reconnect, the console-reconnect path re-pushed SNMP config against a milliseconds-old console session; an empty device enumeration converted the push to `Enabled=false` (silently) and stopped the agent's SNMP polling for the ~60 s until the next cycle - one minute of unrecoverable SNMP data per server restart. Now a lone empty enumeration skips the push (agent keeps its last config) and only a second consecutive empty is adopted as a real disable, keyed per site+agent and cleared on agent disconnect so two transient empties separated by a reconnect can't masquerade as consecutive. Genuine disables land one cycle later; enables and reconfigurations are untouched; disabled pushes now log at debug.
- **`AgentProbeResultSink` - Disable Monitoring now stops agent probes** - every server-side collection tier gates on `MonitoringSettings.Enabled`, but the agent probe push ignored it: a monitoring-disabled site kept probing and recording. The push now mirrors the server gate - disabled or never-configured monitoring sends an empty replacement target set, stopping agent probing within one cycle.
- **`install-native.sh`** - the speed test nginx unit is now `WantedBy=netopt-agent.service` instead of `multi-user.target`, so every agent start (boot, deploys, manual restarts, watchdog self-restarts) relights it - previously `BindsTo=` stopped it with the agent and nothing ever started it again. The dependency lives on the nginx unit's `[Install]`, so installs without the optional speed test (and gateway installs, which use `install-agent-gateway.sh` and have no nginx) carry no reference to it; `reenable` converges upgrade re-runs off the old symlink.
- **`AppVersionInfo.LatestAgentVersion` -> 2.5.2** - this branch changes agent-executed code, so the next release becomes the minimum version carrying current agent behavior; enrolled agents below it get the **Update agent** callout in the Multi-Site agent list.

## Review

Adversarially reviewed (independent pass, code-only); 1 medium and 4 minor findings, all applied in `fb9a0ebe`: the fabricated-loss drop above, the never-disposed semaphore, strike clearing on disconnect, watchdog coverage for tunnel-less agents, and the broadened spool-restore catch.

## Tests

Six new `ResultBuffer` spool tests (round trip, append-after-live, age-cap on restore, truncated-file prefix, hostile ticks, unrecognized file). Full suite passes, zero build warnings. Validated live on three agent sites: spool/restore/replay under real outages with zero data loss, nginx relight through kill -9 auto-restarts, backfill through server restarts, and the monitoring toggle round trip - each verified against InfluxDB windowed point counts, not just logs.