### PR TITLE
v2.5.2 Release Changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,10 +56,15 @@ before/after on the NAS + Mac sites (and ideally a fleet sample), not a blind ed
   weight-to-measured-airtime ratio per site/band from channels that have BOTH pooled weight and
   spectrum data; keep the fixed `w/(1+w/6)` curve as the prior for blind spots. SOAK-GATED: only
   build if the fixed curve shows under/over-reaction on live sites.
-- [ ] **Recompute churn + sighting-pool variance.** The Channels page recomputed recommendations 3x
-  within 2 minutes, and the remembered-neighbor pool jumped 486 -> 626 sightings between two runs a
-  minute apart (pre-saturation, that flipped a plan run-to-run). Coalesce/cache the recompute and
-  find out why the pool varies between adjacent runs (ingestion timing?).
+- [ ] **Recompute churn.** Partly addressed. A minute-bucketed cache now keys the *scan snapshot* by
+  time bucket instead of exact second, so the overview card and the channel-plan tab no longer land on
+  different snapshots and produce different plans. Two things remain:
+  - The cache sits on the scan fetch, not on the recommendation: `GetAllChannelRecommendationsAsync`
+    still recomputes in full on every call, and the Channels page calls it from four places. Results are
+    consistent now but computed several times over - coalesce or cache the recompute itself.
+  - The 486 -> 626 sighting jump between adjacent runs was never root-caused. Rolling strongest-signal
+    pooling plus age-decayed neighbor memory plausibly account for it, but that was not confirmed;
+    if plans still differ run-to-run, start here.
 - [ ] **Degradation cap shape.** `MaxApScoreDegradation` is ratio-based (1.5x), so a pristine victim
   (score 1.0) absorbs only +0.5 of new interference while an already-suffering one (6.0) absorbs +3 -
   inverted from intent, and it silently diverted two synthetic test topologies. Now that scores sit on
@@ -101,21 +106,48 @@ before/after on the NAS + Mac sites (and ideally a fleet sample), not a blind ed
   width-ratio discount. Shifts external magnitudes - re-validate on the saturated scale (pooled
   weights now enter the score through `w/(1+w/6)`, so the impact is smaller than it was raw).
 
+## Applying a channel plan to UniFi (considered, deliberately out of scope for now)
+
+The recommendation ends at a plan the user applies by hand. That is a decision, not an oversight, and
+the reasoning generalises to any mutative config operation against UniFi Network - so it is recorded
+here rather than re-argued each time the question comes up.
+
+- **UniFi Network has no PATCH.** Every change is a full-config PUT/POST, so writing one field means
+  writing back the entire object - including the ~90% we have no intention of touching. Get any of
+  that wrong, or have the console change it concurrently, and the site's configuration is damaged.
+- **Their REST API has a history of bugs and loose form.** Parsing is not necessarily strict, and a
+  release can reinterpret or break a payload shape. On read-only calls that is harmless; on a
+  mutative call the same surprise can wipe an AP's configuration.
+- **The blast radius is the customer's network**, which is exactly the thing this tool exists to keep
+  healthy. Analysis that is wrong costs a bad recommendation; a write that is wrong costs an outage.
+
+So today the only mutative controller operation reachable from the app is the RF quick scan
+(`POST .../cmd/devmgr`) - transient and self-contained rather than a config write, though note there
+is no cancel for a scan already running. No reachable feature rewrites a UniFi device or site
+configuration object.
+
+Two full-object PUT helpers do exist on the client and are currently called by nothing:
+`UpdateNetworkConfigAsync` (`rest/networkconf`) and `UpdateTrafficRouteAsync` (`v2 trafficroutes`).
+Wiring either one up is exactly the step this section argues against, so it should be a deliberate
+decision rather than something that happens because a helper was already sitting there.
+
+Everything else we change goes through our own SSH-deployed components, where we control the format
+and the rollback.
+
+Not a permanent no. Revisit when there is a safe path - e.g. read-modify-write with a verified
+round-trip, a diff against the fetched object before sending, and a way to detect concurrent
+modification. Until then, treat "we compute it, the user applies it" as the intended shape of any
+feature that would otherwise write to the controller.
+
 ## LAN Speed Test
 
 ### Path Analysis Enhancements
-- ✅ ~~Direction-aware bottleneck calculation~~ (done - `GetDirectionalEfficiency()` in PathAnalysisResult, separate TX/RX bottleneck in NetworkPathAnalyzer)
-- More gateway models in routing limits table as we gather data
+- More gateway models in routing limits table as we gather data. `GatewayRoutingLimits` covers USG /
+  USG-Pro-4, UDM / UDM-Pro / UDM-SE, and UCG-Ultra / Max / Fiber today - no UXG, UDR/UDR7 or EFG entries.
 - Threshold tuning based on real-world data collection
 - **Consistent wireless bottleneck attribution across test types:** LAN client speed tests show the bottleneck relative to the AP (e.g., "[AP] Back Yard (wireless)") while WAN client speed tests show it relative to the client (e.g., "[Phone] TJ iPhone (wireless)"). This is because WAN client paths reverse hops and swap ingress/egress, which flips the perspective. The wireless link is the same physical connection - both descriptions are technically correct but inconsistent. Investigate unifying to always name the AP side, since that's what users can control. Relevant code: `CalculateWanClientPathAsync` hop reversal/swap and `CalculateBottleneck` wireless link attribution.
 
-### ✅ ~~Scheduled LAN Speed Test~~ (done - Alerts & Scheduling feature)
-
-### ✅ ~~Scheduled WAN Speed Test~~ (done - Alerts & Scheduling feature)
-
 ## Alerts & Scheduling
-
-### ✅ ~~LAN Speed Test Schedule: UniFi Device Targets~~ (done)
 
 ### DST-Aware Schedule Time Display
 - Schedule start times are stored as UTC hour/minute and converted to local for display using `DateTime.UtcNow.Date.ToLocalTime()`
@@ -145,24 +177,10 @@ Current state (as of v1.5.x): Dedup is working - event-level dedup via InnerAler
 - Currently: Re-alerts on more stages OR (6h elapsed AND 2x events). The `attack_chain_attempt` rule has 1h cooldown.
 - If noisy: Increase cooldown to 6h, or only re-alert on stage progression (not event count growth)
 - If too quiet: Reduce the 2x event multiplier to 1.5x
+- Note the 2x multiplier is the *early-stage* path only; full-chain re-alerting uses 50%+ event growth
 - These are Info severity - users who find them noisy can disable rule 13 in alert settings
 
 ## Security Audit / PDF Report
-
-### Manual Network Purpose Override
-- Allow users to manually set the purpose/classification of their Networks in Security Audit Settings
-- Currently: Network purpose (IoT, Security, Guest, Management, etc.) is auto-detected from network name patterns
-- Problem: Users with non-standard naming conventions get incorrect VLAN placement recommendations
-- Implementation:
-  - Add "Network Classifications" section to Security Audit Settings page
-  - List all detected networks with current auto-detected purpose
-  - Allow override via dropdown: Corporate, Home, IoT, Security, Guest, Management, Printer, Unknown
-  - Store overrides in database (new table or extend existing settings)
-  - VlanAnalyzer should check for user overrides before applying name-based detection
-- Benefits:
-  - Users with custom naming schemes can get accurate audits
-  - Explicit classification removes ambiguity
-  - Auto-detection still works as default for users who don't configure
 
 ### Home → IoT Return Traffic Rule Suggestion
 - When Home network has isolation blocking IoT, suggest adding a return traffic rule or explicit allow
@@ -177,16 +195,20 @@ Current state (as of v1.5.x): Dedup is working - event-level dedup via InnerAler
   2. Add a RESPOND_ONLY allow rule from IoT → Home to permit return traffic
 - **Severity:** Informational (user may have intentionally blocked bidirectional)
 - **Context:** This is a usability issue, not a security issue - blocking return traffic is actually more secure
+- **Building blocks exist:** `FirewallRule.AllowsOnlyReturnTraffic()` and `BlocksNewConnections` already
+  recognize RESPOND_ONLY rules (used today only to suppress shadowing warnings), so the detection side is
+  mostly a matter of inverting an existing check.
 
 ### Third-Party DNS Firewall Rule Check
 - When third-party DNS (Pi-hole, AdGuard, etc.) is detected on a network, check for a firewall rule blocking UDP 53 to the gateway
 - Without this rule, clients could bypass third-party DNS by using the gateway directly
 - Implementation: Look for firewall rules that DROP/REJECT UDP 53 from the affected VLANs to the gateway IP
 - Severity: Recommended (not Critical, since some users intentionally allow fallback)
+- **Distinct from what already ships:** `DnsSecurityAnalyzer`'s port-53 block detection targets the
+  External zone, and DNS-LEAK-001 covers leaks to the internet. Neither checks the *gateway-directed*
+  bypass this item is about; the third-party finding only emits generic "consider enabling DNS firewall
+  rules" copy with no rule verification behind it.
 - **Status:** Awaiting user feedback on current third-party DNS feature before implementing
-
-### ✅ ~~Printer/Scanner Audit Logic Consolidation~~ (done)
-- Consolidated in `VlanPlacementChecker.CheckPrinterPlacement()`, called from `ConfigAuditEngine`
 
 ## Performance Audit
 
@@ -202,41 +224,37 @@ New audit section focused on network performance issues (distinct from security 
   - Bottleneck chains where downstream capacity exceeds upstream link
 - Display as performance findings with recommendations
 
-### Jumbo Frames Suggestion
-- Suggest enabling Jumbo Frames as a global switching setting when high-speed devices are present
-- Trigger: 2+ devices connected at 5 GbE or 10 GbE on access ports (not infrastructure uplinks)
-- Rationale: Jumbo frames (9000 MTU) reduce CPU overhead and improve throughput for high-speed transfers
-- Implementation:
-  - Scan port_table for ports with speed >= 5000 Mbps
-  - Exclude infrastructure ports (uplinks, trunks between switches)
-  - If count >= 2, check if Jumbo Frames is already enabled globally
-  - If not enabled, suggest enabling with explanation of benefits
-- Caveats to mention in recommendation:
-  - All devices in the path must support jumbo frames
-  - Some IoT devices may not support non-standard MTU
-  - WAN traffic still uses standard 1500 MTU
-- Severity: Informational (performance optimization, not a problem)
-
-### MTU Mismatch Detection
-- Detect MTU mismatches along network paths that cause fragmentation or packet drops
-- Implementation:
+### Path-Based MTU Mismatch Detection
+- The *config-level* half already ships: `PerformanceAnalyzer.CheckJumboFrames` suggests jumbo frames
+  (trigger: 2+ access ports at 2.5 GbE or faster, infrastructure trunks excluded) and flags the
+  global-on/device-off and partially-enabled cases as an MTU mismatch that can cause fragmentation.
+- Still open is per-path measurement, which needs SSH rather than config inspection:
   - During path tracing, SSH into each hop (gateway, switches) to query interface MTU
   - Gateway: `ip link show <interface>` or parse `/sys/class/net/<iface>/mtu`
   - Switches: Check port MTU via SSH (UniFi switches support shell access)
   - Compare MTU values across the path - all devices should match
-- Issues to detect:
-  - Standard MTU (1500) mixed with Jumbo Frames (9000) in same path
+- Issues this would add over the config check:
   - Intermediate device with lower MTU than endpoints (causes fragmentation)
   - Jumbo Frames enabled on LAN but not on inter-switch uplinks
   - VPN/tunnel overhead not accounted for (e.g., WireGuard needs ~1420 MTU)
-- Display: Show MTU at each hop in path analysis, flag mismatches
+- Display: Show MTU at each hop in path analysis, flag mismatches (no `Mtu` member exists on
+  `NetworkPathAnalyzer` / `PathAnalysisResult` today)
 - Severity: Warning (mismatches cause performance degradation or silent drops)
 - Prerequisite: Reuse SSH infrastructure from SQM/gateway speed tests
 
 ### WiFi Optimizer Enhancements
-- **Channel recommendation: broaden search candidate generation (long-term, the real fix).** The exhaustive/greedy search prunes each AP to a small candidate channel set (e.g. ~2 channels/AP → only 8 assignments evaluated for a 4-AP 5 GHz site), so it can miss the globally optimal assignment - notably an "altruistic" move where relocating a still-healthy AP declutters a worse neighbor (e.g. move a fine AP off a shared 160 MHz block so a congested one stops sharing it). Today that gap is patched by an altruistic relocation pass in the per-AP fallback (`ChannelRecommendationService`, gated on site-wide score improvement), but the correct long-term fix is for the search itself to consider a richer candidate set per AP (e.g. all valid non-DFS blocks plus historically-good channels, with branch-and-bound pruning to keep the space tractable) so the global optimizer finds these moves directly and the fallback becomes a safety net rather than the source of the recommendation. When this lands, revisit whether the altruistic fallback pass is still needed.
-- **Power & Coverage: per-band signal classification** - `GetSignalClass` and `GetSignalBucketClass` in PowerCoverageAnalysis.razor hardcode `RadioBand.Band5GHz` because they operate on aggregate values (avg signal, dBm bucket ranges) without per-client band context. Could classify each client by their actual band first, then aggregate the results. The signal distribution bar chart would need to either split by band or color each client's contribution by their band. Current behavior matches pre-band-aware thresholds so no regression, just a missed opportunity.
-- **MLO per-AP detection:** Check MLO status per-AP based on which SSIDs each AP broadcasts (via vap_table), not just global WLAN config. An AP only has MLO impact if it broadcasts an MLO-enabled SSID.
+- **Channel recommendation: broaden search candidate generation (long-term, the real fix).** The exhaustive/greedy search evaluates a small candidate set per AP (e.g. ~2 channels/AP → only 8 assignments evaluated for a 4-AP 5 GHz site), so it can miss the globally optimal assignment. Worth being precise about the cause: the set is not arbitrarily pruned - `GetValidChannelsWithWidth` returns *every* regulatory-valid channel, but only at the AP's current width and deduped by bonding group (width reduction is marked "future feature" in that code). So "richer candidate set" mostly means exploring across widths - notably an "altruistic" move where relocating a still-healthy AP declutters a worse neighbor (e.g. move a fine AP off a shared 160 MHz block so a congested one stops sharing it). Today that gap is patched by an altruistic relocation pass in the per-AP fallback (`ChannelRecommendationService`, gated on site-wide score improvement), but the correct long-term fix is for the search itself to consider a richer candidate set per AP (e.g. all valid non-DFS blocks plus historically-good channels, with branch-and-bound pruning to keep the space tractable) so the global optimizer finds these moves directly and the fallback becomes a safety net rather than the source of the recommendation. When this lands, revisit whether the altruistic fallback pass is still needed.
+- **Power & Coverage: per-band signal classification (aggregates only)** - the per-client half shipped: a
+  shared `SignalClassification` helper exists and PowerCoverageAnalysis classifies each client by its
+  actual band for the percentage/count aggregations. What still hardcodes `RadioBand.Band5GHz` is the
+  aggregate layer - the avg/min/max stat cards and the signal-distribution bucket chart - because those
+  operate on aggregate values without per-client band context. The bar chart would need to either split
+  by band or color each client's contribution by their band. No regression today, just a missed opportunity.
+- **MLO per-AP detection in the optimizer** - the mechanism already exists for path analysis:
+  `NetworkPathAnalyzer` sets `hop.MloEnabled` by matching each AP's `vap_table` SSIDs against the
+  MLO-enabled WLANs. The WiFi Optimizer health issue has not adopted it - `WiFiOptimizerService` still
+  flags MLO from `hasWifi7Aps && hasMloEnabledWlan` (any AP + any WLAN), so an AP that broadcasts no
+  MLO SSID is still counted. Reuse the path-analysis pattern.
 - **MLO STR mesh backhaul (multi-band):** Channel recommendations pin a mesh child to its leader's channel only on the single band `AccessPointSnapshot.MeshUplinkBand` reports. AP-to-AP MLO STR backhaul can run over multiple bands at once (e.g. 5 + 6 GHz). When UniFi exposes per-link bands, make `MeshUplinkBand` a set and have `BuildMeshConstraints` emit one constraint per participating band. The reconciliation logic in `ChannelRecommendationService` keys off `MeshGroupLeader` and needs no change - only the constraint-building. See `TODO(MLO)` in `BuildMeshConstraints`. Dormant: no AP-to-AP MLO STR backhaul hardware exists yet (today's MLO STR is client/bridge only - UDB-Switch and AirWire, the MLO STR bridge - which are endpoints, not mesh-AP children, so they never hit this path).
 
 ### AP Catalog: Enforce 5 GHz EIRP Cap (US Regulatory)
@@ -255,6 +273,9 @@ New audit section focused on network performance issues (distinct from security 
   2. Add regulatory-domain-aware EIRP capping in the display/calculation layer (more complex, handles UNII-1 vs UNII-3 differently)
   3. Show "regulatory max EIRP" alongside "hardware max EIRP" in the UI
 - Option 1 is simplest and matches the existing 6 GHz pattern. Option 2 is more accurate but needs channel-to-sub-band mapping.
+- **Mechanism is already there:** `ModeOverrides` carries per-mode `MaxTxPowerDbm` / `DefaultTxPowerDbm`
+  (that is how E7-Audience's 6 GHz caps work), which is what Option 1 needs - several of the 5 GHz
+  offenders only exceed 36 dBm in their directional/narrow antenna mode, not omnidirectional.
 - **Note:** DFS channels (UNII-2/2C) have lower limits but are dynamic - firmware handles those
 
 ### Floor Plan Heatmap - Per-Channel Frequency
@@ -310,17 +331,12 @@ New audit section focused on network performance issues (distinct from security 
 - Consider showing a summary callout: "Most of your clients support 80 MHz - here's what they
   actually experience" to educate users about the per-client negotiation reality
 
-#### Implemented Features (v1.x)
-The following were implemented in the WiFi Optimizer feature:
-- ✅ Channel utilization analysis per AP (Airtime Fairness tab)
-- ✅ Client distribution balance across APs (AP Load Balance tab)
-- ✅ Signal strength / SNR reporting per client (multiple components)
-- ✅ Interference detection - co-channel, adjacent channel (Spectrum Analysis tab)
-- ✅ Band steering effectiveness analysis (Band Steering tab)
-- ✅ Roaming topology visualization (Connectivity Flow tab)
-- ✅ Airtime fairness issues - legacy client impact (Airtime Fairness tab)
-- ✅ Site health score with dimensional breakdown
-- ✅ Power/coverage analysis with TX power recommendations
+#### Leftover from the v1.x feature set
+Everything the old "Implemented Features" checklist tracked is live and verified (utilization per AP,
+AP load balance, interference detection, band steering, connectivity flow, legacy-client airtime impact,
+site health score, power/coverage). One gap hides inside the "signal strength / SNR per client" claim:
+per-client *signal* classification is everywhere, but `WirelessClientSnapshot.Snr` has no UI consumer at
+all - it is collected and never shown. Either surface it or drop the field.
 
 ## SQM (Smart Queue Management)
 
@@ -332,13 +348,17 @@ The following were implemented in the WiFi Optimizer feature:
 
 ### Multi-WAN Support
 - Support for 3rd, 4th, and N number of WAN connections
-- Currently limited to two WAN connections
-- Should dynamically detect and configure all available WAN interfaces
+- **Detection is already there** - `SqmService` walks wan1..wan6. What is hardcoded to two WANs is
+  everything downstream: `SqmDeploymentService.DeploySqmMonitorAsync(wan1Interface, wan1Name,
+  wan2Interface, wan2Name)`, `TcMonitorClient`'s `Wan1`/`Wan2` fields, and the `Sqm.razor` UI
+  (`wan1Config`/`wan2Config` throughout). Open work = monitor deployment, status plumbing, and UI.
 
 ### GRE Tunnel Support (Cellular WAN)
 - Support GRE tunnel connections from cellular modems (U5G-Max, U-LTE)
 - These create GRE tunnels that should be treated as valid WAN interfaces for SQM
-- ✅ ~~PPPoE support~~ (done - uses physical interface for lookup, tunnel interface for SQM)
+- **Partly prepared:** WAN extraction already recognizes GRE virtual WANs and models their null
+  `PhysicalIfName` / `LinkSpeedMbps`. Nothing GRE-specific exists in deployment or shaping, and no GRE
+  tunnel has been shaped end to end - that is the open part.
 
 ## Monitoring
 
@@ -356,22 +376,20 @@ then add the modular span. Blocker: we'd have to know the counter width (2^31 vs
 wrong guess produces a garbage spike - so the safe null-gap stays the default until the widths are
 confirmed. Not worth it for a rare one-point gap; revisit if the frame charts read as too sparse.
 
-### Upstream path discovery: DynamoDB regional endpoints for transit trace exposure (Setup tab)
+### Upstream path discovery: capture every responding hop's ASN (transit attribution)
 Transit Health involvement weighting and destination->transit jitter absolution both key off which
-monitored internet targets a transit ASN provably carries (trace ancestry). The current CDN/DNS
-targets peer at the local IX, so they cross no transit and give the attribution nothing to work with.
-AWS DynamoDB regional endpoints ARE ICMP-pingable and DO ride paid transit, so they're good extra
-trace targets (and can double as monitored targets):
+monitored internet targets a transit ASN provably carries (trace ancestry).
 
-    dynamodb.<region>.amazonaws.com   (nearest region(s) first, e.g. us-west-2, us-west-1, us-east-2, us-east-1)
+The target side of this shipped: AWS DynamoDB regional endpoints are resolved, geo-ordered and
+latency-ranked to the nearest region(s) (they are not anycast), capped by `MaxAwsPathEndTargets` and
+persisted as path-end targets. They ride paid transit, unlike the CDN/DNS targets that peer at the
+local IX and therefore gave the attribution nothing to work with.
 
-- **Not anycast** - resolve + latency-rank to the nearest region(s), else you trace a transcontinental
-  path that misrepresents the transit.
-- **Attribution still needs work (observed in testing):** the endpoint pings and the path is NOT
-  peered, but the intermediate transit hops don't answer traceroute (all stars) - so the current
-  ancestry can't tell WHICH transit ASN it crossed. DynamoDB gives a clean AWS target that genuinely
-  transits; surfacing which transit still needs the responding-hop-ASN capture (record every
-  responding hop's ASN, not just monitored-target IPs), and pure-star segments recover nothing.
+What remains is the attribution itself: `PersistHopOrderAsync` skips responding hops that are not
+monitored targets, so the ancestry still cannot tell WHICH transit ASN a path crossed. Record every
+responding hop's ASN, not just monitored-target IPs. Note the ceiling: in testing the intermediate
+transit hops frequently do not answer traceroute at all, and pure-star segments recover nothing no
+matter how the ancestry is stored.
 
 ### Investigation Functions (Network Performance tab)
 The Investigate card currently jumps the latency charts to the most recent **packet-loss** and **loaded-loss** events and steps event-to-event (coalesced, peak-loss minute). Ideas to extend it:
@@ -380,7 +398,7 @@ The Investigate card currently jumps the latency charts to the most recent **pac
 - **Congestion events** - `CongestionLocalizer` already produces events with disposition (confirmed / self-inflicted / control-plane-noise) and scope (hop / ASN / shared). Add an Investigate button that jumps the latency charts to each event, with the highlight band colored shared-vs-local like the ISP Health chart. Strongest detector, currently invisible on these charts.
 - **Path-shift events** - `StepChangeDetector` already finds RTT step changes; jump to the step with a "+N ms" label.
 - **Outages** - `OutageDetector` already classifies full / partial / brief; jump to the outage window and show the recovery shape.
-- **Unify the two views** - make the ISP Health "Path & Congestion Events" timeline items deep-link into the latency charts (the way the loss findings now do via `?investigate=`).
+- **Unify the two views** - the loss factor headers already deep-link via `?investigate=`; the ISP Health "Path & Congestion Events" timeline items are still plain non-clickable divs. Make them deep-link the same way. (Half-done - the mechanism exists, only these items are unwired.)
 
 **New detections (more work):**
 - **Bufferbloat events** - loaded *latency* spikes (the `latencyTriggered` signal), distinct from loaded loss; bufferbloat often has zero loss, so the loss buttons miss it.
@@ -421,7 +439,20 @@ Suggested order: congestion / path-shift / outage navigation first (cheap, consi
 
 ### Monitoring Interfaces: Alias IP follow-ups
 
-The duplicate-reachable-IP case shipped: `AliasIp` on `MonitoringInterface` with fwmark/DNAT policy routing, live-verified on real UCGF hardware against two devices sharing `192.168.100.1` on different WANs. A Starlink-WAN advisory has also shipped (`StarlinkWanDetector`, matching UniFi's per-WAN geo-IP ISP with a friendly-name fallback): selecting a Starlink WAN in the Monitoring Interface form now steers the user to the native Starlink Stats monitoring instead of creating an interface for the dish. The earlier "warn when a natively-monitored WAN is picked as the plain side" idea was dropped after investigation: UniFi's Starlink widget only exists in Cloud Gateway console builds (the console's Network app embeds a gRPC dish poller that binds its sockets to the Starlink WAN's interface address, so it doesn't depend on the main table; the UniFi OS Server build of the same app version contains no Starlink code at all), and the claimed main-table breakage was never actually reproduced. The real dual-WAN hazard - a plain interface on the OTHER WAN claiming the dish's shared IP - is already handled by alias mode and its stale-route teardown. One follow-up idea remains open (not built):
+Both shipped pieces are live: `AliasIp` on `MonitoringInterface` with fwmark/DNAT policy routing
+(verified on real UCGF hardware against two devices sharing `192.168.100.1` on different WANs), and the
+`StarlinkWanDetector` advisory that steers users to native Starlink Stats instead of creating an
+interface for the dish.
+
+Recorded so it is not re-litigated: the earlier "warn when a natively-monitored WAN is picked as the
+plain side" idea was investigated and dropped. UniFi's Starlink widget exists only in Cloud Gateway
+console builds, and its dish poller binds its sockets to the Starlink WAN's interface address rather
+than depending on the main routing table (the UniFi OS Server build of the same app version contains no
+Starlink code at all). The claimed main-table breakage was never reproduced, and the real dual-WAN
+hazard - a plain interface on the OTHER WAN claiming the dish's shared IP - is already handled by alias
+mode and its stale-route teardown.
+
+One follow-up idea remains open (not built):
 
 - **LAN-client passthrough to the real IP.** An aliased device's own web UI can hard-redirect a browser to its real IP once loaded (anti-DNS-rebinding check), so a human browsing the alias hits a dead end unless something *also* routes their specific LAN IP to the real target. Works today via a manual, non-persistent `ip rule` reusing the alias's private table (`ip rule add from <client-ip> to <real-ip>/32 lookup <table>`). A built-in version is plausible (one extra source-scoped per-row `ip rule` in the boot script, allowlisted to admin-specified LAN IPs) but deliberately **not built** - a "grant direct real-IP access" knob next to a mechanism whose entire point is to never expose the real IP invites the exact dual-WAN misconfiguration this feature prevents. Gauge demand first.
 
@@ -450,7 +481,12 @@ The duplicate-reachable-IP case shipped: `AliasIp` on `MonitoringInterface` with
 UniFi gateway `snmpd` recurrently wedges: process alive and idle in `select()`, sockets
 still bound, but answers nothing - not even `sysUpTime` from localhost (seen on multiple
 gateways; diagnosed live on the UDR7 test gateway 2026-07-24). Today this reads as silent
-stat gaps. Design in `research/multi-site/gateway-agent/snmp-watchdog.md`; summary:
+stat gaps.
+
+Not to be confused with what already exists: `SnmpFailureTracker` + `SnmpRunner` count consecutive
+failures and exclude a failing device from polling for a while (surfaced as `SnmpPollState.Excluded` on
+the Monitoring Setup dashboard). That is failure-driven backoff - it stops polling entirely and never
+compares against ICMP. None of the four items below are covered by it. Summary of the design:
 
 - [ ] **Detect (all agents, default on):** in `SnmpRunner`, count consecutive per-device
   poll failures; when a device misses ~60 s of SNMP (12 misses at the 5 s tier) while its
@@ -469,21 +505,19 @@ stat gaps. Design in `research/multi-site/gateway-agent/snmp-watchdog.md`; summa
   server alert rule, site-settings toggle for auto-restart.
 
 ### Multi-Tenant Architecture
-- Add multi-tenant support for single deployment serving multiple sites
-- Current architecture: Local console access with local UniFi API
-- Target architecture: Support tunneled access to multiple UniFi sites from one deployment
-- Deployment models:
-  - **Local (default):** Deploy instance at each site for direct LAN API access
-  - **Centralized (optional):** Single deployment with VPN/tunnel access to multiple client networks
-    - Requires unique IP structure per client (no overlapping subnets)
-    - Relies on same local API access, just over tunnel instead of local LAN
-- Use cases: MSPs managing multiple customer sites, enterprises with distributed locations
-- Considerations:
-  - Site/tenant isolation for data and configuration
-  - Per-site authentication and API credentials
-  - Tenant-aware database schema or separate databases per tenant
-  - Site selector/switcher in UI
-  - Aggregate dashboard views across sites (optional)
+
+Largely shipped, and via a different mechanism than this item originally proposed. Live today:
+`Sites` / `SiteAgents` tables behind a `MultiSiteEnabled` flag, per-site databases under
+`data/sites/<slug>`, per-site console connections (`SiteContextService`, `UniFiConnectionService`), a
+site switcher, and an aggregate `/sites` page.
+
+The original plan - a VPN/tunnel to each customer network requiring a unique non-overlapping IP
+structure per client - was superseded by the dial-out agent + gRPC tunnel + proxy architecture, which
+does not care about overlapping subnets. Do not resurrect the VPN framing.
+
+Remaining, and tracked elsewhere in this file: real tenant *isolation* (authentication, per-site
+permissions) is the identity work, not this item; site-specific alert channels and site lifecycle
+have their own sections.
 
 ### Agent Tunnel Security Hardening
 
@@ -499,8 +533,11 @@ controls can't fix it; protecting the server is what matters. (See the agent REA
 Worth doing - defends the one risk that does NOT already require owning the server
 (a leaked `agentKey` used standalone):
 - [ ] One live tunnel per `agentKey`: reject a second concurrent connection and alert
-  rather than silently accepting it. First step: confirm whether `AgentTunnelRegistry`
-  already enforces this.
+  rather than silently accepting it. Checked - `AgentTunnelRegistry.Register` does NOT
+  enforce this: it `AddOrUpdate`s, so a second connection silently displaces the first
+  (documented there as "a reconnect replaces the previous connection's channel"). A stolen
+  key therefore evicts the legitimate agent with no signal. `AgentConnectionAlertMonitor`
+  only alerts on agent-offline, so the eviction surfaces at best as a blip.
 - [ ] Alert on a new public source IP for an existing agent (the tunnel already sees it
   on connect). This is the anomaly signal for a stolen key.
 - [ ] Surface each agent's public source IP in the UI, so IP-allowlist maintenance is a
@@ -600,34 +637,32 @@ Optional, only if there's real demand (don't gold-plate a self-hosted tool):
   credentials, same co-location. Fold in only if the KMS path ever happens.
 
 ### Federated Authentication & Identity
-- External IdP integration for enterprise/MSP deployments
-- Protocol support:
-  - **SAML 2.0:** Enterprise SSO (Okta, Azure AD, ADFS, etc.)
-  - **OIDC/OAuth 2.0:** Modern identity providers (Auth0, Keycloak, Google Workspace)
-- Architectural preparation for RBAC (Role-Based Access Control):
-  - Abstract authentication layer to support pluggable identity sources
-  - Claims/roles mapping from IdP to local permissions
-  - Future: Granular permissions per site/tenant (view-only, operator, admin)
-- **Token model upgrade** (prerequisite for multi-user):
-  - Move from current single JWT to proper access_token + refresh_token OIDC model
-  - Short-lived access tokens (1 hour) with long-lived refresh tokens
-  - Applies to local auth as well, not just external IdP
-  - Token rotation and revocation support
-  - Secure refresh token storage (DB-backed with family tracking)
-- Considerations:
-  - SP-initiated vs IdP-initiated login flows
-  - Just-in-time (JIT) user provisioning from IdP claims
-  - Session management and token refresh across federated sessions
-  - Fallback local auth for break-glass scenarios
 
-### Site Lifecycle Management (post-MVP, not essential for initial MVP)
-- **Deactivate a site:** stop its collection / agent coverage and hide it from the UI, but keep its
-  data, per-site DB, and InfluxDB buckets intact for later re-activation.
-- **Permanently remove a site:** delete its `Sites` + `SiteAgents` rows, its per-site DB
-  (`data/sites/<slug>/`), and its InfluxDB buckets (`<slug>-*`), behind a clear confirmation.
-  Today this requires manual DB row deletes + filesystem + bucket surgery (no in-app path).
-- Both should tear down / re-establish agent enrollment cleanly so a removed slug can be re-added
-  from scratch with no stale rows.
+**Status: implemented on `feature/identity-full` (PR #1038 - open, mergeable, not yet reviewed).**
+None of it is on `dev` yet, so this section stays until that lands. Covered by the branch: SAML 2.0 SP
+(incl. SP- vs IdP-initiated flows), OIDC/OAuth 2.0 RP with dynamic scheme registration and IdP presets,
+JIT provisioning with claims/role mapping, break-glass local auth, MFA (TOTP + recovery codes),
+passkeys, audit logging - plus RBAC that is shipped rather than merely "prepared" (Viewer / Operator /
+Site Admin with per-site memberships and groups, enforced by declarative service-layer gates).
+
+The one bullet this section carried that was NOT built, and should not be revived as written:
+
+- **Token model upgrade.** The old plan was access_token + refresh_token with rotation and DB-backed
+  refresh-token families. The branch went the other way for interactive auth: an ASP.NET Identity
+  **cookie** session with revocation driven by the security stamp, checked per request rather than by
+  token expiry. That removes the need for refresh-token machinery on the interactive path entirely.
+  JWTs remain only on the non-interactive API endpoints - if anything is left to do here, it is scoping
+  lifetime/rotation for *those* API tokens, not rebuilding an OIDC token model for the UI.
+
+### Site Lifecycle Management
+
+Shipped: `SetSiteEnabledAsync` deactivates a site (stops collection, drops the console, hides it from
+the switcher, keeps all data), and `DeleteSiteAsync` removes the `Sites` + `SiteAgents` rows and the
+per-site DB directory behind a confirmation dialog, freeing the license seat.
+
+- [ ] **InfluxDB buckets are not deleted** on site removal - `<slug>-*` buckets survive and must be
+  removed by hand in InfluxDB. The confirmation dialog says so explicitly, so this is a deliberate
+  gap rather than a bug; close it only if operators actually trip over the leftovers.
 
 ### Agent LAN IP detection on Docker hosts (test / harden)
 The agent detects its LAN IP once at startup via `NetworkUtilities.DetectLocalIpFromInterfaces()`
@@ -636,31 +671,15 @@ it on enrollment, every heartbeat, and the tunnel hello; the server stores it on
 That IP is what site clients are pointed at for LAN speed tests and what path analysis uses as the
 agent's trace source (LAN and agent-run WAN tests).
 
+The override shipped: `NO_AGENT_LAN_IP` wins over detection, documented in the agent README for
+Docker bridge mode and multi-NIC hosts. What is left is verification, not code:
+
 - **Host network mode:** container sees the real host NICs - should work as-is, but untested.
-- **Bridge mode (the gap):** inside the container, `eth0` is a plain-looking Ethernet NIC with the
+- **Bridge mode:** inside the container, `eth0` is a plain-looking Ethernet NIC with the
   container-internal address (e.g. 172.17.x) - the docker/veth skip-list only matches host-side
-  names, so detection happily reports an IP that is unreachable from the site LAN and absent from
-  the site's UniFi topology. Speed-test targets and traces would silently break.
-- Likely fix: an explicit override in `agent.json` (e.g. `lanIp`) and/or an `AGENT_LAN_IP` env var
-  that wins over detection, plus a docs note that bridge-mode agents require it (or host mode).
-- Test matrix: native (works today), Docker host mode, Docker bridge with override.
-
-### Site-specific alert channels (post-MVP)
-Today delivery channels are global: `DeliveryChannel` has no `SiteId`, `AlertProcessingService` is a
-singleton that dispatches against the main DB, and alert events/rules aren't site-tagged. Alerts are
-evaluated per-site but every one fans out to the single global channel set.
-
-Goal: keep global channels applying everywhere, but let a site add its OWN additional channels.
-- **Model:** nullable `DeliveryChannel.SiteId` (null = global, set = site-specific). Additive
-  migration, fully backward-compatible - existing channels stay global.
-- **Dispatch (the real work):** thread the originating site through the alert event -> incident ->
-  dispatch so the processor can select channels `WHERE SiteId IS NULL OR SiteId = <firing site>`.
-  The alert pipeline is currently main-DB/global-scoped and carries no site identity; adding that
-  end-to-end is the bulk of the effort (and is the same plumbing per-site alert RULES would need).
-- **UI:** per-site channel view - inherited global channels (read-only) plus this site's own
-  additions, mirroring the external-site InfluxDB pattern (Settings > Monitoring).
-- Low-risk and incremental: nullable `SiteId` defaults to global, so nothing changes until a site
-  adds its first channel. Best landed alongside making alert rules site-aware.
+  names, so detection reports an IP that is unreachable from the site LAN and absent from the site's
+  UniFi topology. Speed-test targets and traces break silently unless the override is set.
+- [ ] Run the test matrix: native (works today), Docker host mode, Docker bridge with override.
 
 ## Distribution
 
@@ -683,6 +702,9 @@ Goal: keep global channels applying everywhere, but let a site add its OWN addit
 ### 3D Map - Speed Test Path Overlay Rework
 - Toggle hidden from overlay controls until the feature is useful
 - Code exists in `lan-flow-map.js` (`_loadInitialSpeedTests`, `_renderSpeedTestOverlay`)
+- The `// TODO` next to the commented-out `overlayDefs` entry points at
+  `research/monitoring/3d-map-overlays-TODO.md`, which does not exist in the repo - repoint that
+  comment here (or restore the file) when this is picked up
 - Needs: visual design pass (hard to distinguish from traffic flow), results on hover/click, active test animation, filter by test type, time-based filtering
 - Consider making it a temporary overlay during/after a test rather than a persistent toggle
 
@@ -705,16 +727,19 @@ Goal: keep global channels applying everywhere, but let a site add its OWN addit
 - Extract into a shared JS module so all chart sets reuse one implementation
 - Both files have a TODO marking this
 
-### Refactor Program.cs - Extract Business Logic and Break Up API Sets
-- **Issue:** `Program.cs` has grown into a monolith with schedule executor implementations, API endpoint registrations, and business logic all inline
-- **Goal:** Clean separation of concerns:
-  - Extract schedule executor registrations into a dedicated class (e.g., `ScheduleExecutorSetup.cs`)
-  - Break API endpoints into logical groups using minimal API route groups or extension methods (e.g., `SpeedTestEndpoints.cs`, `AuditEndpoints.cs`, `ThreatEndpoints.cs`)
-  - Move inline business logic out of endpoint handlers into services
+### Refactor Program.cs - Finish Breaking Up the Inline Endpoints
+- **Done so far:** schedule executor registrations live in `ScheduleExecutorRegistration.cs`, and 17
+  endpoint files exist under `Endpoints/` (alerts, speed test, the chart sets, ISP health, LAN flow map,
+  site agent, SNMP, port stats, flaky target, monitoring investigate).
+- **Still open:** `Program.cs` is ~2300 lines with roughly 47 inline `app.Map*` registrations that carry
+  business logic in the handler - mainly auth, UPnP notes, AP locations, and the floor-plan CRUD block.
+  Move those into endpoint groups the same way, and push handler logic into services.
 - **Priority:** Medium - not blocking but makes maintenance harder as the app grows
 
 ### Refactor DnsSecurityAnalyzer.AnalyzeAsync() Parameter Hell
-- **Issue:** `DnsSecurityAnalyzer.AnalyzeAsync()` now takes 12 parameters (was 7, grew during DNAT/firewall groups/URL work):
+- **Issue:** `DnsSecurityAnalyzer.AnalyzeAsync()` now takes **14** parameters (was 7, then 12; it has
+  since gained `networkConfigs` and `trustedDnsRedirectTargets`, and both belong in the record sketch
+  below). Plus 4 convenience overloads. The signature as of the last count:
   ```csharp
   public async Task<DnsSecurityResult> AnalyzeAsync(
       JsonElement? settingsData, List<FirewallRule>? firewallRules,
@@ -725,12 +750,11 @@ Goal: keep global channels applying everywhere, but let a site add its OWN addit
       Dictionary<string, UniFiFirewallGroup>? firewallGroups,
       string? customDnsManagementUrl)
   ```
-  Plus 5 convenience overloads that chain to it.
 - **Problems:**
   - Easy to pass arguments in wrong order (all are nullable)
   - Tests are verbose with many `null` placeholders
   - Adding new parameters requires updating all call sites and overloads
-  - The overload chain (lines 47-77) is getting unwieldy
+  - The overload chain is getting unwieldy, and the parameter count is still growing
 - **Proposed fix:** Create `DnsAnalysisRequest` record/class:
   ```csharp
   public record DnsAnalysisRequest
@@ -816,7 +840,9 @@ Goal: keep global channels applying everywhere, but let a site add its OWN addit
 - **Observed:** 4-5 polls within 4 seconds when navigating dashboard → settings
 - **Fix:** Add debounce or lock around UI-triggered polls in `CellularModemService`
 - **Severity:** Low (causes extra SSH traffic but no errors)
-- **Partial:** Basic `_isPolling` lock prevents concurrent polls, but no time-based debounce yet
+- **Nothing guards this path today:** the `_isPolling` flag only covers the timer-driven
+  `PollAllModemsAsync`. The UI path - `PollModemAsync`, called directly from `CellularStatsPanel` -
+  has neither a lock nor a debounce, so the observed 4-5 polls in 4 seconds are unguarded.
 
 ### Shared IP-to-Client-Name Resolver
 - Threat Dashboard resolves local IPs to UniFi client names inline (fetches clients, builds IP→name dict)
@@ -844,10 +870,14 @@ The UniFi v2 device API (`/proxy/network/v2/api/site/{site}/device`) returns mul
 |-------|-------------|---------------------|--------|
 | `network_devices` | APs, Switches, Gateways | Management VLAN | Existing |
 | `protect_devices` | Cameras, Doorbells, NVRs, Sensors | Security VLAN | Done |
-| `access_devices` | Door locks, readers | Security VLAN | TODO |
-| `connect_devices` | EV chargers, other Connect devices | IoT VLAN | TODO |
-| `talk_devices` | Intercoms, phones | IoT/VoIP VLAN | TODO |
-| `led_devices` | LED controllers, lighting | IoT VLAN | TODO |
+| `drive_devices` | UNAS | n/a | Done (used to exclude Drive devices from camera detection) |
+| `access_devices` | Door locks, readers | Security VLAN | Deserialized, unused |
+| `connect_devices` | EV chargers, other Connect devices | IoT VLAN | Deserialized, unused |
+| `led_devices` | LED controllers, lighting | IoT VLAN | Deserialized, unused |
+| `talk_devices` | Intercoms, phones | IoT/VoIP VLAN | Not even a DTO property |
+
+`UniFiProtectDeviceResponse` already deserializes access/connect/led into generic lists that nothing
+reads, so Phases 2/3/5 start at classification, not parsing. `talk_devices` is one step further back.
 
 ### Protect Infrastructure Devices (SuperLink, Sensors, Chimes)
 - Currently excluded from VLAN placement checks: SuperLink Hub, Sensors, Chimes, Bridges
@@ -891,18 +921,25 @@ The UniFi v2 device API (`/proxy/network/v2/api/site/{site}/device`) returns mul
 
 ## Standalone Controller Support
 
-### API Path Differences
-Currently only tested with UniFi OS controllers (UDM, Cloud Gateway). Standalone controllers use different API paths:
+### Legacy Network Server API paths: test coverage
+
+The non-proxied `/api/s/{site}/...` root belongs to the **legacy UniFi Network Server** only. UniFi OS
+Server and the gateway consoles (UDM, UCG) all go through `/proxy/network/...`, so this branch is
+narrower than "standalone controller" suggests.
 
 | Controller Type | API Path Pattern |
 |-----------------|------------------|
-| UniFi OS (UDM/UCG) | `https://<ip>/proxy/network/api/s/{site}/stat/sta` |
-| Standalone Controller | `https://<ip>/api/s/{site}/stat/sta` |
+| UniFi OS (UDM / UCG / UniFi OS Server) | `https://<ip>/proxy/network/api/s/{site}/stat/sta` |
+| Legacy Network Server | `https://<ip>/api/s/{site}/stat/sta` |
 
-The app auto-detects controller type via login response, but needs testing with standalone controllers to verify:
-- Path detection logic in `UniFiApiClient`
-- All API endpoints work correctly
-- Authentication flow differences (if any)
+Detection is implemented and has worked in practice: `DetectLoginType` probes `GET /login`,
+`DetectControllerType` probes the proxied sysinfo endpoint, `BuildApiPath` / `BuildV2ApiPath` emit both
+shapes, and legacy login goes to `/api/login`. It has been exercised in lab testing and some users run
+it, but not regularly, and Ubiquiti keeps steering people off the legacy server - so this is low
+priority and unlikely to grow.
+
+- [ ] Add test coverage for the path and login detection, so the legacy branch cannot rot silently
+  between releases that nobody exercises it in.
 
 ## Channel Recommendation: Learn From Tried Configs (Outcome History)
 
@@ -921,11 +958,32 @@ knows the swap is actually worse for util/interference. The "improvement" came a
 - **Thin external margins, no direct scan data** - the only location-specific neighbor signal was
   triangulated (logs showed "no scan channel data"), with tiny per-channel deltas.
 
-- [ ] Persist each observed (AP, channel, width) -> rolling util/interference/tx-retry outcome, long-term
-- [ ] Attribute metrics to the combo that was actually live (key off channel-change events)
-- [ ] When a candidate assignment matches a previously-tried combo, prefer measured outcome over inferred score
-- [ ] Down-weight (or flag) recommendations whose predicted gain rests mostly on propagated stress
-- [ ] Distinguish self-induced load from environmental interference - don't credit a move for escaping the AP's own traffic
+**The storage and attribution layer shipped.** `ChannelOutcomeBucket` persists daily
+util/interference/tx-retry per (AP, channel, width) with 365-day retention; the collection service
+attributes each hourly sample to the combo that was actually live via channel-change events (with
+width-provenance rules so an unprovable width is recorded as unknown rather than guessed); and
+`MergeLongTermOutcomes` folds those measurements into `HistoricalStress` age-decayed on a 60-day
+half-life, where measured data wins over inferred wherever both exist. One deliberate ordering rule
+inside that: a resident sibling's LIVE read outranks stale own-outcome memory.
+
+Known ceiling, following from applying being out of scope (see "Applying a channel plan to UniFi"):
+the collector sees the resulting live channel and width, but nothing ties an observed state back to a
+specific recommendation - so the loop cannot tell a followed recommendation from a change the user
+made for their own reasons. Outcomes are still attributed correctly; only the "did our advice help"
+question stays out of reach.
+
+Remaining:
+
+- [ ] Down-weight (or flag) recommendations whose predicted gain rests mostly on propagated stress.
+  Propagated stress is already 50%-dampened, proximity-scaled, kept in its own field and excluded from
+  every ground-truth consumer - but nothing detects or surfaces *this particular recommendation is
+  mostly propagated inference*.
+- [ ] Distinguish self-induced load from environmental interference. Much of this landed (cross-vantage
+  scoring so an AP's own contaminated read is not used for its current channel, own-scan excluded from
+  measured congestion, contention/utilization split with an own-load floor). The gap left: historical
+  utilization of the current channel still includes the AP's own clients, so a move can still take
+  partial credit for "escaping" traffic that would follow it, offset only by `UnknownChannelPenalty`.
+  The 1<->11 example above is the acceptance test.
 
 ## Channel Recommendation: Spectrum-Scan UX (background / on-demand quick-scans)
 
@@ -944,19 +1002,17 @@ Shared piece to build once: a "trigger -> poll `quick_scan_state.in_progress` un
 results -> re-run rec" helper. Expose the trigger through `IWiFiDataProvider` (it currently lives
 only on `UniFiApiClient`).
 
-- [x] **Win 1 (gap-aware prompt)** - DONE & shipped. Gap banner offers a one-click quick scan of the
-  gapped (AP, band)s (mesh APs excluded, per-AP-serial/cross-AP-parallel, scans at live BW), polls,
-  re-runs. Warning tailored by `HasDedicatedScanRadio` + mesh role; disclaimer auto-hides when no gaps.
-- [ ] **Win 2 (staleness + manual "Refresh measurements" button)** - can wait for a PATCH after this
-  minor release: there's a natural window between when people pick up the feature and when their scan
-  data goes stale, so no rush. Two parts:
-  1. *Staleness:* scan data currently never expires - the provider stamps `ScanTime = fetch-time`
-     (not the real scan time), so a days-old scan reads as fresh and never becomes a gap. Propagate the
-     real `spectrum_table_time` into `ChannelScanResult.ScanTime`, then treat an (AP, band) as a gap if
-     missing OR older than a threshold (~7 days). The gap banner then reappears on its own for stale
-     radios. Low effort, no recalibration risk.
-  2. *Manual refresh button* in the same banner area: stagger a quick-scan across all APs (reuse
-     `RunQuickScansAsync`), re-run when done. Harmless, cheap.
+The gap-aware prompt (Win 1) and the shared trigger -> poll -> re-run helper both shipped, as did most
+of the staleness work - in a better form than originally specified. The real `spectrum_table_time` is
+propagated into a dedicated `ChannelScanResult.SpectrumTableTime` (rather than overwriting `ScanTime`
+with it), and staleness drives its own "stale scan data" banner with a Re-scan button, gated on the
+stale reading actually being material and uncorroborated. **Do not re-implement the original
+"older than ~7 days = treat as a gap" design** - the materiality-gated banner deliberately replaced it.
+
+- [ ] **Win 2 remainder.** Age never promotes an (AP, band) to a plain gap - `GetSpectrumScanGapsAsync`
+  still filters on `Channels.Count == 0` only. And there is no manual "Refresh measurements" button for
+  *all* APs; only the gap-targeted and stale-targeted buttons exist. Both are cheap: reuse
+  `RunQuickScansAsync`.
 - [ ] **Win 3 (scheduled off-peak sweep)** - background job that sweeps quick-scans across APs/bands
   during low-utilization hours, determined from the 1d/7d historic stress we already compute. Stagger
   ONE band at a time PER AP (parallel across APs - a radio scans one band at a time); never take the

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -520,8 +520,13 @@ ExecStop=${NGINX_BIN} -s quit -c ${INSTALL_DIR}/nginx-speedtest.conf
 Restart=always
 RestartSec=5
 
+# Enabling under the AGENT's .wants (not multi-user's): BindsTo above stops
+# nginx with the agent but never starts it again, so hook the start side to the
+# agent too - every agent start (boot, deploys, manual restarts, the async-I/O
+# watchdog's self-restart) relights nginx. Lives here in the nginx unit so the
+# dependency only exists on installs that actually include the speed test.
 [Install]
-WantedBy=multi-user.target
+WantedBy=netopt-agent.service
 UNIT
 
         # If the first test fails only because an enforcing AppArmor profile denies
@@ -537,7 +542,10 @@ UNIT
             # Enable now, but START it below, after the agent unit is installed and
             # running - nginx BindsTo the agent, so starting it before the agent exists
             # would immediately stop it again.
-            systemctl enable --quiet netopt-speedtest-nginx.service
+            # reenable (not enable): converges upgrade re-runs onto the current
+            # WantedBy - enable alone would leave a stale multi-user.target.wants
+            # symlink from installs made before nginx was wanted by the agent.
+            systemctl reenable --quiet netopt-speedtest-nginx.service
             START_SPEEDTEST_NGINX=1
             ok "LAN speed test ready on port 3000 (starts with the agent)"
         else

--- a/src/NetworkOptimizer.Agent/AsyncIoWatchdog.cs
+++ b/src/NetworkOptimizer.Agent/AsyncIoWatchdog.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace NetworkOptimizer.Agent;
+
+/// <summary>
+/// Self-heal for a wedged .NET async socket engine, seen on a UniFi gateway's
+/// vendor kernel (2026-07-30): epoll_wait slept through a wakeup, so every
+/// async socket completion stopped being delivered while the kernel kept
+/// completing the underlying work. Timers, sync I/O, and child processes all
+/// keep running, so the agent looks alive while the tunnel, heartbeats, and
+/// probe pipe reads starve forever on connects the kernel already finished.
+///
+/// Detection is a loopback canary: an async connect to our own listener on
+/// 127.0.0.1. That connect cannot time out for network reasons, so several
+/// consecutive in-process timeouts prove the engine is dead - a real WAN or
+/// server outage never trips it. The engine's event loop is process-global,
+/// so the only remedy is a process restart: the watchdog persists the result
+/// backlog and exits non-zero for the unit's Restart=always to relaunch.
+/// </summary>
+public static class AsyncIoWatchdog
+{
+    /// <summary>Consecutive canary failures before declaring the engine dead.</summary>
+    public const int FailuresBeforeRestart = 3;
+
+    /// <summary>EX_SOFTWARE: distinguishes a watchdog restart from a crash in journal/systemd status.</summary>
+    public const int ExitCode = 70;
+
+    private static readonly TimeSpan Interval = TimeSpan.FromSeconds(60);
+    private static readonly TimeSpan CanaryTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Runs for the life of the process. <paramref name="persistState"/> is
+    /// invoked (best-effort) right before the restart exit; it must use only
+    /// sync I/O, since async I/O is exactly what is broken at that point.
+    /// </summary>
+    public static async Task RunAsync(Action persistState, CancellationToken ct)
+    {
+        using var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        listener.Listen(FailuresBeforeRestart + 1);
+        var endpoint = (IPEndPoint)listener.LocalEndPoint!;
+
+        var failures = 0;
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(Interval, ct);
+
+            var completed = await CanaryConnectAsync(endpoint, ct);
+            DrainBacklog(listener);
+            if (ct.IsCancellationRequested)
+                return;
+            if (completed)
+            {
+                failures = 0;
+                continue;
+            }
+
+            failures++;
+            Console.Error.WriteLine(
+                $"Async I/O canary: loopback connect did not complete in {CanaryTimeout.TotalSeconds:0}s ({failures}/{FailuresBeforeRestart})");
+            if (failures < FailuresBeforeRestart)
+                continue;
+
+            Console.Error.WriteLine(
+                "Async socket engine is wedged (the kernel completes loopback connects this process never observes); " +
+                "exiting so systemd relaunches the agent");
+            try
+            {
+                persistState();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"State persist before watchdog restart failed: {ex.Message}");
+            }
+            Environment.Exit(ExitCode);
+        }
+    }
+
+    /// <summary>
+    /// True when the async connect COMPLETED - success or failure both prove
+    /// the engine is delivering completions. False only when nothing arrived
+    /// within the timeout, which on loopback means the delivery path is dead.
+    /// </summary>
+    private static async Task<bool> CanaryConnectAsync(IPEndPoint endpoint, CancellationToken ct)
+    {
+        var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+        Task connect;
+        try
+        {
+            connect = socket.ConnectAsync(endpoint);
+        }
+        catch
+        {
+            socket.Dispose();
+            return true;
+        }
+
+        var winner = await Task.WhenAny(connect, Task.Delay(CanaryTimeout, ct));
+        if (winner == connect)
+        {
+            try { await connect; } catch { }
+            socket.Dispose();
+            return true;
+        }
+
+        // Timed out (or shutdown cancelled the delay - the caller re-checks ct).
+        // Observe the completion that may never fire, and close the kernel-side
+        // connection so it doesn't linger.
+        _ = connect.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+        socket.Dispose();
+        return false;
+    }
+
+    /// <summary>
+    /// Accepts and discards the canary's connections on the SYNC path, which
+    /// works even when the async engine is dead - otherwise kernel-established
+    /// canary connects would fill the listen backlog and fail future canaries
+    /// for the wrong reason.
+    /// </summary>
+    private static void DrainBacklog(Socket listener)
+    {
+        try
+        {
+            while (listener.Poll(0, SelectMode.SelectRead))
+                listener.Accept().Dispose();
+        }
+        catch
+        {
+        }
+    }
+}

--- a/src/NetworkOptimizer.Agent/ProbeRunner.cs
+++ b/src/NetworkOptimizer.Agent/ProbeRunner.cs
@@ -23,7 +23,21 @@ public sealed class ProbeRunner
     private readonly string? _defaultSourceIp;
     private readonly LocalProbeExecutor _executor = new(NullLogger<LocalProbeExecutor>.Instance);
     private readonly ConcurrentDictionary<string, DateTime> _lastProbed = new();
+    private readonly ConcurrentDictionary<string, Task> _inFlight = new();
+    // Deliberately never disposed: in-flight probes release their slot after
+    // RunAsync exits on shutdown, and Release on a disposed semaphore throws
+    // into tasks nobody awaits. Process teardown reclaims it.
+    private readonly SemaphoreSlim _concurrency = new(4);
     private volatile IReadOnlyList<ProbeTargetSpec> _targets = [];
+
+    /// <summary>
+    /// Hard wall-clock cap on one probe. The executor's own overall cap is
+    /// ~11 s worst case (20 pings at 0.2 s + 2 s timeout + margin), so anything
+    /// past this is a hung await, not a slow network - the probe's concurrency
+    /// slot is reclaimed and no result is recorded (a gap is honest; fabricated
+    /// loss is not).
+    /// </summary>
+    private static readonly TimeSpan ProbeDeadline = TimeSpan.FromSeconds(30);
 
     /// <param name="defaultSourceIp">
     /// Source address every probe binds to unless the target spec carries its
@@ -55,13 +69,23 @@ public sealed class ProbeRunner
         try { await Task.Delay(TimeSpan.FromSeconds(20), ct); }
         catch (OperationCanceledException) { return; }
 
-        using var concurrency = new SemaphoreSlim(4);
         while (!ct.IsCancellationRequested)
         {
             var now = DateTime.UtcNow;
-            var due = _targets.Where(t => IsDue(t, now)).ToList();
-            if (due.Count > 0)
-                await Task.WhenAll(due.Select(t => ProbeAsync(t, concurrency, ct)));
+            // Fire-and-track, never await-all: the tick must keep scheduling
+            // even if one probe hangs (a wedged async engine once froze the
+            // whole scheduler through a WhenAll here, taking every target dark
+            // instead of just the stuck one). _inFlight keeps a slow or hung
+            // target from stacking duplicate probes.
+            foreach (var target in _targets)
+            {
+                if (!IsDue(target, now) || _inFlight.ContainsKey(target.TargetId))
+                    continue;
+                var probe = ProbeAsync(target, ct);
+                _inFlight[target.TargetId] = probe;
+                _ = probe.ContinueWith(_ => _inFlight.TryRemove(target.TargetId, out Task? _),
+                    TaskScheduler.Default);
+            }
             await Task.Delay(TimeSpan.FromSeconds(2), ct);
         }
     }
@@ -72,9 +96,9 @@ public sealed class ProbeRunner
         return !_lastProbed.TryGetValue(spec.TargetId, out var last) || now - last >= interval;
     }
 
-    private async Task ProbeAsync(ProbeTargetSpec spec, SemaphoreSlim concurrency, CancellationToken ct)
+    private async Task ProbeAsync(ProbeTargetSpec spec, CancellationToken ct)
     {
-        await concurrency.WaitAsync(ct);
+        await _concurrency.WaitAsync(ct);
         try
         {
             _lastProbed[spec.TargetId] = DateTime.UtcNow;
@@ -88,11 +112,21 @@ public sealed class ProbeRunner
                 spec.Port > 0 ? spec.Port : null,
                 string.IsNullOrEmpty(spec.SourceIp) ? _defaultSourceIp : spec.SourceIp);
 
-            var ping = await _executor.PingAsync(
+            var pingTask = _executor.PingAsync(
                 target,
                 count: Math.Max(3, Math.Min(spec.PingCount, 20)),
                 perPingTimeout: TimeSpan.FromSeconds(2),
                 ct: ct);
+            var winner = await Task.WhenAny(pingTask, Task.Delay(ProbeDeadline, ct));
+            if (winner != pingTask)
+            {
+                _ = pingTask.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
+                if (!ct.IsCancellationRequested)
+                    Console.Error.WriteLine(
+                        $"Probe {spec.TargetId} did not complete within {ProbeDeadline.TotalSeconds:0}s; dropping this sample");
+                return;
+            }
+            var ping = await pingTask;
             if (ct.IsCancellationRequested) return;
 
             var result = new ProbeResult
@@ -120,7 +154,7 @@ public sealed class ProbeRunner
         }
         finally
         {
-            concurrency.Release();
+            _concurrency.Release();
         }
     }
 }

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -197,14 +197,51 @@ ProbeRunner? probeRunner = null;
 SnmpRunner? snmpRunner = null;
 Task? probeTask = null;
 Task? snmpTask = null;
+Task? watchdogTask = null;
+var spoolPath = Path.Combine(
+    Path.GetDirectoryName(Path.GetFullPath(configPath)) ?? ".", "result-spool.bin");
+
+// Best-effort spool of the unacked backlog for the next process to replay.
+// Called on graceful shutdown and by the async-I/O watchdog right before its
+// restart exit, so restarts don't cost the outage data the buffer exists for.
+void SaveSpool()
+{
+    if (resultBuffer is not { Count: > 0 })
+        return;
+    var count = resultBuffer.Count;
+    resultBuffer.SaveTo(spoolPath);
+    Console.WriteLine($"Spooled {count} unsent result message(s) for the next start");
+}
+
 if (!string.IsNullOrEmpty(config.TunnelUrl))
 {
     resultBuffer = new ResultBuffer();
+    if (File.Exists(spoolPath))
+    {
+        try
+        {
+            var restored = resultBuffer.LoadFrom(spoolPath);
+            if (restored > 0)
+                Console.WriteLine($"Restored {restored} spooled result message(s) from the previous run");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Result spool restore failed: {ex.Message}");
+        }
+        try { File.Delete(spoolPath); } catch { }
+    }
     probeRunner = new ProbeRunner(resultBuffer.Enqueue, config.ProbeSourceIp);
     snmpRunner = new SnmpRunner(resultBuffer.Enqueue);
     probeTask = probeRunner.RunAsync(cts.Token);
     snmpTask = snmpRunner.RunAsync(cts.Token);
 }
+
+// Restart-based self-heal for a wedged async socket engine (every install
+// mode restarts the agent on exit); spools the backlog first so the restart
+// is lossless. Deliberately outside the tunnel block: heartbeat-only agents
+// die of the same wedge (async HTTP) and need the same cure - without a
+// buffer the spool callback is a no-op.
+watchdogTask = AsyncIoWatchdog.RunAsync(SaveSpool, cts.Token);
 
 // Prefer the persistent gRPC tunnel; REST heartbeats keep the agent visible as
 // Online whenever the tunnel is unavailable (tunnel disabled server-side, an
@@ -304,6 +341,19 @@ if (probeTask != null)
 if (snmpTask != null)
 {
     try { await snmpTask; } catch (OperationCanceledException) { }
+}
+if (watchdogTask != null)
+{
+    try { await watchdogTask; } catch (OperationCanceledException) { }
+}
+
+try
+{
+    SaveSpool();
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"Result spool save failed: {ex.Message}");
 }
 
 Console.WriteLine("Agent stopped");

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -1,3 +1,5 @@
+using Google.Protobuf;
+
 namespace NetworkOptimizer.AgentProtocol;
 
 /// <summary>
@@ -148,6 +150,76 @@ public sealed class ResultBuffer
                 _entries.RemoveFirst();
             }
         }
+    }
+
+    /// <summary>Spool file header: identifies the format and its version.</summary>
+    private const uint SpoolMagic = 0x4E4F5350; // "NOSP"
+    private const int SpoolVersion = 1;
+
+    /// <summary>
+    /// Writes every buffered (unacked) message with its enqueue time to
+    /// <paramref name="path"/>, replacing any existing file, so a restart
+    /// (deliberate stop, update, or watchdog-forced) keeps the outage backlog
+    /// instead of losing it with the process. Deliberately synchronous file
+    /// I/O: the async-engine watchdog calls this while async I/O is wedged.
+    /// </summary>
+    public void SaveTo(string path)
+    {
+        lock (_lock)
+        {
+            using var file = new FileStream(path, FileMode.Create, FileAccess.Write);
+            var output = new CodedOutputStream(file);
+            output.WriteFixed32(SpoolMagic);
+            output.WriteInt32(SpoolVersion);
+            foreach (var entry in _entries)
+            {
+                output.WriteInt64(entry.EnqueuedUtc.Ticks);
+                output.WriteMessage(entry.Message);
+            }
+            output.Flush();
+        }
+    }
+
+    /// <summary>
+    /// Appends the messages spooled by <see cref="SaveTo"/>, preserving their
+    /// original enqueue times so the age cap still applies, then re-applies the
+    /// caps. A truncated or corrupt spool (crash mid-write) keeps whatever
+    /// decoded cleanly. Returns the number of messages restored.
+    /// </summary>
+    public int LoadFrom(string path)
+    {
+        using var file = File.OpenRead(path);
+        var input = new CodedInputStream(file);
+        var restored = 0;
+        lock (_lock)
+        {
+            try
+            {
+                if (input.ReadFixed32() != SpoolMagic || input.ReadInt32() != SpoolVersion)
+                    return 0;
+                while (!input.IsAtEnd)
+                {
+                    var enqueuedTicks = input.ReadInt64();
+                    var message = new AgentMessage();
+                    input.ReadMessage(message);
+                    var entry = new Entry(++_nextSeq, message,
+                        new DateTime(enqueuedTicks, DateTimeKind.Utc), message.CalculateSize());
+                    _entries.AddLast(entry);
+                    _bytes += entry.SizeBytes;
+                    restored++;
+                }
+            }
+            catch (Exception ex) when (ex is InvalidProtocolBufferException or ArgumentOutOfRangeException)
+            {
+                // Truncated tail or corrupt bytes (crash mid-write, bit rot):
+                // keep the clean prefix. ArgumentOutOfRange covers a corrupt
+                // varint decoding to ticks outside DateTime's range.
+            }
+            EvictLocked();
+        }
+        if (restored > 0)
+            _available.Release();
+        return restored;
     }
 
     private SendFrame? BuildUnsentFrameLocked(long afterSeq, int maxSamples)

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Text.RegularExpressions;
 
 namespace NetworkOptimizer.Core.Helpers;
 
@@ -794,5 +795,21 @@ public static class NetworkUtilities
             uplinkIfName.StartsWith(physicalIfName + ".", StringComparison.OrdinalIgnoreCase))
             return physicalIfName;
         return uplinkIfName;
+    }
+
+    /// <summary>
+    /// True when a WAN's data-path interface name is a PPPoE session interface - "ppp0",
+    /// "ppp3", or the "pppoe0" form some stacks use. The kernel names a PPPoE session this
+    /// way and nothing else, so the interface name alone identifies the encapsulation
+    /// without asking the user or inspecting the session.
+    ///
+    /// Deliberately anchored: a plain "ppp" with no unit number, or any name that merely
+    /// starts with those letters, is not a match. Pass the LOGICAL uplink (uplink_ifname),
+    /// not the physical port - the physical port stays "eth6" while the session rides ppp0.
+    /// </summary>
+    public static bool IsPppoeInterface(string? uplinkIfName)
+    {
+        if (string.IsNullOrWhiteSpace(uplinkIfName)) return false;
+        return Regex.IsMatch(uplinkIfName.Trim(), @"^ppp(oe)?\d+$", RegexOptions.IgnoreCase);
     }
 }

--- a/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/LocalProbeExecutor.cs
@@ -190,11 +190,18 @@ public class LocalProbeExecutor : IProbeExecutor
                 try { proc.Kill(entireProcessTree: true); } catch { }
             }
             var stdout = await SafeReadAsync(stdoutTask);
+            Observe(stderrTask);
+            if (stdout is null)
+                throw new ProbeOutputTimeoutException(
+                    $"ping output read for {target.Address} did not complete within {OutputReadGrace.TotalSeconds:0}s");
 
             var parsed = PingOutputParser.Parse(stdout, target, Vantage, safeCount);
             return parsed;
         }
-        catch (Exception ex)
+        // Output-timeout means async completion delivery is broken, and the managed
+        // Ping path depends on the same machinery - falling back would hang or
+        // fabricate. Let it propagate; callers drop the sample.
+        catch (Exception ex) when (ex is not ProbeOutputTimeoutException)
         {
             _logger.LogDebug(ex, "Native ping invocation failed; falling back to managed Ping");
             return await ManagedPingAsync(target, count, timeout, ct);
@@ -414,8 +421,11 @@ public class LocalProbeExecutor : IProbeExecutor
                 // a hard error.
                 try { proc.Kill(entireProcessTree: true); } catch { }
             }
-            var stdout = stdoutTask.IsCompletedSuccessfully ? stdoutTask.Result : await SafeReadAsync(stdoutTask);
-            var stderr = stderrTask.IsCompletedSuccessfully ? stderrTask.Result : await SafeReadAsync(stderrTask);
+            // A never-completing read degrades to empty here on purpose: a partial or
+            // absent traceroute parses to Reached=false - an honest failure, unlike
+            // ping where empty output would fabricate a loss percentage.
+            var stdout = stdoutTask.IsCompletedSuccessfully ? stdoutTask.Result : (await SafeReadAsync(stdoutTask) ?? string.Empty);
+            var stderr = stderrTask.IsCompletedSuccessfully ? stderrTask.Result : (await SafeReadAsync(stderrTask) ?? string.Empty);
 
             var output = string.IsNullOrWhiteSpace(stdout) ? stderr : stdout;
             return TracerouteOutputParser.Parse(output, target, Vantage, target.Mode);
@@ -440,11 +450,31 @@ public class LocalProbeExecutor : IProbeExecutor
         }
     }
 
-    private static async Task<string> SafeReadAsync(Task<string> readTask)
+    /// <summary>
+    /// Grace period for collecting a finished/killed child's redirected output.
+    /// The pipe normally closes with the child, completing the read instantly;
+    /// the bound exists because a pipe read whose completion is never delivered
+    /// (wedged async engine) would otherwise hang its caller forever.
+    /// </summary>
+    private static readonly TimeSpan OutputReadGrace = TimeSpan.FromSeconds(5);
+
+    private static async Task<string?> SafeReadAsync(Task<string> readTask)
     {
+        var winner = await Task.WhenAny(readTask, Task.Delay(OutputReadGrace));
+        if (winner != readTask)
+        {
+            // Never completed: the output is UNKNOWN, not empty - callers must
+            // treat null as "drop this sample", never parse it as a result.
+            Observe(readTask);
+            return null;
+        }
         try { return await readTask; }
         catch { return string.Empty; }
     }
+
+    /// <summary>Observes a possibly never-completing task's fault so it can't surface as unobserved.</summary>
+    private static void Observe(Task task) =>
+        _ = task.ContinueWith(t => _ = t.Exception, TaskScheduler.Default);
 
     private async Task<PingProbeResult> TcpPingAsync(ProbeTarget target, int count, TimeSpan timeout, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Monitoring/Probes/ProbeOutputTimeoutException.cs
+++ b/src/NetworkOptimizer.Monitoring/Probes/ProbeOutputTimeoutException.cs
@@ -1,0 +1,16 @@
+namespace NetworkOptimizer.Monitoring.Probes;
+
+/// <summary>
+/// Thrown when a probe child process's redirected output read never completes
+/// within the grace period: the child has exited (or been killed) but the
+/// pipe-read completion was never delivered (wedged async engine). The probe
+/// has NO trustworthy outcome, so callers must drop the sample entirely -
+/// parsing the missing output as empty would fabricate a 100% loss result,
+/// planting false outages in monitoring data and the alert evaluators.
+/// </summary>
+public sealed class ProbeOutputTimeoutException : IOException
+{
+    public ProbeOutputTimeoutException(string message) : base(message)
+    {
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -220,13 +220,13 @@ else
                 <IspHealthScoreGauge Score="r.OverallScore" Label="ISP Health" />
                 <div class="isp-health-profile-chip isp-health-profile-chip-selectable"
                      data-tooltip="@(_canOperate ? "Thresholds are tuned per access technology; change it to re-score." : "Thresholds are tuned per access technology. A Site Operator or Admin can change it.")" data-tooltip-hover-only>
-                    Scored as @r.Profile.DisplayName &middot; @ScoredWindowLabel(r)
+                    Scored as @r.Profile.DisplayName@PppoeSuffix(r) &middot; @ScoredWindowLabel(r)
                     <span class="isp-profile-chip-caret"></span>
                     <select class="isp-profile-chip-select" aria-label="Access technology" disabled="@(!_canOperate)"
                             value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                         @foreach (var tech in ProfileTechOptions)
                         {
-                            <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@FormatTechName(tech)</option>
+                            <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@TechLabel(tech, r)</option>
                         }
                     </select>
                 </div>
@@ -360,7 +360,7 @@ else
                                     value="@((int)r.AccessTechnology)" @onchange="OnAccessTechnologyChanged">
                                 @foreach (var tech in ProfileTechOptions)
                                 {
-                                    <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@FormatTechName(tech)</option>
+                                    <option value="@((int)tech)" selected="@(tech == r.AccessTechnology)">@TechLabel(tech, r)</option>
                                 }
                             </select>
                         }
@@ -1235,6 +1235,22 @@ else
     /// one only loses the thresholds the line should be graded against. Upstream Discovery's
     /// selector offers this same set (plus Unknown) - keep the two in step.
     /// </summary>
+    /// <summary>
+    /// " (PPPoE)" when the WAN runs a PPPoE session, otherwise nothing. The session is detected
+    /// from the gateway rather than picked, and it shifts the scored thresholds materially, so
+    /// the two places that state what the line is graded as have to say it.
+    /// </summary>
+    private static string PppoeSuffix(IspHealthReport r) => r.PppoeSession ? " (PPPoE)" : "";
+
+    /// <summary>
+    /// Technology label for the selectors. Only the CURRENT value carries the PPPoE suffix: a
+    /// native select shows the selected option's own text, so this is what puts "GPON (PPPoE)"
+    /// on the collapsed control, while the alternatives stay plain - they name media to switch
+    /// to, and the session rides whichever one is picked.
+    /// </summary>
+    private static string TechLabel(AccessTechnology tech, IspHealthReport r) =>
+        tech == r.AccessTechnology ? FormatTechName(tech) + PppoeSuffix(r) : FormatTechName(tech);
+
     private static readonly AccessTechnology[] ProfileTechOptions =
     [
         AccessTechnology.Gpon,

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1227,10 +1227,13 @@ else
     }
 
     /// <summary>
-    /// Access technologies offered by the pill selector - only those with a scoring profile
-    /// (<see cref="IspHealthProfiles.GetProfile"/>), since the pill is only shown when scoring is
-    /// active. Unknown / PppoE / Other are excluded: picking them would null the profile and
-    /// collapse the pill into the "needs technology" empty state.
+    /// Access technologies offered by the pill selector - only those with a medium-specific
+    /// scoring profile (<see cref="IspHealthProfiles.GetProfile"/>), since the pill is only
+    /// shown when scoring is active. Unknown is excluded because it nulls the profile and
+    /// collapses the pill into the "needs technology" empty state. PppoE and Other are excluded
+    /// because neither names a medium: both resolve to the same wide neutral profile, so picking
+    /// one only loses the thresholds the line should be graded against. Upstream Discovery's
+    /// selector offers this same set (plus Unknown) - keep the two in step.
     /// </summary>
     private static readonly AccessTechnology[] ProfileTechOptions =
     [

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1235,6 +1235,18 @@ else
     /// one only loses the thresholds the line should be graded against. Upstream Discovery's
     /// selector offers this same set (plus Unknown) - keep the two in step.
     /// </summary>
+    private static readonly AccessTechnology[] ProfileTechOptions =
+    [
+        AccessTechnology.Gpon,
+        AccessTechnology.XgsPon,
+        AccessTechnology.Docsis,
+        AccessTechnology.Dsl,
+        AccessTechnology.DirectEthernet,
+        AccessTechnology.FixedWireless,
+        AccessTechnology.Cellular,
+        AccessTechnology.Satellite
+    ];
+
     /// <summary>
     /// " (PPPoE)" when the WAN runs a PPPoE session, otherwise nothing. The session is detected
     /// from the gateway rather than picked, and it shifts the scored thresholds materially, so
@@ -1250,18 +1262,6 @@ else
     /// </summary>
     private static string TechLabel(AccessTechnology tech, IspHealthReport r) =>
         tech == r.AccessTechnology ? FormatTechName(tech) + PppoeSuffix(r) : FormatTechName(tech);
-
-    private static readonly AccessTechnology[] ProfileTechOptions =
-    [
-        AccessTechnology.Gpon,
-        AccessTechnology.XgsPon,
-        AccessTechnology.Docsis,
-        AccessTechnology.Dsl,
-        AccessTechnology.DirectEthernet,
-        AccessTechnology.FixedWireless,
-        AccessTechnology.Cellular,
-        AccessTechnology.Satellite
-    ];
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -629,15 +629,16 @@
     /// The enum's numeric values are persisted and append-only, so new technologies are
     /// slotted here instead of renumbering the enum.
     ///
-    /// PppoE and Other are absent on purpose. Neither names an access medium, so neither
-    /// tells the scorer anything - IspHealthProfiles.GetProfile maps both to the same wide
-    /// NeutralProfile - and picking either costs the user the medium-specific thresholds
-    /// their line would otherwise be graded against. PPPoE especially: it is an
-    /// encapsulation riding GPON, DSL or Active Ethernet, and that is what should be
-    /// picked. If ISP Health ever wants to act on PPPoE itself it never has to ask - a
-    /// PPPoE WAN's uplink interface is named ppp* (uplink_ifname "ppp0", already read into
-    /// UpstreamTracerService._wanUplinkIfName) and the network config carries
-    /// wan_type "pppoe".
+    /// PppoE and Other are absent on purpose. Neither names an access medium, so picking
+    /// either costs the user the medium-specific thresholds their line would otherwise be
+    /// graded against - IspHealthProfiles.GetProfile maps both to the same wide NeutralProfile
+    /// today. PPPoE is expected to earn scoring behavior of its own once there is enough field
+    /// data to calibrate it, and that is exactly why it does not belong here: it is an
+    /// encapsulation riding GPON, DSL or Active Ethernet, so the medium and the encapsulation
+    /// are two facts, not one choice. ISP Health can read the encapsulation without asking -
+    /// a PPPoE WAN's uplink interface is named ppp* (uplink_ifname "ppp0", already read into
+    /// UpstreamTracerService._wanUplinkIfName) and the network config carries wan_type "pppoe" -
+    /// so this selector asks only for the medium.
     /// </summary>
     private static readonly AccessTechnology[] AccessTechDisplayOrder =
     [

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -153,7 +153,7 @@
                     <select class="form-control upstream-tech-select @AccessTechAttentionClass"
                             value="@((int)_state.AccessTechnology)" disabled="@(!_canOperate)"
                             @onchange="OnAccessTechChanged">
-                        @foreach (var tech in AccessTechDisplayOrder)
+                        @foreach (var tech in AccessTechOptions)
                         {
                             <option value="@((int)tech)">@FormatTechName(tech)</option>
                         }
@@ -623,8 +623,21 @@
     private void ToggleCollapse() => _collapsed = !_collapsed;
 
     /// <summary>
-    /// Dropdown display order. The enum's numeric values are persisted and append-only,
-    /// so new technologies are slotted here instead of renumbering the enum.
+    /// Dropdown display order, deliberately the same set and order as the ISP Health
+    /// technology selector (IspHealthPanel.ProfileTechOptions) plus Unknown for the
+    /// not-yet-picked state, so one field offers one set of choices wherever it appears.
+    /// The enum's numeric values are persisted and append-only, so new technologies are
+    /// slotted here instead of renumbering the enum.
+    ///
+    /// PppoE and Other are absent on purpose. Neither names an access medium, so neither
+    /// tells the scorer anything - IspHealthProfiles.GetProfile maps both to the same wide
+    /// NeutralProfile - and picking either costs the user the medium-specific thresholds
+    /// their line would otherwise be graded against. PPPoE especially: it is an
+    /// encapsulation riding GPON, DSL or Active Ethernet, and that is what should be
+    /// picked. If ISP Health ever wants to act on PPPoE itself it never has to ask - a
+    /// PPPoE WAN's uplink interface is named ppp* (uplink_ifname "ppp0", already read into
+    /// UpstreamTracerService._wanUplinkIfName) and the network config carries
+    /// wan_type "pppoe".
     /// </summary>
     private static readonly AccessTechnology[] AccessTechDisplayOrder =
     [
@@ -633,13 +646,23 @@
         AccessTechnology.XgsPon,
         AccessTechnology.Docsis,
         AccessTechnology.Dsl,
-        AccessTechnology.PppoE,
         AccessTechnology.DirectEthernet,
         AccessTechnology.FixedWireless,
-        AccessTechnology.Satellite,
         AccessTechnology.Cellular,
-        AccessTechnology.Other
+        AccessTechnology.Satellite
     ];
+
+    /// <summary>
+    /// What the select actually renders: the display order, plus the stored value when it is
+    /// no longer offered - a WAN saved as PPPoE or Other before those were dropped. Without
+    /// the carry-over the select would find no matching option, render the first one, and
+    /// report a stored PPPoE as "Not detected". The stale entry disappears once the user
+    /// picks something current.
+    /// </summary>
+    private IEnumerable<AccessTechnology> AccessTechOptions =>
+        AccessTechDisplayOrder.Contains(_state.AccessTechnology)
+            ? AccessTechDisplayOrder
+            : AccessTechDisplayOrder.Append(_state.AccessTechnology);
 
     private static string FormatTechName(AccessTechnology tech) => tech switch
     {

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -60,6 +60,14 @@ public class AgentProbeResultSink
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _consoleFetchGate = new();
     private static readonly TimeSpan ConsoleCacheTtl = TimeSpan.FromSeconds(60);
 
+    // Agents (site slug + agent id) whose last SNMP push enumeration found zero
+    // SNMP-enabled devices. One empty sighting is not proof (a just-reconnected
+    // console reports an empty/partial device list for its first moments); only
+    // a second consecutive one is adopted as a real disable. Keyed per agent so
+    // one agent's transient empty can't fast-track a disable to a sibling agent
+    // on the same site. See PushSnmpConfigAsync.
+    private readonly ConcurrentDictionary<string, bool> _snmpEmptyEnumerations = new();
+
     // Samples older than this skip the alert state machines. Agents replay
     // their store-and-forward backlog after a tunnel outage; feeding an
     // hours-old down→up sequence through the evaluators would fire and resolve
@@ -141,6 +149,12 @@ public class AgentProbeResultSink
     /// </summary>
     public void OnAgentDisconnected(AgentTunnelConnection connection)
     {
+        // A strike only means "empty enumeration" if the NEXT one is its true
+        // consecutive sibling. Across a disconnect the next enumeration comes
+        // from a fresh reconnect - exactly the transient-empty condition the
+        // two-strike guard exists for - so a held-over strike would fast-track
+        // the disable on the first sighting. Start clean.
+        _snmpEmptyEnumerations.TryRemove($"{connection.SiteSlug}:{connection.AgentId}", out _);
         _ = Task.Run(async () =>
         {
             try
@@ -221,6 +235,22 @@ public class AgentProbeResultSink
         {
             var isDefault = connection.SiteSlug == SiteManagementService.DefaultSiteSlug;
             await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault);
+
+            // Disabled monitoring stops probing everywhere: every server-side
+            // collection tier (latency included) gates on MonitoringSettings.Enabled
+            // via ShouldRunNowAsync, so mirror that for agent sites. Push an empty
+            // replacement set - the agent stops probing instead of burning cycles
+            // on results the sink would only discard. Absent settings mean
+            // monitoring was never set up: same treatment, matching the server.
+            var monitoringSettings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+            if (monitoringSettings is not { Enabled: true })
+            {
+                connection.TrySend(new ServerMessage { ProbeConfig = new ProbeConfig() });
+                _logger.LogDebug("Monitoring disabled for site {Slug}; pushed empty probe config to agent {Id}",
+                    connection.SiteSlug, connection.AgentId);
+                return;
+            }
+
             var targets = await db.MonitoringTargets
                 .AsNoTracking()
                 .Where(t => t.Enabled)
@@ -427,15 +457,40 @@ public class AgentProbeResultSink
                     }
                 }
 
-                // Console is up but the site genuinely has no SNMP-enabled devices.
                 if (config.Devices.Count == 0)
+                {
+                    // Console is up but enumerated no SNMP-enabled devices. One
+                    // sighting is not proof the site really has none: a console
+                    // that just reconnected (server restart, tunnel bounce)
+                    // reports an empty/partial device list for its first
+                    // moments, and disabling on that stopped the agent's SNMP
+                    // polling until the next refresh cycle - a ~60 s data gap
+                    // per server restart, seen live on an agent site 2026-07-30.
+                    // Skip the push (the agent keeps its last-known-good config)
+                    // and adopt the disable only when a second consecutive
+                    // enumeration agrees.
+                    if (_snmpEmptyEnumerations.TryAdd($"{connection.SiteSlug}:{connection.AgentId}", true))
+                    {
+                        _logger.LogDebug(
+                            "SNMP push for site {Slug}: console enumerated no SNMP-enabled devices; keeping agent {Id}'s last config until a second enumeration confirms",
+                            connection.SiteSlug, connection.AgentId);
+                        return;
+                    }
                     config.Enabled = false;
+                }
+                else
+                {
+                    _snmpEmptyEnumerations.TryRemove($"{connection.SiteSlug}:{connection.AgentId}", out _);
+                }
             }
 
             connection.TrySend(new ServerMessage { SnmpConfig = config });
             if (config.Enabled)
                 _logger.LogInformation("Pushed SNMP config with {Count} device(s) to agent {Id} (site {Slug})",
                     config.Devices.Count, connection.AgentId, connection.SiteSlug);
+            else
+                _logger.LogDebug("Pushed disabled SNMP config to agent {Id} (site {Slug})",
+                    connection.AgentId, connection.SiteSlug);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
+++ b/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
@@ -22,7 +22,7 @@ public static class AppVersionInfo
     /// "Update agent" callout for enrolled agents reporting an older version
     /// than this, and over-bumping nags agents into pointless upgrades.
     /// </summary>
-    public const string LatestAgentVersion = "2.2.0";
+    public const string LatestAgentVersion = "2.5.2";
 
     /// <summary>Full informational version (e.g. "1.4.2" or "0.0.0-alpha.0.12").</summary>
     public static string Informational { get; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -515,6 +515,15 @@ public class IspHealthReport
     /// quick re-score by changing it (the pill selector) without round-tripping Upstream Discovery.</summary>
     public AccessTechnology AccessTechnology { get; set; }
 
+    /// <summary>
+    /// True when the WAN carries its traffic over a PPPoE session, detected from the gateway's
+    /// data-path interface rather than chosen by the user, and <see cref="Profile"/> therefore
+    /// carries the PPPoE overlay (IspHealthProfiles.ApplyPppoeSession). Surfaced so the UI can
+    /// say what the line is being graded as - the overlay shifts the thresholds materially, and
+    /// a user who sees only "GPON" has no way to tell it was accounted for.
+    /// </summary>
+    public bool PppoeSession { get; set; }
+
     public required IspScoreDimension AccessDimension { get; init; }
     public required IspScoreDimension TransitDimension { get; init; }
     public required IspScoreDimension IspAsnDimension { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -816,9 +816,8 @@ public static class IspHealthProfiles
     /// so the full 2.0 would partly double-count - but the 6.0 ms ideal anchor describes a clean
     /// copper loop, which is medium-only, so zero would under-adjust. Revisit with DT VDSL data.
     ///
-    /// Everything else is 0: DOCSIS provisions over DHCP and Starlink/cellular terminate their
-    /// own way, so PPPoE is not expected there at all. If ppp* ever does show up on one, the
-    /// medium's own band is a better answer than an offset nobody has measured.
+    /// Only the media in <see cref="CarriesPppoe"/> reach this, so there is no "everything else"
+    /// case to tune - the overlay does not run at all where PPPoE is not delivered.
     /// </summary>
     private static double PppoeIdleRttOffsetMs(AccessTechnology tech) => tech switch
     {
@@ -828,12 +827,54 @@ public static class IspHealthProfiles
         _ => 0.0
     };
 
+    /// <summary>
+    /// Media a PPPoE session is actually delivered over, and the only ones the overlay touches.
+    /// DOCSIS provisions over DHCP, and Starlink and cellular terminate their own way, so PPPoE
+    /// is not expected on any of them.
+    ///
+    /// Unknown, PppoE and Other are excluded for a different reason: the overlay's numbers are
+    /// calibrated per medium and none of those three names one. PppoE is already the stand-in FOR
+    /// a session, so overlaying it would forgive the same thing twice; Other falls back to the
+    /// deliberately wide neutral band, which has no medium-specific calibration for an overlay to
+    /// sit on top of. Both are legacy stored values - neither is selectable any more.
+    /// </summary>
+    private static bool CarriesPppoe(AccessTechnology tech) => tech is
+        AccessTechnology.Gpon or AccessTechnology.XgsPon or AccessTechnology.DirectEthernet
+        or AccessTechnology.FixedWireless or AccessTechnology.Dsl;
+
     /// <summary>Jitter (ms) the BNG contributes, composed in quadrature - see <see cref="ApplyPppoeSession"/>.</summary>
     private const double PppoeJitterMs = 0.25;
+
+    /// <summary>
+    /// RTT-stability MAD (ms) the BNG contributes, composed in quadrature. Derived from
+    /// <see cref="PppoeJitterMs"/> rather than guessed: across the media whose bands are not
+    /// driven by a documented medium-specific effect, JitterIdealMs / StabilityMadIdealMs sits in
+    /// a tight cluster around 2.8 (GPON 2.67, XGS-PON 2.92, Active Ethernet 2.67, Cellular 2.67,
+    /// DSL 2.86, Fixed Wireless 3.13). DOCSIS at 5.83 and Satellite at 1.0 are excluded from the
+    /// fit - their ratios come from request-grant jitter and LEO handovers, not from the general
+    /// relationship. 0.25 / 2.8 = 0.089, rounded to 0.10.
+    /// </summary>
+    private const double PppoeStabilityMadMs = 0.10;
 
     /// <summary>Loaded-loss (percentage points) the BNG contributes at the low / high anchors.</summary>
     private const double PppoeLoadedLossLowPct = 0.5;
     private const double PppoeLoadedLossHighPct = 1.0;
+
+    /// <summary>
+    /// Loaded-latency delta (ms) the BNG contributes at the excellent / acceptable anchors.
+    /// Applied uniformly, not tiered like the RTT offset: that offset scales with how far away the
+    /// BNG is, this one with how deep its queue is, and distance and queue depth are unrelated.
+    ///
+    /// Deliberately small. The BNG's per-session shaper is a bufferbloat source, and bufferbloat
+    /// is what Adaptive SQM exists to fix - once SQM shapes below the plan rate the CPE becomes
+    /// the bottleneck and the BNG queue stops filling. Widen this too far and a PPPoE user with no
+    /// SQM is told their loaded latency is normal for their line, when the honest answer is to
+    /// turn Adaptive SQM on. These values cover the part that is genuinely not the user's to fix -
+    /// downstream egress queuing at the BNG belongs to the ISP, and a CPE can only answer it with
+    /// cruder ingress policing - and no more.
+    /// </summary>
+    private const double PppoeLoadedDeltaExcellentMs = 1.0;
+    private const double PppoeLoadedDeltaAcceptableMs = 3.0;
 
     /// <summary>
     /// Overlays the cost of a PPPoE session on the medium's profile. Called only when the WAN's
@@ -858,10 +899,13 @@ public static class IspHealthProfiles
     ///   shaper queues then tail-drops), so it is a constant contribution from a different
     ///   device rather than a multiple of the medium's. Multiplying instead would take DSL's
     ///   already-wide 3/5 to 6/10, which is permissive past the point of being useful.
-    ///
-    /// StabilityMad and the loaded deltas are deliberately NOT adjusted yet - both should move
-    /// on the same reasoning, neither has a number behind it, and an unfounded constant here
-    /// becomes the thing future measurements get compared against.
+    /// - RTT stability (MAD) adds in quadrature, for the same reason jitter does - it is the same
+    ///   wander measured as robust dispersion instead of packet-to-packet variation. Its size is
+    ///   derived from the jitter figure via the ratio the profiles already encode; see
+    ///   <see cref="PppoeStabilityMadMs"/>.
+    /// - The loaded deltas add, uniformly across media, and stay small on purpose. See
+    ///   <see cref="PppoeLoadedDeltaExcellentMs"/> - over-widening this axis would forgive exactly
+    ///   the bufferbloat Adaptive SQM exists to fix.
     ///
     /// Caveat worth keeping in view when this gets recalibrated: UniFi gateways terminate the
     /// PPPoE session in software and drop out of the hardware fast path doing it, so part of the
@@ -872,12 +916,7 @@ public static class IspHealthProfiles
     /// </summary>
     public static AccessProfile ApplyPppoeSession(AccessProfile profile, AccessTechnology tech)
     {
-        // A WAN still stored as PppoE already scores on the neutral stand-in FOR a PPPoE line, so
-        // overlaying on top of it would forgive the same session twice. Legacy value, real ppp*
-        // interface, and the honest answer is that the medium is unknown - not that it is unknown
-        // AND further away. Other is deliberately not exempt: it means "some medium we don't
-        // list", which a PPPoE session genuinely does sit on top of.
-        if (tech == AccessTechnology.PppoE)
+        if (!CarriesPppoe(tech))
             return profile;
 
         var rtt = PppoeIdleRttOffsetMs(tech);
@@ -896,7 +935,12 @@ public static class IspHealthProfiles
             LoadedLossUpHighPct = profile.LoadedLossUpHighPct + PppoeLoadedLossHighPct,
             JitterIdealMs = InQuadrature(profile.JitterIdealMs, PppoeJitterMs),
             JitterTypicalMs = InQuadrature(profile.JitterTypicalMs, PppoeJitterMs),
-            JitterPoorMs = InQuadrature(profile.JitterPoorMs, PppoeJitterMs)
+            JitterPoorMs = InQuadrature(profile.JitterPoorMs, PppoeJitterMs),
+            StabilityMadIdealMs = InQuadrature(profile.StabilityMadIdealMs, PppoeStabilityMadMs),
+            StabilityMadTypicalMs = InQuadrature(profile.StabilityMadTypicalMs, PppoeStabilityMadMs),
+            StabilityMadPoorMs = InQuadrature(profile.StabilityMadPoorMs, PppoeStabilityMadMs),
+            LoadedDeltaExcellentMs = profile.LoadedDeltaExcellentMs + PppoeLoadedDeltaExcellentMs,
+            LoadedDeltaAcceptableMs = profile.LoadedDeltaAcceptableMs + PppoeLoadedDeltaAcceptableMs
         };
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -784,14 +784,16 @@ public static class IspHealthProfiles
             JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0,
             StabilityMadIdealMs: 0.35, StabilityMadTypicalMs: 0.9, StabilityMadPoorMs: 3.5),
 
-        // PPPoE and Other are the same profile in everything but the display name: PPPoE is an
-        // encapsulation, not a medium, so it splits nothing here. That is why it is no longer
-        // offered in the Upstream Discovery selector and Upstream Discovery redirects a stored
-        // PppoE to a vendor-derived medium when it can - the user picks what the session rides
-        // (GPON, DSL, Active Ethernet) and gets that medium's thresholds instead of this wide
-        // band. The value stays mapped for WANs still carrying it. If a real PPPoE-specific
-        // split is ever wanted, it needs no user input: a PPPoE WAN's uplink interface is named
-        // ppp* (uplink_ifname "ppp0") and its network config carries wan_type "pppoe".
+        // PPPoE currently shares Other's neutral band, but that is a placeholder, not a verdict:
+        // PPPoE is expected to earn scoring behavior of its own (session/BNG overhead, MTU, the
+        // aggregation tier's own latency and buffering) once there is enough field data to
+        // calibrate it. Whatever that turns out to be, it will not come from a dropdown - PPPoE
+        // is an encapsulation, so it can ride GPON, DSL or Active Ethernet, and the medium and
+        // the encapsulation have to be scored as two facts rather than one choice. ISP Health can
+        // read the encapsulation for itself: a PPPoE WAN's uplink interface is named ppp*
+        // (uplink_ifname "ppp0") and its network config carries wan_type "pppoe". So the selector
+        // asks only for the medium, and Upstream Discovery redirects a stored PppoE to a
+        // vendor-derived one when it can. The value stays mapped for WANs still carrying it.
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),
         AccessTechnology.Other => NeutralProfile("Other"),
         _ => null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -784,6 +784,14 @@ public static class IspHealthProfiles
             JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0,
             StabilityMadIdealMs: 0.35, StabilityMadTypicalMs: 0.9, StabilityMadPoorMs: 3.5),
 
+        // PPPoE and Other are the same profile in everything but the display name: PPPoE is an
+        // encapsulation, not a medium, so it splits nothing here. That is why it is no longer
+        // offered in the Upstream Discovery selector and Upstream Discovery redirects a stored
+        // PppoE to a vendor-derived medium when it can - the user picks what the session rides
+        // (GPON, DSL, Active Ethernet) and gets that medium's thresholds instead of this wide
+        // band. The value stays mapped for WANs still carrying it. If a real PPPoE-specific
+        // split is ever wanted, it needs no user input: a PPPoE WAN's uplink interface is named
+        // ppp* (uplink_ifname "ppp0") and its network config carries wan_type "pppoe".
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),
         AccessTechnology.Other => NeutralProfile("Other"),
         _ => null

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -800,6 +800,102 @@ public static class IspHealthProfiles
     };
 
     /// <summary>
+    /// Idle-RTT offset (ms) added to every anchor when the WAN runs a PPPoE session, by medium.
+    /// PPPoE terminates on a BNG, and the BNG is usually not at the OLT/DSLAM - it aggregates
+    /// deeper, so the first routed hop is topologically further out. The encapsulation itself
+    /// costs nothing measurable (8 bytes, 64 ns of serialization at 1 Gbps); this offset is
+    /// purely the extra distance to the session's endpoint. Additive rather than proportional
+    /// because it is a fixed topology cost, not a property of the medium, so `poor` shifts by
+    /// the same amount as `ideal`.
+    ///
+    /// 2.0 ms for PON is measured, from the Deutsche Telekom population - wholesale-access
+    /// markets (DE, UK, AU, NZ, IE) hand off at a regional POP and are where PPPoE is near
+    /// universal. Active Ethernet and Fixed Wireless get 1.0: AE + PPPoE is mostly regional
+    /// and municipal builds terminating at the local exchange, and WISP PPPoE terminates on the
+    /// operator's own BNG at the tower or NOC. Both are short hops next to a national handover.
+    ///
+    /// DSL's 1.0 is the one reasoned rather than observed number here. Its base band is already
+    /// wide and its calibration comment cites "old BNG" buffering as dragging the typical case,
+    /// so the full 2.0 would partly double-count - but the 6.0 ms ideal anchor describes a clean
+    /// copper loop, which is medium-only, so zero would under-adjust. Revisit with DT VDSL data.
+    ///
+    /// Everything else is 0: DOCSIS provisions over DHCP and Starlink/cellular terminate their
+    /// own way, so PPPoE is not expected there at all. If ppp* ever does show up on one, the
+    /// medium's own band is a better answer than an offset nobody has measured.
+    /// </summary>
+    private static double PppoeIdleRttOffsetMs(AccessTechnology tech) => tech switch
+    {
+        AccessTechnology.Gpon or AccessTechnology.XgsPon => 2.0,
+        AccessTechnology.DirectEthernet or AccessTechnology.FixedWireless => 1.0,
+        AccessTechnology.Dsl => 1.0,
+        _ => 0.0
+    };
+
+    /// <summary>Jitter (ms) the BNG contributes, composed in quadrature - see <see cref="ApplyPppoeSession"/>.</summary>
+    private const double PppoeJitterMs = 0.25;
+
+    /// <summary>Loaded-loss (percentage points) the BNG contributes at the low / high anchors.</summary>
+    private const double PppoeLoadedLossLowPct = 0.5;
+    private const double PppoeLoadedLossHighPct = 1.0;
+
+    /// <summary>
+    /// Overlays the cost of a PPPoE session on the medium's profile. Called only when the WAN's
+    /// data-path interface is ppp* (<see cref="NetworkUtilities.IsPppoeInterface"/>), so it is
+    /// driven by what the gateway reports rather than by anything the user picked - PPPoE is an
+    /// encapsulation and the medium underneath it is a separate fact, which is why the access
+    /// technology selector asks only for the medium.
+    ///
+    /// Each axis composes the way its underlying quantity does:
+    ///
+    /// - Idle RTT adds. Two serial path segments' delays sum, so the BNG offset lands on every
+    ///   anchor equally (see <see cref="PppoeIdleRttOffsetMs"/>).
+    /// - Jitter adds in quadrature - sqrt(a^2 + b^2) - because independent variance sources
+    ///   compose that way, not linearly. This gives the right shape for free: 0.25 ms of BNG
+    ///   jitter moves GPON's 0.4 ms ideal anchor to 0.47 (+18%) but its 3.0 ms poor anchor to
+    ///   3.01 (+0.3%). A fixed independent contributor matters when the medium is quiet and
+    ///   vanishes when it is already noisy. Adding linearly would push the ideal anchor to
+    ///   0.65 (+63%) and let a genuinely jittery line score a flat 100.
+    /// - Loaded loss adds, in percentage points. Independent loss stages compose as
+    ///   1-(1-a)(1-b), which for small values is a+b. The BNG enforces the plan rate per
+    ///   subscriber and the enforcement point is a drop point (a policer drops on exceed; a
+    ///   shaper queues then tail-drops), so it is a constant contribution from a different
+    ///   device rather than a multiple of the medium's. Multiplying instead would take DSL's
+    ///   already-wide 3/5 to 6/10, which is permissive past the point of being useful.
+    ///
+    /// StabilityMad and the loaded deltas are deliberately NOT adjusted yet - both should move
+    /// on the same reasoning, neither has a number behind it, and an unfounded constant here
+    /// becomes the thing future measurements get compared against.
+    ///
+    /// Caveat worth keeping in view when this gets recalibrated: UniFi gateways terminate the
+    /// PPPoE session in software and drop out of the hardware fast path doing it, so part of the
+    /// loaded loss we attribute to the BNG is our own CPE saturating. It is separable (CPE drops
+    /// track gateway CPU and show on both WANs of a dual-WAN box; a BNG effect shows on one),
+    /// but only if gateway CPU is recorded alongside. Until then the loss adders stay small on
+    /// purpose - an over-wide loss band would mask an undersized gateway as "normal for PPPoE".
+    /// </summary>
+    public static AccessProfile ApplyPppoeSession(AccessProfile profile, AccessTechnology tech)
+    {
+        var rtt = PppoeIdleRttOffsetMs(tech);
+        static double? InQuadrature(double? band, double added)
+            => band is { } b ? Math.Round(Math.Sqrt(b * b + added * added), 2) : null;
+
+        return profile with
+        {
+            IdleRttIdealMs = profile.IdleRttIdealMs + rtt,
+            IdleRttNormalLowMs = profile.IdleRttNormalLowMs + rtt,
+            IdleRttNormalHighMs = profile.IdleRttNormalHighMs + rtt,
+            IdleRttPoorMs = profile.IdleRttPoorMs + rtt,
+            LoadedLossDownLowPct = profile.LoadedLossDownLowPct + PppoeLoadedLossLowPct,
+            LoadedLossDownHighPct = profile.LoadedLossDownHighPct + PppoeLoadedLossHighPct,
+            LoadedLossUpLowPct = profile.LoadedLossUpLowPct + PppoeLoadedLossLowPct,
+            LoadedLossUpHighPct = profile.LoadedLossUpHighPct + PppoeLoadedLossHighPct,
+            JitterIdealMs = InQuadrature(profile.JitterIdealMs, PppoeJitterMs),
+            JitterTypicalMs = InQuadrature(profile.JitterTypicalMs, PppoeJitterMs),
+            JitterPoorMs = InQuadrature(profile.JitterPoorMs, PppoeJitterMs)
+        };
+    }
+
+    /// <summary>
     /// Wide-band profile for technologies where the underlying medium is ambiguous.
     /// Deliberately less discriminating so neither fiber nor DSL users are penalized.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -784,16 +784,13 @@ public static class IspHealthProfiles
             JitterIdealMs: 1.0, JitterTypicalMs: 2.0, JitterPoorMs: 5.0,
             StabilityMadIdealMs: 0.35, StabilityMadTypicalMs: 0.9, StabilityMadPoorMs: 3.5),
 
-        // PPPoE currently shares Other's neutral band, but that is a placeholder, not a verdict:
-        // PPPoE is expected to earn scoring behavior of its own (session/BNG overhead, MTU, the
-        // aggregation tier's own latency and buffering) once there is enough field data to
-        // calibrate it. Whatever that turns out to be, it will not come from a dropdown - PPPoE
-        // is an encapsulation, so it can ride GPON, DSL or Active Ethernet, and the medium and
-        // the encapsulation have to be scored as two facts rather than one choice. ISP Health can
-        // read the encapsulation for itself: a PPPoE WAN's uplink interface is named ppp*
-        // (uplink_ifname "ppp0") and its network config carries wan_type "pppoe". So the selector
-        // asks only for the medium, and Upstream Discovery redirects a stored PppoE to a
-        // vendor-derived one when it can. The value stays mapped for WANs still carrying it.
+        // PPPoE is no longer scored HERE - a session is detected from the gateway and overlaid on
+        // the medium's profile instead (see ApplyPppoeSession), because PPPoE is an encapsulation
+        // riding GPON, DSL or Active Ethernet and the two are independent facts. This entry is the
+        // legacy path only: WANs stored as PppoE from before it left the selector, which name no
+        // medium at all and so can only fall back to the neutral band. Upstream Discovery
+        // redirects them to a vendor-derived medium when it can, and ApplyPppoeSession exempts
+        // this profile so a stored PppoE on a real ppp* interface is not forgiven twice.
         AccessTechnology.PppoE => NeutralProfile("PPPoE"),
         AccessTechnology.Other => NeutralProfile("Other"),
         _ => null
@@ -875,6 +872,14 @@ public static class IspHealthProfiles
     /// </summary>
     public static AccessProfile ApplyPppoeSession(AccessProfile profile, AccessTechnology tech)
     {
+        // A WAN still stored as PppoE already scores on the neutral stand-in FOR a PPPoE line, so
+        // overlaying on top of it would forgive the same session twice. Legacy value, real ppp*
+        // interface, and the honest answer is that the medium is unknown - not that it is unknown
+        // AND further away. Other is deliberately not exempt: it means "some medium we don't
+        // list", which a PPPoE session genuinely does sit on top of.
+        if (tech == AccessTechnology.PppoE)
+            return profile;
+
         var rtt = PppoeIdleRttOffsetMs(tech);
         static double? InQuadrature(double? band, double added)
             => band is { } b ? Math.Round(Math.Sqrt(b * b + added * added), 2) : null;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
@@ -164,8 +164,7 @@ public class IspHealthPdfGenerator
 
                 row.RelativeItem(2).Column(detail =>
                 {
-                    LabelledLine(detail, "Scored as",
-                        $"{report.Profile.DisplayName} ({IspHealthPresentation.FormatTechName(report.AccessTechnology)})");
+                    LabelledLine(detail, "Scored as", IspHealthPresentation.ScoredAsLabel(report));
                     LabelledLine(detail, "Window",
                         $"{IspHealthPresentation.WindowLabel(report)} - {IspHealthPresentation.WindowRangeLabel(report)}");
                     LabelledLine(detail, "Computed", report.ComputedAt.ToLocalTime().ToString("MMM d, yyyy HH:mm"));

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
@@ -205,6 +205,11 @@ public static class IspHealthPresentation
 
     public static string FormatLossPct(double? pct) => pct switch { null => "--", 0 => "0%", _ => $"{pct.Value:0.##}%" };
 
+    /// <summary>
+    /// The access medium's name for exports, with its qualifier where one helps ("DOCSIS (Cable)").
+    /// Every enum member is named explicitly: the old catch-all fell through to tech.ToString(),
+    /// which printed the C# casing - a legacy PppoE site's PDF read "PppoE".
+    /// </summary>
     public static string FormatTechName(AccessTechnology tech) => tech switch
     {
         AccessTechnology.Gpon => "GPON",
@@ -212,11 +217,32 @@ public static class IspHealthPresentation
         AccessTechnology.Docsis => "DOCSIS (Cable)",
         AccessTechnology.DirectEthernet => "Active Ethernet",
         AccessTechnology.FixedWireless => "Fixed Wireless",
-        AccessTechnology.Satellite => "Satellite",
+        AccessTechnology.Satellite => "Satellite (LEO)",
         AccessTechnology.Cellular => "Cellular",
         AccessTechnology.Dsl => "DSL (ADSL/VDSL)",
-        _ => tech.ToString()
+        AccessTechnology.PppoE => "PPPoE",
+        AccessTechnology.Other => "Other",
+        AccessTechnology.Unknown => "Not detected",
+        _ => "Not detected"
     };
+
+    /// <summary>
+    /// How the scored profile is named in an export: the medium, plus the encapsulation when a
+    /// session is detected - "GPON (PPPoE)", "DSL (ADSL/VDSL, PPPoE)". PPPoE folds into the
+    /// medium's existing qualifier rather than stacking a second bracket after it.
+    ///
+    /// Replaces "{Profile.DisplayName} ({FormatTechName})", which printed the technology twice
+    /// ("DOCSIS (DOCSIS (Cable))") and had nowhere to put the session. The medium is the single
+    /// source here; the profile's own DisplayName says the same thing less precisely.
+    /// </summary>
+    public static string ScoredAsLabel(IspHealthReport report)
+    {
+        var medium = FormatTechName(report.AccessTechnology);
+        if (!report.PppoeSession) return medium;
+        return medium.EndsWith(')')
+            ? $"{medium[..^1]}, PPPoE)"
+            : $"{medium} (PPPoE)";
+    }
 
     /// <summary>How an ASN is labelled on the Networks on Your Path card.</summary>
     public static string AsnDisplayName(IspAsnHealth asn) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -592,6 +592,32 @@ public class IspHealthService
         if (ispTargets.Count == 0 && transitTargets.Count == 0)
             return new ComputeOutcome(IspHealthStatus.NeedsDiscovery, null, new List<AsnSeries>());
 
+        // Everything below that comes from the console is only trustworthy once the console has
+        // actually SERVED something, and no connection flag tells us that. IsConnected - and so
+        // CanCompute, and WaitForConnectionAsync, which just polls it - means a login succeeded.
+        // It is true before the first stat/device call ever runs, and UniFiApiClient.GetDevicesAsync
+        // returns an EMPTY LIST rather than throwing when that call fails, without caching the
+        // failure. So on the first compute after a restart every console-derived input can come
+        // back empty while every gate reads healthy: no PPPoE overlay, and no expected WAN speeds,
+        // which drops HasExpectedSpeeds and skips loaded analysis altogether. The report is then
+        // cached for CacheTtl, so one unlucky first call sets the score for 15 minutes.
+        //
+        // Getting a device list back is the proof, and it is the same fetch the PPPoE lookup and
+        // the expected-speed lookup ride on: if it answered, they can too. Deferring is safe - a
+        // null report leaves _cached untouched (only forceRefresh clears it) and the TTL
+        // short-circuit needs a cached report to fire, so the very next read recomputes.
+        //
+        // Gated on the list being EMPTY, not on finding a gateway. A site whose devices are all
+        // switches and APs behind a third-party router legitimately has no gateway, and must still
+        // be able to score.
+        var discoveredDevices = await _connectionService.GetDiscoveredDevicesAsync(ct);
+        if (discoveredDevices.Count == 0)
+        {
+            _logger.LogWarning("ISP Health: the console returned no devices, so its data is not yet trustworthy; " +
+                "deferring rather than caching a report computed without the console-derived inputs");
+            return new ComputeOutcome(IspHealthStatus.AwaitingConnection, null, new List<AsnSeries>());
+        }
+
         var profile = IspHealthProfiles.GetProfile(technology);
         if (profile == null)
             return new ComputeOutcome(IspHealthStatus.NeedsTechnology, null, new List<AsnSeries>());
@@ -607,12 +633,12 @@ public class IspHealthService
         if (pppoeSession == true)
             profile = IspHealthProfiles.ApplyPppoeSession(profile, technology);
 
-        // First gateway from the cached UniFi device list (shadow-mode multi-gateway isn't handled
+        // First gateway from the device list above (shadow-mode multi-gateway isn't handled
         // yet - first gateway is fine), matched to its fabric monitoring target by MAC so we can pull
         // its loss for outage scoping. Null when no gateway is monitored - outage scoping then stays
         // unchanged (no Local scope possible).
         static string MacKey(string? m) => new string((m ?? "").Where(Uri.IsHexDigit).ToArray()).ToLowerInvariant();
-        var gatewayDevice = (await _connectionService.GetDiscoveredDevicesAsync(ct)).FirstOrDefault(d => d.Type.IsGateway());
+        var gatewayDevice = discoveredDevices.FirstOrDefault(d => d.Type.IsGateway());
         var gatewayTarget = gatewayDevice == null ? null
             : fabricTargets.FirstOrDefault(t => MacKey(t.DeviceMac) == MacKey(gatewayDevice.Mac));
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -601,8 +601,10 @@ public class IspHealthService
         // from the user: the encapsulation and the medium are independent facts, and only the
         // medium needs asking for. Scoped to the primary WAN, matching what ISP Health grades
         // (see the multi-WAN TODO above).
+        // Null (couldn't tell) scores like false - there is nothing else it can do - but it is
+        // logged as the unknown it is rather than passed off as a settled answer.
         var pppoeSession = await IsPppoeWanAsync(ct);
-        if (pppoeSession)
+        if (pppoeSession == true)
             profile = IspHealthProfiles.ApplyPppoeSession(profile, technology);
 
         // First gateway from the cached UniFi device list (shadow-mode multi-gateway isn't handled
@@ -1155,7 +1157,7 @@ public class IspHealthService
         report.WanName = scoredWan?.Name;
         report.WanNetworkGroup = scoredWan?.NetworkGroup;
         report.WanInterface = scoredWan?.Interface;
-        report.PppoeSession = pppoeSession;
+        report.PppoeSession = pppoeSession == true;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
@@ -1166,24 +1168,47 @@ public class IspHealthService
     /// data-path interface name (uplink_ifname) - "ppp0" is a PPPoE session and nothing else.
     /// Cheap: the underlying device call is already cached.
     ///
-    /// Answers false on any failure. A missing or unreadable answer must leave the medium's own
-    /// profile in place rather than widen it - the overlay is forgiveness, so guessing "yes"
-    /// would grade a non-PPPoE line too leniently on the strength of a failed lookup.
+    /// Three-valued on purpose. False means we read an interface and it is not PPPoE; NULL means
+    /// we could not tell, and the two must not be conflated. There is no safe default to collapse
+    /// them onto: assuming PPPoE would grade an ordinary line too leniently, and assuming no PPPoE
+    /// grades a real PPPoE line against thresholds that expect a nearby first hop - the exact
+    /// mis-scoring the overlay exists to fix.
+    ///
+    /// Unknown is more reachable than it looks, and none of it throws.
+    /// <see cref="UniFiConnectionService.GetPrimaryWanInterfacesAsync"/> returns null when the
+    /// primary WAN cannot be resolved, when no gateway is in the device list, or when no wan
+    /// object matches the primary networkgroup; GetNetworksAsync returns an EMPTY LIST rather
+    /// than throwing when the console is not connected. So a try/catch catches none of it and the
+    /// caller has to handle null explicitly.
+    ///
+    /// Logged at Warning, not Debug, for the same reason as the speed-test pool below: the result
+    /// is baked into a report that is then cached for CacheTtl, so a silent unknown reads as a
+    /// settled "not PPPoE" for 15 minutes. It self-heals on the next recompute, and immediately on
+    /// a forced refresh (which clears the console caches first).
     /// </summary>
-    private async Task<bool> IsPppoeWanAsync(CancellationToken ct)
+    private async Task<bool?> IsPppoeWanAsync(CancellationToken ct)
     {
         try
         {
             var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct);
+            if (string.IsNullOrEmpty(dataPath))
+            {
+                _logger.LogWarning("ISP Health could not resolve the primary WAN's data-path interface; " +
+                    "scoring without the PPPoE overlay, so a PPPoE line will grade against its medium's " +
+                    "unadjusted thresholds until the next recompute");
+                return null;
+            }
+
             var isPppoe = NetworkUtilities.IsPppoeInterface(dataPath);
-            if (isPppoe)
-                _logger.LogDebug("ISP Health: PPPoE session detected on primary WAN ({Interface}); applying the PPPoE overlay", dataPath);
+            _logger.LogDebug("ISP Health: primary WAN data-path interface is {Interface}; PPPoE overlay {Applied}",
+                dataPath, isPppoe ? "applied" : "not applicable");
             return isPppoe;
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "ISP Health: could not resolve the primary WAN data-path interface; scoring without the PPPoE overlay");
-            return false;
+            _logger.LogWarning(ex, "ISP Health could not resolve the primary WAN's data-path interface; " +
+                "scoring without the PPPoE overlay until the next recompute");
+            return null;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -592,24 +592,11 @@ public class IspHealthService
         if (ispTargets.Count == 0 && transitTargets.Count == 0)
             return new ComputeOutcome(IspHealthStatus.NeedsDiscovery, null, new List<AsnSeries>());
 
-        // Everything below that comes from the console is only trustworthy once the console has
-        // actually SERVED something, and no connection flag tells us that. IsConnected - and so
-        // CanCompute, and WaitForConnectionAsync, which just polls it - means a login succeeded.
-        // It is true before the first stat/device call ever runs, and UniFiApiClient.GetDevicesAsync
-        // returns an EMPTY LIST rather than throwing when that call fails, without caching the
-        // failure. So on the first compute after a restart every console-derived input can come
-        // back empty while every gate reads healthy: no PPPoE overlay, and no expected WAN speeds,
-        // which drops HasExpectedSpeeds and skips loaded analysis altogether. The report is then
-        // cached for CacheTtl, so one unlucky first call sets the score for 15 minutes.
-        //
-        // Getting a device list back is the proof, and it is the same fetch the PPPoE lookup and
-        // the expected-speed lookup ride on: if it answered, they can too. Deferring is safe - a
-        // null report leaves _cached untouched (only forceRefresh clears it) and the TTL
-        // short-circuit needs a cached report to fire, so the very next read recomputes.
-        //
-        // Gated on the list being EMPTY, not on finding a gateway. A site whose devices are all
-        // switches and APs behind a third-party router legitimately has no gateway, and must still
-        // be able to score.
+        // Proof the console actually served data. IsConnected only means the login succeeded, and
+        // GetDevicesAsync returns an empty list rather than throwing, so without this a restart can
+        // cache a report that silently lost the PPPoE overlay and expected WAN speeds. A null
+        // report leaves _cached untouched, so the next read recomputes. Empty list rather than a
+        // missing gateway: a site behind a third-party router has no gateway and must still score.
         var discoveredDevices = await _connectionService.GetDiscoveredDevicesAsync(ct);
         if (discoveredDevices.Count == 0)
         {
@@ -1194,23 +1181,11 @@ public class IspHealthService
     /// data-path interface name (uplink_ifname) - "ppp0" is a PPPoE session and nothing else.
     /// Cheap: the underlying device call is already cached.
     ///
-    /// Three-valued on purpose. False means we read an interface and it is not PPPoE; NULL means
-    /// we could not tell, and the two must not be conflated. There is no safe default to collapse
-    /// them onto: assuming PPPoE would grade an ordinary line too leniently, and assuming no PPPoE
-    /// grades a real PPPoE line against thresholds that expect a nearby first hop - the exact
-    /// mis-scoring the overlay exists to fix.
-    ///
-    /// Unknown is more reachable than it looks, and none of it throws.
-    /// <see cref="UniFiConnectionService.GetPrimaryWanInterfacesAsync"/> returns null when the
-    /// primary WAN cannot be resolved, when no gateway is in the device list, or when no wan
-    /// object matches the primary networkgroup; GetNetworksAsync returns an EMPTY LIST rather
-    /// than throwing when the console is not connected. So a try/catch catches none of it and the
-    /// caller has to handle null explicitly.
-    ///
-    /// Logged at Warning, not Debug, for the same reason as the speed-test pool below: the result
-    /// is baked into a report that is then cached for CacheTtl, so a silent unknown reads as a
-    /// settled "not PPPoE" for 15 minutes. It self-heals on the next recompute, and immediately on
-    /// a forced refresh (which clears the console caches first).
+    /// Three-valued on purpose: false means we read an interface and it is not PPPoE, null means we
+    /// could not tell. Neither default is safe - assuming PPPoE grades an ordinary line too
+    /// leniently, assuming no PPPoE grades a real one too harshly. The resolver signals its
+    /// failures by returning null rather than throwing, so the caller has to handle it explicitly.
+    /// Warning-level because the answer is cached in the report for CacheTtl.
     /// </summary>
     private async Task<bool?> IsPppoeWanAsync(CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -596,6 +596,15 @@ public class IspHealthService
         if (profile == null)
             return new ComputeOutcome(IspHealthStatus.NeedsTechnology, null, new List<AsnSeries>());
 
+        // A PPPoE session costs latency and loaded loss on top of whatever the medium does, so it
+        // is overlaid on the medium's profile rather than replacing it. Read from the gateway, not
+        // from the user: the encapsulation and the medium are independent facts, and only the
+        // medium needs asking for. Scoped to the primary WAN, matching what ISP Health grades
+        // (see the multi-WAN TODO above).
+        var pppoeSession = await IsPppoeWanAsync(ct);
+        if (pppoeSession)
+            profile = IspHealthProfiles.ApplyPppoeSession(profile, technology);
+
         // First gateway from the cached UniFi device list (shadow-mode multi-gateway isn't handled
         // yet - first gateway is fine), matched to its fabric monitoring target by MAC so we can pull
         // its loss for outage scoping. Null when no gateway is monitored - outage scoping then stays
@@ -1146,9 +1155,36 @@ public class IspHealthService
         report.WanName = scoredWan?.Name;
         report.WanNetworkGroup = scoredWan?.NetworkGroup;
         report.WanInterface = scoredWan?.Interface;
+        report.PppoeSession = pppoeSession;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
+    }
+
+    /// <summary>
+    /// Whether the primary WAN carries its traffic over a PPPoE session, read from the gateway's
+    /// data-path interface name (uplink_ifname) - "ppp0" is a PPPoE session and nothing else.
+    /// Cheap: the underlying device call is already cached.
+    ///
+    /// Answers false on any failure. A missing or unreadable answer must leave the medium's own
+    /// profile in place rather than widen it - the overlay is forgiveness, so guessing "yes"
+    /// would grade a non-PPPoE line too leniently on the strength of a failed lookup.
+    /// </summary>
+    private async Task<bool> IsPppoeWanAsync(CancellationToken ct)
+    {
+        try
+        {
+            var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct);
+            var isPppoe = NetworkUtilities.IsPppoeInterface(dataPath);
+            if (isPppoe)
+                _logger.LogDebug("ISP Health: PPPoE session detected on primary WAN ({Interface}); applying the PPPoE overlay", dataPath);
+            return isPppoe;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "ISP Health: could not resolve the primary WAN data-path interface; scoring without the PPPoE overlay");
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -128,6 +128,11 @@ public class PhysicalLinkResolver
             case AccessTechnology.PppoE:
                 // Carve-out: PPPoE often rides PON. If exactly one PON source is monitored,
                 // it is safe to assume it is the user's WAN; otherwise stay out of it.
+                // Kept for WANs still stored as PppoE - it is no longer selectable in Upstream
+                // Discovery, since picking the medium it rides resolves the physical link
+                // outright instead of guessing at it. Note the branch does not need the stored
+                // value to know the session is PPPoE: the WAN's uplink interface is named ppp*
+                // (uplink_ifname "ppp0") and its network config carries wan_type "pppoe".
                 var pon = await PonCandidatesAsync(db, ct);
                 return pon.Count == 1 ? pon : new List<Cand>();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/PhysicalLinkResolver.cs
@@ -130,9 +130,12 @@ public class PhysicalLinkResolver
                 // it is safe to assume it is the user's WAN; otherwise stay out of it.
                 // Kept for WANs still stored as PppoE - it is no longer selectable in Upstream
                 // Discovery, since picking the medium it rides resolves the physical link
-                // outright instead of guessing at it. Note the branch does not need the stored
-                // value to know the session is PPPoE: the WAN's uplink interface is named ppp*
-                // (uplink_ifname "ppp0") and its network config carries wan_type "pppoe".
+                // outright instead of guessing at it. The guess stays available regardless of
+                // the stored value: ISP Health can tell a PPPoE session on its own, because the
+                // WAN's uplink interface is named ppp* (uplink_ifname "ppp0") and its network
+                // config carries wan_type "pppoe". Worth wiring up here when PPPoE gets scoring
+                // behavior of its own - the encapsulation is then a fact we detect, layered on
+                // the medium the user picked, rather than a choice competing with it.
                 var pon = await PonCandidatesAsync(db, ct);
                 return pon.Count == 1 ? pon : new List<Cand>();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -864,9 +864,10 @@ public class UpstreamTracerService
         // Unknown makes all of them fall back to generic. Only proposes into an empty slot -
         // a user's (or an earlier run's) choice is never overwritten.
         //
-        // A stored PppoE counts as empty here. PPPoE names an encapsulation, not a medium, so
-        // it scores on the same wide neutral profile as Other (IspHealthProfiles.GetProfile)
-        // and a vendor-derived medium is strictly better evidence. Nothing ever infers PPPoE -
+        // A stored PppoE counts as empty here. PPPoE names an encapsulation, not a medium, so a
+        // vendor-derived medium is strictly better evidence for this field, and the redirect
+        // costs nothing even once PPPoE earns scoring behavior of its own: the encapsulation is
+        // re-derivable any time from uplink_ifname "ppp0" / wan_type "pppoe". Nothing infers PPPoE -
         // TechnologyFromVendor cannot return it, and it is no longer in the Upstream Discovery
         // dropdown - so this only redirects values picked before it was removed.
         if (State.AccessTechnology is AccessTechnology.Unknown or AccessTechnology.PppoE)
@@ -2069,12 +2070,13 @@ public class UpstreamTracerService
     /// AccessHop. Spec 5.5 documents this priority.
     ///
     /// The PppoE branch here (and in <see cref="InferL2NeighborRole"/> and
-    /// <see cref="LabelL2Role"/>) is the only place PPPoE splits behavior deterministically -
-    /// it does not split scoring, where it shares Other's neutral profile. It stays for WANs
-    /// still stored as PppoE, but it never needed the stored value: a PPPoE WAN announces
-    /// itself in the gateway interface name (uplink_ifname "ppp0", already read into
-    /// <see cref="_wanUplinkIfName"/>) and in the network config's wan_type "pppoe". So the BNG
-    /// label can be driven off the interface while the user picks the medium PPPoE rides.
+    /// <see cref="LabelL2Role"/>) is where PPPoE splits behavior today; ISP Health scoring is
+    /// expected to split on it too once there is field data to calibrate against. Neither split
+    /// needs the stored value, which is why PPPoE left the Upstream Discovery selector: a PPPoE
+    /// WAN announces itself in the gateway interface name (uplink_ifname "ppp0", already read
+    /// into <see cref="_wanUplinkIfName"/>) and in the network config's wan_type "pppoe". Drive
+    /// the BNG label off that, and the user is left picking only the medium PPPoE rides - the
+    /// two are independent facts and both are then available to score on.
     /// </summary>
     private static UpstreamRole InferAccessRole(AttributedHop hop, AccessTechnology tech, string? ouiVendor)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -863,7 +863,13 @@ public class UpstreamTracerService
         // nothing: the reachability gate and every role label key off the technology, and
         // Unknown makes all of them fall back to generic. Only proposes into an empty slot -
         // a user's (or an earlier run's) choice is never overwritten.
-        if (State.AccessTechnology == AccessTechnology.Unknown)
+        //
+        // A stored PppoE counts as empty here. PPPoE names an encapsulation, not a medium, so
+        // it scores on the same wide neutral profile as Other (IspHealthProfiles.GetProfile)
+        // and a vendor-derived medium is strictly better evidence. Nothing ever infers PPPoE -
+        // TechnologyFromVendor cannot return it, and it is no longer in the Upstream Discovery
+        // dropdown - so this only redirects values picked before it was removed.
+        if (State.AccessTechnology is AccessTechnology.Unknown or AccessTechnology.PppoE)
         {
             var inferred = TechnologyFromVendor(State.WanNeighborOuiVendor);
             if (inferred != null)
@@ -2061,6 +2067,14 @@ public class UpstreamTracerService
     /// hop position. Hop 1 behind a transparent L2 device (GPON OLT, etc.) is a BNG;
     /// hop 1 on DOCSIS is typically the CMTS; without any context it's a generic
     /// AccessHop. Spec 5.5 documents this priority.
+    ///
+    /// The PppoE branch here (and in <see cref="InferL2NeighborRole"/> and
+    /// <see cref="LabelL2Role"/>) is the only place PPPoE splits behavior deterministically -
+    /// it does not split scoring, where it shares Other's neutral profile. It stays for WANs
+    /// still stored as PppoE, but it never needed the stored value: a PPPoE WAN announces
+    /// itself in the gateway interface name (uplink_ifname "ppp0", already read into
+    /// <see cref="_wanUplinkIfName"/>) and in the network config's wan_type "pppoe". So the BNG
+    /// label can be driven off the interface while the user picks the medium PPPoE rides.
     /// </summary>
     private static UpstreamRole InferAccessRole(AttributedHop hop, AccessTechnology tech, string? ouiVendor)
     {

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -1320,9 +1320,16 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         var discovery = new UniFiDiscovery(_client, discoveryLogger);
         var devices = await discovery.DiscoverDevicesAsync(cancellationToken);
 
-        // Cache the result
-        _cachedDevices = devices;
-        _deviceCacheTime = DateTime.UtcNow;
+        // Cache a real answer only. DiscoverDevicesAsync returns an empty list rather than throwing
+        // when the fetch fails, and UniFiApiClient deliberately doesn't cache that failure - caching
+        // it here would undo that and blank the device list for every consumer until it expires.
+        // The one genuinely device-less site is a standalone UniFi OS Server, which can afford the
+        // re-query.
+        if (devices.Count > 0)
+        {
+            _cachedDevices = devices;
+            _deviceCacheTime = DateTime.UtcNow;
+        }
 
         return devices;
     }
@@ -1338,7 +1345,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
     /// <summary>
     /// Gets the list of configured networks from the UniFi controller.
-    /// Results are cached for 5 minutes.
+    /// Successful results are cached for <see cref="NetworkCacheDuration"/>.
     /// </summary>
     public async Task<List<NetworkInfo>> GetNetworksAsync(CancellationToken cancellationToken = default)
     {
@@ -1356,7 +1363,17 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
 
         var networks = await _client.GetNetworkConfigsAsync(cancellationToken);
 
-        _cachedNetworks = networks?.Select(n => new NetworkInfo
+        // Same rule as the device list: a failed fetch is not an answer. GetNetworkConfigsAsync
+        // returns null rather than throwing, and the old "?? new List<NetworkInfo>()" cached that
+        // as "this console has no networks" - which is what the primary-WAN lookup and expected WAN
+        // speeds read, so one transient failure hid both until the cache expired.
+        if (networks == null || networks.Count == 0)
+        {
+            _logger.LogWarning("No networks returned from the console; not caching, so the next request retries");
+            return new List<NetworkInfo>();
+        }
+
+        _cachedNetworks = networks.Select(n => new NetworkInfo
         {
             Id = n.Id,
             Name = n.Name,
@@ -1378,7 +1395,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             WanLoadBalanceWeight = n.WanLoadBalanceWeight,
             WanFailoverPriority = n.WanFailoverPriority,
             WanIfname = n.WanIfname
-        }).ToList() ?? new List<NetworkInfo>();
+        }).ToList();
         _networkCacheTime = DateTime.UtcNow;
 
         return _cachedNetworks;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -458,6 +458,8 @@ h1:focus {
 }
 .wan-chart-seekable {
     position: relative;
+}
+.wan-chart-seekable.wan-chart-seek-hot {
     cursor: crosshair;
 }
 .wan-chart-mode-cluster {

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -78,14 +78,31 @@ function formatBps(v) {
     return v.toFixed(0) + ' bps';
 }
 
-// Map a click inside the chart to the instant under the cursor. The inner
-// (grid) group's rect avoids translate math; its width is the plotted span.
+// The plot (grid) rect: exactly the X-Y area, excluding the axis gutters and
+// the label strip. .apexcharts-grid rather than .apexcharts-inner - the inner
+// group's bounding box is the union of its children, and the scrolling
+// annotation tick labels overflow the plot edge into the gutters. The grid
+// group is the same rect ApexCharts' own tooltip bounds-check reads.
+function gridRect() {
+    const el = elId ? document.getElementById(elId) : null;
+    return el?.querySelector('.apexcharts-grid')?.getBoundingClientRect() ?? null;
+}
+
+function insideGrid(p) {
+    if (!p) return false;
+    const r = gridRect();
+    return !!r && p.x >= r.left && p.x <= r.right && p.y >= r.top && p.y <= r.bottom;
+}
+
+// Map a click inside the plot to the instant under the cursor. Bounded to the
+// grid rect on both axes, so gutter and label-strip clicks don't seek - the
+// same region the seek crosshair shows over.
 function clickToTime(event, ctx) {
     const g = ctx?.w?.globals;
-    const inner = ctx?.el?.querySelector('.apexcharts-inner');
-    if (!g || !inner || !Number.isFinite(g.minX) || !Number.isFinite(g.maxX)) return null;
-    const rect = inner.getBoundingClientRect();
-    if (!rect.width) return null;
+    if (!g || !Number.isFinite(g.minX) || !Number.isFinite(g.maxX)) return null;
+    const rect = gridRect();
+    if (!rect?.width) return null;
+    if (event.clientY < rect.top || event.clientY > rect.bottom) return null;
     const frac = (event.clientX - rect.left) / rect.width;
     if (frac < 0 || frac > 1) return null;
     return g.minX + frac * (g.maxX - g.minX);
@@ -106,17 +123,7 @@ function tooltipShowing() {
     // missed its mouseout, e.g. a fast exit). A mouse tooltip can't be
     // showing with the cursor gone - trusting the class here froze the chart
     // until the cursor happened to come back.
-    if (!lastMouse) return false;
-    // .apexcharts-grid, not .apexcharts-inner: the inner group's bounding box
-    // is the union of its children, and the scrolling annotation tick labels
-    // overflow the plot edge into the axis gutters - so the gutter hold came
-    // and went with wherever a label sat. The grid group is exactly the plot
-    // area, and it's the same rect ApexCharts' own tooltip bounds-check reads.
-    const grid = el.querySelector('.apexcharts-grid');
-    if (!grid) return false;
-    const r = grid.getBoundingClientRect();
-    return lastMouse.x >= r.left && lastMouse.x <= r.right
-        && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
+    return insideGrid(lastMouse);
 }
 
 function removeMouseTracking() {
@@ -516,8 +523,13 @@ export async function mount(containerId, opts) {
     if (!el) return;
     // On the container div (Blazor-owned, survives ApexCharts' re-renders of
     // its content), so the listeners outlive option updates.
-    mouseMoveHandler = (e) => { lastMouse = { x: e.clientX, y: e.clientY }; };
-    mouseLeaveHandler = () => { lastMouse = null; };
+    // The seek crosshair only over the plot itself, not the axis gutters -
+    // matching where a click actually seeks (clickToTime's grid bound).
+    mouseMoveHandler = (e) => {
+        lastMouse = { x: e.clientX, y: e.clientY };
+        if (seekOnClick && !IS_TOUCH) el.classList.toggle('wan-chart-seek-hot', insideGrid(lastMouse));
+    };
+    mouseLeaveHandler = () => { lastMouse = null; el.classList.remove('wan-chart-seek-hot'); };
     el.addEventListener('mousemove', mouseMoveHandler);
     el.addEventListener('mouseleave', mouseLeaveHandler);
     seekOnClick = !!opts?.seekOnClick;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -59,9 +59,16 @@ let histBadge = null;
 let playBtn = null;
 let unsubFlow = null;
 // Renders forced through the tooltip hold-off until this wall time: a click
-// on the chart (to seek or play) must draw its playhead even though the
-// pointer - and therefore the tooltip - is still over the plot.
+// on the chart (to seek or play) or a play/pause / historic/live flip must
+// draw even though the pointer - and therefore the tooltip - may still be
+// over the plot.
 let clickRenderUntil = 0;
+const CLICK_RENDER_MS = 2000;
+// Last known mouse position over the chart, for the tooltip hold-off's
+// inside-the-plot check (see tooltipShowing).
+let lastMouse = null;
+let mouseMoveHandler = null;
+let mouseLeaveHandler = null;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -82,6 +89,33 @@ function clickToTime(event, ctx) {
     const frac = (event.clientX - rect.left) / rect.width;
     if (frac < 0 || frac > 1) return null;
     return g.minX + frac * (g.maxX - g.minX);
+}
+
+// True only while the value tooltip is actually on screen. ApexCharts marks
+// the whole mount 'apexcharts-tooltip-active' on any mousemove over the svg,
+// and its bounds check is vertical-only - so a cursor parked in a y-axis
+// gutter held redraws indefinitely with no tooltip showing. With a mouse the
+// class is therefore cross-checked against the pointer being inside the plot
+// grid (the region where the shared tooltip really appears); on touch the
+// class stands alone, since tap-to-inspect has no live pointer to check.
+function tooltipShowing() {
+    const el = document.getElementById(elId);
+    if (!el?.classList.contains('apexcharts-tooltip-active')) return false;
+    if (IS_TOUCH || !lastMouse) return true;
+    const inner = el.querySelector('.apexcharts-inner');
+    if (!inner) return true;
+    const r = inner.getBoundingClientRect();
+    return lastMouse.x >= r.left && lastMouse.x <= r.right
+        && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
+}
+
+function removeMouseTracking() {
+    const el = elId ? document.getElementById(elId) : null;
+    if (el && mouseMoveHandler) el.removeEventListener('mousemove', mouseMoveHandler);
+    if (el && mouseLeaveHandler) el.removeEventListener('mouseleave', mouseLeaveHandler);
+    mouseMoveHandler = null;
+    mouseLeaveHandler = null;
+    lastMouse = null;
 }
 
 function buildOpts() {
@@ -113,7 +147,7 @@ function buildOpts() {
                     pause();
                     histAt = t;
                     histWall = Date.now();
-                    clickRenderUntil = Date.now() + 1500;
+                    clickRenderUntil = Date.now() + CLICK_RENDER_MS;
                     renderHistoric(t);
                     inst.seekTo(t);
                 },
@@ -289,8 +323,7 @@ function buildSeriesData() {
 
 function updateChart() {
     if (!chart || buffer.length === 0) return;
-    const el = document.getElementById(elId);
-    if (el?.classList.contains('apexcharts-tooltip-active')) return;
+    if (Date.now() > clickRenderUntil && tooltipShowing()) return;
     const now = Date.now();
     const pts = buildSeriesData();
     chart.updateOptions({
@@ -413,7 +446,7 @@ function ensureModeUi(el) {
         playBtn.className = 'lan-flow-map-scrubber-playpause';
         playBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            clickRenderUntil = Date.now() + 1500;
+            clickRenderUntil = Date.now() + CLICK_RENDER_MS;
             window.__lanFlowMap?.getInstance?.()?._togglePlayPause?.();
         });
         modeCluster.appendChild(playBtn);
@@ -425,6 +458,7 @@ function ensureModeUi(el) {
         histBadge.setAttribute('data-tooltip-hover-only', '');
         histBadge.addEventListener('click', (e) => {
             e.stopPropagation();
+            clickRenderUntil = Date.now() + CLICK_RENDER_MS;
             window.__lanFlowMap?.getInstance?.()?._returnToLive?.();
         });
         modeCluster.appendChild(histBadge);
@@ -435,7 +469,16 @@ function ensureModeUi(el) {
     // cluster anchors to the same visual spot.
     (el.closest('.card-body') ?? el).appendChild(modeCluster);
     if (!unsubFlow) {
-        unsubFlow = flowData.subscribe((ev) => { if (ev === 'playstate') syncModeUi(); });
+        unsubFlow = flowData.subscribe((ev) => {
+            if (ev !== 'playstate') return;
+            // A play/pause or historic/live flip must draw immediately, even
+            // with the cursor parked over the plot: let renders through the
+            // tooltip hold briefly. Fires only on state flips (and the mount
+            // reset), never on playback ticks, so steady playback keeps the
+            // hold for tooltip inspection.
+            clickRenderUntil = Date.now() + CLICK_RENDER_MS;
+            syncModeUi();
+        });
     }
     syncModeUi();
 }
@@ -454,12 +497,19 @@ export async function mount(containerId, opts) {
     if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     if (scrollTimer) { clearInterval(scrollTimer); scrollTimer = null; }
     if (chart) { chart.destroy(); chart = null; }
+    removeMouseTracking();
     buffer = [];
     lastSampleTime = 0;
     const gen = ++mountGen;
     elId = containerId;
     const el = document.getElementById(containerId);
     if (!el) return;
+    // On the container div (Blazor-owned, survives ApexCharts' re-renders of
+    // its content), so the listeners outlive option updates.
+    mouseMoveHandler = (e) => { lastMouse = { x: e.clientX, y: e.clientY }; };
+    mouseLeaveHandler = () => { lastMouse = null; };
+    el.addEventListener('mousemove', mouseMoveHandler);
+    el.addEventListener('mouseleave', mouseLeaveHandler);
     seekOnClick = !!opts?.seekOnClick;
     // Crosshair only where tap-to-seek is actually live (desktop).
     el.classList.toggle('wan-chart-seekable', seekOnClick && !IS_TOUCH);
@@ -533,10 +583,7 @@ export function resume() {
 // advances - the exact behavior the hover-hold exists to preserve.
 function renderHistoric(at, force = false) {
     if (!chart || buffer.length === 0) return;
-    if (!force && Date.now() > clickRenderUntil) {
-        const el = document.getElementById(elId);
-        if (el?.classList.contains('apexcharts-tooltip-active')) return;
-    }
+    if (!force && Date.now() > clickRenderUntil && tooltipShowing()) return;
     const halfWindow = HISTORY_MINUTES * 60000 / 2;
     const maxTime = Math.min(at + halfWindow, Date.now());
     const playhead = {
@@ -674,6 +721,7 @@ export function unmount() {
     if (backfillTimer) { clearInterval(backfillTimer); backfillTimer = null; }
     if (visHandler) { document.removeEventListener('visibilitychange', visHandler); visHandler = null; }
     if (chart) { chart.destroy(); chart = null; }
+    removeMouseTracking();
     buffer = [];
     elId = null;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -109,6 +109,34 @@ function tooltipShowing() {
         && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
 }
 
+// Re-arm the value tooltip after a discrete seek. The seek redraw rebuilds
+// the plot under a stationary pointer, and ApexCharts only computes a tooltip
+// on a real mousemove - so after a click-to-seek the values under the cursor
+// vanished (or went stale) until the mouse jiggled. Replaying the last pointer
+// position as a synthetic mousemove on the chart svg (the element ApexCharts
+// binds its tooltip handler to) makes the tooltip reappear with the freshly
+// fetched values at the parked instant. Desktop only, and only when the
+// pointer is actually inside the plot - a map-scrubber seek leaves the pointer
+// elsewhere, and a tooltip with no cursor under it would just linger.
+function replayHover(gen) {
+    if (IS_TOUCH || !lastMouse) return;
+    // Let the updateSeries render pass settle so the tooltip reads the new
+    // buffer, not the pre-seek points.
+    setTimeout(() => {
+        if (gen !== seekGen || !lastMouse) return;
+        const el = document.getElementById(elId);
+        const inner = el?.querySelector('.apexcharts-inner');
+        const svg = el?.querySelector('.apexcharts-svg');
+        if (!inner || !svg) return;
+        const r = inner.getBoundingClientRect();
+        if (lastMouse.x < r.left || lastMouse.x > r.right
+            || lastMouse.y < r.top || lastMouse.y > r.bottom) return;
+        svg.dispatchEvent(new MouseEvent('mousemove', {
+            clientX: lastMouse.x, clientY: lastMouse.y, bubbles: true, view: window,
+        }));
+    }, 150);
+}
+
 function removeMouseTracking() {
     const el = elId ? document.getElementById(elId) : null;
     if (el && mouseMoveHandler) el.removeEventListener('mousemove', mouseMoveHandler);
@@ -687,7 +715,11 @@ export async function seekTime(isoTimestamp) {
     // scrub): it must land even under the cursor or it's never retried while paused.
     // During active playback leave it unforced so a hover still holds the redraw for
     // inspection while the background timeline (2D/3D maps) keeps advancing.
-    renderHistoric(at, mapPlaybackRate() <= 0);
+    const discrete = mapPlaybackRate() <= 0;
+    renderHistoric(at, discrete);
+    // A discrete seek that landed under the cursor re-shows the tooltip at the
+    // parked instant; playback ticks don't (the hover-hold owns that case).
+    if (discrete) replayHover(gen);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -109,34 +109,6 @@ function tooltipShowing() {
         && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
 }
 
-// Re-arm the value tooltip after a discrete seek. The seek redraw rebuilds
-// the plot under a stationary pointer, and ApexCharts only computes a tooltip
-// on a real mousemove - so after a click-to-seek the values under the cursor
-// vanished (or went stale) until the mouse jiggled. Replaying the last pointer
-// position as a synthetic mousemove on the chart svg (the element ApexCharts
-// binds its tooltip handler to) makes the tooltip reappear with the freshly
-// fetched values at the parked instant. Desktop only, and only when the
-// pointer is actually inside the plot - a map-scrubber seek leaves the pointer
-// elsewhere, and a tooltip with no cursor under it would just linger.
-function replayHover(gen) {
-    if (IS_TOUCH || !lastMouse) return;
-    // Let the updateSeries render pass settle so the tooltip reads the new
-    // buffer, not the pre-seek points.
-    setTimeout(() => {
-        if (gen !== seekGen || !lastMouse) return;
-        const el = document.getElementById(elId);
-        const inner = el?.querySelector('.apexcharts-inner');
-        const svg = el?.querySelector('.apexcharts-svg');
-        if (!inner || !svg) return;
-        const r = inner.getBoundingClientRect();
-        if (lastMouse.x < r.left || lastMouse.x > r.right
-            || lastMouse.y < r.top || lastMouse.y > r.bottom) return;
-        svg.dispatchEvent(new MouseEvent('mousemove', {
-            clientX: lastMouse.x, clientY: lastMouse.y, bubbles: true, view: window,
-        }));
-    }, 150);
-}
-
 function removeMouseTracking() {
     const el = elId ? document.getElementById(elId) : null;
     if (el && mouseMoveHandler) el.removeEventListener('mousemove', mouseMoveHandler);
@@ -715,11 +687,7 @@ export async function seekTime(isoTimestamp) {
     // scrub): it must land even under the cursor or it's never retried while paused.
     // During active playback leave it unforced so a hover still holds the redraw for
     // inspection while the background timeline (2D/3D maps) keeps advancing.
-    const discrete = mapPlaybackRate() <= 0;
-    renderHistoric(at, discrete);
-    // A discrete seek that landed under the cursor re-shows the tooltip at the
-    // parked instant; playback ticks don't (the hover-hold owns that case).
-    if (discrete) replayHover(gen);
+    renderHistoric(at, mapPlaybackRate() <= 0);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -69,6 +69,11 @@ const CLICK_RENDER_MS = 2000;
 let lastMouse = null;
 let mouseMoveHandler = null;
 let mouseLeaveHandler = null;
+// One-shot arm: a chart click requests the value tooltip at the clicked
+// instant once its seek round-trip lands (see seekTime). Wall-clock bounded so
+// a click whose round-trip never arrives can't pop a tooltip on a later
+// map-driven seek.
+let seekTooltipArmedAt = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -107,6 +112,37 @@ function tooltipShowing() {
     const r = inner.getBoundingClientRect();
     return lastMouse.x >= r.left && lastMouse.x <= r.right
         && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
+}
+
+// The value tooltip at the TARGETED instant, not under the cursor: the seek
+// recenters the axis window, so the clicked point slides out from under the
+// pointer (usually to mid-chart) - the playhead is where the requested values
+// sit. Synthesized as a mousemove on the chart svg (the element ApexCharts
+// binds its tooltip handler to) at the playhead's post-seek screen position;
+// the next real mouse move hands the tooltip back to the actual pointer.
+// Desktop only - on touch the native tap paradigm owns the tooltip.
+function showSeekTooltip(gen, at, maxTime) {
+    if (IS_TOUCH) return;
+    // Let the updateSeries render pass settle so the tooltip reads the new
+    // buffer, not the pre-seek points.
+    setTimeout(() => {
+        if (gen !== seekGen) return;
+        const el = document.getElementById(elId);
+        const inner = el?.querySelector('.apexcharts-inner');
+        const svg = el?.querySelector('.apexcharts-svg');
+        if (!inner || !svg) return;
+        const r = inner.getBoundingClientRect();
+        if (!r.width) return;
+        const span = HISTORY_MINUTES * 60000;
+        const frac = (at - (maxTime - span)) / span;
+        if (frac < 0 || frac > 1) return;
+        svg.dispatchEvent(new MouseEvent('mousemove', {
+            clientX: r.left + frac * r.width,
+            clientY: r.top + r.height / 2,
+            bubbles: true,
+            view: window,
+        }));
+    }, 150);
 }
 
 function removeMouseTracking() {
@@ -148,6 +184,7 @@ function buildOpts() {
                     histAt = t;
                     histWall = Date.now();
                     clickRenderUntil = Date.now() + CLICK_RENDER_MS;
+                    seekTooltipArmedAt = Date.now();
                     renderHistoric(t);
                     inst.seekTo(t);
                 },
@@ -506,7 +543,9 @@ export async function mount(containerId, opts) {
     if (!el) return;
     // On the container div (Blazor-owned, survives ApexCharts' re-renders of
     // its content), so the listeners outlive option updates.
-    mouseMoveHandler = (e) => { lastMouse = { x: e.clientX, y: e.clientY }; };
+    // isTrusted: the synthetic showSeekTooltip mousemove must not overwrite
+    // the REAL pointer position the tooltip hold-off checks against.
+    mouseMoveHandler = (e) => { if (e.isTrusted) lastMouse = { x: e.clientX, y: e.clientY }; };
     mouseLeaveHandler = () => { lastMouse = null; };
     el.addEventListener('mousemove', mouseMoveHandler);
     el.addEventListener('mouseleave', mouseLeaveHandler);
@@ -687,7 +726,14 @@ export async function seekTime(isoTimestamp) {
     // scrub): it must land even under the cursor or it's never retried while paused.
     // During active playback leave it unforced so a hover still holds the redraw for
     // inspection while the background timeline (2D/3D maps) keeps advancing.
-    renderHistoric(at, mapPlaybackRate() <= 0);
+    const discrete = mapPlaybackRate() <= 0;
+    renderHistoric(at, discrete);
+    // Only a chart click pops the tooltip at the target - map-scrubber seeks
+    // leave the pointer off the chart, where a tooltip would just linger.
+    if (discrete && Date.now() - seekTooltipArmedAt < 2000) {
+        seekTooltipArmedAt = 0;
+        showSeekTooltip(gen, at, maxTime);
+    }
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -69,11 +69,6 @@ const CLICK_RENDER_MS = 2000;
 let lastMouse = null;
 let mouseMoveHandler = null;
 let mouseLeaveHandler = null;
-// One-shot arm: a chart click requests the value tooltip at the clicked
-// instant once its seek round-trip lands (see seekTime). Wall-clock bounded so
-// a click whose round-trip never arrives can't pop a tooltip on a later
-// map-driven seek.
-let seekTooltipArmedAt = 0;
 
 function formatBps(v) {
     if (v == null || v < 1) return '0';
@@ -112,37 +107,6 @@ function tooltipShowing() {
     const r = inner.getBoundingClientRect();
     return lastMouse.x >= r.left && lastMouse.x <= r.right
         && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
-}
-
-// The value tooltip at the TARGETED instant, not under the cursor: the seek
-// recenters the axis window, so the clicked point slides out from under the
-// pointer (usually to mid-chart) - the playhead is where the requested values
-// sit. Synthesized as a mousemove on the chart svg (the element ApexCharts
-// binds its tooltip handler to) at the playhead's post-seek screen position;
-// the next real mouse move hands the tooltip back to the actual pointer.
-// Desktop only - on touch the native tap paradigm owns the tooltip.
-function showSeekTooltip(gen, at, maxTime) {
-    if (IS_TOUCH) return;
-    // Let the updateSeries render pass settle so the tooltip reads the new
-    // buffer, not the pre-seek points.
-    setTimeout(() => {
-        if (gen !== seekGen) return;
-        const el = document.getElementById(elId);
-        const inner = el?.querySelector('.apexcharts-inner');
-        const svg = el?.querySelector('.apexcharts-svg');
-        if (!inner || !svg) return;
-        const r = inner.getBoundingClientRect();
-        if (!r.width) return;
-        const span = HISTORY_MINUTES * 60000;
-        const frac = (at - (maxTime - span)) / span;
-        if (frac < 0 || frac > 1) return;
-        svg.dispatchEvent(new MouseEvent('mousemove', {
-            clientX: r.left + frac * r.width,
-            clientY: r.top + r.height / 2,
-            bubbles: true,
-            view: window,
-        }));
-    }, 150);
 }
 
 function removeMouseTracking() {
@@ -184,7 +148,6 @@ function buildOpts() {
                     histAt = t;
                     histWall = Date.now();
                     clickRenderUntil = Date.now() + CLICK_RENDER_MS;
-                    seekTooltipArmedAt = Date.now();
                     renderHistoric(t);
                     inst.seekTo(t);
                 },
@@ -543,9 +506,7 @@ export async function mount(containerId, opts) {
     if (!el) return;
     // On the container div (Blazor-owned, survives ApexCharts' re-renders of
     // its content), so the listeners outlive option updates.
-    // isTrusted: the synthetic showSeekTooltip mousemove must not overwrite
-    // the REAL pointer position the tooltip hold-off checks against.
-    mouseMoveHandler = (e) => { if (e.isTrusted) lastMouse = { x: e.clientX, y: e.clientY }; };
+    mouseMoveHandler = (e) => { lastMouse = { x: e.clientX, y: e.clientY }; };
     mouseLeaveHandler = () => { lastMouse = null; };
     el.addEventListener('mousemove', mouseMoveHandler);
     el.addEventListener('mouseleave', mouseLeaveHandler);
@@ -726,14 +687,7 @@ export async function seekTime(isoTimestamp) {
     // scrub): it must land even under the cursor or it's never retried while paused.
     // During active playback leave it unforced so a hover still holds the redraw for
     // inspection while the background timeline (2D/3D maps) keeps advancing.
-    const discrete = mapPlaybackRate() <= 0;
-    renderHistoric(at, discrete);
-    // Only a chart click pops the tooltip at the target - map-scrubber seeks
-    // leave the pointer off the chart, where a tooltip would just linger.
-    if (discrete && Date.now() - seekTooltipArmedAt < 2000) {
-        seekTooltipArmedAt = 0;
-        showSeekTooltip(gen, at, maxTime);
-    }
+    renderHistoric(at, mapPlaybackRate() <= 0);
     if (!histTimer) {
         histTimer = setInterval(() => {
             const rate = mapPlaybackRate();

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -101,10 +101,20 @@ function clickToTime(event, ctx) {
 function tooltipShowing() {
     const el = document.getElementById(elId);
     if (!el?.classList.contains('apexcharts-tooltip-active')) return false;
-    if (IS_TOUCH || !lastMouse) return true;
-    const inner = el.querySelector('.apexcharts-inner');
-    if (!inner) return true;
-    const r = inner.getBoundingClientRect();
+    if (IS_TOUCH) return true;
+    // No pointer over the container at all: the class is stale (ApexCharts
+    // missed its mouseout, e.g. a fast exit). A mouse tooltip can't be
+    // showing with the cursor gone - trusting the class here froze the chart
+    // until the cursor happened to come back.
+    if (!lastMouse) return false;
+    // .apexcharts-grid, not .apexcharts-inner: the inner group's bounding box
+    // is the union of its children, and the scrolling annotation tick labels
+    // overflow the plot edge into the axis gutters - so the gutter hold came
+    // and went with wherever a label sat. The grid group is exactly the plot
+    // area, and it's the same rect ApexCharts' own tooltip bounds-check reads.
+    const grid = el.querySelector('.apexcharts-grid');
+    if (!grid) return false;
+    const r = grid.getBoundingClientRect();
     return lastMouse.x >= r.left && lastMouse.x <= r.right
         && lastMouse.y >= r.top && lastMouse.y <= r.bottom;
 }

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -265,4 +265,149 @@ public class ResultBufferTests
             indices.Should().BeInAscendingOrder();
         }
     }
+
+    private static string TempSpoolPath() =>
+        Path.Combine(Path.GetTempPath(), $"no-spool-test-{Guid.NewGuid():N}.bin");
+
+    [Fact]
+    public async Task SpoolRoundTripPreservesMessagesAndOrder()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("a"));
+            source.Enqueue(SnmpMessage("aa:bb:cc:dd:ee:ff"));
+            source.Enqueue(ProbeMessage("b"));
+            source.SaveTo(path);
+
+            var restored = new ResultBuffer();
+            restored.LoadFrom(path).Should().Be(3);
+            restored.Count.Should().Be(3);
+            restored.ApproxBytes.Should().Be(source.ApproxBytes);
+
+            (await NextAsync(restored)).ProbeResults.Results[0].TargetId.Should().Be("a");
+            (await NextAsync(restored)).PayloadCase.Should().Be(AgentMessage.PayloadOneofCase.SnmpResults);
+            (await NextAsync(restored)).ProbeResults.Results[0].TargetId.Should().Be("b");
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadAppendsAfterExistingEntries()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("spooled"));
+            source.SaveTo(path);
+
+            var buffer = new ResultBuffer();
+            buffer.Enqueue(ProbeMessage("live"));
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadAppliesAgeCapFromOriginalEnqueueTimes()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("stale"));
+            source.SaveTo(path);
+
+            // Everything in the spool is older than the age cap, so a load
+            // into a short-max-age buffer restores then immediately evicts.
+            var buffer = new ResultBuffer(maxAge: TimeSpan.Zero);
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(0);
+            buffer.DroppedTotal.Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadKeepsCleanPrefixOfTruncatedFile()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            var source = new ResultBuffer();
+            source.Enqueue(ProbeMessage("first"));
+            source.Enqueue(ProbeMessage("second"));
+            source.SaveTo(path);
+
+            // Chop mid-way through the last message, as a crash mid-write would.
+            var bytes = File.ReadAllBytes(path);
+            File.WriteAllBytes(path, bytes[..(bytes.Length - 5)]);
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(1);
+            buffer.Count.Should().Be(1);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadSurvivesHostileTicks()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            using (var file = File.Create(path))
+            {
+                // Valid header, then ticks beyond DateTime's range - a corrupt
+                // varint must not take LoadFrom down.
+                var output = new Google.Protobuf.CodedOutputStream(file);
+                output.WriteFixed32(0x4E4F5350);
+                output.WriteInt32(1);
+                output.WriteInt64(long.MaxValue);
+                output.WriteMessage(ProbeMessage("hostile"));
+                output.Flush();
+            }
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(0);
+            buffer.Count.Should().Be(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void SpoolLoadIgnoresUnrecognizedFile()
+    {
+        var path = TempSpoolPath();
+        try
+        {
+            File.WriteAllBytes(path, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+            var buffer = new ResultBuffer();
+            buffer.LoadFrom(path).Should().Be(0);
+            buffer.Count.Should().Be(0);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
 }

--- a/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/Helpers/NetworkUtilitiesTests.cs
@@ -690,5 +690,24 @@ public class NetworkUtilitiesTests
         NetworkUtilities.IsPrivateIpAddress(ip).Should().Be(expected);
     }
 
+    [Theory]
+    [InlineData("ppp0", true)]
+    [InlineData("ppp3", true)]
+    [InlineData("PPP0", true)]              // case-insensitive
+    [InlineData("pppoe0", true)]            // the form some stacks use
+    [InlineData("eth6", false)]
+    [InlineData("eth6.100", false)]         // VLAN-tagged WAN, not a PPPoE session
+    [InlineData("gre1", false)]             // LAN-tunneled cellular WAN
+    [InlineData("ppp", false)]              // no unit number - not an interface
+    [InlineData("pppoe", false)]
+    [InlineData("ppp0.1", false)]           // anchored: no trailing junk
+    [InlineData("xppp0", false)]            // anchored: no leading junk
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    public void IsPppoeInterface_MatchesOnlyPppSessionInterfaces(string? ifName, bool expected)
+    {
+        NetworkUtilities.IsPppoeInterface(ifName).Should().Be(expected);
+    }
+
     #endregion
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthPdfGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthPdfGeneratorTests.cs
@@ -205,6 +205,56 @@ public class IspHealthPdfGeneratorTests
         pdf.Length.Should().BeGreaterThan(1000);
     }
 
+    [Theory]
+    [InlineData(AccessTechnology.Gpon, false, "GPON")]
+    [InlineData(AccessTechnology.Gpon, true, "GPON (PPPoE)")]
+    [InlineData(AccessTechnology.XgsPon, true, "XGS-PON (PPPoE)")]
+    [InlineData(AccessTechnology.DirectEthernet, true, "Active Ethernet (PPPoE)")]
+    // A medium that already carries a qualifier folds the session into it rather than
+    // stacking a second bracket.
+    [InlineData(AccessTechnology.Dsl, false, "DSL (ADSL/VDSL)")]
+    [InlineData(AccessTechnology.Dsl, true, "DSL (ADSL/VDSL, PPPoE)")]
+    [InlineData(AccessTechnology.Docsis, false, "DOCSIS (Cable)")]
+    [InlineData(AccessTechnology.Satellite, false, "Satellite (LEO)")]
+    public void ScoredAsLabel_NamesTheMediumAndAnyDetectedSession(
+        AccessTechnology tech, bool pppoe, string expected)
+    {
+        var report = MinimalReport();
+        report.AccessTechnology = tech;
+        report.PppoeSession = pppoe;
+
+        IspHealthPresentation.ScoredAsLabel(report).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(AccessTechnology.PppoE, "PPPoE")]
+    [InlineData(AccessTechnology.Other, "Other")]
+    [InlineData(AccessTechnology.Unknown, "Not detected")]
+    public void ScoredAsLabel_NeverPrintsRawEnumCasing(AccessTechnology tech, string expected)
+    {
+        // The old catch-all fell through to tech.ToString(), so a legacy PppoE site's exported
+        // PDF read "PppoE" - C# casing in a document that gets sent to an ISP.
+        var report = MinimalReport();
+        report.AccessTechnology = tech;
+
+        IspHealthPresentation.ScoredAsLabel(report).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ScoredAsLabel_NamesTheTechnologyOnlyOnce()
+    {
+        // Regression: the line used to be "{Profile.DisplayName} ({FormatTechName})", which
+        // rendered "DOCSIS (DOCSIS (Cable))".
+        foreach (var tech in Enum.GetValues<AccessTechnology>())
+        {
+            var report = MinimalReport();
+            report.AccessTechnology = tech;
+
+            var label = IspHealthPresentation.ScoredAsLabel(report);
+            label.Count(c => c == '(').Should().BeLessThanOrEqualTo(1, $"{tech} should not nest qualifiers");
+        }
+    }
+
     [Fact]
     public void ScoredWanLabel_NamesTheWanWithItsGroupAndInterface()
     {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1682,4 +1682,111 @@ public class IspHealthProfilesTests
         IspHealthProfiles.GetProfile(AccessTechnology.PppoE)!.JitterTypicalMs.Should().BeNull();
         IspHealthProfiles.GetProfile(AccessTechnology.Other)!.JitterTypicalMs.Should().BeNull();
     }
+
+    // ── PPPoE session overlay ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(AccessTechnology.Gpon, 2.0)]
+    [InlineData(AccessTechnology.XgsPon, 2.0)]
+    [InlineData(AccessTechnology.DirectEthernet, 1.0)]
+    [InlineData(AccessTechnology.FixedWireless, 1.0)]
+    [InlineData(AccessTechnology.Dsl, 1.0)]
+    [InlineData(AccessTechnology.Docsis, 0.0)]
+    [InlineData(AccessTechnology.Satellite, 0.0)]
+    [InlineData(AccessTechnology.Cellular, 0.0)]
+    public void Pppoe_overlay_shifts_every_rtt_anchor_by_the_same_offset(AccessTechnology tech, double offset)
+    {
+        var baseline = IspHealthProfiles.GetProfile(tech)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(baseline, tech);
+
+        // Additive and uniform: a fixed topology cost moves "poor" as far as "ideal".
+        pppoe.IdleRttIdealMs.Should().BeApproximately(baseline.IdleRttIdealMs + offset, 0.001);
+        pppoe.IdleRttNormalLowMs.Should().BeApproximately(baseline.IdleRttNormalLowMs + offset, 0.001);
+        pppoe.IdleRttNormalHighMs.Should().BeApproximately(baseline.IdleRttNormalHighMs + offset, 0.001);
+        pppoe.IdleRttPoorMs.Should().BeApproximately(baseline.IdleRttPoorMs + offset, 0.001);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_composes_jitter_in_quadrature_not_linearly()
+    {
+        var baseline = IspHealthProfiles.GetProfile(AccessTechnology.Gpon)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(baseline, AccessTechnology.Gpon);
+
+        // sqrt(0.4^2 + 0.25^2) = 0.4717, NOT 0.65. The distinction is the point: linear addition
+        // would move the ideal anchor 63% and let a genuinely jittery line score a flat 100.
+        pppoe.JitterIdealMs.Should().BeApproximately(0.47, 0.005);
+        pppoe.JitterTypicalMs.Should().BeApproximately(0.74, 0.005);
+
+        // The same 0.25 ms is absorbed almost entirely once the medium is already noisy.
+        pppoe.JitterPoorMs.Should().BeApproximately(3.01, 0.005);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_leaves_a_null_jitter_band_null()
+    {
+        // Neutral profiles score jitter off the measured path floor; the overlay must not
+        // conjure a band for them, or they would silently switch scoring modes.
+        var neutral = IspHealthProfiles.GetProfile(AccessTechnology.Other)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(neutral, AccessTechnology.Other);
+
+        pppoe.JitterIdealMs.Should().BeNull();
+        pppoe.JitterTypicalMs.Should().BeNull();
+        pppoe.JitterPoorMs.Should().BeNull();
+    }
+
+    [Fact]
+    public void Pppoe_overlay_widens_loaded_loss_additively()
+    {
+        var baseline = IspHealthProfiles.GetProfile(AccessTechnology.Gpon)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(baseline, AccessTechnology.Gpon);
+
+        pppoe.LoadedLossDownLowPct.Should().BeApproximately(1.5, 0.001);
+        pppoe.LoadedLossDownHighPct.Should().BeApproximately(3.0, 0.001);
+        pppoe.LoadedLossUpLowPct.Should().BeApproximately(1.0, 0.001);
+        pppoe.LoadedLossUpHighPct.Should().BeApproximately(2.0, 0.001);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_never_tightens_a_band()
+    {
+        // The overlay exists to forgive a cost the user's medium is not responsible for. Any
+        // axis it makes STRICTER would penalize PPPoE users for having PPPoE detected.
+        foreach (var tech in Enum.GetValues<AccessTechnology>().Where(t => t != AccessTechnology.Unknown))
+        {
+            var b = IspHealthProfiles.GetProfile(tech)!;
+            var p = IspHealthProfiles.ApplyPppoeSession(b, tech);
+
+            p.IdleRttIdealMs.Should().BeGreaterThanOrEqualTo(b.IdleRttIdealMs, $"{tech} ideal RTT");
+            p.IdleRttPoorMs.Should().BeGreaterThanOrEqualTo(b.IdleRttPoorMs, $"{tech} poor RTT");
+            p.LoadedLossDownHighPct.Should().BeGreaterThanOrEqualTo(b.LoadedLossDownHighPct, $"{tech} loaded loss down");
+            p.LoadedLossUpHighPct.Should().BeGreaterThanOrEqualTo(b.LoadedLossUpHighPct, $"{tech} loaded loss up");
+            if (b.JitterIdealMs is { } ideal)
+                p.JitterIdealMs.Should().BeGreaterThanOrEqualTo(ideal, $"{tech} jitter ideal");
+        }
+    }
+
+    [Fact]
+    public void Pppoe_overlay_preserves_the_medium_identity()
+    {
+        // The overlay adjusts thresholds; it does not reclassify the line. SharedMedium in
+        // particular drives the packet-loss recommendation text, and a PPPoE session does not
+        // turn a dedicated pair into a contended one.
+        var dsl = IspHealthProfiles.GetProfile(AccessTechnology.Dsl)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(dsl, AccessTechnology.Dsl);
+
+        pppoe.SharedMedium.Should().BeFalse();
+        pppoe.IsNeutral.Should().Be(dsl.IsNeutral);
+        pppoe.DisplayName.Should().Be(dsl.DisplayName);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_keeps_upstream_loss_band_within_downstream()
+    {
+        // Same invariant the base profiles are held to above - the overlay must not invert it.
+        foreach (var tech in Enum.GetValues<AccessTechnology>().Where(t => t != AccessTechnology.Unknown))
+        {
+            var p = IspHealthProfiles.ApplyPppoeSession(IspHealthProfiles.GetProfile(tech)!, tech);
+            p.LoadedLossUpHighPct.Should().BeLessThanOrEqualTo(p.LoadedLossDownHighPct, $"{tech} upstream band should not exceed downstream");
+        }
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1780,6 +1780,28 @@ public class IspHealthProfilesTests
     }
 
     [Fact]
+    public void Pppoe_overlay_is_a_no_op_on_a_wan_already_stored_as_pppoe()
+    {
+        // The PppoE profile IS the stand-in for a PPPoE line. A legacy WAN still carrying that
+        // value, on a real ppp* interface, would otherwise be forgiven twice.
+        var stored = IspHealthProfiles.GetProfile(AccessTechnology.PppoE)!;
+        var overlaid = IspHealthProfiles.ApplyPppoeSession(stored, AccessTechnology.PppoE);
+
+        overlaid.Should().BeEquivalentTo(stored);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_still_applies_to_other()
+    {
+        // "Other" means a medium we don't list, which a PPPoE session genuinely rides on top of -
+        // unlike PppoE itself, it is not already standing in for the session.
+        var other = IspHealthProfiles.GetProfile(AccessTechnology.Other)!;
+        var overlaid = IspHealthProfiles.ApplyPppoeSession(other, AccessTechnology.Other);
+
+        overlaid.LoadedLossDownHighPct.Should().BeGreaterThan(other.LoadedLossDownHighPct);
+    }
+
+    [Fact]
     public void Pppoe_overlay_keeps_upstream_loss_band_within_downstream()
     {
         // Same invariant the base profiles are held to above - the overlay must not invert it.

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1760,8 +1760,11 @@ public class IspHealthProfilesTests
             p.IdleRttPoorMs.Should().BeGreaterThanOrEqualTo(b.IdleRttPoorMs, $"{tech} poor RTT");
             p.LoadedLossDownHighPct.Should().BeGreaterThanOrEqualTo(b.LoadedLossDownHighPct, $"{tech} loaded loss down");
             p.LoadedLossUpHighPct.Should().BeGreaterThanOrEqualTo(b.LoadedLossUpHighPct, $"{tech} loaded loss up");
+            p.LoadedDeltaAcceptableMs.Should().BeGreaterThanOrEqualTo(b.LoadedDeltaAcceptableMs, $"{tech} loaded delta");
             if (b.JitterIdealMs is { } ideal)
                 p.JitterIdealMs.Should().BeGreaterThanOrEqualTo(ideal, $"{tech} jitter ideal");
+            if (b.StabilityMadIdealMs is { } mad)
+                p.StabilityMadIdealMs.Should().BeGreaterThanOrEqualTo(mad, $"{tech} stability MAD ideal");
         }
     }
 
@@ -1790,15 +1793,63 @@ public class IspHealthProfilesTests
         overlaid.Should().BeEquivalentTo(stored);
     }
 
-    [Fact]
-    public void Pppoe_overlay_still_applies_to_other()
+    [Theory]
+    [InlineData(AccessTechnology.Docsis)]      // provisions over DHCP
+    [InlineData(AccessTechnology.Satellite)]   // terminates its own way
+    [InlineData(AccessTechnology.Cellular)]
+    [InlineData(AccessTechnology.Other)]       // names no medium - nothing to calibrate an overlay against
+    public void Pppoe_overlay_skips_media_that_never_carry_it(AccessTechnology tech)
     {
-        // "Other" means a medium we don't list, which a PPPoE session genuinely rides on top of -
-        // unlike PppoE itself, it is not already standing in for the session.
-        var other = IspHealthProfiles.GetProfile(AccessTechnology.Other)!;
-        var overlaid = IspHealthProfiles.ApplyPppoeSession(other, AccessTechnology.Other);
+        var baseline = IspHealthProfiles.GetProfile(tech)!;
+        var overlaid = IspHealthProfiles.ApplyPppoeSession(baseline, tech);
 
-        overlaid.LoadedLossDownHighPct.Should().BeGreaterThan(other.LoadedLossDownHighPct);
+        overlaid.Should().BeEquivalentTo(baseline);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_composes_stability_mad_in_quadrature()
+    {
+        var baseline = IspHealthProfiles.GetProfile(AccessTechnology.Gpon)!;
+        var pppoe = IspHealthProfiles.ApplyPppoeSession(baseline, AccessTechnology.Gpon);
+
+        // sqrt(0.15^2 + 0.10^2) = 0.1803. Same shape as jitter: the ideal anchor moves ~20% and
+        // the poor anchor barely at all.
+        pppoe.StabilityMadIdealMs.Should().BeApproximately(0.18, 0.005);
+        pppoe.StabilityMadTypicalMs.Should().BeApproximately(0.41, 0.005);
+        pppoe.StabilityMadPoorMs.Should().BeApproximately(1.50, 0.005);
+    }
+
+    [Fact]
+    public void Pppoe_overlay_widens_loaded_delta_uniformly_across_media()
+    {
+        // Uniform, unlike the RTT offset: that scales with how far the BNG is, this with how deep
+        // its queue is, and the two are unrelated.
+        foreach (var tech in new[]
+        {
+            AccessTechnology.Gpon, AccessTechnology.XgsPon, AccessTechnology.DirectEthernet,
+            AccessTechnology.FixedWireless, AccessTechnology.Dsl
+        })
+        {
+            var b = IspHealthProfiles.GetProfile(tech)!;
+            var p = IspHealthProfiles.ApplyPppoeSession(b, tech);
+
+            p.LoadedDeltaExcellentMs.Should().BeApproximately(b.LoadedDeltaExcellentMs + 1.0, 0.001, $"{tech} excellent");
+            p.LoadedDeltaAcceptableMs.Should().BeApproximately(b.LoadedDeltaAcceptableMs + 3.0, 0.001, $"{tech} acceptable");
+        }
+    }
+
+    [Fact]
+    public void Pppoe_overlay_keeps_loaded_delta_from_masking_bufferbloat()
+    {
+        // The BNG shaper is a bufferbloat source and bufferbloat is what Adaptive SQM fixes. This
+        // band has to stay tight enough that a PPPoE line with no SQM still grades down for it -
+        // if GPON's excellent anchor ever drifted past DOCSIS's, the overlay would be excusing a
+        // problem we are supposed to be reporting.
+        var gpon = IspHealthProfiles.ApplyPppoeSession(
+            IspHealthProfiles.GetProfile(AccessTechnology.Gpon)!, AccessTechnology.Gpon);
+
+        gpon.LoadedDeltaExcellentMs.Should().BeLessThan(
+            IspHealthProfiles.GetProfile(AccessTechnology.Docsis)!.LoadedDeltaExcellentMs);
     }
 
     [Fact]


### PR DESCRIPTION
Rolling release PR for v2.5.2. Contents so far:

## Multi-Site

- **On-Site Agent self-heals a wedged async I/O engine** - a site agent went dark for hours while its process stayed alive: the gateway's kernel lost an epoll wakeup, freezing .NET's socket event loop so every async operation timed out while the network was fine. The agent now runs a loopback canary that detects this state (a 127.0.0.1 connect can't time out for network reasons), spools its result backlog to disk, and exits for systemd/Docker to relaunch - recovery in ~3 minutes instead of indefinite silence, with zero data loss. Real WAN or server outages never trip it.
- **Result backlog survives agent restarts** - the store-and-forward buffer now spools to disk on shutdown and reloads on start, so deliberate restarts and updates keep outage data too.
- **Probe scheduler isolation** - one hung probe can no longer freeze the whole probe scheduler (the incident took all targets dark from a single stuck pipe read); each probe also gets a hard deadline, and a probe whose output can't be read is dropped as a gap rather than recorded as fabricated 100% loss. This hardening applies to server-side probing as well.
- **LAN speed test relights with the agent** - on native installs, the speed test nginx stopped whenever the agent stopped and never came back without a manual start. It now follows every agent start automatically; installs without the optional speed test are unaffected.
- `LatestAgentVersion` raised to 2.5.2 - enrolled agents below it get the **Update agent** callout in the Multi-Site agent list.

## Monitoring

- **No more SNMP gap after a server restart on agent sites** - reconnecting to a just-restarted server could push an empty device list to the agent (the console session was milliseconds old), silently disabling its SNMP polling for a minute. An empty enumeration is now confirmed by a second consecutive one before a disable is adopted; the agent keeps its last-known-good config in the meantime.
- **Disable Monitoring now stops agent-site collection completely** - probes kept running and recording on agent sites with monitoring disabled; the toggle now stops probes and SNMP within one config cycle, matching server-polled sites. Data already collected is never discarded.

### ISP Health

- **PPPoE connections are scored for what they actually cost** - a PPPoE session terminates on a BNG, and the BNG usually sits deeper in the network than the OLT or DSLAM, so the first hop is further out through no fault of the line. ISP Health now detects the session from the gateway itself and widens what it expects across latency, jitter, RTT stability, loaded loss and loaded latency, on top of your access medium's own expectations - rather than grading a healthy PPPoE line against thresholds that assume a nearby first hop. The latency allowance is tuned per medium (2 ms on PON, 1 ms where the BNG is typically a local hop), and the jitter and stability allowances are composed so they count on a quiet line and fade on one that is already noisy.
- **Bufferbloat is still called out on PPPoE** - the loaded-latency allowance is deliberately small. The BNG's per-subscriber shaper is a bufferbloat source, and a PPPoE line that buffers badly should still grade down for it rather than be told it is normal - that is what **Adaptive SQM** is for. The allowance covers only the part a gateway cannot answer for itself.
- **The scored profile says when a session is in play** - the header reads **Scored as GPON (PPPoE)**, and the selector beside **Access Layer** shows the same, so a widened threshold is never invisible.

### Network Performance

- **Access network technology asks only for the medium** - PPPoE is no longer offered in **Upstream path discovery**. It is not an access medium: it rides GPON, DSL or Active Ethernet, and choosing it meant giving up that medium's tuned thresholds for a generic band. Pick what the session rides and the session itself is detected for you. Connections already set to PPPoE move to the detected medium where the first upstream device identifies one.

## Fixes

- **A failed console request no longer sticks around as an empty answer** - one bad response from the UniFi Console was cached as though it were real data, so for up to a minute the app believed your site had no devices, or no networks at all. Dashboard, Wi-Fi Optimizer, Security Audit and Monitoring all read those caches. Most likely to bite right after a restart, when the very first request is the one that fails.
- **ISP Health waits for the UniFi Console to actually answer before scoring** - it started as soon as the login succeeded, which is earlier than the console serving any data. A score computed in that window quietly went without its expected WAN speeds (skipping loaded analysis) and without PPPoE detection, then cached that result for 15 minutes. It now defers and scores on the next pass instead.
- **Export PDF names your connection once** - the summary line printed the access technology twice, so a cable connection read "DOCSIS (DOCSIS (Cable))" and a connection still set to PPPoE could show a raw internal value.