### PR TITLE
v2.5.2 Additional Release Changes

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
@@ -286,8 +286,15 @@ public class IspHealthPdfGenerator
 
                 if (dimension.Factors.Count == 0)
                 {
-                    column.Item().PaddingTop(2).Text("No data for this dimension in the window.")
-                        .FontSize(9).FontColor(Colors.Grey.Medium);
+                    // ISP Network never carries factors - BuildIspDimension scores it by averaging
+                    // the per-hop grades, which get their own detail in the ISP Network Hops and
+                    // Networks on Your Path sections. So an empty factor list is normal there, and
+                    // only a missing score means there was genuinely nothing to grade.
+                    if (dimension.Score == null)
+                    {
+                        column.Item().PaddingTop(2).Text("No data for this dimension in the window.")
+                            .FontSize(9).FontColor(Colors.Grey.Medium);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
Rolling release PR. Contents so far:

## Monitoring

### ISP Health

- **Export PDF no longer says "No data" under a scored dimension** - the Score Breakdown printed "No data for this dimension in the window." beneath **ISP Network** on every PDF, directly under its actual score. That dimension is graded from the per-hop results rather than from factors, and the check was looking for factors. The per-hop detail was always there anyway, in **ISP Network Hops** and **Networks on Your Path**.