### PR TITLE
Monitoring - ISP Health: Uptime, window-relative scoring, and a gateway loss floor

### DIFF
--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1536,6 +1536,17 @@ from(bucket: ""{_bucket}"")
         var mac = NormalizeMac(deviceMac);
         var ifFilter = string.Join(" or ", wanIfNames.Select(n =>
             $@"r.if_name == ""{SanitizeFluxString(n)}"""));
+        // Summing across interfaces groups by (_time, _field), which on a long window at a fine
+        // aggregate means one server-side group per sample - measured at 6657ms against 490ms without,
+        // for 148k samples over 30 days. With a single WAN there is nothing to sum: the stage returns
+        // its one input value unchanged, so skipping it is identical output, not an approximation.
+        // Several interfaces still take the summing path, where it earns its cost.
+        var multiWanSum = wanIfNames.Count > 1
+            ? @"
+  |> group(columns: [""_time"", ""_field""])
+  |> sum()
+  |> group()"
+            : string.Empty;
         var flux = $@"
 from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
@@ -1543,10 +1554,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.device_mac == ""{mac}"")
   |> filter(fn: (r) => {ifFilter})
   |> filter(fn: (r) => r._field == ""rate_in_bps"" or r._field == ""rate_out_bps"")
-  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> group(columns: [""_time"", ""_field""])
-  |> sum()
-  |> group()
+  |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false){multiWanSum}
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
   |> sort(columns: [""_time""])
 ";

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2646,13 +2646,16 @@ from(bucket: ""{_longtermBucket}"")
     private static string ToFluxInstant(DateTime t) =>
         t.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
 
-    private static string ToFluxDuration(TimeSpan window)
-    {
-        if (window.TotalDays >= 1) return $"{(int)window.TotalDays}d";
-        if (window.TotalHours >= 1) return $"{(int)window.TotalHours}h";
-        if (window.TotalMinutes >= 1) return $"{(int)window.TotalMinutes}m";
-        return $"{Math.Max(1, (int)window.TotalSeconds)}s";
-    }
+    /// <summary>
+    /// The window as a Flux duration, exactly. Rendering it in whole units truncated anything that was
+    /// not a round number of them - a computed 103.97s asked Influx for "1m", so the query ran at 60s
+    /// and returned 1.7x the points the caller had sized for, and 90s likewise became "1m". Every
+    /// aggregateWindow in this file goes through here, so the drift was silent and app-wide. Seconds
+    /// are a valid Flux duration at any magnitude, so emitting them keeps the requested window and the
+    /// executed window the same thing.
+    /// </summary>
+    private static string ToFluxDuration(TimeSpan window) =>
+        $"{Math.Max(1, (long)Math.Round(window.TotalSeconds))}s";
 
     private static string SanitizeFluxString(string value) =>
         value.Replace("\"", "").Replace("\\", "").Replace(")", "").Replace("|>", "");

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1530,18 +1530,10 @@ from(bucket: ""{_bucket}"")
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
   |> sort(columns: [""_time""])
 ";
-        var results = new List<WanRatePoint>();
-        await foreach (var record in QueryFluxAsync(flux, ct))
-        {
-            // SNMP rate_in_bps on a WAN interface = bytes received from ISP = download.
-            // rate_out_bps = bytes sent to ISP = upload.
-            results.Add(new WanRatePoint
-            {
-                Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
-                DownloadBps = AsDoubleOrNull(record.GetValueByKey("rate_in_bps")),
-                UploadBps = AsDoubleOrNull(record.GetValueByKey("rate_out_bps"))
-            });
-        }
+        // Raw CSV rather than the client's FluxRecord model, same as the latency-detail reads: ISP
+        // Health holds this series fine-grained however long the window is, so a month reads six
+        // figures of rows and the per-record boxing costs multiples of the query itself.
+        var results = ParseWanRatesCsv(await QueryRawAsync(flux, ct));
         // Order on assembly: the Flux result is NOT globally ordered. pivot emits a separate table
         // whenever a row's field set differs, and those tables arrive after the main one - so an
         // interval where a device reported some fields but not others comes back at the END.
@@ -2675,6 +2667,86 @@ from(bucket: ""{_longtermBucket}"")
             _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
             return string.Empty;
         }
+    }
+
+    /// <summary>
+    /// Parses the annotated-CSV result of the WAN rate pivot query (columns _time, rate_in_bps,
+    /// rate_out_bps) into points, on the same span-based basis as <see cref="ParseLatencyDetailCsv"/>
+    /// and for the same reason: ISP Health holds the rate series at a fine interval however long the
+    /// window is - it is the only signal that can tell sustained load from a spike - so a month-long
+    /// window reads six figures of rows here, and the client's FluxRecord model costs more per record
+    /// than the query costs in total.
+    /// </summary>
+    internal static List<WanRatePoint> ParseWanRatesCsv(string csv)
+    {
+        var result = new List<WanRatePoint>();
+        if (string.IsNullOrEmpty(csv)) return result;
+
+        int iTime = -1, iIn = -1, iOut = -1;
+        var expectHeader = true;
+
+        var span = csv.AsSpan();
+        int pos = 0;
+        while (pos < span.Length)
+        {
+            var nl = span.Slice(pos).IndexOf('\n');
+            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
+            pos = nl < 0 ? span.Length : pos + nl + 1;
+            if (line.Length > 0 && line[line.Length - 1] == '\r') line = line.Slice(0, line.Length - 1);
+            if (line.IsEmpty) continue;
+            if (line[0] == '#') { expectHeader = true; continue; }
+
+            if (expectHeader)
+            {
+                // Re-read on every header: pivot emits a fresh table whenever the field set differs,
+                // so a run where one direction went missing has its own column order.
+                iTime = iIn = iOut = -1;
+                int col = 0, p = 0;
+                while (true)
+                {
+                    var comma = line.Slice(p).IndexOf(',');
+                    var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
+                    if (cell.SequenceEqual("_time")) iTime = col;
+                    else if (cell.SequenceEqual("rate_in_bps")) iIn = col;
+                    else if (cell.SequenceEqual("rate_out_bps")) iOut = col;
+                    col++;
+                    if (comma < 0) break;
+                    p += comma + 1;
+                }
+                expectHeader = false;
+                continue;
+            }
+
+            if (iTime < 0) continue;
+
+            ReadOnlySpan<char> tTime = default, tIn = default, tOut = default;
+            int c = 0, q = 0;
+            while (true)
+            {
+                var comma = line.Slice(q).IndexOf(',');
+                var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
+                if (c == iTime) tTime = cell;
+                else if (c == iIn) tIn = cell;
+                else if (c == iOut) tOut = cell;
+                c++;
+                if (comma < 0) break;
+                q += comma + 1;
+            }
+
+            if (tTime.IsEmpty) continue;
+            if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.RoundtripKind, out var time))
+                continue;
+
+            // rate_in_bps on a WAN interface = bytes received from the ISP = download.
+            result.Add(new WanRatePoint
+            {
+                Time = DateTime.SpecifyKind(time.ToUniversalTime(), DateTimeKind.Utc),
+                DownloadBps = ParseDoubleOrNull(tIn),
+                UploadBps = ParseDoubleOrNull(tOut)
+            });
+        }
+        return result;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1796,7 +1796,6 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
@@ -1822,7 +1821,6 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.target_id == ""{targetId}"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
         // Single target filter, but flatten defensively in case the pivot emits more than one key.
@@ -2669,6 +2667,12 @@ from(bucket: ""{_longtermBucket}"")
         }
     }
 
+    private struct LatencyPointBuilder
+    {
+        public DateTime Time;
+        public double? Rtt, RttMax, Jitter, Loss;
+    }
+
     /// <summary>
     /// Parses the annotated-CSV result of the WAN rate pivot query (columns _time, rate_in_bps,
     /// rate_out_bps) into points, on the same span-based basis as <see cref="ParseLatencyDetailCsv"/>
@@ -2750,23 +2754,27 @@ from(bucket: ""{_longtermBucket}"")
     }
 
     /// <summary>
-    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
-    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
-    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
-    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
-    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
-    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
-    /// so a plain comma split is safe.
+    /// Parses the annotated-CSV result of an UN-PIVOTED latency-detail query (long format: one row per
+    /// (target_id, _field, _time), columns _time, _value, _field, target_id) into per-target point
+    /// lists. Accumulates each field onto a per-(target, time) builder and emits sorted points - i.e.
+    /// it does client-side what a Flux <c>pivot()</c> would do on the server, which was ~half the read
+    /// cost (measured), while producing identical points. Span-based: annotation rows (#...) are skipped
+    /// and the column header is re-read whenever Flux emits one, so column order is never assumed.
+    /// Tag/field values in this measurement never contain commas, so a plain comma split is safe.
     /// </summary>
     internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
     {
         var result = new Dictionary<string, List<LatencySeriesPoint>>();
         if (string.IsNullOrEmpty(csv)) return result;
 
-        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
+        // Per target: (time ticks) -> accumulating builder, so the four fields (which arrive on
+        // separate rows / tables in the long format) merge back onto one point per timestamp.
+        var byTarget = new Dictionary<string, Dictionary<long, LatencyPointBuilder>>();
+
+        int iTime = -1, iValue = -1, iField = -1, iTarget = -1;
         var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
         string? lastKey = null;
-        List<LatencySeriesPoint>? lastList = null;
+        Dictionary<long, LatencyPointBuilder>? lastMap = null;
 
         var span = csv.AsSpan();
         int pos = 0;
@@ -2781,18 +2789,16 @@ from(bucket: ""{_longtermBucket}"")
 
             if (expectHeader)
             {
-                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
+                iTime = iValue = iField = iTarget = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
                     if (cell.SequenceEqual("_time")) iTime = col;
+                    else if (cell.SequenceEqual("_value")) iValue = col;
+                    else if (cell.SequenceEqual("_field")) iField = col;
                     else if (cell.SequenceEqual("target_id")) iTarget = col;
-                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
-                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
-                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
-                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
@@ -2801,56 +2807,68 @@ from(bucket: ""{_longtermBucket}"")
                 continue;
             }
 
-            if (iTime < 0 || iTarget < 0) continue;
+            if (iTime < 0 || iValue < 0 || iField < 0 || iTarget < 0) continue;
 
-            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
+            ReadOnlySpan<char> tTime = default, tValue = default, tField = default, tTarget = default;
             int c = 0, q = 0;
             while (true)
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
                 if (c == iTime) tTime = cell;
+                else if (c == iValue) tValue = cell;
+                else if (c == iField) tField = cell;
                 else if (c == iTarget) tTarget = cell;
-                else if (c == iRtt) tRtt = cell;
-                else if (c == iRttMax) tRttMax = cell;
-                else if (c == iJitter) tJitter = cell;
-                else if (c == iLoss) tLoss = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
+            if (tTarget.IsEmpty || tTime.IsEmpty || tField.IsEmpty) continue;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
                 continue;
 
-            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
-            List<LatencySeriesPoint>? list;
+            // Rows are grouped by (target, field), so reuse the target's map across a run.
+            Dictionary<long, LatencyPointBuilder>? map;
             if (lastKey != null && tTarget.SequenceEqual(lastKey))
             {
-                list = lastList;
+                map = lastMap;
             }
             else
             {
                 var key = tTarget.ToString();
-                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
+                if (!byTarget.TryGetValue(key, out map)) { map = new Dictionary<long, LatencyPointBuilder>(); byTarget[key] = map; }
                 lastKey = key;
-                lastList = list;
+                lastMap = map;
             }
 
-            list!.Add(new LatencySeriesPoint
-            {
-                Time = ToUtc(time),
-                RttAvgMs = ParseDoubleOrNull(tRtt),
-                RttMaxMs = ParseDoubleOrNull(tRttMax),
-                JitterMs = ParseDoubleOrNull(tJitter),
-                LossPercent = ParseDoubleOrNull(tLoss)
-            });
+            var utc = ToUtc(time);
+            map!.TryGetValue(utc.Ticks, out var b);
+            b.Time = utc;
+            var v = ParseDoubleOrNull(tValue);
+            if (tField.SequenceEqual("rtt_avg_ms")) b.Rtt = v;
+            else if (tField.SequenceEqual("rtt_max_ms")) b.RttMax = v;
+            else if (tField.SequenceEqual("jitter_ms")) b.Jitter = v;
+            else if (tField.SequenceEqual("loss_percent")) b.Loss = v;
+            map[utc.Ticks] = b;
         }
 
-        foreach (var list in result.Values)
+        foreach (var (target, map) in byTarget)
+        {
+            var list = new List<LatencySeriesPoint>(map.Count);
+            foreach (var b in map.Values)
+                list.Add(new LatencySeriesPoint
+                {
+                    Time = b.Time,
+                    RttAvgMs = b.Rtt,
+                    RttMaxMs = b.RttMax,
+                    JitterMs = b.Jitter,
+                    LossPercent = b.Loss
+                });
             list.Sort((a, b) => a.Time.CompareTo(b.Time));
+            result[target] = list;
+        }
         return result;
     }
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1821,9 +1821,16 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
+        // Per-query timing: the aggregate figure said the reads cost ~6.7s in-process while the same
+        // queries run in ~1s from a shell on the same box, and neither the parser nor the CPU accounts
+        // for the gap. Split it per query so one slow read cannot hide behind the others.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         var parser = new LatencyDetailCsvParser();
         await QueryRawLinesAsync(flux, parser.ProcessLine, ct);
-        return parser.Finish();
+        var result = parser.Finish();
+        _logger.LogDebug("Influx latency-detail read: {Type} in {Ms}ms, {Targets} target(s), {Points} point(s), window {Window}",
+            targetType, sw.ElapsedMilliseconds, result.Count, result.Sum(kv => kv.Value.Count), ToFluxDuration(window));
+        return result;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1796,6 +1796,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => {typeFilter})
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
     }
@@ -1821,6 +1822,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r.target_id == ""{targetId}"")
   |> filter(fn: (r) => r._field == ""rtt_avg_ms"" or r._field == ""rtt_max_ms"" or r._field == ""jitter_ms"" or r._field == ""loss_percent"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
         var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
         // Single target filter, but flatten defensively in case the pivot emits more than one key.
@@ -2667,12 +2669,6 @@ from(bucket: ""{_longtermBucket}"")
         }
     }
 
-    private struct LatencyPointBuilder
-    {
-        public DateTime Time;
-        public double? Rtt, RttMax, Jitter, Loss;
-    }
-
     /// <summary>
     /// Parses the annotated-CSV result of the WAN rate pivot query (columns _time, rate_in_bps,
     /// rate_out_bps) into points, on the same span-based basis as <see cref="ParseLatencyDetailCsv"/>
@@ -2754,27 +2750,23 @@ from(bucket: ""{_longtermBucket}"")
     }
 
     /// <summary>
-    /// Parses the annotated-CSV result of an UN-PIVOTED latency-detail query (long format: one row per
-    /// (target_id, _field, _time), columns _time, _value, _field, target_id) into per-target point
-    /// lists. Accumulates each field onto a per-(target, time) builder and emits sorted points - i.e.
-    /// it does client-side what a Flux <c>pivot()</c> would do on the server, which was ~half the read
-    /// cost (measured), while producing identical points. Span-based: annotation rows (#...) are skipped
-    /// and the column header is re-read whenever Flux emits one, so column order is never assumed.
-    /// Tag/field values in this measurement never contain commas, so a plain comma split is safe.
+    /// Parses the annotated-CSV result of a latency-detail pivot query (columns target_id, _time,
+    /// rtt_avg_ms, rtt_max_ms, jitter_ms, loss_percent) directly into per-target point lists. Span-
+    /// based: the only allocations are the per-target list, the distinct target_id keys, and the
+    /// points themselves - no FluxRecord, no boxing, no intermediate copy. Annotation rows (#...) are
+    /// skipped and the column header is re-read whenever Flux emits one (default annotated dialect),
+    /// so column order is never assumed. Tag/field values in this measurement never contain commas,
+    /// so a plain comma split is safe.
     /// </summary>
     internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
     {
         var result = new Dictionary<string, List<LatencySeriesPoint>>();
         if (string.IsNullOrEmpty(csv)) return result;
 
-        // Per target: (time ticks) -> accumulating builder, so the four fields (which arrive on
-        // separate rows / tables in the long format) merge back onto one point per timestamp.
-        var byTarget = new Dictionary<string, Dictionary<long, LatencyPointBuilder>>();
-
-        int iTime = -1, iValue = -1, iField = -1, iTarget = -1;
+        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
         var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
         string? lastKey = null;
-        Dictionary<long, LatencyPointBuilder>? lastMap = null;
+        List<LatencySeriesPoint>? lastList = null;
 
         var span = csv.AsSpan();
         int pos = 0;
@@ -2789,16 +2781,18 @@ from(bucket: ""{_longtermBucket}"")
 
             if (expectHeader)
             {
-                iTime = iValue = iField = iTarget = -1;
+                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
                     if (cell.SequenceEqual("_time")) iTime = col;
-                    else if (cell.SequenceEqual("_value")) iValue = col;
-                    else if (cell.SequenceEqual("_field")) iField = col;
                     else if (cell.SequenceEqual("target_id")) iTarget = col;
+                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
+                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
+                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
+                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
@@ -2807,68 +2801,56 @@ from(bucket: ""{_longtermBucket}"")
                 continue;
             }
 
-            if (iTime < 0 || iValue < 0 || iField < 0 || iTarget < 0) continue;
+            if (iTime < 0 || iTarget < 0) continue;
 
-            ReadOnlySpan<char> tTime = default, tValue = default, tField = default, tTarget = default;
+            ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
             int c = 0, q = 0;
             while (true)
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
                 if (c == iTime) tTime = cell;
-                else if (c == iValue) tValue = cell;
-                else if (c == iField) tField = cell;
                 else if (c == iTarget) tTarget = cell;
+                else if (c == iRtt) tRtt = cell;
+                else if (c == iRttMax) tRttMax = cell;
+                else if (c == iJitter) tJitter = cell;
+                else if (c == iLoss) tLoss = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTarget.IsEmpty || tTime.IsEmpty || tField.IsEmpty) continue;
+            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
                 continue;
 
-            // Rows are grouped by (target, field), so reuse the target's map across a run.
-            Dictionary<long, LatencyPointBuilder>? map;
+            // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
+            List<LatencySeriesPoint>? list;
             if (lastKey != null && tTarget.SequenceEqual(lastKey))
             {
-                map = lastMap;
+                list = lastList;
             }
             else
             {
                 var key = tTarget.ToString();
-                if (!byTarget.TryGetValue(key, out map)) { map = new Dictionary<long, LatencyPointBuilder>(); byTarget[key] = map; }
+                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
                 lastKey = key;
-                lastMap = map;
+                lastList = list;
             }
 
-            var utc = ToUtc(time);
-            map!.TryGetValue(utc.Ticks, out var b);
-            b.Time = utc;
-            var v = ParseDoubleOrNull(tValue);
-            if (tField.SequenceEqual("rtt_avg_ms")) b.Rtt = v;
-            else if (tField.SequenceEqual("rtt_max_ms")) b.RttMax = v;
-            else if (tField.SequenceEqual("jitter_ms")) b.Jitter = v;
-            else if (tField.SequenceEqual("loss_percent")) b.Loss = v;
-            map[utc.Ticks] = b;
+            list!.Add(new LatencySeriesPoint
+            {
+                Time = ToUtc(time),
+                RttAvgMs = ParseDoubleOrNull(tRtt),
+                RttMaxMs = ParseDoubleOrNull(tRttMax),
+                JitterMs = ParseDoubleOrNull(tJitter),
+                LossPercent = ParseDoubleOrNull(tLoss)
+            });
         }
 
-        foreach (var (target, map) in byTarget)
-        {
-            var list = new List<LatencySeriesPoint>(map.Count);
-            foreach (var b in map.Values)
-                list.Add(new LatencySeriesPoint
-                {
-                    Time = b.Time,
-                    RttAvgMs = b.Rtt,
-                    RttMaxMs = b.RttMax,
-                    JitterMs = b.Jitter,
-                    LossPercent = b.Loss
-                });
+        foreach (var list in result.Values)
             list.Sort((a, b) => a.Time.CompareTo(b.Time));
-            result[target] = list;
-        }
         return result;
     }
 

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -34,6 +34,10 @@ public class MonitoringInfluxClient : IAsyncDisposable
 
     private InfluxDBClient? _client;
     private WriteApiAsync? _writeApi;
+    // Direct HTTP client for the high-volume raw-CSV reads (see QueryRawLinesAsync). Built and torn
+    // down alongside _client from the same settings; holds the token only in its Authorization
+    // header, the same in-memory exposure as the InfluxDB client itself.
+    private HttpClient? _rawQueryHttp;
     private string? _org;
     private string? _bucket;
     private string? _longtermBucket;
@@ -243,6 +247,22 @@ public class MonitoringInfluxClient : IAsyncDisposable
 
             _client = new InfluxDBClient(options);
             _writeApi = _client.GetWriteApiAsync();
+
+            // Sibling client for the streamed raw-CSV reads. Same wire behavior as the InfluxDB
+            // client's transport (RestSharp defaults to requesting compressed responses) and the
+            // same 60 s timeout - which here bounds only the wait for response headers, so the
+            // body read stays governed by the caller's token (ISP Health's compute budget),
+            // exactly the "budget is the single authority" intent of the 60 s bump above.
+            _rawQueryHttp = new HttpClient(new SocketsHttpHandler
+            {
+                AutomaticDecompression = System.Net.DecompressionMethods.All
+            })
+            {
+                BaseAddress = new Uri(url.EndsWith('/') ? url : url + "/"),
+                Timeout = TimeSpan.FromSeconds(60)
+            };
+            _rawQueryHttp.DefaultRequestHeaders.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Token", plainToken);
             _url = url;
             _org = SanitizeFluxString(org);
             _bucket = SanitizeFluxString(bucket);
@@ -1532,8 +1552,11 @@ from(bucket: ""{_bucket}"")
 ";
         // Raw CSV rather than the client's FluxRecord model, same as the latency-detail reads: ISP
         // Health holds this series fine-grained however long the window is, so a month reads six
-        // figures of rows and the per-record boxing costs multiples of the query itself.
-        var results = ParseWanRatesCsv(await QueryRawAsync(flux, ct));
+        // figures of rows and the per-record boxing costs multiples of the query itself. Parsed
+        // line-by-line as the response streams in - never materialized as one large string.
+        var parser = new WanRatesCsvParser();
+        await QueryRawLinesAsync(flux, parser.ProcessLine, ct);
+        var results = parser.Finish();
         // Order on assembly: the Flux result is NOT globally ordered. pivot emits a separate table
         // whenever a row's field set differs, and those tables arrive after the main one - so an
         // interval where a device reported some fields but not others comes back at the END.
@@ -1798,7 +1821,9 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        return ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
+        var parser = new LatencyDetailCsvParser();
+        await QueryRawLinesAsync(flux, parser.ProcessLine, ct);
+        return parser.Finish();
     }
 
     /// <summary>
@@ -1824,7 +1849,9 @@ from(bucket: ""{_bucket}"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
-        var byTarget = ParseLatencyDetailCsv(await QueryRawAsync(flux, ct));
+        var idParser = new LatencyDetailCsvParser();
+        await QueryRawLinesAsync(flux, idParser.ProcessLine, ct);
+        var byTarget = idParser.Finish();
         // Single target filter, but flatten defensively in case the pivot emits more than one key.
         var list = byTarget.Values.SelectMany(x => x).ToList();
         list.Sort((a, b) => a.Time.CompareTo(b.Time));
@@ -2632,31 +2659,40 @@ from(bucket: ""{_longtermBucket}"")
     };
 
     /// <summary>
-    /// Runs a Flux query and returns the raw annotated CSV. Used for the high-volume latency-detail
-    /// reads, where the client's buffered FluxRecord model (a Dictionary&lt;string,object&gt; with
-    /// boxed values per record) is the dominant cost; <see cref="ParseLatencyDetailCsv"/> stream-parses
-    /// this directly into points with no per-record allocation. Same error handling as QueryFluxAsync.
+    /// Runs a Flux query over a directly-streamed HTTP response and feeds each raw annotated-CSV
+    /// line to <paramref name="onLine"/> as it comes off the wire. Used for the high-volume
+    /// latency-detail and WAN-rate reads, where the InfluxDB client is the dominant cost rather
+    /// than the server: its FluxRecord model boxes every value into a per-record dictionary, its
+    /// string-returning QueryRawAsync accumulates every line and joins them into one tens-of-MB
+    /// large-object-heap string, and either way its transport (RestSharp with the default
+    /// ResponseContentRead) buffers the ENTIRE response body in memory before the first line is
+    /// handed over - so a month-long read paid the payload several times over in allocations and
+    /// could not start parsing until the last byte arrived. This path sends the same query and
+    /// annotated-CSV dialect (<see cref="BuildRawQueryBody"/>) with ResponseHeadersRead and parses
+    /// incrementally, so the only per-row allocations left are the result points themselves.
+    /// Query failures are mapped through the client's own <c>HttpException.Create</c>, keeping the
+    /// exception types (and this method's not-found/bad-request/unauthorized handling) identical
+    /// to the buffered path it replaces; same error handling as QueryFluxAsync.
     /// </summary>
-    // The annotated CSV dialect (datatype/group/default header rows) - same as the client's default
-    // query dialect, so QueryRawAsync returns the format ParseLatencyDetailCsv expects.
-    private static readonly InfluxDB.Client.Api.Domain.Dialect AnnotatedCsvDialect = new(
-        header: true,
-        delimiter: ",",
-        annotations: new List<InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum>
-        {
-            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Group,
-            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Datatype,
-            InfluxDB.Client.Api.Domain.Dialect.AnnotationsEnum.Default,
-        },
-        commentPrefix: "#",
-        dateTimeFormat: null);
-
-    private async Task<string> QueryRawAsync(string flux, CancellationToken ct)
+    private async Task QueryRawLinesAsync(string flux, CsvLineSink onLine, CancellationToken ct)
     {
-        if (_client == null || string.IsNullOrEmpty(_org)) return string.Empty;
+        if (_rawQueryHttp == null || string.IsNullOrEmpty(_org)) return;
         try
         {
-            return await _client.GetQueryApi().QueryRawAsync(flux, AnnotatedCsvDialect, _org, ct);
+            using var request = new HttpRequestMessage(HttpMethod.Post,
+                "api/v2/query?org=" + Uri.EscapeDataString(_org));
+            request.Content = new StringContent(BuildRawQueryBody(flux),
+                System.Text.Encoding.UTF8, "application/json");
+            using var response = await _rawQueryHttp
+                .SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+                throw InfluxDB.Client.Core.Exceptions.HttpException.Create(errorBody,
+                    (IEnumerable<RestSharp.HeaderParameter>?)null, response.ReasonPhrase, response.StatusCode);
+            }
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            await FeedStreamLinesAsync(stream, onLine, ct).ConfigureAwait(false);
         }
         catch (Exception ex) when (
             ex is InfluxDB.Client.Core.Exceptions.NotFoundException
@@ -2665,7 +2701,97 @@ from(bucket: ""{_longtermBucket}"")
         {
             _logger.LogWarning("InfluxDB query failed ({Error}) — check Settings > Monitoring", ex.Message);
             _ = PersistHealthAsync(false, ex.Message, CancellationToken.None);
-            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// JSON body for the raw /api/v2/query POST: the same Flux text and the same annotated-CSV
+    /// dialect (group/datatype/default annotations, header row, comma delimiter, '#' comments,
+    /// default RFC3339 timestamps) the InfluxDB client sent for these reads, so the response
+    /// format - and therefore the parsed result - is unchanged.
+    /// </summary>
+    private static string BuildRawQueryBody(string flux) =>
+        System.Text.Json.JsonSerializer.Serialize(new
+        {
+            query = flux,
+            type = "flux",
+            dialect = new
+            {
+                header = true,
+                delimiter = ",",
+                annotations = new[] { "group", "datatype", "default" },
+                commentPrefix = "#"
+            }
+        });
+
+    /// <summary>
+    /// Reads a UTF-8 CSV response stream and feeds each line to <paramref name="sink"/> with no
+    /// per-line string allocation, splitting on LF exactly as <see cref="FeedCsvLines"/> splits the
+    /// buffered string (the parsers strip the trailing CR of InfluxDB's CRLF terminators), so the
+    /// streamed and string entry points deliver an identical line sequence.
+    /// </summary>
+    private static async Task FeedStreamLinesAsync(Stream stream, CsvLineSink sink, CancellationToken ct)
+    {
+        using var reader = new StreamReader(stream, System.Text.Encoding.UTF8);
+        var pool = System.Buffers.ArrayPool<char>.Shared;
+        var buf = pool.Rent(64 * 1024);
+        try
+        {
+            var len = 0;
+            while (true)
+            {
+                if (len == buf.Length)
+                {
+                    // A single line larger than the buffer (never expected for this data): grow.
+                    var bigger = pool.Rent(buf.Length * 2);
+                    Array.Copy(buf, bigger, len);
+                    pool.Return(buf);
+                    buf = bigger;
+                }
+                var read = await reader.ReadAsync(buf.AsMemory(len, buf.Length - len), ct).ConfigureAwait(false);
+                if (read == 0) break;
+                len += read;
+
+                var start = 0;
+                while (true)
+                {
+                    var nl = buf.AsSpan(start, len - start).IndexOf('\n');
+                    if (nl < 0) break;
+                    sink(buf.AsSpan(start, nl));
+                    start += nl + 1;
+                }
+                if (start > 0)
+                {
+                    Array.Copy(buf, start, buf, 0, len - start);
+                    len -= start;
+                }
+            }
+            if (len > 0) sink(buf.AsSpan(0, len));
+        }
+        finally
+        {
+            pool.Return(buf);
+        }
+    }
+
+    private delegate void CsvLineSink(ReadOnlySpan<char> line);
+
+    /// <summary>
+    /// Splits an in-memory CSV string into lines (LF or CRLF; the parsers strip a trailing CR
+    /// themselves) and feeds them to <paramref name="sink"/> - the string-input counterpart of
+    /// <see cref="QueryRawLinesAsync"/>, so the string-based parse entry points and the streamed
+    /// query path run the exact same per-line logic.
+    /// </summary>
+    private static void FeedCsvLines(string csv, CsvLineSink sink)
+    {
+        var span = csv.AsSpan();
+        int pos = 0;
+        while (pos < span.Length)
+        {
+            var nl = span.Slice(pos).IndexOf('\n');
+            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
+            pos = nl < 0 ? span.Length : pos + nl + 1;
+            sink(line);
         }
     }
 
@@ -2679,45 +2805,52 @@ from(bucket: ""{_longtermBucket}"")
     /// </summary>
     internal static List<WanRatePoint> ParseWanRatesCsv(string csv)
     {
-        var result = new List<WanRatePoint>();
-        if (string.IsNullOrEmpty(csv)) return result;
+        var parser = new WanRatesCsvParser();
+        if (!string.IsNullOrEmpty(csv)) FeedCsvLines(csv, parser.ProcessLine);
+        return parser.Finish();
+    }
 
-        int iTime = -1, iIn = -1, iOut = -1;
-        var expectHeader = true;
+    /// <summary>
+    /// Incremental line-by-line form of <see cref="ParseWanRatesCsv"/>, fed straight from
+    /// <see cref="QueryRawLinesAsync"/> so a month-long rate read is parsed as it streams in
+    /// instead of being materialized as one large string first. The per-line logic is the
+    /// string parser's, verbatim; <see cref="ParseWanRatesCsv"/> delegates here so the two
+    /// entry points can never drift.
+    /// </summary>
+    internal sealed class WanRatesCsvParser
+    {
+        private readonly List<WanRatePoint> _result = new();
+        private int _iTime = -1, _iIn = -1, _iOut = -1;
+        private bool _expectHeader = true;
 
-        var span = csv.AsSpan();
-        int pos = 0;
-        while (pos < span.Length)
+        public void ProcessLine(ReadOnlySpan<char> line)
         {
-            var nl = span.Slice(pos).IndexOf('\n');
-            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
-            pos = nl < 0 ? span.Length : pos + nl + 1;
             if (line.Length > 0 && line[line.Length - 1] == '\r') line = line.Slice(0, line.Length - 1);
-            if (line.IsEmpty) continue;
-            if (line[0] == '#') { expectHeader = true; continue; }
+            if (line.IsEmpty) return;
+            if (line[0] == '#') { _expectHeader = true; return; }
 
-            if (expectHeader)
+            if (_expectHeader)
             {
                 // Re-read on every header: pivot emits a fresh table whenever the field set differs,
                 // so a run where one direction went missing has its own column order.
-                iTime = iIn = iOut = -1;
+                _iTime = _iIn = _iOut = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
-                    if (cell.SequenceEqual("_time")) iTime = col;
-                    else if (cell.SequenceEqual("rate_in_bps")) iIn = col;
-                    else if (cell.SequenceEqual("rate_out_bps")) iOut = col;
+                    if (cell.SequenceEqual("_time")) _iTime = col;
+                    else if (cell.SequenceEqual("rate_in_bps")) _iIn = col;
+                    else if (cell.SequenceEqual("rate_out_bps")) _iOut = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
                 }
-                expectHeader = false;
-                continue;
+                _expectHeader = false;
+                return;
             }
 
-            if (iTime < 0) continue;
+            if (_iTime < 0) return;
 
             ReadOnlySpan<char> tTime = default, tIn = default, tOut = default;
             int c = 0, q = 0;
@@ -2725,28 +2858,30 @@ from(bucket: ""{_longtermBucket}"")
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
-                if (c == iTime) tTime = cell;
-                else if (c == iIn) tIn = cell;
-                else if (c == iOut) tOut = cell;
+                if (c == _iTime) tTime = cell;
+                else if (c == _iIn) tIn = cell;
+                else if (c == _iOut) tOut = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTime.IsEmpty) continue;
+            if (tTime.IsEmpty) return;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
-                continue;
+                return;
 
             // rate_in_bps on a WAN interface = bytes received from the ISP = download.
-            result.Add(new WanRatePoint
+            _result.Add(new WanRatePoint
             {
                 Time = DateTime.SpecifyKind(time.ToUniversalTime(), DateTimeKind.Utc),
                 DownloadBps = ParseDoubleOrNull(tIn),
                 UploadBps = ParseDoubleOrNull(tOut)
             });
         }
-        return result;
+
+        /// <summary>Returns the accumulated points in arrival order (callers sort, as before).</summary>
+        public List<WanRatePoint> Finish() => _result;
     }
 
     /// <summary>
@@ -2760,48 +2895,55 @@ from(bucket: ""{_longtermBucket}"")
     /// </summary>
     internal static Dictionary<string, List<LatencySeriesPoint>> ParseLatencyDetailCsv(string csv)
     {
-        var result = new Dictionary<string, List<LatencySeriesPoint>>();
-        if (string.IsNullOrEmpty(csv)) return result;
+        var parser = new LatencyDetailCsvParser();
+        if (!string.IsNullOrEmpty(csv)) FeedCsvLines(csv, parser.ProcessLine);
+        return parser.Finish();
+    }
 
-        int iTime = -1, iTarget = -1, iRtt = -1, iRttMax = -1, iJitter = -1, iLoss = -1;
-        var expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
-        string? lastKey = null;
-        List<LatencySeriesPoint>? lastList = null;
+    /// <summary>
+    /// Incremental line-by-line form of <see cref="ParseLatencyDetailCsv"/>, fed straight from
+    /// <see cref="QueryRawLinesAsync"/> so a month-long latency read is parsed as it streams in
+    /// instead of being materialized as one large string first. The per-line logic is the string
+    /// parser's, verbatim; <see cref="ParseLatencyDetailCsv"/> delegates here so the two entry
+    /// points can never drift.
+    /// </summary>
+    internal sealed class LatencyDetailCsvParser
+    {
+        private readonly Dictionary<string, List<LatencySeriesPoint>> _result = new();
+        private int _iTime = -1, _iTarget = -1, _iRtt = -1, _iRttMax = -1, _iJitter = -1, _iLoss = -1;
+        private bool _expectHeader = true; // first non-# line is a header (annotated dialect re-arms this after each #-block)
+        private string? _lastKey;
+        private List<LatencySeriesPoint>? _lastList;
 
-        var span = csv.AsSpan();
-        int pos = 0;
-        while (pos < span.Length)
+        public void ProcessLine(ReadOnlySpan<char> line)
         {
-            var nl = span.Slice(pos).IndexOf('\n');
-            var line = nl < 0 ? span.Slice(pos) : span.Slice(pos, nl);
-            pos = nl < 0 ? span.Length : pos + nl + 1;
             if (line.Length > 0 && line[line.Length - 1] == '\r') line = line.Slice(0, line.Length - 1);
-            if (line.IsEmpty) continue;
-            if (line[0] == '#') { expectHeader = true; continue; }
+            if (line.IsEmpty) return;
+            if (line[0] == '#') { _expectHeader = true; return; }
 
-            if (expectHeader)
+            if (_expectHeader)
             {
-                iTime = iTarget = iRtt = iRttMax = iJitter = iLoss = -1;
+                _iTime = _iTarget = _iRtt = _iRttMax = _iJitter = _iLoss = -1;
                 int col = 0, p = 0;
                 while (true)
                 {
                     var comma = line.Slice(p).IndexOf(',');
                     var cell = comma < 0 ? line.Slice(p) : line.Slice(p, comma);
-                    if (cell.SequenceEqual("_time")) iTime = col;
-                    else if (cell.SequenceEqual("target_id")) iTarget = col;
-                    else if (cell.SequenceEqual("rtt_avg_ms")) iRtt = col;
-                    else if (cell.SequenceEqual("rtt_max_ms")) iRttMax = col;
-                    else if (cell.SequenceEqual("jitter_ms")) iJitter = col;
-                    else if (cell.SequenceEqual("loss_percent")) iLoss = col;
+                    if (cell.SequenceEqual("_time")) _iTime = col;
+                    else if (cell.SequenceEqual("target_id")) _iTarget = col;
+                    else if (cell.SequenceEqual("rtt_avg_ms")) _iRtt = col;
+                    else if (cell.SequenceEqual("rtt_max_ms")) _iRttMax = col;
+                    else if (cell.SequenceEqual("jitter_ms")) _iJitter = col;
+                    else if (cell.SequenceEqual("loss_percent")) _iLoss = col;
                     col++;
                     if (comma < 0) break;
                     p += comma + 1;
                 }
-                expectHeader = false;
-                continue;
+                _expectHeader = false;
+                return;
             }
 
-            if (iTime < 0 || iTarget < 0) continue;
+            if (_iTime < 0 || _iTarget < 0) return;
 
             ReadOnlySpan<char> tTime = default, tTarget = default, tRtt = default, tRttMax = default, tJitter = default, tLoss = default;
             int c = 0, q = 0;
@@ -2809,34 +2951,34 @@ from(bucket: ""{_longtermBucket}"")
             {
                 var comma = line.Slice(q).IndexOf(',');
                 var cell = comma < 0 ? line.Slice(q) : line.Slice(q, comma);
-                if (c == iTime) tTime = cell;
-                else if (c == iTarget) tTarget = cell;
-                else if (c == iRtt) tRtt = cell;
-                else if (c == iRttMax) tRttMax = cell;
-                else if (c == iJitter) tJitter = cell;
-                else if (c == iLoss) tLoss = cell;
+                if (c == _iTime) tTime = cell;
+                else if (c == _iTarget) tTarget = cell;
+                else if (c == _iRtt) tRtt = cell;
+                else if (c == _iRttMax) tRttMax = cell;
+                else if (c == _iJitter) tJitter = cell;
+                else if (c == _iLoss) tLoss = cell;
                 c++;
                 if (comma < 0) break;
                 q += comma + 1;
             }
 
-            if (tTarget.IsEmpty || tTime.IsEmpty) continue;
+            if (tTarget.IsEmpty || tTime.IsEmpty) return;
             if (!DateTime.TryParse(tTime, System.Globalization.CultureInfo.InvariantCulture,
                     System.Globalization.DateTimeStyles.RoundtripKind, out var time))
-                continue;
+                return;
 
             // Rows are grouped by target, so reuse the key/list across a run rather than re-allocating.
             List<LatencySeriesPoint>? list;
-            if (lastKey != null && tTarget.SequenceEqual(lastKey))
+            if (_lastKey != null && tTarget.SequenceEqual(_lastKey))
             {
-                list = lastList;
+                list = _lastList;
             }
             else
             {
                 var key = tTarget.ToString();
-                if (!result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); result[key] = list; }
-                lastKey = key;
-                lastList = list;
+                if (!_result.TryGetValue(key, out list)) { list = new List<LatencySeriesPoint>(); _result[key] = list; }
+                _lastKey = key;
+                _lastList = list;
             }
 
             list!.Add(new LatencySeriesPoint
@@ -2849,9 +2991,13 @@ from(bucket: ""{_longtermBucket}"")
             });
         }
 
-        foreach (var list in result.Values)
-            list.Sort((a, b) => a.Time.CompareTo(b.Time));
-        return result;
+        /// <summary>Sorts each target's points by time and returns the accumulated result.</summary>
+        public Dictionary<string, List<LatencySeriesPoint>> Finish()
+        {
+            foreach (var list in _result.Values)
+                list.Sort((a, b) => a.Time.CompareTo(b.Time));
+            return _result;
+        }
     }
 
     private static double? ParseDoubleOrNull(ReadOnlySpan<char> s) =>
@@ -3394,6 +3540,8 @@ from(bucket: ""{_longtermBucket}"")
         _client?.Dispose();
         _client = null;
         _writeApi = null;
+        _rawQueryHttp?.Dispose();
+        _rawQueryHttp = null;
     }
 
     private static string NormalizeMac(string mac) =>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -269,7 +269,7 @@
                     placement: 'top',
                     theme: 'custom',
                     appendTo: document.body,
-                    maxWidth: isWide ? 380 : 320,
+                    maxWidth: isWide ? 'min(100vw - 10px, 400px)' : 'min(100vw - 10px, 360px)',
                     onShow(instance) {
                         // Close other open tooltips
                         document.querySelectorAll('.tooltip-icon').forEach(function(other) {
@@ -321,7 +321,9 @@
                     placement: 'top',
                     theme: 'custom',
                     appendTo: document.body,
-                    maxWidth: el.hasAttribute('data-tooltip-wrap') ? 320 : 'none',
+                    maxWidth: el.hasAttribute('data-tooltip-wrap')
+                        ? 'min(100vw - 10px, 320px)'
+                        : 'min(100vw - 10px, 360px)',
                     onShow: function(instance) {
                         // Suppress if an adjacent sibling already shows the same tooltip
                         var ref = instance.reference;
@@ -400,7 +402,9 @@
                     placement: 'top',
                     theme: 'custom',
                     appendTo: document.body,
-                    maxWidth: el.hasAttribute('data-tooltip-wrap') ? 320 : 'none',
+                    maxWidth: el.hasAttribute('data-tooltip-wrap')
+                        ? 'min(100vw - 10px, 320px)'
+                        : 'min(100vw - 10px, 360px)',
                     onShow: function(instance) {
                         var ref = instance.reference;
                         var siblings = [ref.previousElementSibling, ref.nextElementSibling];

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -323,7 +323,9 @@
                     appendTo: document.body,
                     maxWidth: el.hasAttribute('data-tooltip-wrap')
                         ? 'min(100vw - 10px, 320px)'
-                        : 'min(100vw - 10px, 360px)',
+                        : el.hasAttribute('data-tooltip-wide')
+                            ? 'min(100vw - 10px, 400px)'
+                            : 'min(100vw - 10px, 360px)',
                     onShow: function(instance) {
                         // Suppress if an adjacent sibling already shows the same tooltip
                         var ref = instance.reference;
@@ -404,7 +406,9 @@
                     appendTo: document.body,
                     maxWidth: el.hasAttribute('data-tooltip-wrap')
                         ? 'min(100vw - 10px, 320px)'
-                        : 'min(100vw - 10px, 360px)',
+                        : el.hasAttribute('data-tooltip-wide')
+                            ? 'min(100vw - 10px, 400px)'
+                            : 'min(100vw - 10px, 360px)',
                     onShow: function(instance) {
                         var ref = instance.reference;
                         var siblings = [ref.previousElementSibling, ref.nextElementSibling];

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -668,7 +668,8 @@
                         <span class="form-hint" style="margin: 0;">seconds</span>
                     </div>
                 </div>
-                <div class="form-group">
+                @* Tour anchor sits on WAN 1 only; a duplicate selector would just resolve to this one. *@
+                <div class="form-group" data-tour="sqm-download-burst">
                     <label class="toggle-label">
                         <input type="checkbox" @bind="wan1Config.RateProportionalDownloadBurst" />
                         <span>Larger download burst</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -430,11 +430,16 @@ else
                                         </span>
                                     </span>
                                     <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
-                                    @if (target.LatencyStabilityScore.HasValue)
+                                    @{
+                                        var hopLimit = LimitingAspect(target.LatencyStabilityScore, target.CongestionScore,
+                                            target.CongestionEventCount, IspHealth.Options.AsnLatencyStabilityWeight,
+                                            IspHealth.Options.AsnCongestionWeight);
+                                    }
+                                    @if (hopLimit is not null)
                                     {
                                         <span class="isp-target-stat">
-                                            <span class="isp-target-stat-label">Stability</span>
-                                            <span class="isp-target-stat-value @ScoreTextClass(target.LatencyStabilityScore)">@target.LatencyStabilityScore</span>
+                                            <span class="isp-target-stat-label">@hopLimit.Value.Label</span>
+                                            <span class="isp-target-stat-value @ScoreTextClass(hopLimit.Value.Score)">@hopLimit.Value.Value</span>
                                         </span>
                                     }
                                     @if (target.ReachDeltaMs is > 0.15)
@@ -593,11 +598,16 @@ else
                                     </span>
                                 </div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
-                                @if (asn.LatencyStabilityScore.HasValue)
+                                @{
+                                    var asnLimit = LimitingAspect(asn.LatencyStabilityScore, asn.CongestionScore,
+                                        asn.CongestionEventCount, IspHealth.Options.AsnLatencyStabilityWeight,
+                                        IspHealth.Options.AsnCongestionWeight);
+                                }
+                                @if (asnLimit is not null)
                                 {
                                     <div class="isp-asn-stat">
-                                        <span class="detail-label">Stability</span>
-                                        <span class="detail-value @ScoreTextClass(asn.LatencyStabilityScore)">@asn.LatencyStabilityScore</span>
+                                        <span class="detail-label">@asnLimit.Value.Label</span>
+                                        <span class="detail-value @ScoreTextClass(asnLimit.Value.Score)">@asnLimit.Value.Value</span>
                                     </div>
                                 }
                                 @if (asn.ReachDeltaMs.HasValue)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -267,7 +267,7 @@ else
             </a>
             <div class="isp-health-hero-side">
                 <div class="isp-health-uptime" data-tour="isp-uptime"
-                     data-tooltip="Share of the window the internet was reachable. Partial-loss disruptions count for the share they dropped; LAN/gateway drops and ones you marked &quot;that was me&quot; are excluded."
+                     data-tooltip="Share of the window the internet was reachable. Excludes your own LAN drops and &quot;that was me&quot; events."
                      data-tooltip-click>
                     <div class="isp-uptime-label">Uptime</div>
                     <div class="isp-uptime-value">@FormatUptime(r)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -430,6 +430,13 @@ else
                                         </span>
                                     </span>
                                     <span class="isp-target-stat"><span class="isp-target-stat-label">Loss</span>@FormatLossPct(target.LossPct)</span>
+                                    @if (target.LatencyStabilityScore.HasValue)
+                                    {
+                                        <span class="isp-target-stat">
+                                            <span class="isp-target-stat-label">Stability</span>
+                                            <span class="isp-target-stat-value @ScoreTextClass(target.LatencyStabilityScore)">@target.LatencyStabilityScore</span>
+                                        </span>
+                                    }
                                     @if (target.ReachDeltaMs is > 0.15)
                                     {
                                         <span class="isp-target-stat"><span class="isp-target-stat-label">Beyond nearest</span>+@FormatMs(target.ReachDeltaMs)</span>
@@ -586,6 +593,13 @@ else
                                     </span>
                                 </div>
                                 <div class="isp-asn-stat"><span class="detail-label">Loss</span><span class="detail-value">@FormatLossPct(asn.LossPct)</span></div>
+                                @if (asn.LatencyStabilityScore.HasValue)
+                                {
+                                    <div class="isp-asn-stat">
+                                        <span class="detail-label">Stability</span>
+                                        <span class="detail-value @ScoreTextClass(asn.LatencyStabilityScore)">@asn.LatencyStabilityScore</span>
+                                    </div>
+                                }
                                 @if (asn.ReachDeltaMs.HasValue)
                                 {
                                     <div class="isp-asn-stat"><span class="detail-label">Beyond ISP</span><span class="detail-value">+@FormatMs(asn.ReachDeltaMs)</span></div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -234,7 +234,7 @@ else
             <a href="/wan-speedtest" class="isp-health-hero-speed">
                 <div class="isp-speed-label">Speed vs Plan</div>
                 <div class="isp-speed-headline" data-tooltip="Best download and best upload from your recent WAN speed tests; each may come from a different test."
-                     data-tooltip-click>
+                     data-tooltip-click data-tooltip-wide>
                     <span class="isp-speed-measured">@FormatSpeed(r.MeasuredDownloadMbps) / @FormatSpeed(r.MeasuredUploadMbps)</span>
                     <span class="isp-speed-unit">Mbps</span>
                 </div>
@@ -268,7 +268,7 @@ else
             <div class="isp-health-hero-side">
                 <div class="isp-health-uptime" data-tour="isp-uptime"
                      data-tooltip="Share of the window the internet was reachable. Excludes your own LAN drops and &quot;that was me&quot; events."
-                     data-tooltip-click>
+                     data-tooltip-click data-tooltip-wide>
                     <div class="isp-uptime-label">Uptime</div>
                     <div class="isp-uptime-value">@FormatUptime(r)</div>
                     <div class="isp-uptime-sub">@FormatDowntime(r.Downtime) &middot; @WindowLabel(r)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -266,7 +266,8 @@ else
                 }
             </a>
             <div class="isp-health-hero-side">
-                <div class="isp-health-uptime" data-tooltip="Share of the window the internet was reachable. Counts full and brief outages; LAN/gateway and acknowledged events are excluded."
+                <div class="isp-health-uptime" data-tour="isp-uptime"
+                     data-tooltip="Share of the window the internet was reachable. Partial-loss disruptions count for the share they dropped; LAN/gateway drops and ones you marked &quot;that was me&quot; are excluded."
                      data-tooltip-click>
                     <div class="isp-uptime-label">Uptime</div>
                     <div class="isp-uptime-value">@FormatUptime(r)</div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -265,10 +265,18 @@ else
                     <div class="isp-speed-sub">Set your ISP speeds in UniFi Network to grade throughput</div>
                 }
             </a>
-            <div class="isp-health-hero-dimensions">
-                <IspHealthScoreGauge Score="r.AccessDimension.Score" Label="Access Layer" Small="true" />
-                <IspHealthScoreGauge Score="r.IspAsnDimension.Score" Label="ISP Network" Small="true" />
-                <IspHealthScoreGauge Score="r.TransitDimension.Score" Label="Transit" Small="true" />
+            <div class="isp-health-hero-side">
+                <div class="isp-health-uptime" data-tooltip="Share of the window the internet was reachable. Counts full and brief outages; LAN/gateway and acknowledged events are excluded."
+                     data-tooltip-click>
+                    <div class="isp-uptime-label">Uptime</div>
+                    <div class="isp-uptime-value">@FormatUptime(r)</div>
+                    <div class="isp-uptime-sub">@FormatDowntime(r.Downtime) &middot; @WindowLabel(r)</div>
+                </div>
+                <div class="isp-health-hero-dimensions">
+                    <IspHealthScoreGauge Score="r.AccessDimension.Score" Label="Access Layer" Small="true" />
+                    <IspHealthScoreGauge Score="r.IspAsnDimension.Score" Label="ISP Network" Small="true" />
+                    <IspHealthScoreGauge Score="r.TransitDimension.Score" Label="Transit" Small="true" />
+                </div>
             </div>
         </div>
     </div>

--- a/src/NetworkOptimizer.Web/Services/Gates/AuditContext.cs
+++ b/src/NetworkOptimizer.Web/Services/Gates/AuditContext.cs
@@ -14,8 +14,17 @@ public interface IAuditContext
     /// <summary>Overrides the target id/name recorded on the event.</summary>
     void SetTarget(string? targetId, string? targetName = null);
 
+    /// <summary>
+    /// Declares that this call changed nothing, so no event is written. For an idempotent "ensure"
+    /// method that found everything already in place: it is reached on ordinary page loads, and a
+    /// "changed" entry for a call that changed nothing is both noise and untrue - it buries the real
+    /// changes an audit log exists to show. Only ever called on the success path, so a method that
+    /// throws is still audited as a failure.
+    /// </summary>
+    void SuppressNoChange();
+
     /// <summary>Reads and clears the pending detail (called by the interceptor after the method runs).</summary>
-    (object? Details, string? TargetId, string? TargetName) Drain();
+    (object? Details, string? TargetId, string? TargetName, bool Suppressed) Drain();
 }
 
 /// <inheritdoc />
@@ -24,6 +33,7 @@ public sealed class AuditContext : IAuditContext
     private object? _details;
     private string? _targetId;
     private string? _targetName;
+    private bool _suppressed;
 
     /// <inheritdoc />
     public void SetDetails(object details) => _details = details;
@@ -36,12 +46,16 @@ public sealed class AuditContext : IAuditContext
     }
 
     /// <inheritdoc />
-    public (object? Details, string? TargetId, string? TargetName) Drain()
+    public void SuppressNoChange() => _suppressed = true;
+
+    /// <inheritdoc />
+    public (object? Details, string? TargetId, string? TargetName, bool Suppressed) Drain()
     {
-        var result = (_details, _targetId, _targetName);
+        var result = (_details, _targetId, _targetName, _suppressed);
         _details = null;
         _targetId = null;
         _targetName = null;
+        _suppressed = false;
         return result;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Gates/MethodSecurityInterceptor.cs
+++ b/src/NetworkOptimizer.Web/Services/Gates/MethodSecurityInterceptor.cs
@@ -175,7 +175,10 @@ public sealed class MethodSecurityInterceptor : AsyncInterceptorBase
 
     private void EmitAudit(CallerInfo caller, AuditActionAttribute auditAttr, string? siteSlug, string outcome)
     {
-        var (details, targetId, targetName) = _auditContext.Drain();
+        var (details, targetId, targetName, suppressed) = _auditContext.Drain();
+        // A method that ran fine and changed nothing writes no event. Never applied to a failure:
+        // only the success path can call SuppressNoChange, so a throw still lands in the log.
+        if (suppressed && outcome == AuditOutcomes.Success) return;
         _audit.Log(AuditEventBuilder.From(
             caller,
             auditAttr.Category,

--- a/src/NetworkOptimizer.Web/Services/InfluxDbProvisioningService.cs
+++ b/src/NetworkOptimizer.Web/Services/InfluxDbProvisioningService.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using NetworkOptimizer.Web.Services.Gates;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -21,13 +22,16 @@ public class InfluxDbProvisioningService : IInfluxDbProvisioningService
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<InfluxDbProvisioningService> _logger;
+    private readonly IAuditContext _auditContext;
 
     public InfluxDbProvisioningService(
         IHttpClientFactory httpClientFactory,
-        ILogger<InfluxDbProvisioningService> logger)
+        ILogger<InfluxDbProvisioningService> logger,
+        IAuditContext auditContext)
     {
         _httpClientFactory = httpClientFactory;
         _logger = logger;
+        _auditContext = auditContext;
     }
 
     /// <summary>
@@ -169,16 +173,35 @@ public class InfluxDbProvisioningService : IInfluxDbProvisioningService
     {
         var primary = await EnsureBucketAsync(url, adminToken, orgId, primaryBucket, retentionSeconds: 90 * 86400, ct);
         var longterm = await EnsureBucketAsync(url, adminToken, orgId, longtermBucket, retentionSeconds: 365 * 86400, ct);
+
+        // This method is idempotent and sits on a path the Monitoring page walks on every load, so
+        // most calls create nothing. Say so: no event at all when nothing was created, and when
+        // something was, name the buckets rather than filing a bare "monitoring setup changed".
+        var created = new List<string>();
+        if (primary.Created) created.Add(primary.Bucket.Name);
+        if (longterm.Created) created.Add(longterm.Bucket.Name);
+        if (created.Count == 0)
+        {
+            _auditContext.SuppressNoChange();
+        }
+        else
+        {
+            _auditContext.SetTarget(string.Join(",", created), string.Join(", ", created));
+            _auditContext.SetDetails(new { createdBuckets = created, orgId });
+        }
+
         return new BucketProvisionResult
         {
-            PrimaryBucketId = primary.Id,
-            PrimaryBucketName = primary.Name,
-            LongtermBucketId = longterm.Id,
-            LongtermBucketName = longterm.Name
+            PrimaryBucketId = primary.Bucket.Id,
+            PrimaryBucketName = primary.Bucket.Name,
+            LongtermBucketId = longterm.Bucket.Id,
+            LongtermBucketName = longterm.Bucket.Name,
+            CreatedBucketNames = created
         };
     }
 
-    private async Task<InfluxBucket> EnsureBucketAsync(string url, string adminToken, string orgId, string name, long retentionSeconds, CancellationToken ct)
+    /// <summary>Finds or creates one bucket, reporting which of the two it did.</summary>
+    private async Task<(InfluxBucket Bucket, bool Created)> EnsureBucketAsync(string url, string adminToken, string orgId, string name, long retentionSeconds, CancellationToken ct)
     {
         using var http = _httpClientFactory.CreateClient();
         var listUri = $"{NormalizeUrl(url)}/api/v2/buckets?orgID={Uri.EscapeDataString(orgId)}&name={Uri.EscapeDataString(name)}";
@@ -190,7 +213,7 @@ public class InfluxDbProvisioningService : IInfluxDbProvisioningService
             var listBody = await listResp.Content.ReadAsStringAsync(ct);
             var existing = JsonSerializer.Deserialize<InfluxBucketList>(listBody, SerializerOptions);
             var found = existing?.Buckets?.FirstOrDefault();
-            if (found != null) return found;
+            if (found != null) return (found, false);
         }
 
         var createReq = new HttpRequestMessage(HttpMethod.Post, NormalizeUrl(url) + "/api/v2/buckets")
@@ -210,8 +233,9 @@ public class InfluxDbProvisioningService : IInfluxDbProvisioningService
             throw new InvalidOperationException($"Create bucket {name} failed: HTTP {(int)createResp.StatusCode}: {errBody}");
         }
         var body = await createResp.Content.ReadAsStringAsync(ct);
-        return JsonSerializer.Deserialize<InfluxBucket>(body, SerializerOptions)
+        var createdBucket = JsonSerializer.Deserialize<InfluxBucket>(body, SerializerOptions)
             ?? throw new InvalidOperationException("Bucket created but response could not be parsed");
+        return (createdBucket, true);
     }
 
     /// <summary>
@@ -361,6 +385,9 @@ public class InfluxDbProvisioningService : IInfluxDbProvisioningService
         public required string PrimaryBucketName { get; init; }
         public required string LongtermBucketId { get; init; }
         public required string LongtermBucketName { get; init; }
+
+        /// <summary>Names of the buckets this call actually created; empty when both already existed.</summary>
+        public IReadOnlyList<string> CreatedBucketNames { get; init; } = Array.Empty<string>();
     }
 
     public record ScopedTokenResult

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
@@ -1,0 +1,112 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Loss measured to the LAN gateway, used as a floor under every upstream loss measurement.
+///
+/// Every probe this host sends crosses its own NIC, its cable, the switching fabric and the gateway
+/// before it can reach anything beyond - so loss to the gateway is the common-mode noise floor of the
+/// whole measurement chain. A healthy UniFi gateway does not drop ICMP addressed to itself; when it
+/// does, the cause is on this side of the WAN (gateway CPU or forwarding path, switching overload or
+/// errors, cabling, or the monitoring host's own NIC), and a gateway dropping under load is dropping
+/// the packets it routes to the WAN too. None of it is the ISP's, and all of it lands on every
+/// upstream target at once.
+///
+/// Subtractive only: it caps what may be attributed upstream and can never invent upstream health,
+/// nor make a target read worse than it measured.
+///
+/// LOSS ONLY. Gateway RTT inflates under CPU pressure with no forwarding fault at all, so the same
+/// treatment applied to latency would absolve real upstream latency. Drops are the clean signal
+/// precisely because a gateway only drops when forwarding or switching is genuinely in trouble.
+/// </summary>
+public sealed class GatewayLossFloor
+{
+    private readonly DateTime[] _times;
+    private readonly double[] _lossPct;
+    private readonly double _stalenessSeconds;
+
+    private GatewayLossFloor(DateTime[] times, double[] lossPct, double stalenessSeconds)
+    {
+        _times = times;
+        _lossPct = lossPct;
+        _stalenessSeconds = stalenessSeconds;
+    }
+
+    /// <summary>An empty floor: subtracts nothing. Used when no gateway target is monitored.</summary>
+    public static GatewayLossFloor None { get; } =
+        new(Array.Empty<DateTime>(), Array.Empty<double>(), 0);
+
+    /// <summary>True when any gateway loss was measured at all - i.e. when the floor can bite.</summary>
+    public bool HasLoss { get; private set; }
+
+    /// <summary>Highest gateway loss seen, for the finding that reports the local fault.</summary>
+    public double PeakLossPct { get; private set; }
+
+    /// <summary>Mean gateway loss across the samples that carried a reading.</summary>
+    public double MeanLossPct { get; private set; }
+
+    /// <summary>
+    /// Builds the floor from the gateway target's series. Samples without a loss reading are dropped
+    /// rather than treated as zero: an absent measurement is not evidence the chain was clean.
+    /// </summary>
+    public static GatewayLossFloor Build(IReadOnlyList<LatencySample> gatewaySamples, IspHealthOptions options)
+    {
+        if (gatewaySamples.Count == 0) return None;
+
+        var ordered = gatewaySamples
+            .Where(s => s.LossPercent.HasValue)
+            .OrderBy(s => s.Time)
+            .ToList();
+        if (ordered.Count == 0) return None;
+
+        var times = new DateTime[ordered.Count];
+        var loss = new double[ordered.Count];
+        var sum = 0.0;
+        var peak = 0.0;
+        for (var i = 0; i < ordered.Count; i++)
+        {
+            times[i] = ordered[i].Time;
+            var v = Math.Clamp(ordered[i].LossPercent!.Value, 0, 100);
+            loss[i] = v;
+            sum += v;
+            if (v > peak) peak = v;
+        }
+
+        return new GatewayLossFloor(times, loss, options.GatewayFloorMaxStalenessSeconds)
+        {
+            HasLoss = peak > 0,
+            PeakLossPct = peak,
+            MeanLossPct = sum / ordered.Count
+        };
+    }
+
+    /// <summary>
+    /// The floor at an instant: the most recent gateway reading at or before it, provided that reading
+    /// is not stale. Carried forward rather than re-interpolated because the floor reflects a physical
+    /// condition that persists across a poll or two; past the staleness bound it decays to zero, so an
+    /// old reading cannot keep suppressing loss indefinitely. Zero when nothing is known, which leaves
+    /// the measurement untouched.
+    /// </summary>
+    public double FloorAt(DateTime time)
+    {
+        if (_times.Length == 0) return 0;
+
+        var i = Array.BinarySearch(_times, time);
+        if (i < 0)
+        {
+            i = ~i - 1;          // the entry immediately before the insertion point
+            if (i < 0) return 0; // before the first reading
+        }
+        return (time - _times[i]).TotalSeconds <= _stalenessSeconds ? _lossPct[i] : 0;
+    }
+
+    /// <summary>
+    /// One target's loss with the local chain's contribution removed. Never negative: a target
+    /// measuring less loss than the gateway did is reporting a clean path, not a negative one.
+    /// </summary>
+    public double Apply(double lossPct, DateTime time)
+    {
+        if (_times.Length == 0) return lossPct;
+        var floor = FloorAt(time);
+        return floor <= 0 ? lossPct : Math.Max(0, lossPct - floor);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
@@ -23,17 +23,19 @@ public sealed class GatewayLossFloor
     private readonly DateTime[] _times;
     private readonly double[] _lossPct;
     private readonly double _stalenessSeconds;
+    private readonly double _matchSeconds;
 
-    private GatewayLossFloor(DateTime[] times, double[] lossPct, double stalenessSeconds)
+    private GatewayLossFloor(DateTime[] times, double[] lossPct, double stalenessSeconds, double matchSeconds)
     {
         _times = times;
         _lossPct = lossPct;
         _stalenessSeconds = stalenessSeconds;
+        _matchSeconds = matchSeconds;
     }
 
     /// <summary>An empty floor: subtracts nothing. Used when no gateway target is monitored.</summary>
     public static GatewayLossFloor None { get; } =
-        new(Array.Empty<DateTime>(), Array.Empty<double>(), 0);
+        new(Array.Empty<DateTime>(), Array.Empty<double>(), 0, 0);
 
     /// <summary>True when any gateway loss was measured at all - i.e. when the floor can bite.</summary>
     public bool HasLoss { get; private set; }
@@ -85,7 +87,7 @@ public sealed class GatewayLossFloor
             if (v > peak) peak = v;
         }
 
-        return new GatewayLossFloor(times, loss, options.GatewayFloorMaxStalenessSeconds)
+        return new GatewayLossFloor(times, loss, options.GatewayFloorMaxStalenessSeconds, options.GatewayFloorMatchSeconds)
         {
             HasLoss = peak > 0,
             PeakLossPct = peak,
@@ -94,23 +96,46 @@ public sealed class GatewayLossFloor
     }
 
     /// <summary>
-    /// The floor at an instant: the most recent gateway reading at or before it, provided that reading
-    /// is not stale. Carried forward rather than re-interpolated because the floor reflects a physical
-    /// condition that persists across a poll or two; past the staleness bound it decays to zero, so an
-    /// old reading cannot keep suppressing loss indefinitely. Zero when nothing is known, which leaves
-    /// the measurement untouched.
+    /// The floor at an instant: the worst gateway reading in the immediate neighborhood, looking both
+    /// directions. An impairment that drops probes does so for as long as it lasts, so a probe landing
+    /// between two gateway ticks was crossing the same impaired chain as the ticks either side of it.
+    ///
+    /// Where no reading is close enough - a series sampled far coarser than the match window - the
+    /// last reading is carried forward instead, decaying to zero once stale, so an old value cannot
+    /// keep suppressing loss indefinitely. Zero when nothing is known, leaving the measurement alone.
     /// </summary>
     public double FloorAt(DateTime time)
     {
         if (_times.Length == 0) return 0;
 
-        var i = Array.BinarySearch(_times, time);
-        if (i < 0)
+        // Worst gateway reading in the immediate neighborhood, looking both ways. An impairment that
+        // drops probes does so continuously for as long as it lasts, while the gateway is sampled on
+        // its own cadence - so which tick happens to precede a given probe is an artifact of timing,
+        // not a fact about the network. Reading only backwards made one saturation burst subtract
+        // between 0% and 46.7% across the same ten seconds, purely on sample alignment.
+        var lo = LowerBound(time.AddSeconds(-_matchSeconds));
+        var best = -1.0;
+        var limit = time.AddSeconds(_matchSeconds);
+        for (var i = lo; i < _times.Length && _times[i] <= limit; i++)
+            if (_lossPct[i] > best) best = _lossPct[i];
+        if (best >= 0) return best;
+
+        // Nothing close by - fall back to carrying the last reading forward, which covers a series
+        // sampled far coarser than the match window, and decays to zero once it is stale.
+        var j = Array.BinarySearch(_times, time);
+        if (j < 0)
         {
-            i = ~i - 1;          // the entry immediately before the insertion point
-            if (i < 0) return 0; // before the first reading
+            j = ~j - 1;
+            if (j < 0) return 0;
         }
-        return (time - _times[i]).TotalSeconds <= _stalenessSeconds ? _lossPct[i] : 0;
+        return (time - _times[j]).TotalSeconds <= _stalenessSeconds ? _lossPct[j] : 0;
+    }
+
+    /// <summary>Index of the first reading at or after <paramref name="from"/>.</summary>
+    private int LowerBound(DateTime from)
+    {
+        var i = Array.BinarySearch(_times, from);
+        return i >= 0 ? i : ~i;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/GatewayLossFloor.cs
@@ -44,6 +44,20 @@ public sealed class GatewayLossFloor
     /// <summary>Mean gateway loss across the samples that carried a reading.</summary>
     public double MeanLossPct { get; private set; }
 
+    /// <summary>Gateway readings behind the floor, and the span they cover.</summary>
+    public int ReadingCount => _times.Length;
+    public DateTime? FirstReading => _times.Length > 0 ? _times[0] : null;
+    public DateTime? LastReading => _times.Length > 0 ? _times[^1] : null;
+
+    /// <summary>
+    /// How the floor actually behaved this report: upstream loss readings seen, how many it reduced,
+    /// and by how much in total. Counted rather than inferred, so "did it do anything" is answerable
+    /// from a log line instead of from the shape of the input.
+    /// </summary>
+    public long SamplesSeen { get; private set; }
+    public long SamplesReduced { get; private set; }
+    public double TotalReductionPct { get; private set; }
+
     /// <summary>
     /// Builds the floor from the gateway target's series. Samples without a loss reading are dropped
     /// rather than treated as zero: an absent measurement is not evidence the chain was clean.
@@ -106,7 +120,15 @@ public sealed class GatewayLossFloor
     public double Apply(double lossPct, DateTime time)
     {
         if (_times.Length == 0) return lossPct;
+        SamplesSeen++;
         var floor = FloorAt(time);
-        return floor <= 0 ? lossPct : Math.Max(0, lossPct - floor);
+        if (floor <= 0) return lossPct;
+        var reduced = Math.Max(0, lossPct - floor);
+        if (reduced < lossPct)
+        {
+            SamplesReduced++;
+            TotalReductionPct += lossPct - reduced;
+        }
+        return reduced;
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -198,6 +198,16 @@ public class IspTargetHealth
     /// </summary>
     public int? LatencyStabilityScore { get; init; }
 
+    /// <summary>
+    /// 0-100 for how little of the window this hop spent congested. Score-only, like stability: the
+    /// card shows jitter and loss as measurements, so these two are the components of the grade that
+    /// have no other representation on screen.
+    /// </summary>
+    public int? CongestionScore { get; init; }
+
+    /// <summary>Confirmed congestion events attributed to this hop, shown in place of the score.</summary>
+    public int CongestionEventCount { get; init; }
+
     /// <summary>Per-hop quality grade (stability, jitter, loss, congestion, intra-ASN reach).</summary>
     public int? OverallScore { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -524,6 +524,13 @@ public class IspHealthReport
     /// <summary>Total downtime behind <see cref="UptimePercent"/>; zero when nothing dropped.</summary>
     public TimeSpan Downtime { get; init; }
 
+    /// <summary>
+    /// Targets left out of the Packet Loss and Loaded Loss pool because they were dark for the whole
+    /// window while their peers kept measuring (see <see cref="LossPoolFilter"/>). Investigate reads
+    /// this so its pooled figure grades the same set the score did.
+    /// </summary>
+    public IReadOnlyCollection<string> LossPoolExcludedTargetIds { get; init; } = Array.Empty<string>();
+
     public required AccessProfile Profile { get; init; }
 
     /// <summary>The access technology that selected <see cref="Profile"/>, so the UI can offer a
@@ -706,6 +713,13 @@ public class IspHealthInputs
 
     /// <summary>Per-target series pooled for packet loss (ISP + transit + anycast DNS targets).</summary>
     public List<List<LatencySample>> LossPoolSeries { get; init; } = new();
+
+    /// <summary>
+    /// Targets dropped from <see cref="LossPoolSeries"/> as flat-lined (see
+    /// <see cref="LossPoolFilter"/>). Carried through so the report can name them: the pool itself is
+    /// anonymous, and Investigate has to grade the same set the score did.
+    /// </summary>
+    public IReadOnlyCollection<string> LossPoolExcludedTargetIds { get; init; } = Array.Empty<string>();
 
     /// <summary>Per-ASN series for transit targets.</summary>
     public List<AsnSeries> TransitAsnSeries { get; init; } = new();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -516,7 +516,7 @@ public class IspHealthReport
     /// the detector only declares one past a broad multi-ASN half-loss (an interruption, not a blip)
     /// but half the packets is not half the clock. Local (LAN/gateway) and acknowledged outages are
     /// excluded, same as from the score penalty. Deliberately NOT usage-weighted, unlike the penalty:
-    /// how much an outage mattered is a scoring judgement, while uptime is a fact about the line -
+    /// how much an outage mattered is a scoring judgment, while uptime is a fact about the line -
     /// so this figure and the scored unavailability can differ, by design. 100 when nothing dropped.
     /// </summary>
     public double UptimePercent { get; init; } = 100;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -509,6 +509,20 @@ public class IspHealthReport
     public DateTime ComputedAt { get; init; }
     public DateTime WindowStart { get; init; }
     public DateTime WindowEnd { get; init; }
+
+    /// <summary>
+    /// Percent of the window the internet was reachable, 0..100. Counts BLACKOUT time only (full and
+    /// brief outages) at raw duration, so it agrees with the minutes shown on the timeline: no usage
+    /// or peak-loss weighting, and partial-loss disruptions are degraded service rather than downtime.
+    /// Local (LAN/gateway) and acknowledged outages are excluded, same as from the score penalty.
+    /// 100 when nothing went dark. The scored unavailability additionally folds in weighted partial
+    /// minutes, so the penalty and this figure can differ slightly by design.
+    /// </summary>
+    public double UptimePercent { get; init; } = 100;
+
+    /// <summary>Total blackout time behind <see cref="UptimePercent"/>; zero when nothing went dark.</summary>
+    public TimeSpan Downtime { get; init; }
+
     public required AccessProfile Profile { get; init; }
 
     /// <summary>The access technology that selected <see cref="Profile"/>, so the UI can offer a

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -721,6 +721,14 @@ public class IspHealthInputs
     /// </summary>
     public IReadOnlyCollection<string> LossPoolExcludedTargetIds { get; init; } = Array.Empty<string>();
 
+    /// <summary>
+    /// The LAN gateway's own series, when a gateway target is monitored. Its LOSS becomes the floor
+    /// under every upstream loss measurement (see <see cref="GatewayLossFloor"/>); its latency is
+    /// deliberately not used that way. Empty when no gateway target exists, which leaves every
+    /// measurement untouched.
+    /// </summary>
+    public List<LatencySample> GatewayLossSeries { get; init; } = new();
+
     /// <summary>Per-ASN series for transit targets.</summary>
     public List<AsnSeries> TransitAsnSeries { get; init; } = new();
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -190,6 +190,14 @@ public class IspTargetHealth
 
     public double? LossPct { get; init; }
 
+    /// <summary>
+    /// 0-100 for how steady this hop's round-trip time stayed across the window, from its RTT median
+    /// absolute deviation. Distinct from jitter, which measures variation between probes: a hop can be
+    /// jittery per-probe yet steady across the day, or smooth per-probe while drifting badly. Taken
+    /// from the hop's grade so the row and the grade beside it cannot disagree; null when ungraded.
+    /// </summary>
+    public int? LatencyStabilityScore { get; init; }
+
     /// <summary>Per-hop quality grade (stability, jitter, loss, congestion, intra-ASN reach).</summary>
     public int? OverallScore { get; init; }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -511,16 +511,17 @@ public class IspHealthReport
     public DateTime WindowEnd { get; init; }
 
     /// <summary>
-    /// Percent of the window the internet was reachable, 0..100. Counts BLACKOUT time only (full and
-    /// brief outages) at raw duration, so it agrees with the minutes shown on the timeline: no usage
-    /// or peak-loss weighting, and partial-loss disruptions are degraded service rather than downtime.
-    /// Local (LAN/gateway) and acknowledged outages are excluded, same as from the score penalty.
-    /// 100 when nothing went dark. The scored unavailability additionally folds in weighted partial
-    /// minutes, so the penalty and this figure can differ slightly by design.
+    /// Percent of the window the internet was reachable, 0..100. A blackout counts for its full
+    /// duration; a partial-loss disruption counts for the share of it that was actually lost, since
+    /// the detector only declares one past a broad multi-ASN half-loss (an interruption, not a blip)
+    /// but half the packets is not half the clock. Local (LAN/gateway) and acknowledged outages are
+    /// excluded, same as from the score penalty. Deliberately NOT usage-weighted, unlike the penalty:
+    /// how much an outage mattered is a scoring judgement, while uptime is a fact about the line -
+    /// so this figure and the scored unavailability can differ, by design. 100 when nothing dropped.
     /// </summary>
     public double UptimePercent { get; init; } = 100;
 
-    /// <summary>Total blackout time behind <see cref="UptimePercent"/>; zero when nothing went dark.</summary>
+    /// <summary>Total downtime behind <see cref="UptimePercent"/>; zero when nothing dropped.</summary>
     public TimeSpan Downtime { get; init; }
 
     public required AccessProfile Profile { get; init; }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -564,6 +564,18 @@ public class IspHealthOptions
     public int GatewayFloorMaxStalenessSeconds { get; set; } = 300;
 
     /// <summary>
+    /// How far either side of an upstream sample the floor looks for gateway readings, taking the
+    /// worst it finds. An impairment that drops probes drops them continuously, but the gateway is
+    /// sampled on its own cadence, so which tick precedes a given probe is an artifact of timing. A
+    /// real capture made the point: saturating the LAN between the gateway and this server took every
+    /// upstream target to 60-80% loss for about ten seconds while the gateway itself read 66.7% then
+    /// 33.3%, and matching backwards only would have subtracted anywhere from 0% to 46.7% across that
+    /// one burst depending purely on alignment. Kept small - a couple of sample intervals at the fine
+    /// end - so an isolated gateway spike cannot absolve a span it did not overlap.
+    /// </summary>
+    public int GatewayFloorMatchSeconds { get; set; } = 15;
+
+    /// <summary>
     /// Mean gateway loss (percent) at or above which the local-network finding is raised. Any loss to
     /// the gateway is worth knowing about, but a single dropped probe over a long window is noise
     /// rather than a fault, and a finding that fires on it would train people to ignore the one that

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -531,6 +531,33 @@ public class IspHealthOptions
     };
 
     /// <summary>
+    /// Loss (percent) at or above which one sample counts as dark for flat-line detection. Just under
+    /// total: a blocked or retired target answers nothing at all, so this is deliberately stricter
+    /// than any congestion threshold and cannot catch a merely lossy hop.
+    /// </summary>
+    public double LossPoolFlatlineLossPct { get; set; } = 99.0;
+
+    /// <summary>
+    /// Fraction of a target's samples that must be dark before it is treated as flat-lined rather
+    /// than badly degraded. Near-total, so a target that recovered for even a small slice of the
+    /// window stays in the pool - that recovery is real measurement.
+    /// </summary>
+    public double LossPoolFlatlineFraction { get; set; } = 0.98;
+
+    /// <summary>
+    /// Minimum loss samples before a target can be judged flat-lined or counted as a healthy peer.
+    /// A target that barely reported cannot support either conclusion.
+    /// </summary>
+    public int LossPoolFlatlineMinSamples { get; set; } = 20;
+
+    /// <summary>
+    /// Mean loss (percent) at or below which a peer counts as still measuring healthily. At least one
+    /// such peer must exist before anything is excluded, which is what keeps a genuine path-wide
+    /// outage - where every target reads 100% at once - from having its own evidence filtered away.
+    /// </summary>
+    public double LossPoolHealthyPeerMaxLossPct { get; set; } = 5.0;
+
+    /// <summary>
     /// Minimum window length before findings quote an uptime percentage. Below this the figure is
     /// read as a monthly SLA number when it actually covers a few hours. The score card states the
     /// period right next to the number, so it is not gated - only the prose is.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -553,6 +553,26 @@ public class IspHealthOptions
     };
 
     /// <summary>
+    /// Ceiling on the WAN rate aggregation interval, independent of the report window. Everything else
+    /// is thinned as the window grows, but load classification is the one signal that cannot survive
+    /// it: at a month-long window the rate series arrived aggregated to ~60 s, which collapses a
+    /// minute-long transfer and a single counter artifact into the same thing - one sample, no
+    /// neighbors - so sustained load became indistinguishable from a spike. The rate series is ONE
+    /// series against roughly twenty-five per-target latency series, so holding it fine costs little.
+    /// </summary>
+    public int WanRateMaxAggregateSeconds { get; set; } = 15;
+
+    /// <summary>
+    /// Consecutive loaded rate samples required before a span counts as loaded. Real saturation
+    /// sustains across samples; a counter artifact is one sample with idle neighbors, and magnitude
+    /// cannot tell them apart because bursty access media legitimately read well above plan (a gig
+    /// GPON line under full load sawtooths roughly 0.8x to 1.4x, so even its troughs clear the loaded
+    /// threshold and a run requirement passes easily). Two samples is deliberately low: it is enough
+    /// to reject the singleton, without demanding a transfer longer than a scheduled speed test.
+    /// </summary>
+    public int MinLoadedRunSamples { get; set; } = 2;
+
+    /// <summary>
     /// Multiple of the configured plan speed above which a WAN throughput sample is treated as a
     /// counter artifact and discarded (see <see cref="WanRateSanitizer"/>) rather than as load. Well
     /// above 1 because ISPs over-provision and a burst can genuinely beat the plan; this exists only

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -357,6 +357,28 @@ public class IspHealthOptions
     public int TransitUnreachableMaxGapSeconds { get; set; } = 300;
 
     /// <summary>
+    /// Fraction of a span's samples that must be dark for a FLAPPING transit target to read as
+    /// unreachable (see TransitUnreachableDetector.DetectMostlyDark). A target answering under half
+    /// its probes is not measuring the path either, but it never sustains a solid run, so the
+    /// every-sample rule never sees it.
+    /// </summary>
+    public double TransitUnreachableMostlyDarkFraction { get; set; } = 0.5;
+
+    /// <summary>
+    /// Minimum span in seconds before a mostly-dark (flapping) target is carved out. Much longer than
+    /// the solid-dark rule's: intermittent evidence is weaker, so a brief burst of flapping stays in
+    /// the loss pool and only a persistent one is treated as a path event.
+    /// </summary>
+    public int TransitUnreachableMostlyDarkMinSeconds { get; set; } = 600;
+
+    /// <summary>
+    /// How long a flapping target must answer continuously before its mostly-dark span is considered
+    /// over. Short enough that a genuine recovery ends the span promptly, long enough that one or two
+    /// answered probes mid-event do not split it into fragments that each miss the duration bar.
+    /// </summary>
+    public int TransitUnreachableRecoverySeconds { get; set; } = 120;
+
+    /// <summary>
     /// Bucket size in seconds for outage detection. Sub-minute so a brief (~30 s) drop resolves
     /// into its own fully-dark buckets instead of being diluted to a partial-loss bucket inside a
     /// one-minute window and failing the dark-fraction gate. At the internet targets' ~7-10 s
@@ -529,6 +551,15 @@ public class IspHealthOptions
     {
         (0, 0), (0.1, 3), (0.5, 8), (1, 14), (3, 25), (8, 35)
     };
+
+    /// <summary>
+    /// Multiple of the configured plan speed above which a WAN throughput sample is treated as a
+    /// counter artifact and discarded (see <see cref="WanRateSanitizer"/>) rather than as load. Well
+    /// above 1 because ISPs over-provision and a burst can genuinely beat the plan; this exists only
+    /// to reject the impossible readings a counter reset produces at a link flap, which would
+    /// otherwise mark the window loaded and pull the flap's own loss into Loaded Loss.
+    /// </summary>
+    public double WanRateImplausibleMultiple { get; set; } = 2.0;
 
     /// <summary>
     /// Loss (percent) at or above which one sample counts as dark for flat-line detection. Just under

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -480,39 +480,62 @@ public class IspHealthOptions
     public int OutageAccessGroupToleranceSeconds { get; set; } = 10;
 
     /// <summary>
-    /// Outage severity curve: points deducted from the OVERALL score per (totalDowntimeMinutes,
-    /// penaltyPoints) anchor, interpolated. This is the DURATION component of the outage penalty,
-    /// applied at the top level rather than buried in the Packet Loss factor (where the dimension
-    /// weights would dilute a multi-hour outage to a couple of points). The front is deliberately
-    /// steep - a 30 s drop is felt out of all proportion to its seconds (a dropped call, a stalled
-    /// stream), so a sub-minute outage carries a couple of points on duration alone rather than
-    /// rounding to zero; ~10 min is a clear ding; multi-hour drives the score toward zero. Recurrence
-    /// is scored separately by <see cref="OutageEventCost"/>, so this curve need not also encode "many
-    /// short drops are bad".
+    /// Unavailability curve: points deducted from the OVERALL score per (percent of the window spent
+    /// down, penaltyPoints) anchor, interpolated. This is the RATIO half of the outage DURATION
+    /// penalty, applied at the top level rather than buried in the Packet Loss factor (where the
+    /// dimension weights would dilute a multi-hour outage to a couple of points). Downtime only means
+    /// something against the time observed - 15 min is two-nines over 48 h but four-nines over 30
+    /// days, and scoring both the same (as the old absolute minutes curve did) made a good line on a
+    /// long window read as a bad one. Anchors sit on the SLA nines people already argue with their ISP
+    /// about: 0.1% is the 99.9% line, 43 min/month. Floored by <see cref="OutageFeltEventCurve"/>.
     /// </summary>
-    public (double Minutes, double Penalty)[] OutageSeverityCurve { get; set; } =
+    public (double DownPercent, double Penalty)[] OutageUnavailabilityCurve { get; set; } =
     {
-        (0, 0), (0.5, 1.5), (1, 2.5), (2, 4), (5, 7), (10, 14), (30, 28), (60, 45), (180, 70), (480, 90)
+        (0, 0), (0.01, 1), (0.1, 4), (0.5, 12), (1, 20), (3, 40), (10, 70), (25, 90)
     };
 
     /// <summary>
-    /// Per-event occurrence cost: the OCCURRENCE component of the outage penalty, summed across every
-    /// WAN outage on top of the duration curve. Each event contributes OutageEventCost x severity,
-    /// where severity = breadth (fraction of monitored targets that dropped) x depth (peak loss
-    /// fraction), 0..1. This is what makes recurrence bite: ten separate micro-drops cost ~ten times
-    /// a single one, where the duration curve alone would treat them as one slightly-longer drop. It
-    /// also lifts a single felt short outage off the floor. Kept modest because these events still
-    /// feed the Packet Loss factor (not masked), so we don't want to triple-count.
+    /// Felt-event curve: points the SINGLE worst outage earns on its own absolute effective minutes,
+    /// regardless of window length. The duration penalty is the GREATER of this and
+    /// <see cref="OutageUnavailabilityCurve"/>, because a four-hour outage is a memorable,
+    /// complaint-worthy event whether you are looking at two days or a month, and a pure availability
+    /// ratio would price it at almost nothing on a long window. Deliberately far gentler than the
+    /// ratio curve - it is a floor for what was FELT, not a second full penalty - and it is what keeps
+    /// a single short drop off zero now that the ratio term is tiny on long windows. The front stays
+    /// steep (the old severity curve's shape): a 30 s drop is felt out of all proportion to its
+    /// seconds - a dropped call, a stalled stream - so it carries a couple of points rather than the
+    /// near-nothing its share of a day would suggest. The tail is flat by comparison, because past a
+    /// few minutes the ratio term is the one that should be doing the talking.
     /// </summary>
-    public double OutageEventCost { get; set; } = 3.0;
+    public (double Minutes, double Penalty)[] OutageFeltEventCurve { get; set; } =
+    {
+        (0, 0), (0.5, 1.5), (1, 2.5), (2, 3.5), (5, 5), (15, 6.5), (60, 12), (240, 20), (720, 30)
+    };
 
     /// <summary>
-    /// Cap on the summed occurrence component so a pathologically flaky window doesn't run the penalty
-    /// away on its own (the duration curve still adds on top, uncapped). Set high - a line dropping
-    /// dozens of times in the window SHOULD score badly - but bounded so occurrence can't alone zero a
-    /// score that the duration barely touched.
+    /// Occurrence curve: points deducted per (severity-weighted WAN outages per DAY, penaltyPoints)
+    /// anchor. This is the RECURRENCE component, on top of the duration penalty, and it is scored as a
+    /// true rate so a given drop rate costs the same in any window. Eight drops in 48 h is a crisis
+    /// and the same eight over a month is a quirk; the previous per-event cost scaled by the window
+    /// ratio scored those two identically, and worse, made a sustained rate cost LESS the longer it
+    /// was observed. Each event contributes its severity (breadth x depth x usage weight, 0..1) to the
+    /// daily rate, so shallow or narrow events push the rate up less than clean blackouts. The rate is
+    /// built from every event PAST the worst one, since recurrence starts at the second: a lone outage
+    /// is an incident rather than a pattern, and rating one drop in 48 h as "0.5 a day" would read a
+    /// single sample as a trend and charge it here as well as on duration. The top anchor caps the
+    /// component, so occurrence alone cannot zero a score the duration barely touched.
     /// </summary>
-    public double OutageOccurrenceCap { get; set; } = 35.0;
+    public (double EventsPerDay, double Penalty)[] OutageOccurrenceRateCurve { get; set; } =
+    {
+        (0, 0), (0.1, 3), (0.5, 8), (1, 14), (3, 25), (8, 35)
+    };
+
+    /// <summary>
+    /// Minimum window length before findings quote an uptime percentage. Below this the figure is
+    /// read as a monthly SLA number when it actually covers a few hours. The score card states the
+    /// period right next to the number, so it is not gated - only the prose is.
+    /// </summary>
+    public int UptimeProseMinWindowHours { get; set; } = 24;
 
     /// <summary>
     /// Weight outage severity by a time-of-day usage fingerprint: an outage during the hours the user

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -553,6 +553,17 @@ public class IspHealthOptions
     };
 
     /// <summary>
+    /// How long a gateway loss reading stays valid as the loss floor after the sample it came from
+    /// (see <see cref="GatewayLossFloor"/>). The floor reflects a physical condition - a struggling
+    /// forwarding path, an overloaded switch, a bad cable - that persists across a poll or two, so
+    /// carrying the last reading forward is more faithful than assuming the chain went clean between
+    /// samples. Past this it decays to zero, so a stale reading cannot keep suppressing loss forever.
+    /// Set well above the aggregate interval a long window uses, and comfortably above the probe
+    /// cadence, so an ordinary gap does not drop the floor mid-incident.
+    /// </summary>
+    public int GatewayFloorMaxStalenessSeconds { get; set; } = 300;
+
+    /// <summary>
     /// Ceiling on the WAN rate aggregation interval, independent of the report window. Everything else
     /// is thinned as the window grows, but load classification is the one signal that cannot survive
     /// it: at a month-long window the rate series arrived aggregated to ~60 s, which collapses a

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -564,6 +564,14 @@ public class IspHealthOptions
     public int GatewayFloorMaxStalenessSeconds { get; set; } = 300;
 
     /// <summary>
+    /// Mean gateway loss (percent) at or above which the local-network finding is raised. Any loss to
+    /// the gateway is worth knowing about, but a single dropped probe over a long window is noise
+    /// rather than a fault, and a finding that fires on it would train people to ignore the one that
+    /// matters. The floor still subtracts below this threshold - only the finding is gated.
+    /// </summary>
+    public double GatewayLossFindingMinPct { get; set; } = 0.5;
+
+    /// <summary>
     /// Ceiling on the WAN rate aggregation interval, independent of the report window. Everything else
     /// is thinned as the window grows, but load classification is the one signal that cannot survive
     /// it: at a month-long window the rate series arrived aggregated to ~60 s, which collapses a

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -189,6 +189,21 @@ public class IspHealthOptions
     /// </summary>
     public double CongestionPenaltyPerHour { get; set; } = 20.0;
 
+    /// <summary>
+    /// Congestion curve: the network's congestion sub-score per (percent of the window spent
+    /// congested, score) anchor. Congested hours only mean something against the time observed - nine
+    /// hours across two days is a fifth of the line's life and bad, the same nine hours across a month
+    /// is an afternoon - and the flat per-hour penalty scored them identically. It also saturated: at
+    /// 20 points an hour anything past five hours floored the component, so a hop congested for five
+    /// hours and one congested for the entire window were indistinguishable, and at weight 0.3 that is
+    /// a flat 30-point deduction that no amount of otherwise-perfect latency, jitter, loss or
+    /// stability can offset. Same reasoning as the outage unavailability curve.
+    /// </summary>
+    public (double CongestedPercent, double Score)[] AsnCongestionCurve { get; set; } =
+    {
+        (0, 100), (1, 95), (3, 88), (5, 80), (10, 65), (20, 45), (40, 20), (70, 0)
+    };
+
     /// <summary>Minimum number of ASNs with overlapping events to merge them into a shared upstream event.</summary>
     public int SharedEventMinAsns { get; set; } = 2;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPdfGenerator.cs
@@ -173,6 +173,17 @@ public class IspHealthPdfGenerator
                 });
             });
 
+            // Uptime leads the dimension grades for the same reason it leads the score card: those say
+            // how the path behaved, this says whether it was there at all. Column widths match the
+            // table below so it reads as that table's first line rather than a floating stat.
+            column.Item().PaddingTop(12).Row(row =>
+            {
+                row.RelativeItem(2f).Text("Uptime").FontSize(10).SemiBold();
+                row.RelativeItem(1f).Text(IspHealthPresentation.FormatUptime(report)).FontSize(10).Bold();
+                row.RelativeItem(1f).Text(IspHealthPresentation.FormatDowntime(report.Downtime))
+                    .FontSize(10).FontColor(Colors.Grey.Medium);
+            });
+
             column.Item().PaddingTop(12).Table(table =>
             {
                 table.ColumnsDefinition(columns =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
@@ -230,8 +230,10 @@ public static class IspHealthPresentation
         var stabilityDeficit = stabilityScore is int s ? stabilityWeight * (100 - s) : -1;
         var congestionDeficit = congestionScore is int c ? congestionWeight * (100 - c) : -1;
 
-        // Ties go to congestion: with both clean it reads "0 Events", which says more than a bare 100.
-        if (congestionScore is int cs && congestionDeficit >= stabilityDeficit)
+        // Ties go to congestion, except when it has nothing to report - "0 Events" only ever wins
+        // the slot against a perfect stability score, and the number is the more useful of the two.
+        if (congestionScore is int cs && congestionDeficit >= stabilityDeficit
+            && (congestionEvents > 0 || stabilityScore is null))
             return ("Congestion", congestionEvents == 1 ? "1 Event" : $"{congestionEvents} Events", cs);
         return stabilityScore is int ss ? ("Stability", ss.ToString(), ss) : null;
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
@@ -181,6 +181,35 @@ public static class IspHealthPresentation
         return $"{span.TotalDays:0.#} {(Math.Abs(span.TotalDays - 1) < 0.05 ? "day" : "days")}";
     }
 
+    /// <summary>Window span written out for prose ("30 days", "48 hours"), where
+    /// <see cref="WindowLabel"/>'s abbreviated units would read badly mid-sentence.</summary>
+    public static string ProseWindowLabel(IspHealthReport r)
+    {
+        var span = r.WindowEnd - r.WindowStart;
+        if (span.TotalMinutes < 60)
+            return $"{span.TotalMinutes:0} minutes";
+        if (span.TotalHours < 72)
+            return $"{span.TotalHours:0.#} hours";
+        return $"{span.TotalDays:0.#} {(Math.Abs(span.TotalDays - 1) < 0.05 ? "day" : "days")}";
+    }
+
+    /// <summary>
+    /// The window's uptime percentage. A window that had ANY downtime never renders as a flat 100%:
+    /// the outage is right there on the timeline, so a near-miss is held at 99.99% rather than
+    /// rounding into a claim the timeline contradicts.
+    /// </summary>
+    public static string FormatUptime(IspHealthReport r) =>
+        r.Downtime > TimeSpan.Zero && r.UptimePercent >= 99.995
+            ? "99.99%"
+            : $"{r.UptimePercent:0.##}%";
+
+    /// <summary>Total downtime for the score card's uptime sub-line; "no downtime" when nothing went dark.</summary>
+    public static string FormatDowntime(TimeSpan d) =>
+        d <= TimeSpan.Zero ? "no downtime"
+        : d.TotalSeconds < 90 ? $"{d.TotalSeconds:0} sec down"
+        : d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min down"
+        : $"{d.TotalHours:0.#} h down";
+
     /// <summary>The window's absolute bounds in local time, for a report that outlives the page.</summary>
     public static string WindowRangeLabel(IspHealthReport r) =>
         $"{r.WindowStart.ToLocalTime():MMM d, yyyy HH:mm} to {r.WindowEnd.ToLocalTime():MMM d, yyyy HH:mm}";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthPresentation.cs
@@ -210,6 +210,32 @@ public static class IspHealthPresentation
         : d.TotalMinutes < 90 ? $"{d.TotalMinutes:0} min down"
         : $"{d.TotalHours:0.#} h down";
 
+    /// <summary>
+    /// Which of the two score-only grade components is costing this network more, for the single stat
+    /// the row has space for. Jitter and loss already appear as measurements; stability and congestion
+    /// exist only as scores, so without this the card can show four healthy numbers beside a grade
+    /// that does not follow from them - a hop reading 100 stability, 0% loss and unremarkable jitter
+    /// while grading in the sixties on congestion nothing on screen mentioned.
+    ///
+    /// Compared by contribution to the deficit - weight x shortfall - not by raw score, because the
+    /// components carry different weights. Congestion reports its event COUNT rather than its score:
+    /// "2 Events" says what happened, where "Congestion 48" invites being read as a percentage.
+    /// </summary>
+    public static (string Label, string Value, int? Score)? LimitingAspect(
+        int? stabilityScore, int? congestionScore, int congestionEvents,
+        double stabilityWeight, double congestionWeight)
+    {
+        if (stabilityScore is null && congestionScore is null) return null;
+
+        var stabilityDeficit = stabilityScore is int s ? stabilityWeight * (100 - s) : -1;
+        var congestionDeficit = congestionScore is int c ? congestionWeight * (100 - c) : -1;
+
+        // Ties go to congestion: with both clean it reads "0 Events", which says more than a bare 100.
+        if (congestionScore is int cs && congestionDeficit >= stabilityDeficit)
+            return ("Congestion", congestionEvents == 1 ? "1 Event" : $"{congestionEvents} Events", cs);
+        return stabilityScore is int ss ? ("Stability", ss.ToString(), ss) : null;
+    }
+
     /// <summary>The window's absolute bounds in local time, for a report that outlives the page.</summary>
     public static string WindowRangeLabel(IspHealthReport r) =>
         $"{r.WindowStart.ToLocalTime():MMM d, yyyy HH:mm} to {r.WindowEnd.ToLocalTime():MMM d, yyyy HH:mm}";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1694,6 +1694,7 @@ public class IspHealthScorer
             RawJitterMs = grade?.RawJitterMs ?? rawScored,
             JitterAssimilated = grade?.JitterAssimilated ?? false,
             LossPct = losses.Count > 0 ? losses.Average() : null,
+            LatencyStabilityScore = grade?.LatencyStabilityScore,
             OverallScore = grade?.OverallScore,
             ReachDeltaMs = grade?.ReachDeltaMs,
             IsGradedHop = isGraded,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -809,6 +809,14 @@ public class IspHealthScorer
                 && loaded.Contains(FloorToWindow(s.Time)))
             .Select(s => s.LossPercent!.Value)
             .ToList();
+        // Loaded loss rests on however many samples happen to fall inside the loaded windows, and on
+        // a long window the rate series is aggregated far coarser than LoadWindowSeconds, so that set
+        // can be small enough for a few dark samples to set the whole figure. Log what it was built
+        // from - a mean over a handful of samples is a very different claim from one over thousands.
+        _logger?.LogDebug(
+            "ISP Health: loaded loss pool {Count} sample(s) from {Windows} loaded window key(s), {Dark} at/above 99% ({Mean}% mean)",
+            losses.Count, loaded.Count, losses.Count(l => l >= 99.0),
+            losses.Count > 0 ? losses.Average().ToString("0.##", CultureInfo.InvariantCulture) : "n/a");
         if (losses.Count < _options.MinLoadedSamples) return null;
         return losses.Average();
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -293,13 +293,15 @@ public class IspHealthScorer
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
 
-        // Displayed uptime counts BLACKOUT time only (full and brief outages), at raw duration: the
-        // card must agree with the minutes on the timeline, so no usage or loss weighting here, and a
-        // partial-loss disruption is degraded service rather than downtime. Local and acknowledged
-        // events are excluded on the same grounds as the penalty. The scored figure above additionally
-        // folds in weighted partial minutes, so the two can differ slightly by design.
-        var blackouts = wanOutages.Where(o => !o.IsPartial).ToList();
-        var downtime = TimeSpan.FromMinutes(blackouts.Sum(o => o.Duration.TotalMinutes));
+        // Displayed uptime counts a blackout for its full duration and a partial-loss disruption for
+        // the share of it that was actually lost - the detector only declares one past a broad,
+        // multi-ASN half-loss, which is an interruption rather than a blip, but 50% loss is not 50%
+        // down either. Deliberately NOT usage-weighted, unlike the penalty: how much an outage
+        // mattered is a scoring judgement, while uptime is a fact about the line. Local and
+        // acknowledged events are excluded on the same grounds as the penalty.
+        double DowntimeMinutes(OutageEvent o) => o.Duration.TotalMinutes *
+            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) : 1.0);
+        var downtime = TimeSpan.FromMinutes(wanOutages.Sum(DowntimeMinutes));
         var uptimePercent = windowMinutes > 0
             ? Math.Clamp(100.0 - 100.0 * downtime.TotalMinutes / windowMinutes, 0, 100)
             : 100.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -327,6 +327,7 @@ public class IspHealthScorer
             WindowEnd = inputs.WindowEnd,
             UptimePercent = uptimePercent,
             Downtime = downtime,
+            LossPoolExcludedTargetIds = inputs.LossPoolExcludedTargetIds,
             Profile = profile,
             AccessDimension = accessDimension,
             TransitDimension = transitDimension,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -50,11 +50,15 @@ public class IspHealthScorer
         // upstream, so whatever is lost there is lost to every target at once and none of it is the
         // ISP's. Subtracted from each upstream loss reading below.
         _gatewayFloor = GatewayLossFloor.Build(inputs.GatewayLossSeries, _options);
-        if (_gatewayFloor.HasLoss)
-            _logger?.LogDebug(
-                "ISP Health: gateway loss floor active - {Mean}% mean, {Peak}% peak; upstream loss is graded net of it",
-                _gatewayFloor.MeanLossPct.ToString("0.###", CultureInfo.InvariantCulture),
-                _gatewayFloor.PeakLossPct.ToString("0.###", CultureInfo.InvariantCulture));
+        // Log the floor's state whether or not it bites: "no gateway readings" and "readings that were
+        // all clean" are different situations, and only one of them means the floor is untested.
+        _logger?.LogDebug(
+            _gatewayFloor.ReadingCount == 0
+                ? "ISP Health: gateway loss floor inactive - no gateway loss readings in the window; upstream loss is graded as measured"
+                : "ISP Health: gateway loss floor built from {Readings} reading(s) covering {From:MM-dd HH:mm} to {To:MM-dd HH:mm}, {Mean}% mean, {Peak}% peak",
+            _gatewayFloor.ReadingCount, _gatewayFloor.FirstReading, _gatewayFloor.LastReading,
+            _gatewayFloor.MeanLossPct.ToString("0.###", CultureInfo.InvariantCulture),
+            _gatewayFloor.PeakLossPct.ToString("0.###", CultureInfo.InvariantCulture));
         if (inputs.LoadExclusionWindows.Count > 0)
         {
             foreach (var (exStart, exEnd) in inputs.LoadExclusionWindows)
@@ -368,6 +372,14 @@ public class IspHealthScorer
         };
         report.Issues.AddRange(CollectIssues(inputs, profile, report, loadWindows, loadedDeltas));
         report.Issues.AddRange(physicalIssues);
+        // What the floor actually did, counted during scoring: a floor that was built but never
+        // reduced anything is the healthy case, and it should look different in the log from one that
+        // was never built at all.
+        if (_gatewayFloor.ReadingCount > 0)
+            _logger?.LogDebug(
+                "ISP Health: gateway loss floor saw {Seen} upstream loss sample(s) and reduced {Reduced}, {Total} percentage-points removed in total",
+                _gatewayFloor.SamplesSeen, _gatewayFloor.SamplesReduced,
+                _gatewayFloor.TotalReductionPct.ToString("0.##", CultureInfo.InvariantCulture));
         return report;
     }
 
@@ -1797,6 +1809,28 @@ public class IspHealthScorer
 
         // Local (LAN/gateway) outages are surfaced in the waterfall but are not internet outages and
         // don't affect the score, so they never appear in this ISP-impact issue.
+        // Loss to the gateway is loss inside the user's own network, and the score has already stopped
+        // attributing it to the ISP - so say so, or a failing switch reads as a normal report with an
+        // unexplained deduction. Gated on a mean rather than any loss at all: one dropped probe over a
+        // long window is noise, and a finding that fires on it teaches people to ignore this one.
+        if (_gatewayFloor.MeanLossPct >= _options.GatewayLossFindingMinPct)
+        {
+            issues.Add(new IspHealthIssue
+            {
+                Severity = IspIssueSeverity.Warning,
+                Title = "Packet loss inside your own network",
+                Description =
+                    $"Your gateway dropped {FormatPct(_gatewayFloor.MeanLossPct)} of probes to itself, peaking at "
+                    + $"{FormatPct(_gatewayFloor.PeakLossPct)}. A healthy UniFi gateway does not drop pings addressed to it, "
+                    + "so this points at the path between this server and the gateway rather than at your ISP. That loss "
+                    + "has been subtracted from every upstream measurement, so your ISP scores are not being penalized for it.",
+                Recommendation =
+                    "Check the switching path between this server and the gateway: port errors, a marginal cable or SFP, "
+                    + "an overloaded uplink, or gateway CPU under sustained load. Gateway CPU shows as high latency too; "
+                    + "errors or a bad link usually do not."
+            });
+        }
+
         // Full outages and brief disruptions are surfaced as separate findings: a 30 s transit flap
         // shouldn't read as the same event as a multi-minute outage. Both ride the same duration and
         // occurrence terms (a brief disruption costs about a point on its own), so the per-event score

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -19,6 +19,10 @@ public class IspHealthScorer
     // they would double-count and tank the Transit/ISP dimensions. Set per Score() call.
     private IReadOnlyList<OutageEvent> _outages = System.Array.Empty<OutageEvent>();
 
+    // The loss floor for the current report; GatewayLossFloor.None when no gateway target is
+    // monitored, which subtracts nothing.
+    private GatewayLossFloor _gatewayFloor = GatewayLossFloor.None;
+
     // The access profile for the current report, set per Score() call. Carries the per-tech jitter
     // band (Item E) used to grade ISP and transit jitter against the access medium's inherent floor.
     private AccessProfile? _profile;
@@ -41,6 +45,16 @@ public class IspHealthScorer
         _profile = profile;
         _loadedDownKeys = null;
         _loadedUpKeys = null;
+        // Loss to the gateway is the common-mode floor of the measurement chain: every probe crosses
+        // the host's NIC, its cable, the switching fabric and the gateway before reaching anything
+        // upstream, so whatever is lost there is lost to every target at once and none of it is the
+        // ISP's. Subtracted from each upstream loss reading below.
+        _gatewayFloor = GatewayLossFloor.Build(inputs.GatewayLossSeries, _options);
+        if (_gatewayFloor.HasLoss)
+            _logger?.LogDebug(
+                "ISP Health: gateway loss floor active - {Mean}% mean, {Peak}% peak; upstream loss is graded net of it",
+                _gatewayFloor.MeanLossPct.ToString("0.###", CultureInfo.InvariantCulture),
+                _gatewayFloor.PeakLossPct.ToString("0.###", CultureInfo.InvariantCulture));
         if (inputs.LoadExclusionWindows.Count > 0)
         {
             foreach (var (exStart, exEnd) in inputs.LoadExclusionWindows)
@@ -583,7 +597,7 @@ public class IspHealthScorer
         // against the profile's loaded band.
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time))
-            .Select(s => s.LossPercent!.Value)
+            .Select(s => _gatewayFloor.Apply(s.LossPercent!.Value, s.Time))
             .ToList();
         if (losses.Count == 0)
         {
@@ -809,7 +823,7 @@ public class IspHealthScorer
         var losses = lossPool.SelectMany(series => series)
             .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
                 && loaded.Contains(FloorToWindow(s.Time)))
-            .Select(s => s.LossPercent!.Value)
+            .Select(s => _gatewayFloor.Apply(s.LossPercent!.Value, s.Time))
             .ToList();
         // Loaded loss rests on however many samples happen to fall inside the loaded windows, and on
         // a long window the rate series is aggregated far coarser than LoadWindowSeconds, so that set
@@ -911,7 +925,8 @@ public class IspHealthScorer
         double? stabilityMadOverrideMs = null)
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
-        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
+        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time))
+            .Select(s => _gatewayFloor.Apply(s.LossPercent!.Value, s.Time)).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
 
         // Sort the RTT set once; median, MAD, and the winsorized-mean / P95 below all read from it.
@@ -1648,7 +1663,8 @@ public class IspHealthScorer
     {
         var rtts = series.Samples.Where(s => s.RttAvgMs.HasValue).Select(s => s.RttAvgMs!.Value).ToList();
         var jitters = series.Samples.Select(s => s.EffectiveJitterMs).Where(j => j.HasValue).Select(j => j!.Value).ToList();
-        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time)).Select(s => s.LossPercent!.Value).ToList();
+        var losses = series.Samples.Where(s => s.LossPercent.HasValue && !InOutage(s.Time))
+            .Select(s => _gatewayFloor.Apply(s.LossPercent!.Value, s.Time)).ToList();
         var targetId = series.TargetIds.FirstOrDefault() ?? "";
         var grade = hopGrades.FirstOrDefault(g => g.TargetIds.Contains(targetId));
         // Jitter comes from the grade (the effective/absolved value the hop is scored on), so

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -39,6 +39,8 @@ public class IspHealthScorer
     {
         _outages = inputs.Outages;
         _profile = profile;
+        _loadedDownKeys = null;
+        _loadedUpKeys = null;
         if (inputs.LoadExclusionWindows.Count > 0)
         {
             foreach (var (exStart, exEnd) in inputs.LoadExclusionWindows)
@@ -831,6 +833,31 @@ public class IspHealthScorer
     /// tail does not bleed into its upload phase. Idle classification is unaffected (this builds a
     /// loaded set only), keeping the baseline a clean uncongested floor.
     /// </summary>
+    // Loaded window keys per direction for the current report. Both lists are filled on the first
+    // request from a single pass, since the dilation asks for them four times.
+    private List<DateTime>? _loadedDownKeys;
+    private List<DateTime>? _loadedUpKeys;
+
+    /// <summary>The keys the selector calls loaded, scanning the window dictionary at most once.</summary>
+    private List<DateTime> LoadedKeysFor(Dictionary<DateTime, LoadWindow> loadWindows, Func<LoadWindow, bool> directionSelector)
+    {
+        if (_loadedDownKeys == null || _loadedUpKeys == null)
+        {
+            var down = new List<DateTime>();
+            var up = new List<DateTime>();
+            foreach (var (key, w) in loadWindows)
+            {
+                if (w.IsLoadedDown) down.Add(key);
+                if (w.IsLoadedUp) up.Add(key);
+            }
+            _loadedDownKeys = down;
+            _loadedUpKeys = up;
+        }
+        // The selector is one of the two direction predicates; probe it with a window loaded in
+        // download only, which the up selector rejects.
+        return directionSelector(new LoadWindow(false, true, false)) ? _loadedDownKeys : _loadedUpKeys;
+    }
+
     private HashSet<DateTime> DilateLoadedWindows(
         Dictionary<DateTime, LoadWindow> loadWindows,
         Func<LoadWindow, bool> directionSelector,
@@ -840,9 +867,11 @@ public class IspHealthScorer
         var tailWindows = (int)Math.Ceiling((double)_options.LoadedTailSeconds / _options.LoadWindowSeconds);
 
         var loaded = new HashSet<DateTime>();
-        foreach (var (key, w) in loadWindows)
+        // Only the loaded keys matter, and there are a couple of dozen of them against six figures of
+        // windows on a long span. This runs four times - latency and loss, each direction - so the
+        // scan is cached per Score() call rather than repeated.
+        foreach (var key in LoadedKeysFor(loadWindows, directionSelector))
         {
-            if (!directionSelector(w)) continue;
             loaded.Add(key);
             for (var i = 1; i <= leadWindows; i++)
             {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -218,10 +218,23 @@ public class IspHealthScorer
                 : 1.0;
             return depth * breadth * (o.IsPartial ? _options.OutagePartialPenaltyWeight : 1.0);
         }
-        // Effective minutes: wall-clock duration discounted by how much of the path actually went
+        // Minutes of this event that actually fall INSIDE the window. Outage detection reaches back
+        // OutageDetectionLeadInHours so an outage straddling the window start is stitched whole, and
+        // such an event keeps its true onset (IspHealthService only drops ones that ended before the
+        // start). Since downtime is now graded as a fraction of the window, the pre-window part must
+        // not count against it - otherwise a window catching the last five minutes of a two-hour
+        // outage reads as two hours down. o.Duration stays the true shape for the timeline and the
+        // findings, which is what it is for.
+        double InWindowMinutes(OutageEvent o)
+        {
+            var start = o.Start > inputs.WindowStart ? o.Start : inputs.WindowStart;
+            var end = o.End < inputs.WindowEnd ? o.End : inputs.WindowEnd;
+            return end > start ? (end - start).TotalMinutes : 0.0;
+        }
+        // Effective minutes: in-window duration discounted by how much of the path actually went
         // dark, how deep it went, and how much the line is typically used at that hour. An event that
         // took two of nine targets half-lossy did not cost you its full wall-clock minutes.
-        double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes * SeverityFactor(o) * o.UsageWeight;
+        double EffectiveMinutes(OutageEvent o) => InWindowMinutes(o) * SeverityFactor(o) * o.UsageWeight;
         // Severity 0..1 for the occurrence rate. A widespread near-total event at a busy hour reads hottest.
         double Severity(OutageEvent o) => SeverityFactor(o) * o.UsageWeight;
         var windowMinutes = (inputs.WindowEnd - inputs.WindowStart).TotalMinutes;
@@ -293,13 +306,13 @@ public class IspHealthScorer
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
 
-        // Displayed uptime counts a blackout for its full duration and a partial-loss disruption for
-        // the share of it that was actually lost - the detector only declares one past a broad,
-        // multi-ASN half-loss, which is an interruption rather than a blip, but 50% loss is not 50%
-        // down either. Deliberately NOT usage-weighted, unlike the penalty: how much an outage
+        // Displayed uptime counts a blackout for its full in-window duration and a partial-loss
+        // disruption for the share of it that was actually lost - the detector only declares one past
+        // a broad, multi-ASN half-loss, which is an interruption rather than a blip, but 50% loss is
+        // not 50% down either. Deliberately NOT usage-weighted, unlike the penalty: how much an outage
         // mattered is a scoring judgement, while uptime is a fact about the line. Local and
         // acknowledged events are excluded on the same grounds as the penalty.
-        double DowntimeMinutes(OutageEvent o) => o.Duration.TotalMinutes *
+        double DowntimeMinutes(OutageEvent o) => InWindowMinutes(o) *
             (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) : 1.0);
         var downtime = TimeSpan.FromMinutes(wanOutages.Sum(DowntimeMinutes));
         var uptimePercent = windowMinutes > 0

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -181,13 +181,19 @@ public class IspHealthScorer
         var overall = CombineDimensions(accessDimension, transitDimension, ispAsnDimension);
         // Outages are scored once, here at the top level (not inside a factor, where the dimension
         // weights would dilute a multi-hour outage to a couple of points), as TWO components:
-        //   - DURATION: one severity-curve lookup on the summed effective downtime. A partial-loss
-        //     disruption's minutes are weighted by its peak loss fraction (and a tunable weight), so a
+        //   - DURATION: the GREATER of (a) the summed effective downtime as a PERCENT OF THE WINDOW,
+        //     on the unavailability curve, and (b) what the single worst event earns on the felt-event
+        //     curve from its absolute minutes. (a) makes the penalty mean an availability figure, so
+        //     15 min costs what four-nines is worth on a 30-day window and what two-nines is worth on
+        //     48 h; (b) stops a long outage dissolving into a long window, because four hours down is
+        //     memorable no matter how much clean time surrounds it. A partial-loss disruption's
+        //     minutes are weighted by its peak loss fraction (and a tunable weight) into both, so a
         //     shallow degradation dings less than a blackout of the same length.
-        //   - OCCURRENCE: each event's severity (breadth x depth) x a per-event cost, summed and
-        //     capped. This is what makes recurrence bite - ten separate micro-drops cost ~ten times a
-        //     single one, where the duration curve alone treats them as one slightly-longer drop - and
-        //     lifts a single felt short outage off the floor.
+        //   - OCCURRENCE: severity-weighted events per DAY on the occurrence rate curve. This is what
+        //     makes recurrence bite - ten separate micro-drops cost far more than a single one, where
+        //     the duration terms treat them as one slightly-longer drop. Scoring it as a rate (rather
+        //     than the old per-event cost scaled by window ratio) means a given drop rate costs the
+        //     same however long you look, instead of a steady rate looking BETTER on a longer window.
         // Local (LAN/gateway) outages are surfaced but never penalize the ISP - the gateway being
         // unreachable is the user's own LAN, not the ISP's fault (they still mask their dark window
         // from the other factors via InOutage, so that loss isn't double-counted against the ISP).
@@ -197,46 +203,71 @@ public class IspHealthScorer
         // Acknowledged ("that was me") outages are the user's own maintenance, not the ISP:
         // excluded from the penalty like Local ones, while their dark windows still mask loss.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local && !o.Acknowledged).ToList();
-        double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes *
-            (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) * _options.OutagePartialPenaltyWeight : 1.0)
-            * o.UsageWeight;
-        // Severity 0..1 = breadth (fraction of monitored targets that dropped) x depth (peak loss
-        // fraction) x usage weight. A widespread near-total event at a busy hour reads hottest.
-        double Severity(OutageEvent o)
+        // Severity factor 0..1 = breadth (fraction of monitored targets that dropped) x depth (peak
+        // loss fraction), with a partial-loss disruption additionally scaled by its tunable weight.
+        // BOTH fall back to 1.0 rather than 0 when the event carries no census or no recorded peak
+        // loss. The detector only declares an outage past OutageMinReportingTargets and (for a
+        // blackout) past OutageDarkLossPct, so an absent field is missing metadata, not a lossless
+        // outage that touched nothing - and since this factor now scales effective MINUTES, reading
+        // it as zero would let a real outage score completely free.
+        double SeverityFactor(OutageEvent o)
         {
-            var depth = Math.Clamp(o.PeakLossPct / 100.0, 0, 1);
+            var depth = o.PeakLossPct > 0 ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) : 1.0;
             var breadth = o.PathTargetCount > 0
                 ? Math.Clamp((double)o.DegradedTargetCount / o.PathTargetCount, 0, 1)
-                : 0.0;
-            return depth * breadth * o.UsageWeight;
+                : 1.0;
+            return depth * breadth * (o.IsPartial ? _options.OutagePartialPenaltyWeight : 1.0);
+        }
+        // Effective minutes: wall-clock duration discounted by how much of the path actually went
+        // dark, how deep it went, and how much the line is typically used at that hour. An event that
+        // took two of nine targets half-lossy did not cost you its full wall-clock minutes.
+        double EffectiveMinutes(OutageEvent o) => o.Duration.TotalMinutes * SeverityFactor(o) * o.UsageWeight;
+        // Severity 0..1 for the occurrence rate. A widespread near-total event at a busy hour reads hottest.
+        double Severity(OutageEvent o) => SeverityFactor(o) * o.UsageWeight;
+        var windowMinutes = (inputs.WindowEnd - inputs.WindowStart).TotalMinutes;
+        // Percent of the window one event's effective (loss- and usage-weighted) minutes represent.
+        double DownPercent(double effectiveMinutes) => windowMinutes > 0 ? 100.0 * effectiveMinutes / windowMinutes : 0.0;
+        // What one event claims on its own: the greater of its ratio cost and its felt cost. Used both
+        // as the worst-event floor below and, normalized, to attribute the duration penalty per event.
+        double Claim(OutageEvent o)
+        {
+            var em = EffectiveMinutes(o);
+            return Math.Max(
+                ScoreCurve.Interpolate(DownPercent(em), _options.OutageUnavailabilityCurve),
+                ScoreCurve.Interpolate(em, _options.OutageFeltEventCurve));
         }
         if (wanOutages.Count > 0)
         {
             var outageMinutes = wanOutages.Sum(EffectiveMinutes);
-            var durationPenalty = outageMinutes > 0 ? OutageScorePenalty(outageMinutes) : 0.0;
-            // Occurrence is a FREQUENCY signal, so judge it as a RATE against the canonical window:
-            // the same few micro-drops spread over a week is a steadier line than the same number in
-            // 48 h. Dilute occurrence for windows LONGER than the reference; never amplify a shorter
-            // (e.g. zoomed-in) window. Duration is left absolute, so a long outage weighs the same in
-            // any window - only the count-based part rescales.
-            var windowHours = (inputs.WindowEnd - inputs.WindowStart).TotalHours;
-            var occurrenceWindowScale = _options.ScoreWindowHours > 0 && windowHours > _options.ScoreWindowHours
-                ? _options.ScoreWindowHours / windowHours
-                : 1.0;
-            double EventOccurrence(OutageEvent o) => _options.OutageEventCost * Severity(o) * occurrenceWindowScale;
-            var rawOccurrence = wanOutages.Sum(EventOccurrence);
-            var occurrencePenalty = Math.Min(_options.OutageOccurrenceCap, rawOccurrence);
-            var occCapScale = rawOccurrence > 0 ? occurrencePenalty / rawOccurrence : 0.0;
+            var downPercent = DownPercent(outageMinutes);
+            var unavailabilityPenalty = ScoreCurve.Interpolate(downPercent, _options.OutageUnavailabilityCurve);
+            // The floor is the WORST single event, never the sum of every event's felt cost - summing
+            // would double-count against the ratio term, which already has all of their minutes.
+            var feltFloor = wanOutages.Max(Claim);
+            var durationPenalty = Math.Max(unavailabilityPenalty, feltFloor);
+            var windowDays = windowMinutes / 1440.0;
+            var severityTotal = wanOutages.Sum(Severity);
+            // Recurrence starts at the SECOND event, so the rate is built from everything past the
+            // worst one. A lone outage is an incident, not a pattern - rating one event in 48 h as
+            // "0.5 a day" would read a single sample as a trend and charge it twice, once here and
+            // once on duration. Its cost belongs entirely to the duration terms.
+            var recurringSeverity = Math.Max(0, severityTotal - wanOutages.Max(Severity));
+            var eventsPerDay = windowDays > 0 ? recurringSeverity / windowDays : 0.0;
+            var occurrencePenalty = ScoreCurve.Interpolate(eventsPerDay, _options.OutageOccurrenceRateCurve);
             // Floor a flagged WAN event at one point: if we surfaced it on the timeline it should
             // visibly register, not round to a silent zero.
             var penalty = Math.Max(1.0, durationPenalty + occurrencePenalty);
-            // Attribute the total across events so each row shows its own "-N points": its duration
-            // share (by effective-minute) plus its (capped) occurrence cost. Rounded shares may differ
-            // from the total by <=1 pt - cosmetic; the actual deduction uses the total below.
+            // Attribute the total across events so each row shows its own "-N points". Duration goes by
+            // each event's share of the summed claim, which tracks whichever term won: when one long
+            // outage set the floor its claim dominates and it takes most of the points, and when many
+            // events summed into the ratio cost they split it by how much each contributed. Occurrence
+            // goes by severity share. Rounded shares may differ from the total by <=1 pt - cosmetic;
+            // the actual deduction uses the total below.
+            var claimTotal = wanOutages.Sum(Claim);
             foreach (var o in wanOutages)
             {
-                var durShare = outageMinutes > 0 ? durationPenalty * (EffectiveMinutes(o) / outageMinutes) : 0.0;
-                var occShare = EventOccurrence(o) * occCapScale;
+                var durShare = claimTotal > 0 ? durationPenalty * (Claim(o) / claimTotal) : 0.0;
+                var occShare = severityTotal > 0 ? occurrencePenalty * (Severity(o) / severityTotal) : 0.0;
                 o.ScorePenaltyPoints = (int)Math.Round(durShare + occShare);
                 // Per-event "show your work": time, kind, duration, depth (peak loss), breadth, and the
                 // time-of-day usage weight that scaled it, then the duration/occurrence point split.
@@ -251,13 +282,27 @@ public class IspHealthScorer
                     durShare.ToString("0.0", CultureInfo.InvariantCulture),
                     occShare.ToString("0.0", CultureInfo.InvariantCulture));
             }
-            _logger?.LogDebug("ISP Health: outage penalty {Penalty} pts = {Dur} duration + {Occ} occurrence over {N} event(s), {Min} eff min ({Before} -> {After})",
+            _logger?.LogDebug(
+                "ISP Health: outage penalty {Penalty} pts = {Dur} duration ({Unavail} unavailability vs {Felt} worst-event floor, {Pct}% of window) + {Occ} occurrence ({Rate}/day over {N} event(s), {Min} eff min) ({Before} -> {After})",
                 penalty.ToString("0.#", CultureInfo.InvariantCulture), durationPenalty.ToString("0.#", CultureInfo.InvariantCulture),
-                occurrencePenalty.ToString("0.#", CultureInfo.InvariantCulture), wanOutages.Count,
-                outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
+                unavailabilityPenalty.ToString("0.#", CultureInfo.InvariantCulture), feltFloor.ToString("0.#", CultureInfo.InvariantCulture),
+                downPercent.ToString("0.###", CultureInfo.InvariantCulture),
+                occurrencePenalty.ToString("0.#", CultureInfo.InvariantCulture), eventsPerDay.ToString("0.##", CultureInfo.InvariantCulture),
+                wanOutages.Count, outageMinutes.ToString("0.#", CultureInfo.InvariantCulture),
                 overall, (int)Math.Max(0, Math.Round(overall - penalty)));
             overall = (int)Math.Max(0, Math.Round(overall - penalty));
         }
+
+        // Displayed uptime counts BLACKOUT time only (full and brief outages), at raw duration: the
+        // card must agree with the minutes on the timeline, so no usage or loss weighting here, and a
+        // partial-loss disruption is degraded service rather than downtime. Local and acknowledged
+        // events are excluded on the same grounds as the penalty. The scored figure above additionally
+        // folds in weighted partial minutes, so the two can differ slightly by design.
+        var blackouts = wanOutages.Where(o => !o.IsPartial).ToList();
+        var downtime = TimeSpan.FromMinutes(blackouts.Sum(o => o.Duration.TotalMinutes));
+        var uptimePercent = windowMinutes > 0
+            ? Math.Clamp(100.0 - 100.0 * downtime.TotalMinutes / windowMinutes, 0, 100)
+            : 100.0;
 
         var report = new IspHealthReport
         {
@@ -265,6 +310,8 @@ public class IspHealthScorer
             ComputedAt = DateTime.UtcNow,
             WindowStart = inputs.WindowStart,
             WindowEnd = inputs.WindowEnd,
+            UptimePercent = uptimePercent,
+            Downtime = downtime,
             Profile = profile,
             AccessDimension = accessDimension,
             TransitDimension = transitDimension,
@@ -1682,9 +1729,9 @@ public class IspHealthScorer
         // Local (LAN/gateway) outages are surfaced in the waterfall but are not internet outages and
         // don't affect the score, so they never appear in this ISP-impact issue.
         // Full outages and brief disruptions are surfaced as separate findings: a 30 s transit flap
-        // shouldn't read as the same event as a multi-minute outage. Both ride the same severity
-        // curve (a brief disruption costs at most a point), so the per-event score share is taken
-        // from the already-attributed ScorePenaltyPoints rather than recomputing the curve per group.
+        // shouldn't read as the same event as a multi-minute outage. Both ride the same duration and
+        // occurrence terms (a brief disruption costs about a point on its own), so the per-event score
+        // share is taken from the already-attributed ScorePenaltyPoints rather than re-deriving it here.
         // Acknowledged ("that was me") outages were the user's own doing and are left out of the
         // findings entirely, same as the penalty.
         var wanOutages = inputs.Outages.Where(o => o.Scope != OutageScope.Local && !o.Acknowledged).ToList();
@@ -1709,6 +1756,14 @@ public class IspHealthScorer
             var impact = penalty > 0
                 ? $" {(multiple ? "Together they" : "It")} lowered your ISP Health score by {penalty} {(penalty == 1 ? "point" : "points")}."
                 : string.Empty;
+            // The score is graded on downtime as a FRACTION of the window, so state the availability
+            // that produced it - "15 min" alone reads the same on a 48 h window and a 30 day one, and
+            // those are wildly different lines. Suppressed on short windows, where a percentage
+            // invites being read as a monthly SLA figure when it covers a few hours.
+            var rate = multiple ? DropRatePhrase(fullOutages.Count, (inputs.WindowEnd - inputs.WindowStart).TotalHours) : string.Empty;
+            var uptime = (inputs.WindowEnd - inputs.WindowStart).TotalHours >= _options.UptimeProseMinWindowHours
+                ? $" That is {IspHealthPresentation.FormatUptime(report)} uptime across the last {IspHealthPresentation.ProseWindowLabel(report)}{(rate.Length > 0 ? $", {rate}" : "")}."
+                : string.Empty;
             var realPhrase = multiple
                 ? "so these are real outages, not monitoring gaps"
                 : "so this is a real outage, not a monitoring gap";
@@ -1716,7 +1771,7 @@ public class IspHealthScorer
             {
                 Severity = IspIssueSeverity.Warning,
                 Title = multiple ? "Internet outages in the window" : "Internet outage in the window",
-                Description = $"{count} occurred while the Monitoring Agent kept probing ({realPhrase}).{where}{impact}{UsageNote(fullOutages)}",
+                Description = $"{count} occurred while the Monitoring Agent kept probing ({realPhrase}).{where}{uptime}{impact}{UsageNote(fullOutages)}",
                 Recommendation = allUpstream
                     ? "No action needed on your side for an upstream outage; it is logged here so you can correlate it with ISP incidents."
                     : "Logged here so you can correlate it with ISP incidents; if the first ISP hop keeps dropping, check your modem/ONT and the line to your ISP.",
@@ -1937,12 +1992,20 @@ public class IspHealthScorer
         CongestionDetector.FloorTime(time, TimeSpan.FromSeconds(_options.LoadWindowSeconds));
 
     /// <summary>
-    /// The overall-score deduction for outages of the given total downtime, interpolated on the
-    /// configured severity curve. Applied at the top level (not inside a factor) so a long
-    /// outage isn't diluted by the dimension weights; scored by duration alone, shape-independent.
+    /// How often outages recurred, phrased for the findings: "about one drop a week". Picks the unit
+    /// that keeps the count at or above one so a sparse month doesn't read as "about 0 drops a day".
+    /// Empty when there is nothing to rate.
     /// </summary>
-    private double OutageScorePenalty(double totalDowntimeMinutes) =>
-        ScoreCurve.Interpolate(totalDowntimeMinutes, _options.OutageSeverityCurve);
+    private static string DropRatePhrase(int count, double windowHours)
+    {
+        if (count <= 0 || windowHours <= 0) return string.Empty;
+        var perDay = count / (windowHours / 24.0);
+        var (rate, unit) = perDay >= 1 ? (perDay, "day")
+            : perDay * 7 >= 1 ? (perDay * 7, "week")
+            : (perDay * 30, "month");
+        var n = Math.Max(1, (int)Math.Round(rate));
+        return n == 1 ? $"about one drop a {unit}" : $"about {n} drops a {unit}";
+    }
 
     /// <summary>A cosmetic note for an outage finding whose events fell during typically-idle hours.
     /// The score impact already reflects the lower usage weight; this just explains why it's modest.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -310,7 +310,7 @@ public class IspHealthScorer
         // disruption for the share of it that was actually lost - the detector only declares one past
         // a broad, multi-ASN half-loss, which is an interruption rather than a blip, but 50% loss is
         // not 50% down either. Deliberately NOT usage-weighted, unlike the penalty: how much an outage
-        // mattered is a scoring judgement, while uptime is a fact about the line. Local and
+        // mattered is a scoring judgment, while uptime is a fact about the line. Local and
         // acknowledged events are excluded on the same grounds as the penalty.
         double DowntimeMinutes(OutageEvent o) => InWindowMinutes(o) *
             (o.IsPartial ? Math.Clamp(o.PeakLossPct / 100.0, 0, 1) : 1.0);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -19,6 +19,10 @@ public class IspHealthScorer
     // they would double-count and tank the Transit/ISP dimensions. Set per Score() call.
     private IReadOnlyList<OutageEvent> _outages = System.Array.Empty<OutageEvent>();
 
+    // Hours in the report's window, so congestion can be judged as a share of the time observed
+    // rather than in absolute hours. Set per Score() call.
+    private double _windowHours;
+
     // The loss floor for the current report; GatewayLossFloor.None when no gateway target is
     // monitored, which subtracts nothing.
     private GatewayLossFloor _gatewayFloor = GatewayLossFloor.None;
@@ -43,6 +47,7 @@ public class IspHealthScorer
     {
         _outages = inputs.Outages;
         _profile = profile;
+        _windowHours = (inputs.WindowEnd - inputs.WindowStart).TotalHours;
         _loadedDownKeys = null;
         _loadedUpKeys = null;
         // Loss to the gateway is the common-mode floor of the measurement chain: every probe crosses
@@ -1073,7 +1078,11 @@ public class IspHealthScorer
         // same window (e.g. parallel backbone links, or a dead-end hop confirmed by its sibling)
         // are one incident and must not double-count the congestion hours.
         var eventHours = UnionHours(asnEvents);
-        var congestionScore = (int)Math.Round(Math.Max(0, 100 - _options.CongestionPenaltyPerHour * eventHours));
+        // Graded against the window rather than in absolute hours: the same congested hours are a
+        // fifth of a two-day window and an afternoon of a month, and the flat per-hour penalty scored
+        // them the same and saturated to zero past five hours either way.
+        var congestedPct = _windowHours > 0 ? Math.Clamp(100.0 * eventHours / _windowHours, 0, 100) : 0;
+        var congestionScore = (int)Math.Round(ScoreCurve.Interpolate(congestedPct, _options.AsnCongestionCurve));
 
         int? overall = null;
         var weighted = new List<(double Score, double Weight)>();
@@ -1092,12 +1101,13 @@ public class IspHealthScorer
             // loss and unremarkable jitter can still grade in the sixties with nothing on screen or
             // in the log saying which component took it there.
             _logger?.LogDebug(
-                "ISP Health: AS{Asn} grade {Overall} = ceiling {Ceiling} - deficit {Deficit} | stability {Stab} jitter {Jit} loss {Loss} congestion {Cong} ({Hours} h over {Events} event(s))",
+                "ISP Health: AS{Asn} grade {Overall} = ceiling {Ceiling} - deficit {Deficit} | stability {Stab} jitter {Jit} loss {Loss} congestion {Cong} ({Hours} h = {Pct}% of window, {Events} event(s))",
                 series.AsnNumber, overall, reachCeiling?.ToString() ?? "none",
                 (100 - quality).ToString("0.#", CultureInfo.InvariantCulture),
                 stabilityScore?.ToString() ?? "-", jitterScore?.ToString() ?? "-",
                 lossScore?.ToString() ?? "-", congestionScore,
-                eventHours.ToString("0.##", CultureInfo.InvariantCulture), asnEvents.Count);
+                eventHours.ToString("0.##", CultureInfo.InvariantCulture),
+                congestedPct.ToString("0.#", CultureInfo.InvariantCulture), asnEvents.Count);
         }
 
         return new IspAsnHealth
@@ -1711,6 +1721,8 @@ public class IspHealthScorer
             JitterAssimilated = grade?.JitterAssimilated ?? false,
             LossPct = losses.Count > 0 ? losses.Average() : null,
             LatencyStabilityScore = grade?.LatencyStabilityScore,
+            CongestionScore = grade?.CongestionScore,
+            CongestionEventCount = grade?.CongestionEventCount ?? 0,
             OverallScore = grade?.OverallScore,
             ReachDeltaMs = grade?.ReachDeltaMs,
             IsGradedHop = isGraded,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -1088,6 +1088,16 @@ public class IspHealthScorer
             // Quality deficits subtract below the ceiling so congestion, loss, and
             // jitter always move the grade even on distant POPs
             overall = (int)Math.Round(Math.Max(0, (reachCeiling ?? 100) - (100 - quality)));
+            // The arithmetic behind the grade. Without this a hop showing perfect stability, zero
+            // loss and unremarkable jitter can still grade in the sixties with nothing on screen or
+            // in the log saying which component took it there.
+            _logger?.LogDebug(
+                "ISP Health: AS{Asn} grade {Overall} = ceiling {Ceiling} - deficit {Deficit} | stability {Stab} jitter {Jit} loss {Loss} congestion {Cong} ({Hours} h over {Events} event(s))",
+                series.AsnNumber, overall, reachCeiling?.ToString() ?? "none",
+                (100 - quality).ToString("0.#", CultureInfo.InvariantCulture),
+                stabilityScore?.ToString() ?? "-", jitterScore?.ToString() ?? "-",
+                lossScore?.ToString() ?? "-", congestionScore,
+                eventHours.ToString("0.##", CultureInfo.InvariantCulture), asnEvents.Count);
         }
 
         return new IspAsnHealth
@@ -1644,6 +1654,11 @@ public class IspHealthScorer
             var lossVals = hops.Select(h => h.LossPct).Where(l => l.HasValue).Select(l => l!.Value).ToList();
             var medianRtts = hops.Select(h => h.MedianRttMs).Where(m => m.HasValue).Select(m => m!.Value).ToList();
             var scored = hops.Where(h => h.OverallScore.HasValue).Select(h => h.OverallScore!.Value).ToList();
+            // Averaged across the ASN's hops, like every other figure on this card and like the grade
+            // itself. A worst-hop minimum would read as a different kind of number from the RTT, jitter
+            // and loss beside it, and the per-hop rows below already show where the spread really sits.
+            var stabilities = hops.Where(h => h.LatencyStabilityScore.HasValue)
+                .Select(h => h.LatencyStabilityScore!.Value).ToList();
             result.Add(new IspAsnHealth
             {
                 AsnNumber = group.Key,
@@ -1656,6 +1671,7 @@ public class IspHealthScorer
                 MaxRttMs = means.Count > 0 ? means.Max() : null,
                 ScoredJitterMs = effMean,
                 LossPct = lossVals.Count > 0 ? lossVals.Average() : null,
+                LatencyStabilityScore = stabilities.Count > 0 ? (int)Math.Round(stabilities.Average()) : null,
                 OverallScore = scored.Count > 0 ? (int)Math.Round(scored.Average()) : null,
                 CongestionEventCount = asnEvents.Count,
                 JitterAssimilated = effMean.HasValue && rawMean.HasValue && effMean.Value < rawMean.Value - assimilationMinDeltaMs,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -761,17 +761,33 @@ public class IspHealthService
         // nearest hop because far-hop RTT carries transit variance that isn't the access
         // link's loaded behavior - see PickFirstCleanHop / spec "Measurement sources".)
         // Transit series enter minus their unreachable windows (see transitDarkWindows above).
-        var lossPool = new List<List<LatencySample>>();
-        lossPool.AddRange(ispTargets.Where(t => ispSeries.ContainsKey(t.TargetId)).Select(t => ispSeries[t.TargetId]));
-        lossPool.AddRange(transitTargets.Where(t => transitSeries.ContainsKey(t.TargetId)).Select(t =>
-            darkByTargetId.TryGetValue(t.TargetId, out var dark)
-                ? transitSeries[t.TargetId].Where(s => !dark.Any(w => s.Time >= w.Start && s.Time <= w.End)).ToList()
-                : transitSeries[t.TargetId]));
-        lossPool.AddRange(targets
+        // Built WITH target ids so flat-lined members can be identified before the ids are dropped:
+        // the scorer's pool is anonymous (LatencySample carries no target), so this is the last point
+        // where a target can be named.
+        var identifiedPool = new List<LossPoolFilter.PoolEntry>();
+        identifiedPool.AddRange(ispTargets.Where(t => ispSeries.ContainsKey(t.TargetId))
+            .Select(t => new LossPoolFilter.PoolEntry(t.TargetId, ispSeries[t.TargetId])));
+        identifiedPool.AddRange(transitTargets.Where(t => transitSeries.ContainsKey(t.TargetId)).Select(t =>
+            new LossPoolFilter.PoolEntry(t.TargetId,
+                darkByTargetId.TryGetValue(t.TargetId, out var dark)
+                    ? transitSeries[t.TargetId].Where(s => !dark.Any(w => s.Time >= w.Start && s.Time <= w.End)).ToList()
+                    : transitSeries[t.TargetId])));
+        identifiedPool.AddRange(targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService
                 && AnycastDnsIps.Contains(t.Address)
                 && internetSeries.ContainsKey(t.TargetId))
-            .Select(t => internetSeries[t.TargetId]));
+            .Select(t => new LossPoolFilter.PoolEntry(t.TargetId, internetSeries[t.TargetId])));
+
+        // A target dark for the whole window while its peers keep measuring is blocked or retired, not
+        // losing; its constant 100% would swamp the pooled mean both loss factors are graded on.
+        var flatlined = LossPoolFilter.FindFlatlined(identifiedPool, _options);
+        if (flatlined.Count > 0)
+            _logger.LogInformation("ISP Health: excluding {Count} flat-lined target(s) from the loss pool: {Targets}",
+                flatlined.Count, string.Join(", ", flatlined));
+        var lossPool = identifiedPool
+            .Where(e => !flatlined.Contains(e.TargetId))
+            .Select(e => e.Samples.ToList())
+            .ToList();
 
         var (ispGrading, transitGrading, allClusters, ispChart, transitChart) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
         var chartClusters = ispChart.Concat(transitChart).ToList();
@@ -1135,6 +1151,7 @@ public class IspHealthService
             IspTargetSeries = ispTargetSeries,
             TargetAddresses = await ResolveHopAddressesAsync(ispTargets, ct),
             LossPoolSeries = lossPool,
+            LossPoolExcludedTargetIds = flatlined,
             TransitAsnSeries = transitGrading,
             IspAsnSeries = ispGrading,
             DestinationSeries = internetTargetSeries,
@@ -1368,12 +1385,17 @@ public class IspHealthService
                 || t.TargetType == MonitoringTargetType.Transit
                 || t.TargetType == MonitoringTargetType.InternetService))
             .ToListAsync(ct);
+        // Flat-lined targets the last computed report dropped come out here too. Subtracting from the
+        // report rather than re-deriving it keeps this the single definition: the exclusion is a
+        // measurement judgement and this method only reads the database, so it cannot make it itself.
+        var excluded = _cached?.Report.LossPoolExcludedTargetIds ?? Array.Empty<string>();
         return targets
             .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
                 || (t.TargetType == MonitoringTargetType.Transit
                     && !(t.AsnNumber is int a && WellKnownAsns.NonTransitInfrastructure.Contains(a)))
                 || (t.TargetType == MonitoringTargetType.InternetService && AnycastDnsIps.Contains(t.Address)))
             .Select(t => t.TargetId)
+            .Where(id => !excluded.Contains(id))
             .ToList();
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -676,6 +676,15 @@ public class IspHealthService
         var customSeries = ToSamples(await customSeriesTask);
         var wanRates = await ratesTask;
         var (expectedDown, expectedUp, expectedSource, smartQueuesEnabled, scoredWan) = await speedsTask;
+
+        // A counter reset at a link flap reports a rate the line cannot carry. Left in, one such
+        // sample marks its window loaded and drags the flap's own loss into Loaded Loss.
+        var sanitized = WanRateSanitizer.Filter(wanRates, expectedDown, expectedUp, _options);
+        if (sanitized.Dropped > 0)
+            _logger.LogInformation(
+                "ISP Health: discarded {Dropped} of {Total} WAN rate sample(s) above {Multiple}x the {Down}/{Up} Mbps plan (counter artifacts)",
+                sanitized.Dropped, wanRates.Count, _options.WanRateImplausibleMultiple, expectedDown, expectedUp);
+        wanRates = sanitized.Samples;
         var wanSpeedTests = await speedTestsTask;
         // Gateway samples feed only the outage waterfall's gateway hop, so they carry the full extended
         // window (the detector clips each hop's series to the detected event span anyway).
@@ -743,10 +752,14 @@ public class IspHealthService
         // feeding the pool through the same span, so pooled loss stays usable on paths with
         // several upstream ASNs - and surfaced as path events after outage detection. The
         // ASN's own grade uses the unfiltered grading series, so it still takes the hit.
+        // Both rules: cleanly withdrawn (every sample dark for minutes) and flapping (mostly dark for
+        // longer, answering the odd probe). Overlapping windows are harmless - masking is a range test.
         var transitDarkWindows = transitTargets
             .Where(t => transitSeries.ContainsKey(t.TargetId))
             .SelectMany(t => TransitUnreachableDetector.Detect(
-                t.TargetId, t.AsnNumber ?? 0, AsnNameCleanup.Clean(t.AsnName), transitSeries[t.TargetId], _options))
+                    t.TargetId, t.AsnNumber ?? 0, AsnNameCleanup.Clean(t.AsnName), transitSeries[t.TargetId], _options)
+                .Concat(TransitUnreachableDetector.DetectMostlyDark(
+                    t.TargetId, t.AsnNumber ?? 0, AsnNameCleanup.Clean(t.AsnName), transitSeries[t.TargetId], _options)))
             .ToList();
         var darkByTargetId = transitDarkWindows
             .GroupBy(w => w.TargetId)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -656,6 +656,10 @@ public class IspHealthService
         // bursts, which a coarse mean blunts), so it diverged from the fine-resolution attribution on
         // transit-heavy paths. Kept fine everywhere; the compute-time wins now come from the in-memory
         // detector/scorer paths, not from coarsening the input.
+        // Everything above runs before a single query is issued - site database reads, target and
+        // technology resolution, and console calls. The "fetch" figure lumped it in with the reads,
+        // which measured the four latency queries at ~1s from the box while fetch showed ~6.8s.
+        var setupMs = computeSw.ElapsedMilliseconds;
         var ispSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.AccessIsp, outageQueryStart, windowEnd, aggregate, ct);
         var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
         var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, outageQueryStart, windowEnd, aggregate, ct);
@@ -1226,9 +1230,9 @@ public class IspHealthService
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
         _logger.LogDebug(
-            "ISP Health compute timing: {Hours}h in {Ms}ms = fetch {Fetch} + trim/mask {Trim} + asn {Asn} + detect {Detect} + score {Score} + other {Other}; {Rates} rates, {LatencyPoints} latency points, {LossSeries} loss series",
+            "ISP Health compute timing: {Hours}h in {Ms}ms = setup {Setup} + query {Query} + trim/mask {Trim} + asn {Asn} + detect {Detect} + score {Score} + other {Other}; {Rates} rates, {LatencyPoints} latency points, {LossSeries} loss series",
             (windowEnd - windowStart).TotalHours.ToString("0.#"), computeSw.ElapsedMilliseconds,
-            fetchMs, trimAndMaskMs, asnBuildMs, detectorsMs, scoreMs,
+            setupMs, fetchMs - setupMs, trimAndMaskMs, asnBuildMs, detectorsMs, scoreMs,
             computeSw.ElapsedMilliseconds - fetchMs - trimAndMaskMs - asnBuildMs - detectorsMs - scoreMs,
             wanRates.Count,
             ispSeries.Sum(kv => kv.Value.Count) + transitSeries.Sum(kv => kv.Value.Count)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -660,7 +660,14 @@ public class IspHealthService
         var transitSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Transit, windowStart, windowEnd, aggregate, ct);
         var internetSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.InternetService, outageQueryStart, windowEnd, aggregate, ct);
         var customSeriesTask = _influx.QueryLatencyDetailByTargetTypeAsync(MonitoringTargetType.Custom, windowStart, windowEnd, aggregate, ct);
-        var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, aggregate, ct);
+        // Rates keep a fine interval whatever the window length. Thinning them with everything else
+        // destroys the only property that separates sustained load from a spike - whether neighboring
+        // samples are loaded too - because a minute-long transfer and a one-sample counter artifact
+        // both collapse to a single point. One series against ~25 per-target latency series, so the
+        // extra rows are cheap relative to what the compute already carries.
+        var rateAggregate = TimeSpan.FromSeconds(
+            Math.Min(aggregate.TotalSeconds, Math.Max(_options.LoadWindowSeconds, _options.WanRateMaxAggregateSeconds)));
+        var ratesTask = QueryWanRatesAsync(windowStart, windowEnd, rateAggregate, ct);
         var speedsTask = ResolveExpectedSpeedsAsync(ct);
         var speedTestsTask = LoadWanSpeedTestsAsync(windowStart, windowEnd, ct);
         var gatewaySeriesTask = gatewayTarget == null
@@ -1408,7 +1415,7 @@ public class IspHealthService
             .ToListAsync(ct);
         // Flat-lined targets the last computed report dropped come out here too. Subtracting from the
         // report rather than re-deriving it keeps this the single definition: the exclusion is a
-        // measurement judgement and this method only reads the database, so it cannot make it itself.
+        // measurement judgment and this method only reads the database, so it cannot make it itself.
         var excluded = _cached?.Report.LossPoolExcludedTargetIds ?? Array.Empty<string>();
         return targets
             .Where(t => t.TargetType == MonitoringTargetType.AccessIsp

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -674,6 +674,10 @@ public class IspHealthService
             ? Task.FromResult(new List<MonitoringInfluxClient.LatencySeriesPoint>())
             : _influx.QueryLatencyDetailByTargetIdAsync(gatewayTarget.TargetId, outageQueryStart, windowEnd, aggregate, ct);
         await Task.WhenAll(ispSeriesTask, transitSeriesTask, internetSeriesTask, customSeriesTask, ratesTask, speedsTask, speedTestsTask, gatewaySeriesTask);
+        // Split the compute at the point every query has returned. Three rounds of optimizing the rate
+        // path moved the total by nothing, which means the cost is not where it was assumed to be -
+        // and query time versus post-query work are the two halves that need different answers.
+        var fetchMs = computeSw.ElapsedMilliseconds;
 
         // Extended (lead-in) series: used only to build the outage detector's trigger and hops below.
         var ispSeriesExt = ToSamples(await ispSeriesTask);
@@ -814,7 +818,9 @@ public class IspHealthService
             .Select(e => e.Samples.ToList())
             .ToList();
 
+        var trimAndMaskMs = computeSw.ElapsedMilliseconds - fetchMs;
         var (ispGrading, transitGrading, allClusters, ispChart, transitChart) = BuildAsnSeriesSets(ispTargets, transitTargets, ispSeries, transitSeries, ancestorIpsByTargetId);
+        var asnBuildMs = computeSw.ElapsedMilliseconds - fetchMs - trimAndMaskMs;
         var chartClusters = ispChart.Concat(transitChart).ToList();
         var internetTargetSeries = targets
             .Where(t => t.TargetType == MonitoringTargetType.InternetService && internetSeries.ContainsKey(t.TargetId))
@@ -936,6 +942,7 @@ public class IspHealthService
         // Internet/CDN targets join step detection because routing shifts in a transit
         // network show up on every path that crosses it (per the real shift examples)
         var stepInput = allClusters.Concat(internetTargetSeries).ToList();
+        var detectorsStartMs = computeSw.ElapsedMilliseconds;
         var pathShifts = StepChangeDetector.Detect(stepInput, _options);
 
         // Outage detection: the internet targets going dark defines an outage; every hop is
@@ -1203,7 +1210,10 @@ public class IspHealthService
         };
 
         ct.ThrowIfCancellationRequested();
+        var detectorsMs = computeSw.ElapsedMilliseconds - detectorsStartMs;
+        var scoreStartMs = computeSw.ElapsedMilliseconds;
         var report = new IspHealthScorer(_options, _logger).Score(inputs, profile);
+        var scoreMs = computeSw.ElapsedMilliseconds - scoreStartMs;
         report.AccessTechnology = technology;
         report.PhysicalLinkCandidates = physical.Candidates;
         report.PhysicalLinkSelectedKey = physical.SelectedKey;
@@ -1215,9 +1225,15 @@ public class IspHealthService
         report.PppoeSession = pppoeSession == true;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
-        _logger.LogDebug("ISP Health compute timing: {Hours}h window in {Ms}ms ({Rates} rate sample(s), {LossSeries} loss series)",
+        _logger.LogDebug(
+            "ISP Health compute timing: {Hours}h in {Ms}ms = fetch {Fetch} + trim/mask {Trim} + asn {Asn} + detect {Detect} + score {Score} + other {Other}; {Rates} rates, {LatencyPoints} latency points, {LossSeries} loss series",
             (windowEnd - windowStart).TotalHours.ToString("0.#"), computeSw.ElapsedMilliseconds,
-            wanRates.Count, lossPool.Count);
+            fetchMs, trimAndMaskMs, asnBuildMs, detectorsMs, scoreMs,
+            computeSw.ElapsedMilliseconds - fetchMs - trimAndMaskMs - asnBuildMs - detectorsMs - scoreMs,
+            wanRates.Count,
+            ispSeries.Sum(kv => kv.Value.Count) + transitSeries.Sum(kv => kv.Value.Count)
+                + internetSeries.Sum(kv => kv.Value.Count),
+            lossPool.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -465,7 +465,96 @@ public class IspHealthService
         var outcome = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct);
         if (outcome.Report != null)
             _customCache = new CustomWindowSnapshot(windowStart, windowEnd, outcome.Report, outcome.ChartClusters, DateTime.UtcNow);
+        await CompareResolutionsAsync(windowStart, windowEnd, referenceEvents, outcome.Report, ct);
         return (outcome.Report, outcome.ChartClusters);
+    }
+
+    /// <summary>
+    /// Diagnostic: recomputes this window at other aggregate resolutions and logs how the findings
+    /// differ from the one just produced. Off unless ISP_HEALTH_COMPARE_AGGREGATES lists the
+    /// resolutions to try, in seconds, e.g. "60,104". Each entry is a full extra compute, so it is
+    /// meant for answering "does resolution actually change the answer" on a test box, not for
+    /// production. Never touches the cache or the returned report.
+    /// </summary>
+    private async Task CompareResolutionsAsync(
+        DateTime windowStart, DateTime windowEnd, IReadOnlyList<CongestionEvent>? referenceEvents,
+        IspHealthReport? baseline, CancellationToken ct)
+    {
+        var spec = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPARE_AGGREGATES");
+        if (string.IsNullOrWhiteSpace(spec) || baseline == null) return;
+
+        var seconds = spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => int.TryParse(s, out var v) ? v : 0)
+            .Where(v => v > 0)
+            .Distinct()
+            .ToList();
+        if (seconds.Count == 0) return;
+
+        _logger.LogInformation("ISP Health resolution compare: baseline {Baseline}", Fingerprint(baseline));
+        foreach (var s in seconds)
+        {
+            try
+            {
+                var alt = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct,
+                    aggregateOverride: TimeSpan.FromSeconds(s));
+                if (alt.Report == null)
+                {
+                    _logger.LogInformation("ISP Health resolution compare: {Sec}s produced no report ({Status})", s, alt.Status);
+                    continue;
+                }
+                _logger.LogInformation("ISP Health resolution compare: {Sec,4}s {Fingerprint}", s, Fingerprint(alt.Report));
+                foreach (var d in DiffReports(baseline, alt.Report))
+                    _logger.LogInformation("ISP Health resolution compare: {Sec,4}s   DIFF {Detail}", s, d);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogInformation(ex, "ISP Health resolution compare: {Sec}s failed", s);
+            }
+        }
+    }
+
+    /// <summary>One line capturing everything a resolution change could plausibly move.</summary>
+    private static string Fingerprint(IspHealthReport r) =>
+        $"score={r.OverallScore} access={r.AccessDimension.Score} isp={r.IspAsnDimension.Score} transit={r.TransitDimension.Score} " +
+        $"uptime={r.UptimePercent:0.###}% down={r.Downtime.TotalMinutes:0.#}m " +
+        $"congestion={r.CongestionEvents.Count} shifts={r.PathShifts.Count} outages={r.Outages.Count} findings={r.Issues.Count} " +
+        $"factors=[{string.Join(" ", r.AccessDimension.Factors.Select(f => $"{Abbrev(f.Name)}:{f.Score?.ToString() ?? "-"}"))}]";
+
+    private static string Abbrev(string name) =>
+        new string(name.Split(' ').Select(w => w[0]).ToArray());
+
+    /// <summary>Field-level differences between two reports of the same window, most consequential first.</summary>
+    private static IEnumerable<string> DiffReports(IspHealthReport a, IspHealthReport b)
+    {
+        if (a.OverallScore != b.OverallScore) yield return $"overall {a.OverallScore} -> {b.OverallScore}";
+        if (a.AccessDimension.Score != b.AccessDimension.Score) yield return $"access {a.AccessDimension.Score} -> {b.AccessDimension.Score}";
+        if (a.IspAsnDimension.Score != b.IspAsnDimension.Score) yield return $"isp {a.IspAsnDimension.Score} -> {b.IspAsnDimension.Score}";
+        if (a.TransitDimension.Score != b.TransitDimension.Score) yield return $"transit {a.TransitDimension.Score} -> {b.TransitDimension.Score}";
+        if (a.Outages.Count != b.Outages.Count) yield return $"outages {a.Outages.Count} -> {b.Outages.Count}";
+        if (a.CongestionEvents.Count != b.CongestionEvents.Count) yield return $"congestion events {a.CongestionEvents.Count} -> {b.CongestionEvents.Count}";
+        if (a.PathShifts.Count != b.PathShifts.Count) yield return $"path shifts {a.PathShifts.Count} -> {b.PathShifts.Count}";
+        if (Math.Abs(a.UptimePercent - b.UptimePercent) > 0.0005) yield return $"uptime {a.UptimePercent:0.###}% -> {b.UptimePercent:0.###}%";
+
+        // Congestion localization is the thing prior tuning moved without anyone noticing, so compare
+        // where each event landed, not just how many there were.
+        var aHops = a.CongestionEvents.Select(e => e.BottleneckHopIp ?? "unlocalized").OrderBy(x => x).ToList();
+        var bHops = b.CongestionEvents.Select(e => e.BottleneckHopIp ?? "unlocalized").OrderBy(x => x).ToList();
+        if (!aHops.SequenceEqual(bHops))
+            yield return $"congestion localization {aHops.Count(h => h != "unlocalized")} localized -> {bHops.Count(h => h != "unlocalized")} localized (hop set differs)";
+
+        foreach (var fa in a.AccessDimension.Factors)
+        {
+            var fb = b.AccessDimension.Factors.FirstOrDefault(x => x.Name == fa.Name);
+            if (fb != null && fa.Score != fb.Score)
+                yield return $"factor {fa.Name} {fa.Score?.ToString() ?? "-"} -> {fb.Score?.ToString() ?? "-"} ({fa.ValueText} -> {fb.ValueText})";
+        }
+
+        foreach (var ga in a.IspAsns.Concat(a.TransitAsns))
+        {
+            var gb = b.IspAsns.Concat(b.TransitAsns).FirstOrDefault(x => x.AsnNumber == ga.AsnNumber);
+            if (gb != null && ga.OverallScore != gb.OverallScore)
+                yield return $"AS{ga.AsnNumber} grade {ga.OverallScore?.ToString() ?? "-"} -> {gb.OverallScore?.ToString() ?? "-"}";
+        }
     }
 
     /// <summary>
@@ -489,8 +578,30 @@ public class IspHealthService
             .ToList();
     }
 
+    /// <summary>
+    /// Rounds the aggregate down to whole units - days, then hours, then minutes, then seconds.
+    ///
+    /// This is not a nicety: until the Flux duration renderer was corrected it truncated to whole
+    /// units on the way out, so a computed 103.97 s ran as 60 s and ISP Health's real resolution on a
+    /// 30-day window was 60 s, not 104 s. Rendering it exactly would silently coarsen every detector
+    /// and score on long windows, so the historical value is reproduced here deliberately instead.
+    /// Charts are left on the corrected value - they target ~150 points and do not care - but ISP
+    /// Health's resolution is a correctness property of the outage, congestion and loss analysis, and
+    /// is not something to change as a side effect of fixing a renderer.
+    /// </summary>
+    internal static TimeSpan SnapAggregate(TimeSpan window)
+    {
+        var seconds =
+            window.TotalDays >= 1 ? Math.Floor(window.TotalDays) * 86400
+            : window.TotalHours >= 1 ? Math.Floor(window.TotalHours) * 3600
+            : window.TotalMinutes >= 1 ? Math.Floor(window.TotalMinutes) * 60
+            : Math.Floor(window.TotalSeconds);
+        return TimeSpan.FromSeconds(Math.Max(1, seconds));
+    }
+
     private async Task<ComputeOutcome> ComputeCoreAsync(DateTime windowStart, DateTime windowEnd,
-        IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct)
+        IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct,
+        TimeSpan? aggregateOverride = null)
     {
         // Only the auto-compute path was timed, so a custom window - which is where the expensive
         // long spans are actually requested - had no cost signal at all. The budget's failure mode is
@@ -638,8 +749,8 @@ public class IspHealthService
         // loaded instead of diluting into minute-level means. Longer (filter-selected) windows
         // coarsen it to keep the point count bounded; the canonical 48 h window lands on exactly
         // LoadWindowSeconds, so the auto-computed report is unchanged.
-        var aggregate = TimeSpan.FromSeconds(Math.Max(
-            _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0));
+        var aggregate = aggregateOverride ?? SnapAggregate(TimeSpan.FromSeconds(Math.Max(
+            _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0)));
 
         // Outage detection reaches back a bounded lead-in BEFORE the window start so an outage already
         // in progress when the window opens is detected from its true onset instead of being clipped to

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -465,129 +465,8 @@ public class IspHealthService
         var outcome = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct);
         if (outcome.Report != null)
             _customCache = new CustomWindowSnapshot(windowStart, windowEnd, outcome.Report, outcome.ChartClusters, DateTime.UtcNow);
-        await CompareResolutionsAsync(windowStart, windowEnd, referenceEvents, outcome.Report, ct);
         return (outcome.Report, outcome.ChartClusters);
     }
-
-    /// <summary>
-    /// Diagnostic: recomputes this window at other aggregate resolutions and logs how the findings
-    /// differ from the one just produced. Off unless ISP_HEALTH_COMPARE_AGGREGATES lists the
-    /// resolutions to try, in seconds, e.g. "60,104". Each entry is a full extra compute, so it is
-    /// meant for answering "does resolution actually change the answer" on a test box, not for
-    /// production. Never touches the cache or the returned report.
-    /// </summary>
-    private async Task CompareResolutionsAsync(
-        DateTime windowStart, DateTime windowEnd, IReadOnlyList<CongestionEvent>? referenceEvents,
-        IspHealthReport? baseline, CancellationToken ct)
-    {
-        var spec = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPARE_AGGREGATES");
-        if (string.IsNullOrWhiteSpace(spec) || baseline == null) return;
-
-        var seconds = spec.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(s => int.TryParse(s, out var v) ? v : 0)
-            .Where(v => v > 0)
-            .Distinct()
-            .ToList();
-        if (seconds.Count == 0) return;
-
-        var label = $"{_siteSlug}_{windowStart.ToLocalTime():yyyyMMdd-HHmm}_to_{windowEnd.ToLocalTime():yyyyMMdd-HHmm}";
-        _logger.LogInformation("ISP Health resolution compare [{Label}]: baseline({Agg}s) {Baseline}",
-            label, SnapAggregate(TimeSpan.FromSeconds(Math.Max(
-                _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0))).TotalSeconds,
-            Fingerprint(baseline));
-        SaveComparisonPdf(baseline, label, "baseline");
-
-        foreach (var s in seconds)
-        {
-            try
-            {
-                var alt = await ComputeCoreAsync(windowStart, windowEnd, referenceEvents, ct,
-                    aggregateOverride: TimeSpan.FromSeconds(s));
-                if (alt.Report == null)
-                {
-                    _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec}s produced no report ({Status})", label, s, alt.Status);
-                    continue;
-                }
-                _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec,4}s {Fingerprint}", label, s, Fingerprint(alt.Report));
-                foreach (var d in DiffReports(baseline, alt.Report))
-                    _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec,4}s   DIFF {Detail}", label, s, d);
-                SaveComparisonPdf(alt.Report, label, $"{s}s");
-            }
-            catch (Exception ex)
-            {
-                _logger.LogInformation(ex, "ISP Health resolution compare [{Label}]: {Sec}s failed", label, s);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Writes the report as it would be exported, one file per resolution, so the comparison can be
-    /// made on what a user actually receives rather than on the fields a diff happened to check.
-    /// Directory comes from ISP_HEALTH_COMPARE_PDF_DIR; skipped when unset. Named by site, window and
-    /// resolution so runs across several sites and windows - including historical ones - accumulate
-    /// side by side without colliding.
-    /// </summary>
-    private void SaveComparisonPdf(IspHealthReport report, string label, string resolution)
-    {
-        var dir = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPARE_PDF_DIR");
-        if (string.IsNullOrWhiteSpace(dir)) return;
-        try
-        {
-            Directory.CreateDirectory(dir);
-            var path = Path.Combine(dir, $"{label}__{resolution}.pdf");
-            File.WriteAllBytes(path, new IspHealthPdfGenerator().GenerateReportBytes(report, _siteSlug));
-            _logger.LogInformation("ISP Health resolution compare: wrote {Path}", path);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogInformation(ex, "ISP Health resolution compare: could not write the {Resolution} PDF", resolution);
-        }
-    }
-
-    /// <summary>One line capturing everything a resolution change could plausibly move.</summary>
-    private static string Fingerprint(IspHealthReport r) =>
-        $"score={r.OverallScore} access={r.AccessDimension.Score} isp={r.IspAsnDimension.Score} transit={r.TransitDimension.Score} " +
-        $"uptime={r.UptimePercent:0.###}% down={r.Downtime.TotalMinutes:0.#}m " +
-        $"congestion={r.CongestionEvents.Count} shifts={r.PathShifts.Count} outages={r.Outages.Count} findings={r.Issues.Count} " +
-        $"factors=[{string.Join(" ", r.AccessDimension.Factors.Select(f => $"{Abbrev(f.Name)}:{f.Score?.ToString() ?? "-"}"))}]";
-
-    private static string Abbrev(string name) =>
-        new string(name.Split(' ').Select(w => w[0]).ToArray());
-
-    /// <summary>Field-level differences between two reports of the same window, most consequential first.</summary>
-    private static IEnumerable<string> DiffReports(IspHealthReport a, IspHealthReport b)
-    {
-        if (a.OverallScore != b.OverallScore) yield return $"overall {a.OverallScore} -> {b.OverallScore}";
-        if (a.AccessDimension.Score != b.AccessDimension.Score) yield return $"access {a.AccessDimension.Score} -> {b.AccessDimension.Score}";
-        if (a.IspAsnDimension.Score != b.IspAsnDimension.Score) yield return $"isp {a.IspAsnDimension.Score} -> {b.IspAsnDimension.Score}";
-        if (a.TransitDimension.Score != b.TransitDimension.Score) yield return $"transit {a.TransitDimension.Score} -> {b.TransitDimension.Score}";
-        if (a.Outages.Count != b.Outages.Count) yield return $"outages {a.Outages.Count} -> {b.Outages.Count}";
-        if (a.CongestionEvents.Count != b.CongestionEvents.Count) yield return $"congestion events {a.CongestionEvents.Count} -> {b.CongestionEvents.Count}";
-        if (a.PathShifts.Count != b.PathShifts.Count) yield return $"path shifts {a.PathShifts.Count} -> {b.PathShifts.Count}";
-        if (Math.Abs(a.UptimePercent - b.UptimePercent) > 0.0005) yield return $"uptime {a.UptimePercent:0.###}% -> {b.UptimePercent:0.###}%";
-
-        // Congestion localization is the thing prior tuning moved without anyone noticing, so compare
-        // where each event landed, not just how many there were.
-        var aHops = a.CongestionEvents.Select(e => e.BottleneckHopIp ?? "unlocalized").OrderBy(x => x).ToList();
-        var bHops = b.CongestionEvents.Select(e => e.BottleneckHopIp ?? "unlocalized").OrderBy(x => x).ToList();
-        if (!aHops.SequenceEqual(bHops))
-            yield return $"congestion localization {aHops.Count(h => h != "unlocalized")} localized -> {bHops.Count(h => h != "unlocalized")} localized (hop set differs)";
-
-        foreach (var fa in a.AccessDimension.Factors)
-        {
-            var fb = b.AccessDimension.Factors.FirstOrDefault(x => x.Name == fa.Name);
-            if (fb != null && fa.Score != fb.Score)
-                yield return $"factor {fa.Name} {fa.Score?.ToString() ?? "-"} -> {fb.Score?.ToString() ?? "-"} ({fa.ValueText} -> {fb.ValueText})";
-        }
-
-        foreach (var ga in a.IspAsns.Concat(a.TransitAsns))
-        {
-            var gb = b.IspAsns.Concat(b.TransitAsns).FirstOrDefault(x => x.AsnNumber == ga.AsnNumber);
-            if (gb != null && ga.OverallScore != gb.OverallScore)
-                yield return $"AS{ga.AsnNumber} grade {ga.OverallScore?.ToString() ?? "-"} -> {gb.OverallScore?.ToString() ?? "-"}";
-        }
-    }
-
     /// <summary>
     /// Drops congestion events in the canonical-covered recent window (the trailing
     /// <see cref="IspHealthOptions.ScoreWindowHours"/>) that the fine-resolution canonical report
@@ -631,8 +510,7 @@ public class IspHealthService
     }
 
     private async Task<ComputeOutcome> ComputeCoreAsync(DateTime windowStart, DateTime windowEnd,
-        IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct,
-        TimeSpan? aggregateOverride = null)
+        IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct)
     {
         // Only the auto-compute path was timed, so a custom window - which is where the expensive
         // long spans are actually requested - had no cost signal at all. The budget's failure mode is
@@ -780,7 +658,7 @@ public class IspHealthService
         // loaded instead of diluting into minute-level means. Longer (filter-selected) windows
         // coarsen it to keep the point count bounded; the canonical 48 h window lands on exactly
         // LoadWindowSeconds, so the auto-computed report is unchanged.
-        var aggregate = aggregateOverride ?? SnapAggregate(TimeSpan.FromSeconds(Math.Max(
+        var aggregate = SnapAggregate(TimeSpan.FromSeconds(Math.Max(
             _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0)));
 
         // Outage detection reaches back a bounded lead-in BEFORE the window start so an outage already

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -492,6 +492,11 @@ public class IspHealthService
     private async Task<ComputeOutcome> ComputeCoreAsync(DateTime windowStart, DateTime windowEnd,
         IReadOnlyList<CongestionEvent>? referenceEvents, CancellationToken ct)
     {
+        // Only the auto-compute path was timed, so a custom window - which is where the expensive
+        // long spans are actually requested - had no cost signal at all. The budget's failure mode is
+        // silently dropping the user to a shorter window, so changes near the query path need a
+        // before/after number rather than an assumption.
+        var computeSw = System.Diagnostics.Stopwatch.StartNew();
         if (!_influx.IsConfigured && !await _influx.ReconfigureAsync(ct))
             return new ComputeOutcome(IspHealthStatus.NotConfigured, null, new List<AsnSeries>());
 
@@ -1203,6 +1208,9 @@ public class IspHealthService
         report.PppoeSession = pppoeSession == true;
         _logger.LogDebug("ISP Health computed: {Score} ({Tech}), {Events} congestion events, {Shifts} path shifts",
             report.OverallScore, profile.DisplayName, congestionEvents.Count, pathShifts.Count);
+        _logger.LogDebug("ISP Health compute timing: {Hours}h window in {Ms}ms ({Rates} rate sample(s), {LossSeries} loss series)",
+            (windowEnd - windowStart).TotalHours.ToString("0.#"), computeSw.ElapsedMilliseconds,
+            wanRates.Count, lossPool.Count);
         return new ComputeOutcome(IspHealthStatus.Ready, report, chartClusters);
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -490,7 +490,13 @@ public class IspHealthService
             .ToList();
         if (seconds.Count == 0) return;
 
-        _logger.LogInformation("ISP Health resolution compare: baseline {Baseline}", Fingerprint(baseline));
+        var label = $"{_siteSlug}_{windowStart.ToLocalTime():yyyyMMdd-HHmm}_to_{windowEnd.ToLocalTime():yyyyMMdd-HHmm}";
+        _logger.LogInformation("ISP Health resolution compare [{Label}]: baseline({Agg}s) {Baseline}",
+            label, SnapAggregate(TimeSpan.FromSeconds(Math.Max(
+                _options.LoadWindowSeconds, (windowEnd - windowStart).TotalSeconds / 25000.0))).TotalSeconds,
+            Fingerprint(baseline));
+        SaveComparisonPdf(baseline, label, "baseline");
+
         foreach (var s in seconds)
         {
             try
@@ -499,17 +505,42 @@ public class IspHealthService
                     aggregateOverride: TimeSpan.FromSeconds(s));
                 if (alt.Report == null)
                 {
-                    _logger.LogInformation("ISP Health resolution compare: {Sec}s produced no report ({Status})", s, alt.Status);
+                    _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec}s produced no report ({Status})", label, s, alt.Status);
                     continue;
                 }
-                _logger.LogInformation("ISP Health resolution compare: {Sec,4}s {Fingerprint}", s, Fingerprint(alt.Report));
+                _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec,4}s {Fingerprint}", label, s, Fingerprint(alt.Report));
                 foreach (var d in DiffReports(baseline, alt.Report))
-                    _logger.LogInformation("ISP Health resolution compare: {Sec,4}s   DIFF {Detail}", s, d);
+                    _logger.LogInformation("ISP Health resolution compare [{Label}]: {Sec,4}s   DIFF {Detail}", label, s, d);
+                SaveComparisonPdf(alt.Report, label, $"{s}s");
             }
             catch (Exception ex)
             {
-                _logger.LogInformation(ex, "ISP Health resolution compare: {Sec}s failed", s);
+                _logger.LogInformation(ex, "ISP Health resolution compare [{Label}]: {Sec}s failed", label, s);
             }
+        }
+    }
+
+    /// <summary>
+    /// Writes the report as it would be exported, one file per resolution, so the comparison can be
+    /// made on what a user actually receives rather than on the fields a diff happened to check.
+    /// Directory comes from ISP_HEALTH_COMPARE_PDF_DIR; skipped when unset. Named by site, window and
+    /// resolution so runs across several sites and windows - including historical ones - accumulate
+    /// side by side without colliding.
+    /// </summary>
+    private void SaveComparisonPdf(IspHealthReport report, string label, string resolution)
+    {
+        var dir = Environment.GetEnvironmentVariable("ISP_HEALTH_COMPARE_PDF_DIR");
+        if (string.IsNullOrWhiteSpace(dir)) return;
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, $"{label}__{resolution}.pdf");
+            File.WriteAllBytes(path, new IspHealthPdfGenerator().GenerateReportBytes(report, _siteSlug));
+            _logger.LogInformation("ISP Health resolution compare: wrote {Path}", path);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex, "ISP Health resolution compare: could not write the {Resolution} PDF", resolution);
         }
     }
 
@@ -1299,6 +1330,7 @@ public class IspHealthService
             TargetAddresses = await ResolveHopAddressesAsync(ispTargets, ct),
             LossPoolSeries = lossPool,
             LossPoolExcludedTargetIds = flatlined,
+            GatewayLossSeries = gatewaySamples,
             TransitAsnSeries = transitGrading,
             IspAsnSeries = ispGrading,
             DestinationSeries = internetTargetSeries,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
@@ -26,30 +26,52 @@ public static class LoadClassifier
         var windowSize = TimeSpan.FromSeconds(options.LoadWindowSeconds);
         var excluded = 0;
         var excludedLoaded = 0;
-        foreach (var group in rates.GroupBy(r => CongestionDetector.FloorTime(r.Time, windowSize)))
+        // Peak per window, accumulated in one pass. GroupBy allocated an IGrouping and a backing list
+        // per window, and ISP Health now holds the rate series fine on long spans - six figures of
+        // windows, nearly all of them holding a single sample.
+        var peaks = new Dictionary<DateTime, (double Down, double Up)>();
+        var maxDown = 0.0;
+        var maxUp = 0.0;
+        DateTime firstTime = default, lastTime = default;
+        for (var i = 0; i < rates.Count; i++)
         {
-            var down = group.Max(r => r.DownloadBps ?? 0);
-            var up = group.Max(r => r.UploadBps ?? 0);
+            var r = rates[i];
+            var key = CongestionDetector.FloorTime(r.Time, windowSize);
+            var d = r.DownloadBps ?? 0;
+            var u = r.UploadBps ?? 0;
+            if (peaks.TryGetValue(key, out var cur))
+                peaks[key] = (d > cur.Down ? d : cur.Down, u > cur.Up ? u : cur.Up);
+            else
+                peaks[key] = (d, u);
 
-            var loadedDown = expectedDownBps.HasValue && down >= options.LoadedThresholdFraction * expectedDownBps.Value;
-            var loadedUp = expectedUpBps.HasValue && up >= options.LoadedThresholdFraction * expectedUpBps.Value;
+            // Log inputs gathered here rather than in four more passes over the series.
+            if (d > maxDown) maxDown = d;
+            if (u > maxUp) maxUp = u;
+            if (i == 0 || r.Time < firstTime) firstTime = r.Time;
+            if (i == 0 || r.Time > lastTime) lastTime = r.Time;
+        }
 
-            if (exclusionWindows != null && IsExcluded(group.Key, windowSize, exclusionWindows))
+        foreach (var (key, peak) in peaks)
+        {
+            var loadedDown = expectedDownBps.HasValue && peak.Down >= options.LoadedThresholdFraction * expectedDownBps.Value;
+            var loadedUp = expectedUpBps.HasValue && peak.Up >= options.LoadedThresholdFraction * expectedUpBps.Value;
+
+            if (exclusionWindows != null && IsExcluded(key, windowSize, exclusionWindows))
             {
                 // Still drop the window from the analysis, but classify it first so the
                 // log reflects how many GENUINELY-LOADED windows were removed - the only
                 // exclusions that change the loaded-line result. Idle exclusions are noise.
-                result[group.Key] = new LoadWindow(false, false, false);
+                result[key] = new LoadWindow(false, false, false);
                 excluded++;
                 if (loadedDown || loadedUp) excludedLoaded++;
                 continue;
             }
 
             var idle = expectedDownBps.HasValue && expectedUpBps.HasValue
-                && down < options.IdleThresholdFraction * expectedDownBps.Value
-                && up < options.IdleThresholdFraction * expectedUpBps.Value;
+                && peak.Down < options.IdleThresholdFraction * expectedDownBps.Value
+                && peak.Up < options.IdleThresholdFraction * expectedUpBps.Value;
 
-            result[group.Key] = new LoadWindow(idle, loadedDown, loadedUp);
+            result[key] = new LoadWindow(idle, loadedDown, loadedUp);
         }
 
         // Demote loaded windows that stand alone. A saturating transfer holds across consecutive
@@ -64,21 +86,23 @@ public static class LoadClassifier
                 "ISP Health: excluded {Count} window(s) overlapping SQM probe schedule, {Loaded} of which would have classified as loaded",
                 excluded, excludedLoaded);
 
-        // What the classifier actually saw. On a long window the rate series arrives aggregated far
-        // coarser than LoadWindowSeconds, so each sample keys one narrow window while standing for a
-        // much wider span - print the rates and the windows they produced rather than inferring them
-        // from the raw series, which is aggregated differently.
-        var loadedKeys = result.Where(kv => kv.Value.IsLoadedDown || kv.Value.IsLoadedUp).Select(kv => kv.Key).OrderBy(k => k).ToList();
-        logger?.LogDebug(
-            "ISP Health: load classify - {Rates} rate sample(s) spanning {First:MM-dd HH:mm:ss} to {Last:MM-dd HH:mm:ss}, max {MaxDown}/{MaxUp} Mbps vs {PlanDown}/{PlanUp} plan, {Loaded} of {Total} window(s) loaded: {Keys}",
-            rates.Count,
-            rates.Count > 0 ? rates.Min(r => r.Time) : default,
-            rates.Count > 0 ? rates.Max(r => r.Time) : default,
-            (rates.Count > 0 ? rates.Max(r => r.DownloadBps ?? 0) / 1e6 : 0).ToString("0.#"),
-            (rates.Count > 0 ? rates.Max(r => r.UploadBps ?? 0) / 1e6 : 0).ToString("0.#"),
-            expectedDownloadMbps, expectedUploadMbps,
-            loadedKeys.Count, result.Count,
-            string.Join(" | ", loadedKeys.Take(8).Select(k => k.ToString("MM-dd HH:mm:ss"))));
+        // What the classifier actually saw. Guarded, and built from values gathered in the pass above:
+        // debug logging is on permanently at the test sites, so an unguarded diagnostic here walked
+        // six figures of samples several more times on every compute.
+        if (logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            var loadedKeys = new List<DateTime>();
+            foreach (var (key, w) in result)
+                if (w.IsLoadedDown || w.IsLoadedUp) loadedKeys.Add(key);
+            loadedKeys.Sort();
+            logger.LogDebug(
+                "ISP Health: load classify - {Rates} rate sample(s) spanning {First:MM-dd HH:mm:ss} to {Last:MM-dd HH:mm:ss}, max {MaxDown}/{MaxUp} Mbps vs {PlanDown}/{PlanUp} plan, {Loaded} of {Total} window(s) loaded: {Keys}",
+                rates.Count, firstTime, lastTime,
+                (maxDown / 1e6).ToString("0.#"), (maxUp / 1e6).ToString("0.#"),
+                expectedDownloadMbps, expectedUploadMbps,
+                loadedKeys.Count, result.Count,
+                string.Join(" | ", loadedKeys.Take(8).Select(k => k.ToString("MM-dd HH:mm:ss"))));
+        }
         return result;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
@@ -55,6 +55,22 @@ public static class LoadClassifier
             logger?.LogDebug(
                 "ISP Health: excluded {Count} window(s) overlapping SQM probe schedule, {Loaded} of which would have classified as loaded",
                 excluded, excludedLoaded);
+
+        // What the classifier actually saw. On a long window the rate series arrives aggregated far
+        // coarser than LoadWindowSeconds, so each sample keys one narrow window while standing for a
+        // much wider span - print the rates and the windows they produced rather than inferring them
+        // from the raw series, which is aggregated differently.
+        var loadedKeys = result.Where(kv => kv.Value.IsLoadedDown || kv.Value.IsLoadedUp).Select(kv => kv.Key).OrderBy(k => k).ToList();
+        logger?.LogDebug(
+            "ISP Health: load classify - {Rates} rate sample(s) spanning {First:MM-dd HH:mm:ss} to {Last:MM-dd HH:mm:ss}, max {MaxDown}/{MaxUp} Mbps vs {PlanDown}/{PlanUp} plan, {Loaded} of {Total} window(s) loaded: {Keys}",
+            rates.Count,
+            rates.Count > 0 ? rates.Min(r => r.Time) : default,
+            rates.Count > 0 ? rates.Max(r => r.Time) : default,
+            (rates.Count > 0 ? rates.Max(r => r.DownloadBps ?? 0) / 1e6 : 0).ToString("0.#"),
+            (rates.Count > 0 ? rates.Max(r => r.UploadBps ?? 0) / 1e6 : 0).ToString("0.#"),
+            expectedDownloadMbps, expectedUploadMbps,
+            loadedKeys.Count, result.Count,
+            string.Join(" | ", loadedKeys.Take(8).Select(k => k.ToString("MM-dd HH:mm:ss"))));
         return result;
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
@@ -51,6 +51,14 @@ public static class LoadClassifier
 
             result[group.Key] = new LoadWindow(idle, loadedDown, loadedUp);
         }
+
+        // Demote loaded windows that stand alone. A saturating transfer holds across consecutive
+        // samples; a counter artifact - a delta spanning a reset - is a single sample with idle
+        // neighbors. Magnitude cannot separate them, because bursty access media legitimately read
+        // well above plan, so persistence is the discriminator. Runs are counted over samples in time
+        // order rather than adjacent window keys: the rate series is coarser than the window size, so
+        // consecutive samples are never in adjacent keys.
+        DemoteIsolated(result, options);
         if (excluded > 0)
             logger?.LogDebug(
                 "ISP Health: excluded {Count} window(s) overlapping SQM probe schedule, {Loaded} of which would have classified as loaded",
@@ -72,6 +80,66 @@ public static class LoadClassifier
             loadedKeys.Count, result.Count,
             string.Join(" | ", loadedKeys.Take(8).Select(k => k.ToString("MM-dd HH:mm:ss"))));
         return result;
+    }
+
+    /// <summary>
+    /// Clears the loaded flags on any run shorter than
+    /// <see cref="IspHealthOptions.MinLoadedRunSamples"/>. Each direction is judged on its own - a
+    /// download transfer and an upload one rarely coincide - and a gap longer than a couple of sample
+    /// intervals breaks a run, so load either side of a monitoring outage is not stitched into one.
+    /// </summary>
+    private static void DemoteIsolated(Dictionary<DateTime, LoadWindow> windows, IspHealthOptions options)
+    {
+        if (options.MinLoadedRunSamples <= 1 || windows.Count == 0) return;
+
+        var ordered = windows.Keys.OrderBy(k => k).ToList();
+        // Samples arrive on the rate aggregation interval, which is coarser than the window size, so
+        // "adjacent" is measured against the observed spacing rather than assumed to be one window.
+        var spacing = ordered.Count > 1
+            ? TimeSpan.FromSeconds(Math.Max(options.LoadWindowSeconds,
+                (ordered[^1] - ordered[0]).TotalSeconds / (ordered.Count - 1)))
+            : TimeSpan.FromSeconds(options.LoadWindowSeconds);
+        var maxGap = TimeSpan.FromSeconds(spacing.TotalSeconds * 2.5);
+
+        void Sweep(Func<LoadWindow, bool> isLoaded, Func<LoadWindow, LoadWindow> demote)
+        {
+            var i = 0;
+            while (i < ordered.Count)
+            {
+                if (!isLoaded(windows[ordered[i]])) { i++; continue; }
+
+                // Extend while the next window is loaded AND close enough to belong to the same run,
+                // so load either side of a monitoring gap is not stitched into one.
+                var start = i;
+                var end = i + 1;
+                while (end < ordered.Count
+                    && isLoaded(windows[ordered[end]])
+                    && ordered[end] - ordered[end - 1] <= maxGap)
+                    end++;
+
+                // Demote only on POSITIVE evidence of isolation: a neighbor that exists, sits within
+                // the sampling gap, and is not loaded. A run at the edge of the series, or one whose
+                // neighbors are missing, goes unjudged - absence of evidence is not evidence of a
+                // spike, and treating it as one would discard the only sample a short window has.
+                if (end - start < options.MinLoadedRunSamples)
+                {
+                    var quietBefore = start > 0
+                        && ordered[start] - ordered[start - 1] <= maxGap
+                        && !isLoaded(windows[ordered[start - 1]]);
+                    var quietAfter = end < ordered.Count
+                        && ordered[end] - ordered[end - 1] <= maxGap
+                        && !isLoaded(windows[ordered[end]]);
+                    if (quietBefore || quietAfter)
+                        for (var j = start; j < end; j++)
+                            windows[ordered[j]] = demote(windows[ordered[j]]);
+                }
+
+                i = end;
+            }
+        }
+
+        Sweep(w => w.IsLoadedDown, w => w with { IsLoadedDown = false });
+        Sweep(w => w.IsLoadedUp, w => w with { IsLoadedUp = false });
     }
 
     private static bool IsExcluded(DateTime windowStart, TimeSpan windowSize, IReadOnlyList<(DateTime Start, DateTime End)> exclusions)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
@@ -92,7 +92,10 @@ public static class LoadClassifier
     {
         if (options.MinLoadedRunSamples <= 1 || windows.Count == 0) return;
 
-        var ordered = windows.Keys.OrderBy(k => k).ToList();
+        // Sorted once and reused for both directions: at a long window this list runs to six figures,
+        // and sorting it twice was pure waste.
+        var ordered = windows.Keys.ToList();
+        ordered.Sort();
         // Samples arrive on the rate aggregation interval, which is coarser than the window size, so
         // "adjacent" is measured against the observed spacing rather than assumed to be one window.
         var spacing = ordered.Count > 1

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LossPoolFilter.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LossPoolFilter.cs
@@ -1,0 +1,56 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Decides which pooled loss targets are flat-lined: dark for essentially the whole window while
+/// their peers keep measuring. Such a target is blocked or retired rather than losing - it reports a
+/// constant 100% that swamps the pooled mean the Packet Loss and Loaded Loss factors are graded on,
+/// and drags Investigate's highlight with it. Pure and I/O-free so the one rule that matters here can
+/// be tested on its own.
+/// </summary>
+public static class LossPoolFilter
+{
+    /// <summary>One pooled series with the identity the scorer's anonymous pool has lost.</summary>
+    public record PoolEntry(string TargetId, IReadOnlyList<LatencySample> Samples);
+
+    /// <summary>
+    /// Target IDs to drop from the loss pool. The test is RELATIVE, never absolute: a target only
+    /// counts as flat-lined while at least one peer is still measuring healthily. A real WAN outage
+    /// takes every target to 100% at once, and an absolute rule would delete exactly the evidence of
+    /// it and grade the window as clean. For the same reason the last surviving series is never
+    /// dropped, and a target with too few samples to judge is left in.
+    /// </summary>
+    public static HashSet<string> FindFlatlined(IReadOnlyList<PoolEntry> pool, IspHealthOptions options)
+    {
+        var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (pool.Count < 2) return excluded;
+
+        var stats = pool
+            .Select(e =>
+            {
+                var losses = e.Samples.Where(s => s.LossPercent.HasValue).Select(s => s.LossPercent!.Value).ToList();
+                var darkFraction = losses.Count > 0
+                    ? (double)losses.Count(l => l >= options.LossPoolFlatlineLossPct) / losses.Count
+                    : 0.0;
+                return (Entry: e, Count: losses.Count, DarkFraction: darkFraction, Mean: losses.Count > 0 ? losses.Average() : 0.0);
+            })
+            .ToList();
+
+        // A peer counts as still measuring when it has enough samples to judge and its mean loss sits
+        // in ordinary territory. Without one of these the window is not "one dead target among healthy
+        // peers", it is a path-wide event, and nothing is excluded.
+        var hasHealthyPeer = stats.Any(s =>
+            s.Count >= options.LossPoolFlatlineMinSamples && s.Mean <= options.LossPoolHealthyPeerMaxLossPct);
+        if (!hasHealthyPeer) return excluded;
+
+        foreach (var s in stats)
+        {
+            if (s.Count < options.LossPoolFlatlineMinSamples) continue;
+            if (s.DarkFraction < options.LossPoolFlatlineFraction) continue;
+            excluded.Add(s.Entry.TargetId);
+        }
+
+        // Never empty the pool, however the thresholds land.
+        if (excluded.Count >= pool.Count) excluded.Clear();
+        return excluded;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/TransitUnreachableDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/TransitUnreachableDetector.cs
@@ -65,6 +65,68 @@ public static class TransitUnreachableDetector
     }
 
     /// <summary>
+    /// Second pass for a transit target that FLAPS rather than going cleanly dark: unreachable,
+    /// answering for a probe or two, unreachable again. <see cref="Detect"/> requires every sample in
+    /// a run to be dark, so a single answered probe resets it and a target that spent most of an hour
+    /// unreachable never produces a window - while contributing its ~100% samples to the pooled loss
+    /// the whole time. That is the same routing event, just seen through a hop that answers
+    /// intermittently, and it is no more usable as an access-layer loss measurement.
+    ///
+    /// A span opens on the first dark sample and closes once the target has answered continuously for
+    /// <see cref="IspHealthOptions.TransitUnreachableRecoverySeconds"/>, and only counts if it was
+    /// dark for at least <see cref="IspHealthOptions.TransitUnreachableMostlyDarkFraction"/> of its
+    /// samples across at least <see cref="IspHealthOptions.TransitUnreachableMostlyDarkMinSeconds"/>.
+    /// The bar is deliberately longer than the solid-dark rule's: intermittent evidence is weaker, so
+    /// it has to persist before we stop believing the target. Bounds still run first dark sample to
+    /// last, so masking never hides a sample the target actually answered after recovering.
+    /// </summary>
+    public static List<DarkWindow> DetectMostlyDark(string targetId, int asnNumber, string? asnName,
+        IReadOnlyList<LatencySample> samples, IspHealthOptions options)
+    {
+        var windows = new List<DarkWindow>();
+        DateTime? runStart = null, lastDark = null, aliveSince = null;
+        // Counted as of the last dark sample, so trailing answered probes before recovery cannot
+        // dilute the fraction of the span we actually emit.
+        int darkAtLastDark = 0, totalAtLastDark = 0, dark = 0, total = 0;
+
+        void CloseRun()
+        {
+            if (runStart.HasValue && lastDark.HasValue && totalAtLastDark > 0
+                && (lastDark.Value - runStart.Value).TotalSeconds >= options.TransitUnreachableMostlyDarkMinSeconds
+                && (double)darkAtLastDark / totalAtLastDark >= options.TransitUnreachableMostlyDarkFraction)
+                windows.Add(new DarkWindow(targetId, asnNumber, asnName, runStart.Value, lastDark.Value));
+            runStart = null;
+            lastDark = null;
+            aliveSince = null;
+            darkAtLastDark = totalAtLastDark = dark = total = 0;
+        }
+
+        foreach (var s in samples)
+        {
+            if (!s.LossPercent.HasValue) continue;
+            if (s.LossPercent.Value >= options.TransitUnreachableLossPct)
+            {
+                runStart ??= s.Time;
+                lastDark = s.Time;
+                aliveSince = null;
+                dark++;
+                total++;
+                darkAtLastDark = dark;
+                totalAtLastDark = total;
+            }
+            else if (runStart.HasValue)
+            {
+                total++;
+                aliveSince ??= s.Time;
+                if ((s.Time - aliveSince.Value).TotalSeconds >= options.TransitUnreachableRecoverySeconds)
+                    CloseRun();
+            }
+        }
+        CloseRun();
+        return windows;
+    }
+
+    /// <summary>
     /// Collapses per-target dark windows into one event per ASN: windows on the same network
     /// that overlap (or sit within the run-coalescing gap of each other) merge, so an RTT
     /// cluster's members washing out together read as a single path event rather than one per

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/WanRateSanitizer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/WanRateSanitizer.cs
@@ -1,0 +1,58 @@
+namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+/// <summary>
+/// Drops physically impossible WAN throughput samples before they reach load classification.
+///
+/// Interface counters reset when a link flaps or the gateway restarts, and the poller's next delta
+/// spans that discontinuity - it reports a rate that never happened, several times the line's
+/// capacity. One such sample is enough to mark its window fully loaded, and because these artifacts
+/// land exactly at a flap, the outage's own 100%-loss samples then get averaged in as LOADED loss.
+/// A real observed case read 1.09 Gbps on a plan a third of that, at the same second as an outage.
+///
+/// Clamping utilization does not help: the clamp happens after the sample has already been believed.
+/// The sample has to be rejected, not squashed.
+/// </summary>
+public static class WanRateSanitizer
+{
+    /// <summary>Filtered samples plus how many were dropped, for the caller to log.</summary>
+    public record Result(List<ThroughputSample> Samples, int Dropped);
+
+    /// <summary>
+    /// Rejects any sample whose download or upload exceeds its configured plan speed by more than
+    /// <see cref="IspHealthOptions.WanRateImplausibleMultiple"/>. ISPs over-provision, and a burst can
+    /// legitimately beat the plan, so the multiple is well above 1 - this is only meant to catch
+    /// counter artifacts, never a fast line.
+    ///
+    /// A direction with no configured plan is not judged: with nothing to compare against, guessing a
+    /// ceiling would risk discarding real traffic, and a missing plan already disables the load-based
+    /// factors anyway. The whole sample is dropped when either direction is implausible, because a
+    /// counter discontinuity corrupts the reading rather than one field of it.
+    /// </summary>
+    public static Result Filter(
+        IReadOnlyList<ThroughputSample> samples,
+        double? expectedDownloadMbps,
+        double? expectedUploadMbps,
+        IspHealthOptions options)
+    {
+        var downCeiling = expectedDownloadMbps is > 0
+            ? expectedDownloadMbps.Value * 1_000_000 * options.WanRateImplausibleMultiple
+            : (double?)null;
+        var upCeiling = expectedUploadMbps is > 0
+            ? expectedUploadMbps.Value * 1_000_000 * options.WanRateImplausibleMultiple
+            : (double?)null;
+
+        if (downCeiling is null && upCeiling is null)
+            return new Result(samples.ToList(), 0);
+
+        var kept = new List<ThroughputSample>(samples.Count);
+        var dropped = 0;
+        foreach (var s in samples)
+        {
+            var bad = (downCeiling.HasValue && s.DownloadBps > downCeiling.Value)
+                || (upCeiling.HasValue && s.UploadBps > upCeiling.Value);
+            if (bad) dropped++;
+            else kept.Add(s);
+        }
+        return new Result(kept, dropped);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Tours/TourPredicateResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Tours/TourPredicateResolver.cs
@@ -26,6 +26,13 @@ public class TourPredicateResolver
     /// </summary>
     public const string IspHealth = "isp-health";
 
+    /// <summary>
+    /// The site runs Adaptive SQM on at least one WAN. Without it the page is a setup prompt with no
+    /// WAN cards at all, so a step pointing at a per-WAN control has nothing to spotlight and must be
+    /// filtered out BEFORE the driver navigates - "optional" only skips the step once you are there.
+    /// </summary>
+    public const string SqmEnabled = "sqm-enabled";
+
     private readonly SiteManagementService _siteManagement;
     private readonly GatewaySshRegistry _gatewaySshRegistry;
     private readonly AgentEnrollmentService _agentEnrollment;
@@ -111,6 +118,7 @@ public class TourPredicateResolver
         // others down with it - a site whose database is unreachable simply qualifies for neither.
         var gatewaySshSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var ispHealthSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sqmSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var site in sites)
         {
             try
@@ -132,11 +140,23 @@ public class TourPredicateResolver
             {
                 _logger.LogDebug(ex, "Tour predicate {Predicate} evaluation failed for site {Slug}", IspHealth, site.Slug);
             }
+
+            try
+            {
+                if (await HasSqmEnabledAsync(site.Slug, site.IsDefault))
+                    sqmSites.Add(site.Slug);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Tour predicate {Predicate} evaluation failed for site {Slug}", SqmEnabled, site.Slug);
+            }
         }
         if (gatewaySshSites.Count > 0)
             qualifying[GatewaySsh] = gatewaySshSites;
         if (ispHealthSites.Count > 0)
             qualifying[IspHealth] = ispHealthSites;
+        if (sqmSites.Count > 0)
+            qualifying[SqmEnabled] = sqmSites;
 
         return new PredicateContext
         {
@@ -162,5 +182,17 @@ public class TourPredicateResolver
         using var db = _siteDbFactory.CreateForSite(slug, isDefault);
         return await db.MonitoringTargets.AsNoTracking()
             .AnyAsync(t => t.Enabled && t.TargetType == MonitoringTargetType.AccessIsp);
+    }
+
+    /// <summary>
+    /// Whether the site has Adaptive SQM turned on for at least one WAN. A saved row check rather
+    /// than asking the gateway what tc is currently doing: the question is whether the user has this
+    /// feature configured, and reaching a gateway over SSH to answer it would put a network round
+    /// trip on a path that runs on every Dashboard visit.
+    /// </summary>
+    private async Task<bool> HasSqmEnabledAsync(string slug, bool isDefault)
+    {
+        using var db = _siteDbFactory.CreateForSite(slug, isDefault);
+        return await db.SqmWanConfigurations.AsNoTracking().AnyAsync(c => c.Enabled);
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17361,6 +17361,41 @@ a.isp-health-hero-speed:hover {
     margin-top: 0.1rem;
 }
 
+.isp-health-hero-side {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.isp-health-uptime {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.15rem;
+    text-align: center;
+}
+
+.isp-uptime-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--text-muted);
+}
+
+.isp-uptime-value {
+    font-size: 2rem;
+    font-weight: 700;
+    letter-spacing: -1px;
+    line-height: 1.15;
+}
+
+.isp-uptime-sub {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+}
+
 .isp-health-hero-dimensions {
     display: flex;
     gap: 0.75rem;
@@ -18045,10 +18080,16 @@ a.isp-outage-ack:hover {
         /* Stacked layout is much taller than desktop's row, so the desktop min-height lets
            the hero collapse (and jump) when the loading spinner replaces the score. Hold the
            stacked height so the spinner box matches the score box. */
-        min-height: 440px;
+        min-height: 525px;
     }
     .isp-speed-measured {
         font-size: 2rem;
+    }
+    .isp-health-hero-side {
+        gap: 1rem;
+    }
+    .isp-uptime-value {
+        font-size: 1.75rem;
     }
     .isp-health-hero-dimensions {
         gap: 0.4rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2224,6 +2224,9 @@ a.stat-card-link:active {
     padding: 0 20px;
     border: none;
     border-radius: var(--border-radius);
+    /* Form controls carry an explicit UA font, which beats inheritance - without this every
+       <button class="btn"> renders in the browser's default while <a class="btn"> uses ours. */
+    font-family: inherit;
     font-size: 0.875rem;
     font-weight: 500;
     cursor: pointer;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2231,7 +2231,7 @@ a.stat-card-link:active {
     text-decoration: none;
     white-space: nowrap;
     box-sizing: border-box;
-    line-height: 1;
+    line-height: normal;
     vertical-align: middle;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
@@ -12,7 +12,7 @@
       "title": "Uptime",
       "listLabel": "Outages scored against the window, not in flat minutes",
       "badge": "improved",
-      "body": "**Uptime** now sits above the three gauges, and outages are scored against the window you are looking at rather than in flat minutes. Fifteen minutes down is a very different line over a month than over a day, and those no longer cost the same. A long outage still lands hard wherever you look from, and a line that drops over and over is now judged on how often it does it.",
+      "body": "**Uptime** now sits above the three gauges. Outages are scored against the window you are looking at, so fifteen minutes down costs far less over a month than over a day.",
       "placement": "bottom",
       "requires": ["isp-health"],
       "optional": true

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
@@ -2,7 +2,7 @@
   "id": "2.5.3",
   "kind": "whats-new",
   "title": "What's new in v2.5.3",
-  "summary": "Uptime on the ISP Health score card, and outages scored against the window you are looking at.",
+  "summary": "Uptime on the ISP Health score card, outages scored against the window you are looking at, and a larger download burst for Adaptive SQM.",
   "steps": [
     {
       "id": "isp-uptime",
@@ -15,6 +15,18 @@
       "body": "**Uptime** now sits above the three gauges. Outages are scored against the window you are looking at, so fifteen minutes down costs far less over a month than over a day.",
       "placement": "bottom",
       "requires": ["isp-health"],
+      "optional": true
+    },
+    {
+      "id": "sqm-download-burst",
+      "level": "minor",
+      "url": "/sqm",
+      "selector": "[data-tour=\"sqm-download-burst\"]",
+      "title": "Larger download burst",
+      "listLabel": "Downloads that fall short of your plan may have more to give",
+      "body": "If your downloads never quite reach your plan, **Larger download burst** may find the rest. Turn it on for your WAN and redeploy to try it.",
+      "placement": "top",
+      "requires": ["sqm-enabled"],
       "optional": true
     }
   ]

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
@@ -1,0 +1,21 @@
+{
+  "id": "2.5.3",
+  "kind": "whats-new",
+  "title": "What's new in v2.5.3",
+  "summary": "Uptime on the ISP Health score card, and outages scored against the window you are looking at.",
+  "steps": [
+    {
+      "id": "isp-uptime",
+      "level": "minor",
+      "url": "/monitoring?tab=isp-health",
+      "selector": "[data-tour=\"isp-uptime\"]",
+      "title": "Uptime",
+      "listLabel": "Outages scored against the window, not in flat minutes",
+      "badge": "improved",
+      "body": "**Uptime** now sits above the three gauges, and outages are scored against the window you are looking at rather than in flat minutes. Fifteen minutes down is a very different line over a month than over a day, and those no longer cost the same. A long outage still lands hard wherever you look from, and a line that drops over and over is now judged on how often it does it.",
+      "placement": "bottom",
+      "requires": ["isp-health"],
+      "optional": true
+    }
+  ]
+}

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
@@ -2,7 +2,7 @@
   "id": "2.5.3",
   "kind": "whats-new",
   "title": "What's new in v2.5.3",
-  "summary": "Uptime on the ISP Health score card, outages scored against the window you are looking at, and a larger download burst for Adaptive SQM.",
+  "summary": "Uptime on the ISP Health score card, outages and congestion scored against the window you are looking at, and a larger download burst for Adaptive SQM.",
   "steps": [
     {
       "id": "isp-uptime",
@@ -10,9 +10,9 @@
       "url": "/monitoring?tab=isp-health",
       "selector": "[data-tour=\"isp-uptime\"]",
       "title": "Uptime",
-      "listLabel": "Outages scored against the window, not in flat minutes",
+      "listLabel": "Outages and congestion scored against the window, not in flat minutes",
       "badge": "improved",
-      "body": "**Uptime** now sits above the three gauges. Outages are scored against the window you are looking at, so fifteen minutes down costs far less over a month than over a day.",
+      "body": "**Uptime** now sits above the three gauges. Outages and congestion are both scored against the window you are looking at, so fifteen minutes down costs far less over a month than over a day.",
       "placement": "bottom",
       "requires": ["isp-health"],
       "optional": true

--- a/src/NetworkOptimizer.Web/wwwroot/js/tour.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/tour.js
@@ -10,44 +10,63 @@ window.noTour = (function () {
     // must not build a zombie overlay for a tour that already moved on.
     let generation = 0;
 
-    // A step can target something inside a collapsed card, as the Adaptive SQM WAN panels do.
-    // Collapsed content is still laid out, at zero height, so it satisfies an offsetParent test
-    // while being invisible - open the section and let a later tick take it once the transition
-    // has run. Each wrapper is clicked once per wait so a section the user closes behind us does
-    // not get reopened in a loop.
-    function revealCollapsedAncestors(el, opened) {
+    // A collapsed section clips its content rather than removing it: the wrapper is a zero-height
+    // grid row and the content overflows hidden, so a target inside still reports a normal
+    // offsetParent and a normal height. Measuring the target alone cannot tell collapsed from
+    // visible - the answer is in its ancestors.
+    function collapsedAncestors(el) {
+        const found = [];
         for (let node = el.parentElement; node && node !== document.body; node = node.parentElement) {
-            if (!node.classList.contains('expand-wrapper') || node.classList.contains('expanded')) continue;
+            if (node.classList.contains('expand-wrapper') && !node.classList.contains('expanded')) found.push(node);
+        }
+        return found;
+    }
+
+    // Open any collapsed section the target sits in, by clicking the header that owns it so the
+    // component's own state flips (setting the class by hand would be undone on its next render).
+    // Each wrapper is opened at most once per step: a section the user closes deliberately during
+    // the tour stays closed. Returns whether anything was opened.
+    function revealCollapsedAncestors(el, opened) {
+        let clicked = false;
+        for (const node of collapsedAncestors(el)) {
             if (opened.has(node)) continue;
             opened.add(node);
             const toggle = node.previousElementSibling;
             if (toggle && toggle.classList.contains('card-header-collapsible')) {
                 toggle.click();
+                clicked = true;
             } else {
                 console.warn('noTour: target sits in a collapsed section with no recognized toggle', node);
             }
         }
+        return clicked;
     }
 
-    function waitFor(selector, timeoutMs) {
+    function waitFor(selector, timeoutMs, opened) {
         return new Promise(resolve => {
             const started = Date.now();
-            const opened = new Set();
+            let settleUntil = 0;
             const tick = () => {
                 if (!document.body) return resolve(null);
+                const matches = Array.from(document.querySelectorAll(selector));
+                // Open before measuring, not after: a clipped target passes every measurement a
+                // visible one does, so a filter-first pass would accept it and never get here.
+                if (matches.map(e => revealCollapsedAncestors(e, opened)).some(Boolean)) {
+                    settleUntil = Date.now() + 350; // let the expand transition finish before measuring
+                }
+                if (Date.now() - started > timeoutMs) return resolve(null);
+                if (Date.now() < settleUntil) return setTimeout(tick, 100);
                 // The same anchor can exist more than once (the 3D and 2D Live View maps
                 // both carry the timeline anchor). Pick by LAYOUT order, not DOM order:
                 // the user can swap the two maps, and the spotlight should follow
                 // whichever is actually on top.
-                const matches = Array.from(document.querySelectorAll(selector));
                 const visible = matches.filter(e => e.offsetParent !== null
-                    && e.getBoundingClientRect().width > 0 && e.getBoundingClientRect().height > 0);
+                    && e.getBoundingClientRect().width > 0 && e.getBoundingClientRect().height > 0
+                    && collapsedAncestors(e).length === 0);
                 if (visible.length) {
                     visible.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
                     return resolve(visible[0]);
                 }
-                matches.forEach(e => revealCollapsedAncestors(e, opened));
-                if (Date.now() - started > timeoutMs) return resolve(null);
                 setTimeout(tick, 150);
             };
             tick();
@@ -111,6 +130,11 @@ window.noTour = (function () {
 
     function position() {
         if (!active || !active.target || !document.contains(active.target)) return;
+        // A page that finishes loading after the spotlight lands can collapse the section out from
+        // under it - Adaptive SQM opens its WAN cards, then closes the ones that turn out to have a
+        // saved config. Reopen on the drift tick; the once-per-step rule keeps a section the user
+        // closed on purpose from springing back.
+        revealCollapsedAncestors(active.target, active.opened);
         const pad = 6;
         const r = active.target.getBoundingClientRect();
         const hole = active.hole;
@@ -220,7 +244,10 @@ window.noTour = (function () {
         showStep: async function (dotNetRef, opts) {
             const gen = ++generation;
             teardown();
-            const el = await waitFor(opts.selector, opts.waitMs || 8000);
+            // Shared with position() so a section opened during the wait is not reopened after,
+            // and so the once-per-step rule spans the whole step rather than just the wait.
+            const opened = new Set();
+            const el = await waitFor(opts.selector, opts.waitMs || 8000, opened);
             if (gen !== generation) return 'stale';
             if (!el) return 'missing';
 
@@ -238,7 +265,7 @@ window.noTour = (function () {
             overlay.appendChild(card);
             document.body.appendChild(overlay);
 
-            active = { dotNetRef, overlay, hole, card, target: el, placement: opts.placement, cleanup: [] };
+            active = { dotNetRef, overlay, hole, card, target: el, placement: opts.placement, opened, cleanup: [] };
 
             const onKey = e => {
                 if (e.key === 'Escape') { e.stopPropagation(); invoke('escape'); }

--- a/src/NetworkOptimizer.Web/wwwroot/js/tour.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/tour.js
@@ -207,12 +207,17 @@ window.noTour = (function () {
         const actions = document.createElement('div');
         actions.className = 'tour-card-actions';
 
-        const skip = document.createElement('button');
-        skip.type = 'button';
-        skip.className = 'tour-card-skip';
-        skip.textContent = 'Skip tour';
-        skip.addEventListener('click', () => invoke('skip'));
-        actions.appendChild(skip);
+        // No Skip on the last step: there is nothing left to skip, and taking it there would file
+        // a tour the user actually finished as deferred. Done is the only sensible exit.
+        const isLast = opts.index + 1 >= opts.total;
+        if (!isLast) {
+            const skip = document.createElement('button');
+            skip.type = 'button';
+            skip.className = 'tour-card-skip';
+            skip.textContent = 'Skip tour';
+            skip.addEventListener('click', () => invoke('skip'));
+            actions.appendChild(skip);
+        }
 
         const spacer = document.createElement('div');
         spacer.className = 'tour-card-spacer';
@@ -230,7 +235,7 @@ window.noTour = (function () {
         const next = document.createElement('button');
         next.type = 'button';
         next.className = 'btn btn-primary btn-sm';
-        next.textContent = opts.index + 1 >= opts.total ? 'Done' : 'Next';
+        next.textContent = isLast ? 'Done' : 'Next';
         next.addEventListener('click', () => invoke('next'));
         actions.appendChild(next);
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/tour.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/tour.js
@@ -10,21 +10,43 @@ window.noTour = (function () {
     // must not build a zombie overlay for a tour that already moved on.
     let generation = 0;
 
+    // A step can target something inside a collapsed card, as the Adaptive SQM WAN panels do.
+    // Collapsed content is still laid out, at zero height, so it satisfies an offsetParent test
+    // while being invisible - open the section and let a later tick take it once the transition
+    // has run. Each wrapper is clicked once per wait so a section the user closes behind us does
+    // not get reopened in a loop.
+    function revealCollapsedAncestors(el, opened) {
+        for (let node = el.parentElement; node && node !== document.body; node = node.parentElement) {
+            if (!node.classList.contains('expand-wrapper') || node.classList.contains('expanded')) continue;
+            if (opened.has(node)) continue;
+            opened.add(node);
+            const toggle = node.previousElementSibling;
+            if (toggle && toggle.classList.contains('card-header-collapsible')) {
+                toggle.click();
+            } else {
+                console.warn('noTour: target sits in a collapsed section with no recognized toggle', node);
+            }
+        }
+    }
+
     function waitFor(selector, timeoutMs) {
         return new Promise(resolve => {
             const started = Date.now();
+            const opened = new Set();
             const tick = () => {
                 if (!document.body) return resolve(null);
                 // The same anchor can exist more than once (the 3D and 2D Live View maps
                 // both carry the timeline anchor). Pick by LAYOUT order, not DOM order:
                 // the user can swap the two maps, and the spotlight should follow
                 // whichever is actually on top.
-                const visible = Array.from(document.querySelectorAll(selector))
-                    .filter(e => e.offsetParent !== null && e.getBoundingClientRect().width > 0);
+                const matches = Array.from(document.querySelectorAll(selector));
+                const visible = matches.filter(e => e.offsetParent !== null
+                    && e.getBoundingClientRect().width > 0 && e.getBoundingClientRect().height > 0);
                 if (visible.length) {
                     visible.sort((a, b) => a.getBoundingClientRect().top - b.getBoundingClientRect().top);
                     return resolve(visible[0]);
                 }
+                matches.forEach(e => revealCollapsedAncestors(e, opened));
                 if (Date.now() - started > timeoutMs) return resolve(null);
                 setTimeout(tick, 150);
             };

--- a/tests/NetworkOptimizer.Storage.Tests/InfluxHttpErrorMappingTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/InfluxHttpErrorMappingTests.cs
@@ -1,0 +1,49 @@
+using FluentAssertions;
+using InfluxDB.Client.Core.Exceptions;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+/// <summary>
+/// The streamed raw-CSV reads map non-2xx responses through the InfluxDB client's own
+/// HttpException.Create so the existing NotFound / BadRequest / Unauthorized handling keeps its
+/// types. That call is made without RestSharp headers, which the client's own transport always
+/// supplies - so these pin that the null-header path produces the right exception type rather than
+/// throwing something the read path's filter would miss and let escape as a hard failure.
+/// </summary>
+public class InfluxHttpErrorMappingTests
+{
+    private const string InfluxErrorBody = "{\"code\":\"unauthorized\",\"message\":\"unauthorized access\"}";
+
+    [Theory]
+    [InlineData(401, typeof(UnauthorizedException))]
+    [InlineData(403, typeof(ForbiddenException))]
+    [InlineData(404, typeof(NotFoundException))]
+    [InlineData(400, typeof(BadRequestException))]
+    public void Maps_status_to_the_typed_exception_without_headers(int status, Type expected)
+    {
+        var ex = HttpException.Create(InfluxErrorBody, null, "reason", (System.Net.HttpStatusCode)status);
+
+        ex.Should().BeOfType(expected);
+        ex.Status.Should().Be(status);
+    }
+
+    [Fact]
+    public void Extracts_the_message_from_an_influx_error_body()
+    {
+        var ex = HttpException.Create(InfluxErrorBody, null, "reason", System.Net.HttpStatusCode.Unauthorized);
+
+        ex.Message.Should().Contain("unauthorized access");
+    }
+
+    [Fact]
+    public void A_non_json_body_still_produces_an_exception_rather_than_throwing()
+    {
+        // A proxy or gateway in front of InfluxDB can return HTML; the read path must still surface a
+        // typed failure instead of dying inside its own error handling.
+        var act = () => HttpException.Create("<html>502 Bad Gateway</html>", null, "reason",
+            System.Net.HttpStatusCode.BadGateway);
+
+        act.Should().NotThrow();
+    }
+}

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -69,4 +69,51 @@ public class MonitoringInfluxCsvParserTests
         result["transit-x"].Should().HaveCount(2);
         result["cdn-y"][0].RttAvgMs.Should().Be(12.3);
     }
+
+    // The WAN rate pivot, with rate_out_bps before rate_in_bps to prove name-based mapping, and a
+    // second table whose header omits rate_out_bps - which is exactly what pivot emits for an
+    // interval where only one direction reported, and why the header is re-read after each #-block.
+    private const string RatesCsv =
+        "#group,false,false,true,true,false,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,double\r\n" +
+        "#default,_result,,,,,,\r\n" +
+        ",result,table,_start,_stop,_time,rate_out_bps,rate_in_bps\r\n" +
+        ",,0,2026-07-06T00:00:00Z,2026-07-07T00:00:00Z,2026-07-06T22:00:00Z,5000000,350000000\r\n" +
+        ",,0,2026-07-06T00:00:00Z,2026-07-07T00:00:00Z,2026-07-06T22:00:15Z,4000000,340000000\r\n" +
+        "#group,false,false,true,true,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double\r\n" +
+        "#default,_result,,,,,\r\n" +
+        ",result,table,_start,_stop,_time,rate_in_bps\r\n" +
+        ",,1,2026-07-06T00:00:00Z,2026-07-07T00:00:00Z,2026-07-06T22:00:30Z,120000000\r\n";
+
+    [Fact]
+    public void Parses_wan_rates_mapping_columns_by_name_across_tables()
+    {
+        var result = MonitoringInfluxClient.ParseWanRatesCsv(RatesCsv);
+
+        result.Should().HaveCount(3);
+        result[0].Time.Should().Be(new DateTime(2026, 7, 6, 22, 0, 0, DateTimeKind.Utc));
+        result[0].Time.Kind.Should().Be(DateTimeKind.Utc);
+        result[0].DownloadBps.Should().Be(350_000_000);
+        result[0].UploadBps.Should().Be(5_000_000);
+
+        // Second table: upload column absent entirely, so upload is null rather than misread from
+        // whatever sat in that position in the previous header.
+        result[2].DownloadBps.Should().Be(120_000_000);
+        result[2].UploadBps.Should().BeNull();
+    }
+
+    [Fact]
+    public void Wan_rates_empty_or_null_csv_returns_empty()
+    {
+        MonitoringInfluxClient.ParseWanRatesCsv("").Should().BeEmpty();
+        MonitoringInfluxClient.ParseWanRatesCsv(null!).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Wan_rates_tolerate_lf_only_line_endings()
+    {
+        MonitoringInfluxClient.ParseWanRatesCsv(RatesCsv.Replace("\r\n", "\n"))
+            .Should().HaveCount(3);
+    }
 }

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -11,24 +11,17 @@ namespace NetworkOptimizer.Storage.Tests;
 /// </summary>
 public class MonitoringInfluxCsvParserTests
 {
-    // Annotated CSV exactly as Flux returns the UN-PIVOTED latency-detail query: one row per
-    // (target_id, _field, _time), fields spread across separate tables and arriving out of time order.
-    // The parser must reassemble them onto one point per (target, timestamp), map by column name (the
-    // _time/_value/_field/target_id columns can sit anywhere), and sort by time.
+    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
+    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
+    // by column name, not index.
     private const string Csv =
-        "#group,false,false,true,true,false,false,true,true,true,true,false\r\n" +
-        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string\r\n" +
+        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
         "#default,_result,,,,,,,,,,\r\n" +
-        ",result,table,_start,_stop,_time,_value,_field,_measurement,target_id,target_type,vantage_point\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0.7,jitter_ms,latency,transit-x,transit,server\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0.3,jitter_ms,latency,transit-x,transit,server\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
-        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
-        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,2.8,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
-        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3.4,rtt_max_ms,latency,transit-x,transit,server\r\n" +
-        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,3.1,rtt_max_ms,latency,transit-x,transit,server\r\n" +
-        ",,4,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,12.3,rtt_avg_ms,latency,cdn-y,internetservice,server\r\n";
+        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
 
     [Fact]
     public void Parses_points_per_target_mapping_columns_by_name()

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -11,17 +11,24 @@ namespace NetworkOptimizer.Storage.Tests;
 /// </summary>
 public class MonitoringInfluxCsvParserTests
 {
-    // Annotated CSV exactly as Flux returns the latency-detail pivot query. The field columns are in
-    // a deliberately non-positional order (jitter, loss, rtt_avg, rtt_max) to prove the parser maps
-    // by column name, not index.
+    // Annotated CSV exactly as Flux returns the UN-PIVOTED latency-detail query: one row per
+    // (target_id, _field, _time), fields spread across separate tables and arriving out of time order.
+    // The parser must reassemble them onto one point per (target, timestamp), map by column name (the
+    // _time/_value/_field/target_id columns can sit anywhere), and sort by time.
     private const string Csv =
-        "#group,false,false,true,true,false,true,true,false,false,false,false\r\n" +
-        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double,double,double,double\r\n" +
+        "#group,false,false,true,true,false,false,true,true,true,true,false\r\n" +
+        "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string,string\r\n" +
         "#default,_result,,,,,,,,,,\r\n" +
-        ",result,table,_start,_stop,_time,target_id,target_type,jitter_ms,loss_percent,rtt_avg_ms,rtt_max_ms\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,transit-x,transit,0.7,0,3,3.4\r\n" +
-        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,transit-x,transit,0.3,0,2.8,3.1\r\n" +
-        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,cdn-y,internetservice,,,12.3,\r\n";
+        ",result,table,_start,_stop,_time,_value,_field,_measurement,target_id,target_type,vantage_point\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0.7,jitter_ms,latency,transit-x,transit,server\r\n" +
+        ",,0,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0.3,jitter_ms,latency,transit-x,transit,server\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
+        ",,1,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,0,loss_percent,latency,transit-x,transit,server\r\n" +
+        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
+        ",,2,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,2.8,rtt_avg_ms,latency,transit-x,transit,server\r\n" +
+        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T01:00:00Z,3.4,rtt_max_ms,latency,transit-x,transit,server\r\n" +
+        ",,3,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,3.1,rtt_max_ms,latency,transit-x,transit,server\r\n" +
+        ",,4,2026-06-19T00:00:00Z,2026-06-19T02:00:00Z,2026-06-19T00:45:00Z,12.3,rtt_avg_ms,latency,cdn-y,internetservice,server\r\n";
 
     [Fact]
     public void Parses_points_per_target_mapping_columns_by_name()

--- a/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/MonitoringInfluxCsvParserTests.cs
@@ -116,4 +116,32 @@ public class MonitoringInfluxCsvParserTests
         MonitoringInfluxClient.ParseWanRatesCsv(RatesCsv.Replace("\r\n", "\n"))
             .Should().HaveCount(3);
     }
+
+    // The streamed query path feeds the parser one line at a time, exactly as the InfluxDB client's
+    // line reader delivers them (line terminators already stripped). These pin that the line-fed
+    // path produces identical results to the whole-string parse it replaced as the query-time path.
+
+    [Fact]
+    public void Line_fed_latency_parser_matches_string_parse()
+    {
+        var parser = new MonitoringInfluxClient.LatencyDetailCsvParser();
+        foreach (var line in Csv.Split("\r\n"))
+            parser.ProcessLine(line);
+        var streamed = parser.Finish();
+
+        var buffered = MonitoringInfluxClient.ParseLatencyDetailCsv(Csv);
+        streamed.Keys.Should().BeEquivalentTo(buffered.Keys);
+        foreach (var key in buffered.Keys)
+            streamed[key].Should().Equal(buffered[key]);
+    }
+
+    [Fact]
+    public void Line_fed_wan_rates_parser_matches_string_parse()
+    {
+        var parser = new MonitoringInfluxClient.WanRatesCsvParser();
+        foreach (var line in RatesCsv.Split("\r\n"))
+            parser.ProcessLine(line);
+
+        parser.Finish().Should().Equal(MonitoringInfluxClient.ParseWanRatesCsv(RatesCsv));
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/Identity/MethodSecurityInterceptorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Identity/MethodSecurityInterceptorTests.cs
@@ -22,6 +22,11 @@ public class MethodSecurityInterceptorTests
         [RequireRoleAttribute(Roles.Admin)]
         [AuditActionAttribute("widget.changed", Category = AuditCategories.Settings, TargetType = "widget")]
         Task ApplyAsync(string value);
+
+        /// <summary>An idempotent "ensure" that found everything already in place.</summary>
+        [RequireRoleAttribute(Roles.Admin)]
+        [AuditActionAttribute("widget.changed", Category = AuditCategories.Settings, TargetType = "widget")]
+        Task EnsureAsync(bool changed);
     }
 
     private sealed class WidgetService : IWidgetService
@@ -35,6 +40,14 @@ public class MethodSecurityInterceptorTests
             Ran = true;
             _auditContext.SetDetails(new { value });
             _auditContext.SetTarget("widget-1", value);
+            return Task.CompletedTask;
+        }
+
+        public Task EnsureAsync(bool changed)
+        {
+            Ran = true;
+            if (changed) _auditContext.SetTarget("widget-1", "created");
+            else _auditContext.SuppressNoChange();
             return Task.CompletedTask;
         }
     }
@@ -86,6 +99,29 @@ public class MethodSecurityInterceptorTests
         e.Outcome.Should().Be(AuditOutcomes.Success);
         e.TargetId.Should().Be("widget-1");
         e.ActorName.Should().Be("tester");
+    }
+
+    [Fact]
+    public async Task NoOp_Ensure_Writes_No_Event_But_A_Real_Change_Still_Does()
+    {
+        var audit = new CapturingAudit();
+        await using var provider = Build(audit);
+        using var scope = provider.CreateScope();
+        scope.ServiceProvider.GetRequiredService<ICallerContext>()
+            .SetUser(CallerInfo.ForUser(User(Roles.Admin), null, null, null));
+        var svc = scope.ServiceProvider.GetRequiredService<IWidgetService>();
+
+        // An ensure that found everything in place is not a change, so it files nothing. This is what
+        // keeps a page load that touches an idempotent provisioning call out of the audit log.
+        await svc.EnsureAsync(changed: false);
+        audit.Events.Should().BeEmpty();
+
+        // The suppression must not persist past the call that asked for it - the context is scoped and
+        // reused, so a leaked flag would silently swallow every later change in the same circuit.
+        await svc.EnsureAsync(changed: true);
+        audit.Events.Should().ContainSingle();
+        audit.Events[0].Outcome.Should().Be(AuditOutcomes.Success);
+        audit.Events[0].TargetId.Should().Be("widget-1");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/GatewayLossFloorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/GatewayLossFloorTests.cs
@@ -1,0 +1,115 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// Loss to the gateway is the common-mode floor of the measurement chain - every probe crosses the
+/// host NIC, its cable, the switching fabric and the gateway before reaching anything upstream. These
+/// pin the rules that keep the subtraction honest: it only ever removes, it never invents health, and
+/// it stops applying once the reading behind it is stale.
+/// </summary>
+public class GatewayLossFloorTests
+{
+    private static readonly IspHealthOptions Options = new();
+    private static readonly DateTime Start = TestSeries.Start;
+
+    private static LatencySample At(int minute, double? lossPct) =>
+        new(Start.AddMinutes(minute), 1.0, 1.2, 0.1, lossPct);
+
+    [Fact]
+    public void No_gateway_series_subtracts_nothing()
+    {
+        var floor = GatewayLossFloor.Build(new List<LatencySample>(), Options);
+
+        floor.HasLoss.Should().BeFalse();
+        floor.Apply(3.5, Start).Should().Be(3.5);
+    }
+
+    [Fact]
+    public void Upstream_loss_is_reported_net_of_the_gateway()
+    {
+        // The chain dropped 2% at this instant, so only the excess is the ISP's.
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 2.0) }, Options);
+
+        floor.Apply(5.0, Start).Should().Be(3.0);
+    }
+
+    [Fact]
+    public void A_target_cleaner_than_the_gateway_never_goes_negative()
+    {
+        // Reporting less loss than the local chain is a clean path, not a negative one.
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 4.0) }, Options);
+
+        floor.Apply(1.0, Start).Should().Be(0);
+    }
+
+    [Fact]
+    public void A_clean_gateway_leaves_upstream_loss_untouched()
+    {
+        // The floor caps what may be blamed upstream; it can never manufacture upstream health.
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 0) }, Options);
+
+        floor.HasLoss.Should().BeFalse();
+        floor.Apply(7.5, Start).Should().Be(7.5);
+    }
+
+    [Fact]
+    public void The_floor_follows_the_gateway_over_time_rather_than_averaging_it()
+    {
+        // A fabric incident in the middle of the window must not raise the floor across the whole of
+        // it, nor a clean stretch dilute the floor while the incident is happening.
+        var floor = GatewayLossFloor.Build(new List<LatencySample>
+        {
+            At(0, 0),
+            At(1, 30.0),
+            At(2, 0)
+        }, Options);
+
+        floor.Apply(35.0, Start).Should().Be(35.0);
+        floor.Apply(35.0, Start.AddMinutes(1)).Should().Be(5.0);
+        floor.Apply(35.0, Start.AddMinutes(2)).Should().Be(35.0);
+    }
+
+    [Fact]
+    public void A_reading_is_carried_forward_but_only_while_it_is_fresh()
+    {
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 10.0) }, Options);
+
+        // Within the staleness bound the physical condition is assumed to persist.
+        floor.Apply(12.0, Start.AddSeconds(Options.GatewayFloorMaxStalenessSeconds - 1))
+            .Should().BeApproximately(2.0, 0.001);
+
+        // Past it, an old reading must not keep suppressing loss.
+        floor.Apply(12.0, Start.AddSeconds(Options.GatewayFloorMaxStalenessSeconds + 60))
+            .Should().Be(12.0);
+    }
+
+    [Fact]
+    public void Nothing_is_subtracted_before_the_first_gateway_reading()
+    {
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(10, 5.0) }, Options);
+
+        floor.Apply(6.0, Start).Should().Be(6.0);
+    }
+
+    [Fact]
+    public void Samples_without_a_loss_reading_are_not_treated_as_clean()
+    {
+        // An absent measurement is not evidence the chain was fine, so it must not reset the floor.
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 8.0), At(1, null) }, Options);
+
+        floor.Apply(10.0, Start.AddMinutes(1)).Should().Be(2.0);
+    }
+
+    [Fact]
+    public void Peak_and_mean_describe_the_local_fault_for_reporting()
+    {
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { At(0, 1.0), At(1, 9.0) }, Options);
+
+        floor.HasLoss.Should().BeTrue();
+        floor.PeakLossPct.Should().Be(9.0);
+        floor.MeanLossPct.Should().Be(5.0);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/GatewayLossFloorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/GatewayLossFloorTests.cs
@@ -87,6 +87,38 @@ public class GatewayLossFloorTests
     }
 
     [Fact]
+    public void A_saturation_burst_is_subtracted_evenly_across_its_span()
+    {
+        // Modeled on a real capture: saturating the LAN between the gateway and this server took every
+        // upstream target to 60-80% loss for about ten seconds, while the gateway itself read 66.7%
+        // then 33.3% on its own cadence. Matching only backwards subtracted 0% to 46.7% across that
+        // one burst depending on which tick preceded each probe; the whole span crossed the same
+        // impaired chain, so the worst nearby reading governs all of it.
+        var floor = GatewayLossFloor.Build(new List<LatencySample>
+        {
+            new(Start, 1, 1, 0.1, 66.7),
+            new(Start.AddSeconds(8), 1, 1, 0.1, 33.3)
+        }, Options);
+
+        foreach (var offset in new[] { 1, 4, 10 })
+            floor.Apply(80, Start.AddSeconds(offset)).Should().BeApproximately(13.3, 0.05,
+                $"the burst was continuous, so the probe at +{offset}s crossed the same impairment");
+    }
+
+    [Fact]
+    public void An_isolated_spike_does_not_absolve_a_span_it_never_overlapped()
+    {
+        // The match window is deliberately narrow: a gateway blip must not excuse upstream loss
+        // minutes away from it.
+        var floor = GatewayLossFloor.Build(new List<LatencySample> { new(Start, 1, 1, 0.1, 60.0) }, Options);
+
+        floor.Apply(50, Start.AddSeconds(Options.GatewayFloorMatchSeconds + 5))
+            .Should().BeLessThan(50, "still inside the carry-forward window");
+        floor.Apply(50, Start.AddSeconds(Options.GatewayFloorMaxStalenessSeconds + 60))
+            .Should().Be(50, "far past any reading, nothing is subtracted");
+    }
+
+    [Fact]
     public void Nothing_is_subtracted_before_the_first_gateway_reading()
     {
         var floor = GatewayLossFloor.Build(new List<LatencySample> { At(10, 5.0) }, Options);

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -212,7 +212,42 @@ public class IspHealthScorerTests
     }
 
     [Fact]
-    public void Uptime_counts_blackouts_only_and_never_rounds_a_bad_window_to_a_clean_one()
+    public void Uptime_counts_a_partial_disruption_by_the_share_it_dropped()
+    {
+        // A 20 min disruption at 75% loss is 15 min of lost service, not 20 and not zero: the
+        // detector only declares one past a broad multi-ASN half-loss, but half the packets is not
+        // half the clock.
+        var partial = new OutageEvent
+        {
+            Start = TestSeries.Start.AddHours(2),
+            End = TestSeries.Start.AddHours(2).AddMinutes(20),
+            PeakLossPct = 75,
+            DegradedTargetCount = 6,
+            PathTargetCount = 9,
+            IsPartial = true
+        };
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(outages: new List<OutageEvent> { partial }, scoreWindow: TimeSpan.FromHours(720)), Gpon);
+
+        report.Downtime.Should().Be(TimeSpan.FromMinutes(15));
+
+        // Usage weighting softens the SCORE but must not move uptime - how much an outage mattered is
+        // a judgement, while uptime is a fact about the line.
+        var quiet = new IspHealthScorer(Options).Score(
+            BuildInputs(
+                outages: new List<OutageEvent> { new()
+                {
+                    Start = partial.Start, End = partial.End, PeakLossPct = 75,
+                    DegradedTargetCount = 6, PathTargetCount = 9, IsPartial = true, UsageWeight = 0.4
+                } },
+                scoreWindow: TimeSpan.FromHours(720)),
+            Gpon);
+        quiet.Downtime.Should().Be(report.Downtime);
+        quiet.OverallScore.Should().BeGreaterThan(report.OverallScore);
+    }
+
+    [Fact]
+    public void Uptime_never_rounds_a_bad_window_to_a_clean_one()
     {
         var report = new IspHealthScorer(Options).Score(
             BuildInputs(outages: new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(15)) }, scoreWindow: TimeSpan.FromHours(720)),

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -101,8 +101,9 @@ public class IspHealthScorerTests
         int OverallWith(double mins) => new IspHealthScorer(Options)
             .Score(BuildInputs(outages: new List<OutageEvent> { Outage(mins) }), Gpon).OverallScore;
 
-        // Default severity curve: 10 min -> 14, 60 min -> 45, 8 h -> 90 (off a clean 100).
-        OverallWith(10).Should().Be(86);
+        // Graded as a share of the 24 h window: 10 min is 0.69% down -> 15, 60 min is 4.2% -> 45,
+        // 8 h is a third of the window and pins the curve's tail -> 90 (all off a clean 100).
+        OverallWith(10).Should().Be(85);
         OverallWith(60).Should().Be(55);
         OverallWith(480).Should().Be(10);
     }
@@ -117,6 +118,123 @@ public class IspHealthScorerTests
         PathTargetCount = total
     };
 
+    /// <summary>A full-breadth, near-total blackout of the given length, starting 2 h into the window.</summary>
+    private static OutageEvent Blackout(TimeSpan duration) => new()
+    {
+        Start = TestSeries.Start.AddHours(2),
+        End = TestSeries.Start.AddHours(2) + duration,
+        PeakLossPct = 100,
+        DegradedTargetCount = 9,
+        PathTargetCount = 9
+    };
+
+    /// <summary><paramref name="count"/> identical blackouts spaced 2 h apart so they never coalesce.</summary>
+    private static List<OutageEvent> Blackouts(int count, TimeSpan each) =>
+        Enumerable.Range(0, count).Select(i => new OutageEvent
+        {
+            Start = TestSeries.Start.AddHours(2 + i * 2),
+            End = TestSeries.Start.AddHours(2 + i * 2) + each,
+            PeakLossPct = 100,
+            DegradedTargetCount = 9,
+            PathTargetCount = 9
+        }).ToList();
+
+    private static int DropFor(TimeSpan window, List<OutageEvent> outages) =>
+        100 - new IspHealthScorer(Options)
+            .Score(BuildInputs(outages: outages, scoreWindow: window), Gpon).OverallScore;
+
+    [Theory]
+    // 15 min down reads as four-nines over a month and barely two-nines over 24 h. The old absolute
+    // minutes curve scored all three of these identically, at ~16 points.
+    [InlineData(15, 720, 5, 9)]
+    [InlineData(15, 48, 10, 15)]
+    [InlineData(15, 24, 17, 24)]
+    // 4 h down: the felt-event floor keeps it plainly visible on a month, where the availability ratio
+    // alone would price a memorable outage at about a dozen points; on 48 h the ratio takes over.
+    [InlineData(240, 720, 17, 24)]
+    [InlineData(240, 48, 58, 68)]
+    public void Outage_duration_is_graded_against_the_window(int downMinutes, int windowHours, int minDrop, int maxDrop)
+    {
+        DropFor(TimeSpan.FromHours(windowHours), new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(downMinutes)) })
+            .Should().BeInRange(minDrop, maxDrop);
+    }
+
+    [Fact]
+    public void Same_outage_never_scores_worse_on_a_longer_window()
+    {
+        var windows = new[] { 24, 48, 168, 720 };
+        var drops = windows
+            .Select(h => DropFor(TimeSpan.FromHours(h), new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(15)) }))
+            .ToList();
+
+        drops.Should().BeInDescendingOrder();
+        // And the floor holds: more clean time around an outage never erases it.
+        drops[^1].Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Longer_outage_never_scores_better_on_the_same_window()
+    {
+        var drops = new[] { 1, 5, 15, 60, 240 }
+            .Select(m => DropFor(Day, new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(m)) }))
+            .ToList();
+
+        drops.Should().BeInAscendingOrder();
+    }
+
+    [Fact]
+    public void Same_events_at_double_the_rate_score_worse()
+    {
+        // Eight one-minute drops is a flaky line over two days and a quirk over a month. The old
+        // window-ratio scaling of the per-event cost scored these two the same.
+        var dense = DropFor(TimeSpan.FromHours(48), Blackouts(8, TimeSpan.FromMinutes(1)));
+        var sparse = DropFor(TimeSpan.FromHours(720), Blackouts(8, TimeSpan.FromMinutes(1)));
+
+        dense.Should().BeGreaterThan(sparse * 3);
+        sparse.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void A_lone_outage_is_not_charged_as_recurrence()
+    {
+        // One event must cost the same whether the window is 48 h or a week: rating a single sample as
+        // a per-day rate would let window length alone change what "one outage" costs.
+        var outage = new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(2)) };
+        var twoDay = DropFor(TimeSpan.FromHours(48), outage);
+        var week = DropFor(TimeSpan.FromHours(168), outage);
+
+        // Only the availability ratio may differ, and at 2 min both are deep in felt-floor territory.
+        twoDay.Should().Be(week);
+
+        // A second event of the same size is where recurrence starts, so it must cost more than double.
+        var twoEvents = DropFor(TimeSpan.FromHours(48), Blackouts(2, TimeSpan.FromMinutes(2)));
+        twoEvents.Should().BeGreaterThan(twoDay * 2);
+    }
+
+    [Fact]
+    public void Uptime_counts_blackouts_only_and_never_rounds_a_bad_window_to_a_clean_one()
+    {
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(outages: new List<OutageEvent> { Blackout(TimeSpan.FromMinutes(15)) }, scoreWindow: TimeSpan.FromHours(720)),
+            Gpon);
+
+        report.Downtime.Should().Be(TimeSpan.FromMinutes(15));
+        report.UptimePercent.Should().BeApproximately(99.965, 0.01);
+        IspHealthPresentation.FormatUptime(report).Should().Be("99.97%");
+
+        // A one-second blackout is five-nines-plus, but the timeline shows an outage, so the card
+        // must not claim a flat 100%.
+        var sliver = new IspHealthScorer(Options).Score(
+            BuildInputs(outages: new List<OutageEvent> { Blackout(TimeSpan.FromSeconds(1)) }, scoreWindow: TimeSpan.FromHours(720)),
+            Gpon);
+        IspHealthPresentation.FormatUptime(sliver).Should().Be("99.99%");
+
+        var clean = new IspHealthScorer(Options).Score(BuildInputs(scoreWindow: TimeSpan.FromHours(720)), Gpon);
+        clean.Downtime.Should().Be(TimeSpan.Zero);
+        IspHealthPresentation.FormatUptime(clean).Should().Be("100%");
+        IspHealthPresentation.FormatDowntime(clean.Downtime).Should().Be("no downtime");
+    }
+
     [Fact]
     public void Recurring_micro_outages_compound_far_beyond_one_point()
     {
@@ -128,9 +246,11 @@ public class IspHealthScorerTests
             return 100 - new IspHealthScorer(Options).Score(BuildInputs(outages: events), Gpon).OverallScore;
         }
 
-        // A single 28 s near-total broad drop is felt: a few points, not the old flat 1.
+        // A single 28 s drop across 5 of 9 targets is 99.97% uptime over the day. It registers rather
+        // than rounding to zero - that is the felt-event floor's job - but it is not a few points:
+        // downtime is now graded as a share of the window, and this is a rounding error of one.
         var one = DropFor(1);
-        one.Should().BeInRange(2, 5);
+        one.Should().BeInRange(1, 3);
 
         // Ten of them across the window cost far more - the occurrence component compounds rather
         // than collapsing to ~one point the way summed-duration alone would.
@@ -208,7 +328,7 @@ public class IspHealthScorerTests
     }
 
     [Fact]
-    public void Micro_outages_weigh_less_over_a_longer_window_a_long_outage_does_not()
+    public void Outages_weigh_less_over_a_longer_window_but_a_long_one_stays_visible()
     {
         int Drop(List<OutageEvent> outages, TimeSpan window) => 100 - new IspHealthScorer(Options)
             .Score(BuildInputs(outages: outages, scoreWindow: window), Gpon).OverallScore;
@@ -221,22 +341,14 @@ public class IspHealthScorerTests
         micro7d.Should().BeLessThan(micro48h);
         (micro48h - micro7d).Should().BeGreaterThanOrEqualTo(2);
 
-        // A long, duration-dominated outage weighs roughly the same in either window (duration is
-        // absolute; only its small occurrence part rescales).
-        var longOutage = new List<OutageEvent>
-        {
-            new()
-            {
-                Start = TestSeries.Start.AddHours(2),
-                End = TestSeries.Start.AddHours(4),
-                PeakLossPct = 100,
-                DegradedTargetCount = 9,
-                PathTargetCount = 9
-            }
-        };
+        // A long outage also eases over a longer window - 2 h is 4.2% of two days but 1.2% of a week,
+        // and those are genuinely different lines - but the felt-event floor keeps it substantial
+        // rather than letting a memorable outage dissolve into the surrounding clean time.
+        var longOutage = new List<OutageEvent> { Blackout(TimeSpan.FromHours(2)) };
         var long48h = Drop(longOutage, TimeSpan.FromHours(48));
         var long7d = Drop(longOutage, TimeSpan.FromDays(7));
-        long7d.Should().BeCloseTo(long48h, 3);
+        long7d.Should().BeLessThan(long48h);
+        long7d.Should().BeGreaterThan(15);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -212,6 +212,30 @@ public class IspHealthScorerTests
     }
 
     [Fact]
+    public void Straddling_outage_is_counted_only_for_its_in_window_minutes()
+    {
+        // Outage detection reaches back OutageDetectionLeadInHours before the window so an outage
+        // that STRADDLES the start is stitched whole, and such an event keeps its true onset
+        // (IspHealthService only drops events that ended before the start). A 2 h outage whose last
+        // 5 min land in the window is 5 min of this window's downtime, not 120.
+        var straddling = new OutageEvent
+        {
+            Start = TestSeries.Start.AddHours(-2),
+            End = TestSeries.Start.AddMinutes(5),
+            PeakLossPct = 100,
+            DegradedTargetCount = 9,
+            PathTargetCount = 9
+        };
+        var report = new IspHealthScorer(Options).Score(
+            BuildInputs(outages: new List<OutageEvent> { straddling }, scoreWindow: TimeSpan.FromHours(48)), Gpon);
+
+        report.Downtime.Should().Be(TimeSpan.FromMinutes(5));
+
+        // 5 min of 48 h is 0.17% unavailability, which the felt-event floor prices at about 5 points.
+        (100 - report.OverallScore).Should().BeInRange(3, 9);
+    }
+
+    [Fact]
     public void Uptime_counts_a_partial_disruption_by_the_share_it_dropped()
     {
         // A 20 min disruption at 75% loss is 15 min of lost service, not 20 and not zero: the

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -1606,8 +1606,50 @@ public class IspHealthScorerTests
 
         var graded = withEvents.TransitAsns.Single();
         graded.CongestionEventCount.Should().Be(1);
-        graded.CongestionScore.Should().Be(20); // 100 - 20/hr x 4 h
+        // 4 h of a 24 h window is a sixth of it, graded on the congestion curve.
+        graded.CongestionScore.Should().BeInRange(45, 60);
         graded.OverallScore.Should().BeLessThan(withoutEvents.TransitAsns.Single().OverallScore!.Value);
+    }
+
+    [Fact]
+    public void The_same_congested_hours_matter_less_over_a_longer_window()
+    {
+        // Congested hours only mean something against the time observed. Four hours is a sixth of two
+        // days and an afternoon of a week, and the old flat per-hour penalty scored them identically -
+        // and floored the component past five hours, so a hop congested briefly and one congested for
+        // the whole window were indistinguishable.
+        var series = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 10, 0.5)) };
+        var congestion = new List<CongestionEvent>
+        {
+            new() { Start = TestSeries.Start.AddHours(2), End = TestSeries.Start.AddHours(6), AsnNumbers = { 64500 } }
+        };
+
+        int ScoreFor(TimeSpan window) => new IspHealthScorer(Options)
+            .Score(BuildInputs(transit: series, congestion: congestion, scoreWindow: window), Gpon)
+            .TransitAsns.Single().CongestionScore!.Value;
+
+        var day = ScoreFor(Day);
+        var week = ScoreFor(TimeSpan.FromDays(7));
+        var month = ScoreFor(TimeSpan.FromDays(30));
+
+        week.Should().BeGreaterThan(day);
+        month.Should().BeGreaterThan(week);
+        month.Should().BeGreaterThan(90, "four congested hours in a month is a good line, not a floored one");
+    }
+
+    [Fact]
+    public void Sustained_congestion_still_grades_badly()
+    {
+        // The other direction: the curve must not be so forgiving that a network congested for most
+        // of the window escapes. Twelve hours of a twenty-four hour window is half its life.
+        var series = new List<AsnSeries> { TestSeries.Asn(64500, "TransitOne", TestSeries.Flat(TestSeries.Start, Day, 10, 0.5)) };
+        var congestion = new List<CongestionEvent>
+        {
+            new() { Start = TestSeries.Start.AddHours(6), End = TestSeries.Start.AddHours(18), AsnNumbers = { 64500 } }
+        };
+
+        new IspHealthScorer(Options).Score(BuildInputs(transit: series, congestion: congestion), Gpon)
+            .TransitAsns.Single().CongestionScore.Should().BeLessThan(25);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -256,7 +256,7 @@ public class IspHealthScorerTests
         report.Downtime.Should().Be(TimeSpan.FromMinutes(15));
 
         // Usage weighting softens the SCORE but must not move uptime - how much an outage mattered is
-        // a judgement, while uptime is a fact about the line.
+        // a judgment, while uptime is a fact about the line.
         var quiet = new IspHealthScorer(Options).Score(
             BuildInputs(
                 outages: new List<OutageEvent> { new()

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/LimitingAspectTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/LimitingAspectTests.cs
@@ -1,0 +1,69 @@
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// The ASN cards and hop rows have room for one of the two score-only aspects, so the picker
+/// has to choose the one actually holding the grade down.
+/// </summary>
+public class LimitingAspectTests
+{
+    private const double StabilityWeight = 0.25;
+    private const double CongestionWeight = 0.2;
+
+    private static (string Label, string Value, int? Score)? Pick(
+        int? stability, int? congestion, int events) =>
+        IspHealthPresentation.LimitingAspect(stability, congestion, events, StabilityWeight, CongestionWeight);
+
+    [Fact]
+    public void Congestion_wins_when_it_costs_the_grade_more()
+    {
+        var pick = Pick(stability: 100, congestion: 45, events: 3);
+
+        Assert.Equal("Congestion", pick!.Value.Label);
+        Assert.Equal("3 Events", pick.Value.Value);
+        Assert.Equal(45, pick.Value.Score);
+    }
+
+    [Fact]
+    public void A_single_event_reads_singular()
+    {
+        Assert.Equal("1 Event", Pick(stability: 100, congestion: 45, events: 1)!.Value.Value);
+    }
+
+    [Fact]
+    public void Stability_wins_when_it_costs_the_grade_more()
+    {
+        var pick = Pick(stability: 39, congestion: 95, events: 1);
+
+        Assert.Equal("Stability", pick!.Value.Label);
+        Assert.Equal("39", pick.Value.Value);
+        Assert.Equal(39, pick.Value.Score);
+    }
+
+    [Fact]
+    public void Clean_congestion_yields_the_slot_to_stability()
+    {
+        // Both perfect: "0 Events" says less than the number, so the number wins.
+        var pick = Pick(stability: 100, congestion: 100, events: 0);
+
+        Assert.Equal("Stability", pick!.Value.Label);
+        Assert.Equal("100", pick.Value.Value);
+    }
+
+    [Fact]
+    public void Clean_congestion_still_shows_when_stability_is_unavailable()
+    {
+        var pick = Pick(stability: null, congestion: 100, events: 0);
+
+        Assert.Equal("Congestion", pick!.Value.Label);
+        Assert.Equal("0 Events", pick.Value.Value);
+    }
+
+    [Fact]
+    public void Nothing_scored_shows_nothing()
+    {
+        Assert.Null(Pick(stability: null, congestion: null, events: 0));
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/LoadClassifierTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/LoadClassifierTests.cs
@@ -104,8 +104,12 @@ public class LoadClassifierTests
     }
 
     [Fact]
-    public void Short_burst_registers_as_loaded_in_its_own_window()
+    public void Lone_loaded_window_between_idle_ones_does_not_count_as_load()
     {
+        // This used to register as loaded. It no longer does, because it is indistinguishable from a
+        // counter artifact - a rate delta spanning a counter reset at a link flap - and magnitude
+        // cannot separate the two: bursty access media legitimately read well above plan. One such
+        // sample, beside an outage, defined an entire month's Loaded Loss on a real site.
         var ws = Options.LoadWindowSeconds;
         var rates = new List<ThroughputSample>
         {
@@ -118,9 +122,45 @@ public class LoadClassifierTests
 
         windows.Should().HaveCount(3);
         var keys = windows.Keys.OrderBy(k => k).ToList();
-        windows[keys[1]].IsLoadedDown.Should().BeTrue();
+        windows[keys[1]].IsLoadedDown.Should().BeFalse();
         windows[keys[0]].IsIdle.Should().BeTrue();
         windows[keys[2]].IsIdle.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Sustained_load_across_consecutive_samples_still_counts()
+    {
+        // The other side of the same rule: real saturation holds across samples, so it survives.
+        // A gig line under full load sawtooths roughly 0.8x to 1.4x of plan, and even its troughs
+        // clear the loaded threshold - so the run requirement never costs a genuine transfer.
+        var ws = Options.LoadWindowSeconds;
+        var rates = new List<ThroughputSample>
+        {
+            new(TestSeries.Start, 10_000_000, 1_000_000),
+            new(TestSeries.Start.AddSeconds(ws), 1_400_000_000, 2_000_000),
+            new(TestSeries.Start.AddSeconds(ws * 2), 800_000_000, 2_000_000),
+            new(TestSeries.Start.AddSeconds(ws * 3), 1_300_000_000, 2_000_000),
+            new(TestSeries.Start.AddSeconds(ws * 4), 10_000_000, 1_000_000)
+        };
+
+        var windows = LoadClassifier.Classify(rates, expectedDownloadMbps: 1000, expectedUploadMbps: 100, Options);
+
+        var keys = windows.Keys.OrderBy(k => k).ToList();
+        windows[keys[1]].IsLoadedDown.Should().BeTrue();
+        windows[keys[2]].IsLoadedDown.Should().BeTrue();
+        windows[keys[3]].IsLoadedDown.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_single_sample_series_is_not_demoted()
+    {
+        // Nothing to compare against. Absence of a neighbor is not evidence of a spike, and demoting
+        // here would discard the only load a short window ever saw.
+        var rates = new List<ThroughputSample> { new(TestSeries.Start, 900_000_000, 2_000_000) };
+
+        var windows = LoadClassifier.Classify(rates, expectedDownloadMbps: 1000, expectedUploadMbps: 100, Options);
+
+        windows.Values.Single().IsLoadedDown.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/LossPoolFilterTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/LossPoolFilterTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// The one rule that matters for dropping a target from the loss pool: it is RELATIVE. A target dark
+/// while its peers measure is blocked or retired; every target dark at once is an outage, and
+/// filtering that would delete the evidence of the thing being scored.
+/// </summary>
+public class LossPoolFilterTests
+{
+    private static readonly IspHealthOptions Options = new();
+
+    private static LossPoolFilter.PoolEntry Target(string id, double lossPct, int samples = 60) =>
+        new(id, Enumerable.Range(0, samples)
+            .Select(i => new LatencySample(TestSeries.Start.AddMinutes(i), 10, 12, 1, lossPct))
+            .ToList());
+
+    [Fact]
+    public void Flatlined_target_is_dropped_when_peers_are_healthy()
+    {
+        var pool = new List<LossPoolFilter.PoolEntry>
+        {
+            Target("dead", 100),
+            Target("isp-hop", 0.1),
+            Target("dns", 0.0)
+        };
+
+        LossPoolFilter.FindFlatlined(pool, Options).Should().BeEquivalentTo(new[] { "dead" });
+    }
+
+    [Fact]
+    public void Nothing_is_dropped_when_every_target_is_dark()
+    {
+        // A real WAN outage. Excluding here would filter away exactly the evidence the score exists
+        // to reflect, and the window would grade as clean.
+        var pool = new List<LossPoolFilter.PoolEntry>
+        {
+            Target("isp-hop", 100),
+            Target("transit", 100),
+            Target("dns", 100)
+        };
+
+        LossPoolFilter.FindFlatlined(pool, Options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void A_merely_lossy_target_stays_in_the_pool()
+    {
+        // 40% loss is a badly degraded hop and real signal for the score. Only a target reporting
+        // nothing usable at all is excluded.
+        var pool = new List<LossPoolFilter.PoolEntry> { Target("lossy", 40), Target("isp-hop", 0.2) };
+
+        LossPoolFilter.FindFlatlined(pool, Options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void A_target_that_recovered_for_part_of_the_window_stays_in()
+    {
+        // Dark for most of the window but measuring at the end - that recovery is real data, and it
+        // also means the target is reachable, so its loss belongs in the pool.
+        var samples = Enumerable.Range(0, 60)
+            .Select(i => new LatencySample(TestSeries.Start.AddMinutes(i), 10, 12, 1, i < 50 ? 100 : 0.5))
+            .ToList();
+        var pool = new List<LossPoolFilter.PoolEntry>
+        {
+            new("recovered", samples),
+            Target("isp-hop", 0.2)
+        };
+
+        LossPoolFilter.FindFlatlined(pool, Options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void A_barely_reporting_target_is_not_judged()
+    {
+        // Too few samples to conclude anything - it could be a target that just came online.
+        var pool = new List<LossPoolFilter.PoolEntry> { Target("new", 100, samples: 5), Target("isp-hop", 0.2) };
+
+        LossPoolFilter.FindFlatlined(pool, Options).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void The_pool_is_never_emptied_and_a_lone_target_is_never_dropped()
+    {
+        LossPoolFilter.FindFlatlined(new List<LossPoolFilter.PoolEntry> { Target("only", 100) }, Options)
+            .Should().BeEmpty();
+
+        // Two dark targets and one healthy peer: the healthy peer alone cannot make both others
+        // droppable without leaving the pool grading a single target, but it is still a peer, so the
+        // guard that matters is that something survives.
+        var pool = new List<LossPoolFilter.PoolEntry> { Target("dead-a", 100), Target("dead-b", 100), Target("isp-hop", 0.2) };
+        var excluded = LossPoolFilter.FindFlatlined(pool, Options);
+        excluded.Should().BeEquivalentTo(new[] { "dead-a", "dead-b" });
+        excluded.Count.Should().BeLessThan(pool.Count);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/TransitUnreachableDetectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/TransitUnreachableDetectorTests.cs
@@ -13,6 +13,73 @@ public class TransitUnreachableDetectorTests
     private static List<TransitUnreachableDetector.DarkWindow> Detect(List<LatencySample> samples) =>
         TransitUnreachableDetector.Detect("t1", 3356, "Lumen", samples, Options);
 
+    private static List<TransitUnreachableDetector.DarkWindow> DetectMostlyDark(List<LatencySample> samples) =>
+        TransitUnreachableDetector.DetectMostlyDark("t1", 3356, "Lumen", samples, Options);
+
+    /// <summary>
+    /// A target that answers roughly one probe in three, for the given span. This is the shape that
+    /// slipped through every filter: never a solid run so <see cref="TransitUnreachableDetector.Detect"/>
+    /// never fires, healthy on a month-wide average so neither the flat-line nor the flaky check sees
+    /// it, and ~100% loss for most of the samples that land inside a loaded window.
+    /// </summary>
+    private static List<LatencySample> Flapping(DateTime from, TimeSpan span, int answerEveryNth = 3)
+    {
+        var samples = new List<LatencySample>();
+        var minutes = (int)span.TotalMinutes;
+        for (var i = 0; i < minutes; i++)
+            samples.Add(new LatencySample(from.AddMinutes(i), 12, 14, 1, i % answerEveryNth == 0 ? 0.5 : 100));
+        return samples;
+    }
+
+    [Fact]
+    public void Flapping_target_is_carved_out_even_though_it_never_goes_solidly_dark()
+    {
+        var samples = TestSeries.Flat(Start, Hour, 12, 0.5).Take(10).ToList();
+        samples.AddRange(Flapping(Start.AddMinutes(10), TimeSpan.FromMinutes(40)));
+
+        // The every-sample rule sees nothing: an answered probe resets it before it reaches 180 s.
+        Detect(samples).Should().BeEmpty();
+
+        var windows = DetectMostlyDark(samples);
+        windows.Should().ContainSingle();
+        windows[0].Start.Should().Be(Start.AddMinutes(11));
+        windows[0].AsnNumber.Should().Be(3356);
+    }
+
+    [Fact]
+    public void Brief_flapping_stays_in_the_loss_pool()
+    {
+        // Intermittent evidence is weaker than a solid washout, so it has to persist. Five minutes of
+        // flapping is a loss burst and belongs in the pool.
+        var samples = TestSeries.Flat(Start, Hour, 12, 0.5).Take(10).ToList();
+        samples.AddRange(Flapping(Start.AddMinutes(10), TimeSpan.FromMinutes(5)));
+
+        DetectMostlyDark(samples).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void A_target_answering_most_probes_is_never_carved_out()
+    {
+        // Answers 2 of every 3. Lossy, and that loss is real signal the score should keep.
+        var samples = Flapping(Start, TimeSpan.FromMinutes(40), answerEveryNth: 2)
+            .Select((s, i) => i % 3 == 0 ? s with { LossPercent = 100 } : s with { LossPercent = 0.5 })
+            .ToList();
+
+        DetectMostlyDark(samples).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Recovery_ends_the_span_at_the_last_dark_sample()
+    {
+        // Masking must never hide samples the target actually answered after it came back.
+        var samples = Flapping(Start, TimeSpan.FromMinutes(40)).ToList();
+        samples.AddRange(TestSeries.Flat(Start.AddMinutes(40), TimeSpan.FromMinutes(20), 12, 0.5));
+
+        var windows = DetectMostlyDark(samples);
+        windows.Should().ContainSingle();
+        windows[0].End.Should().BeBefore(Start.AddMinutes(40));
+    }
+
     [Fact]
     public void Sustained_total_loss_becomes_a_dark_window()
     {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/WanRateSanitizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/WanRateSanitizerTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.IspHealth;
+
+/// <summary>
+/// A counter reset at a link flap reports a rate the line cannot carry, and one such sample marks its
+/// window loaded - pulling the flap's own loss into Loaded Loss. Modelled on a real capture: 1.09 Gbps
+/// on a 350/350 plan, in the same second as an outage.
+/// </summary>
+public class WanRateSanitizerTests
+{
+    private static readonly IspHealthOptions Options = new();
+
+    private static ThroughputSample At(int minute, double downBps, double upBps) =>
+        new(TestSeries.Start.AddMinutes(minute), downBps, upBps);
+
+    [Fact]
+    public void Counter_artifact_is_dropped_and_ordinary_traffic_is_kept()
+    {
+        var samples = new List<ThroughputSample>
+        {
+            At(0, 50_000_000, 5_000_000),
+            At(1, 1_093_717_987, 1_079_896_299), // the observed artifact
+            At(2, 60_000_000, 6_000_000)
+        };
+
+        var result = WanRateSanitizer.Filter(samples, expectedDownloadMbps: 350, expectedUploadMbps: 350, Options);
+
+        result.Dropped.Should().Be(1);
+        result.Samples.Should().HaveCount(2);
+        result.Samples.Should().NotContain(s => s.DownloadBps > 1_000_000_000);
+    }
+
+    [Fact]
+    public void A_line_beating_its_plan_is_not_treated_as_an_artifact()
+    {
+        // ISPs over-provision and bursts happen. 1.4x plan is a fast line, not a counter reset, and
+        // discarding it would throw away the loaded windows the score needs.
+        var samples = new List<ThroughputSample> { At(0, 490_000_000, 480_000_000) };
+
+        WanRateSanitizer.Filter(samples, 350, 350, Options).Dropped.Should().Be(0);
+    }
+
+    [Fact]
+    public void An_implausible_upload_drops_the_whole_sample()
+    {
+        // A counter discontinuity corrupts the reading, not one field of it.
+        var samples = new List<ThroughputSample> { At(0, 50_000_000, 4_000_000_000) };
+
+        var result = WanRateSanitizer.Filter(samples, 350, 350, Options);
+        result.Dropped.Should().Be(1);
+        result.Samples.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Without_a_configured_plan_nothing_is_judged()
+    {
+        // No ceiling to compare against, and guessing one risks discarding real traffic.
+        var samples = new List<ThroughputSample> { At(0, 8_017_576_149, 6_279_766_857) };
+
+        var result = WanRateSanitizer.Filter(samples, null, null, Options);
+        result.Dropped.Should().Be(0);
+        result.Samples.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void One_direction_configured_still_guards_that_direction()
+    {
+        var samples = new List<ThroughputSample> { At(0, 1_093_717_987, 5_000_000) };
+
+        WanRateSanitizer.Filter(samples, expectedDownloadMbps: 350, expectedUploadMbps: null, Options)
+            .Dropped.Should().Be(1);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/WanRateSanitizerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/WanRateSanitizerTests.cs
@@ -6,7 +6,7 @@ namespace NetworkOptimizer.Web.Tests.IspHealth;
 
 /// <summary>
 /// A counter reset at a link flap reports a rate the line cannot carry, and one such sample marks its
-/// window loaded - pulling the flap's own loss into Loaded Loss. Modelled on a real capture: 1.09 Gbps
+/// window loaded - pulling the flap's own loss into Loaded Loss. Modeled on a real capture: 1.09 Gbps
 /// on a 350/350 plan, in the same second as an outage.
 /// </summary>
 public class WanRateSanitizerTests


### PR DESCRIPTION
ISP Health scored outages and congestion on absolute counts, so a 15 minute disruption cost the same whether it happened on a 24 hour window or a 30 day one. Both now scale to the window they are shown against. Alongside that: an Uptime figure on the score card and in the PDF, a gateway loss floor so loss inside your own network stops being charged to your ISP, and several filters that keep dead or implausible samples out of the numbers.

## Monitoring - ISP Health

- **Uptime** - Sits above the three dimension gauges on the score card, and leads the dimension grades in Export PDF. Counts partial path disruptions, not just total blackouts, so a path that lost most of its targets for ten minutes shows up rather than reading as a clean 100%.
- **Outage penalties are relative to the window** - An outage is now weighed by how much of the selected window it actually consumed, and by how deep and how broad it was. Outages that straddle the window edge only count the part inside it. One brief outage no longer takes double digits off a 30 day score, while a genuinely bad month still grades like one.
- **Congestion penalties are relative to the window** - Congested hours are scored as a share of the window for the same reason. Nine congested hours used to bottom out the curve at zero regardless of window length, which quietly cost otherwise healthy networks around 30 points on a month view.
- **Stability and Congestion on the network cards and hop rows** - The two aspects that fed the grade invisibly are now surfaced next to P90 Jitter and Loss%. Each row shows whichever one is actually holding its grade down, so a low grade points at its own cause. When that is congestion the stat reads the event count in the grade's color.
- **Packet loss inside your own network** - If the gateway is present and reporting loss to itself, that loss is a floor: it is subtracted from every upstream measurement at matching points in time, so the ISP is not graded for a bad cable, a marginal SFP, or a saturated uplink between this server and the gateway. The floor is a time series rather than a single number, so it only applies where it was actually measured, and a window with no gateway readings grades exactly as before. When the floor is meaningful, a finding names it and points at the switching path.
- **Flat-lined targets stay out of Loaded Loss** - A target sitting at 100% loss for the whole window says nothing about how the path behaves under load, but it dominated the pooled loss mean. Targets that never answer, and transit hops that flap dark for most of a span rather than going cleanly dark, are now excluded from the loss pool and from Investigation.
- **Implausible throughput samples no longer define Loaded Loss** - A single WAN rate sample reading multiples over the plan speed could mark a window as loaded on its own, which is how a counter artifact turned a healthy month into a double digit Loaded Loss figure. Rate samples well over plan speed are discarded, and a loaded window now needs more than one sample behind it.
- **Faster on long windows** - 30 day compute on a large site dropped from roughly 13 seconds to under 7 without changing resolution or results. The monitoring reads stream and parse their CSV rather than buffering it twice, WAN rate reads use the span based parser instead of record deserialization, and the multi-WAN sum is skipped where there is only one WAN interface. Phase timings and the grade arithmetic are logged at debug so a slow or surprising run can be read back from the logs.

## Adaptive SQM

- **Guided tour step for Larger download burst** - Included in the v2.5.3 tour, gated so it only appears for installs that actually have Adaptive SQM enabled.

## Fixes

- **Guided tour steps anchored inside a collapsed section** - A collapsed card clips its content rather than removing it, so a step targeting something inside one spotlighted a strip of clipped page. The driver now reads collapsed state off the ancestors, opens the section before measuring, and reopens it if the page collapses it after the spotlight has landed.
- **Skip tour no longer appears on the final step** - There is nothing left to skip there, and taking it filed a tour the user read to the end as deferred, which re-offered it on the next minor release.
- **Chart resolution no longer truncates** - Flux durations were rendered in whole units, so any interval that was not a round number of minutes was silently rounded down. Now rendered exactly.
- **Audit Log no longer files "monitoring setup changed" for reads** - Refreshing ISP Health or picking a different time window recorded a configuration change event every time. Calls that change nothing no longer write an entry.
- **Button labels center consistently across browsers** - Labels sat about a pixel high in Chrome relative to Firefox. Buttons now render in our own font with a line box that contains the glyphs, so the alignment matches everywhere.
- **Tooltip width is capped on desktop** - Long tooltips stretched across wide screens and got hard to read. Capped at 360px, with a 400px opt-in for the few genuinely dense ones, and the mobile viewport fit is unchanged.
