### PR TITLE
Monitoring: gated setup writes, offline site readback, and collection that can move to an on-site agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
           file: ./docker/agent/Dockerfile
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.agent-meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.AGENT_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=agent-${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,scope=agent-${{ env.PLATFORM_PAIR }},mode=max

--- a/TODO.md
+++ b/TODO.md
@@ -681,6 +681,32 @@ Docker bridge mode and multi-NIC hosts. What is left is verification, not code:
   UniFi topology. Speed-test targets and traces break silently unless the override is set.
 - [ ] Run the test matrix: native (works today), Docker host mode, Docker bridge with override.
 
+### Main site agent: speed test capability consistency (only if a user asks)
+`site.agent_covers_collection` moves probes, upstream path discovery, SNMP and device reachability
+to a main site's agent, and the client speed test target follows it. Speed test *hosting* is a
+separate capability: the agent announces `serves_speed_test` in its tunnel hello (driven by
+`lanSpeedTest` in `agent.json`), and `SiteSpeedTestTargetResolver` takes it at its word, so an agent
+that hosts no speed test sends Client Speed Test, Client Dashboard and Client WAN Test back to the
+central server while everything else stays on the agent.
+
+WAN Speed Test does not follow that flag. `RunsOnAgent` keys on coverage alone, and the agent's WAN
+test is `uwnspeedtest` - a different binary from the nginx LAN page, so declining to host the page
+says nothing about whether it can run a WAN test. The result is that WAN tests can only be moved
+back to the server by turning coverage off entirely, which drags probes and SNMP back with them.
+
+Deliberately left alone: the split is coherent (hosting a page for site clients is not the same
+capability as running a test from the site), and nobody has asked for the two to move together. If
+someone wants a covered main site whose speed tests all stay on the server:
+
+- [ ] Decide whether WAN Speed Test should consult `ServesSpeedTest`, or whether the agent needs a
+      second capability flag for "can run a WAN test" so the two stay independently addressable.
+- [ ] Tear down `netopt-speedtest-nginx` when `lanSpeedTest` goes false. The unit is `WantedBy` the
+      agent service and is not driven by `agent.json`, so it relights on every agent start and keeps
+      serving port 24443 with no relay behind it: the page loads and results silently never post.
+      Today that needs a manual `systemctl disable --now`.
+- [ ] Surface it in the UI. Both switches are file-level today (`agent.json`, plus the installer's
+      `--lan-speed-test`), which is fine for an operator and not something to document to users.
+
 ## Distribution
 
 ### ISO/OVA Image for MSP Deployment

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -62,7 +62,11 @@ COPY docker/agent/config.js /usr/share/nginx/html/assets/js/config.js
 # nginx-standalone.conf the bare-metal installer uses), wrapping the shared server
 # block - rather than leaning on the base image's top-level nginx.conf. The webroot
 # stays /usr/share/nginx/html (set in the server block).
-COPY docker/agent/nginx.conf /etc/nginx/netopt-speedtest-server.conf
+COPY docker/agent/nginx.conf /etc/nginx/netopt-speedtest-server.conf.template
+# The entrypoint rewrites the listener and (optionally) strips TLS into the live file each
+# start. It works from this pristine copy rather than editing in place, because a container
+# restart keeps the filesystem - an in-place edit would be permanent and the next boot could
+# not put it back.
 COPY docker/agent/nginx-standalone.conf /etc/nginx/netopt-speedtest.conf
 # The self-signed cert lives in the persisted /data volume so it survives restarts
 # (entrypoint.sh generates it once); wire the server block's cert paths to it.
@@ -74,7 +78,7 @@ RUN sed -i \
     && sed -i \
         -e 's#__CERTFILE__#/data/speedtest-tls/cert.pem#' \
         -e 's#__KEYFILE__#/data/speedtest-tls/key.pem#' \
-        /etc/nginx/netopt-speedtest-server.conf
+        /etc/nginx/netopt-speedtest-server.conf.template
 COPY docker/agent/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -3,9 +3,14 @@
 # so TARGETARCH matches the build host and no QEMU emulation is needed.
 
 ARG DOTNET_VERSION=10.0
+# Passed from CI on tag push. MinVer reads git tags and .dockerignore keeps .git out of the
+# build context, so without this every image - released ones included - calls itself
+# 0.0.0-alpha.0.
+ARG VERSION=0.0.0-alpha.0
 
 FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build
 ARG TARGETARCH
+ARG VERSION
 WORKDIR /src
 COPY . .
 # Grpc.Tools' bundled linux_arm64 protoc segfaults (exit 139) under dotnet on native
@@ -21,6 +26,7 @@ RUN case "$TARGETARCH" in \
     dotnet publish src/NetworkOptimizer.Agent/NetworkOptimizer.Agent.csproj \
         -c Release -r "$RID" --self-contained true \
         -p:PublishSingleFile=true \
+        -p:MinVerVersionOverride=${VERSION} \
         -o /app/publish
 
 # uwnspeedtest Go binary for WAN speed tests run site-local at the agent

--- a/docker/agent/docker-compose.yml
+++ b/docker/agent/docker-compose.yml
@@ -3,7 +3,7 @@
 # The agent dials OUT to the central server over HTTPS only - no inbound access
 # to the site is required for the tunnel. Host networking is used so latency/loss
 # probes see the site's real network position (and per-WAN source binding works),
-# and so the optional LAN speed test (port 3000) and iperf3 (port 5201) are
+# and so the optional LAN speed test (port 24443) and iperf3 (port 5201) are
 # reachable by site clients on the host's address.
 #
 # scripts/agent/install.sh writes ./data/agent.json (server URL + enrollment
@@ -23,6 +23,9 @@ services:
       # default self-signed TLS (then set the site's speed test URL override
       # to the matching http:// address - see the agent README).
       #- AGENT_SPEEDTEST_TLS=0
+      # Uncomment to serve the LAN speed test page on a different port (the agent tells the
+      # server, so in-app links follow). Host networking, so this must be free on the host.
+      #- AGENT_SPEEDTEST_PORT=443
       # Uncomment to override the agent's auto-detected LAN IP (e.g. when running
       # in Docker bridge mode instead of host networking, or on a multi-NIC host).
       #- NO_AGENT_LAN_IP=192.168.1.50

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -6,12 +6,19 @@
 # down and nginx goes with it.
 set -e
 
-# Serve the page somewhere other than 24443 when asked. Only the public listener moves - the
-# loopback relay stays where the agent binary expects it - and the agent announces the port it
-# was given, so the server's speed test links follow without being configured separately.
-if [ -n "${AGENT_SPEEDTEST_PORT:-}" ] && [ "${AGENT_SPEEDTEST_PORT}" != "24443" ]; then
-    sed -i "/listen/ s/24443/${AGENT_SPEEDTEST_PORT}/" /etc/nginx/netopt-speedtest-server.conf
-    echo "entrypoint: LAN speed test page on port ${AGENT_SPEEDTEST_PORT}"
+# Which port the page is served on. nginx and the agent must resolve this identically or the agent
+# announces a port nginx is not listening on: environment variable first, then whatever agent.json
+# records, then the image's own default. The config case matters on upgrade - an agent enrolled
+# before the port was configurable has 3000 written in its config and should keep serving it, rather
+# than being moved to a port its clients and firewall rules have never heard of. Deleting that line
+# from agent.json is all it takes to adopt the current default.
+PAGE_PORT="${AGENT_SPEEDTEST_PORT:-}"
+if [ -z "$PAGE_PORT" ] && [ -f /data/agent.json ]; then
+    PAGE_PORT=$(sed -n 's/.*"lanSpeedTestPort"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' /data/agent.json | head -1)
+fi
+if [ -n "$PAGE_PORT" ] && [ "$PAGE_PORT" != "24443" ]; then
+    sed -i "/listen/ s/24443/${PAGE_PORT}/" /etc/nginx/netopt-speedtest-server.conf
+    echo "entrypoint: LAN speed test page on port ${PAGE_PORT}"
 fi
 
 # Self-signed TLS opt-out (AGENT_SPEEDTEST_TLS=0): serve the speed test listener as

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # The agent container runs two processes: nginx (serves OpenSpeedTest + the
 # throughput-critical transfer legs on port 3000) and the .NET agent (the tunnel
-# plus the loopback results relay on 3001). nginx runs in the background; the
+# plus the loopback results relay on 18042). nginx runs in the background; the
 # agent is the main process, so `docker stop` (SIGTERM to it) tears the container
 # down and nginx goes with it.
 set -e

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -12,6 +12,10 @@ set -e
 # before the port was configurable has 3000 written in its config and should keep serving it, rather
 # than being moved to a port its clients and firewall rules have never heard of. Deleting that line
 # from agent.json is all it takes to adopt the current default.
+# Start from the pristine config every boot: a restart reuses the container filesystem, so
+# editing the live file in place would make the first boot's choices permanent.
+cp /etc/nginx/netopt-speedtest-server.conf.template /etc/nginx/netopt-speedtest-server.conf
+
 PAGE_PORT="${AGENT_SPEEDTEST_PORT:-}"
 if [ -z "$PAGE_PORT" ] && [ -f /data/agent.json ]; then
     PAGE_PORT=$(sed -n 's/.*"lanSpeedTestPort"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' /data/agent.json | head -1)

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
 # The agent container runs two processes: nginx (serves OpenSpeedTest + the
-# throughput-critical transfer legs on port 3000) and the .NET agent (the tunnel
-# plus the loopback results relay on 18042). nginx runs in the background; the
+# throughput-critical transfer legs on port 24443) and the .NET agent (the tunnel
+# plus the loopback results relay on 24042). nginx runs in the background; the
 # agent is the main process, so `docker stop` (SIGTERM to it) tears the container
 # down and nginx goes with it.
 set -e
+
+# Serve the page somewhere other than 24443 when asked. Only the public listener moves - the
+# loopback relay stays where the agent binary expects it - and the agent announces the port it
+# was given, so the server's speed test links follow without being configured separately.
+if [ -n "${AGENT_SPEEDTEST_PORT:-}" ] && [ "${AGENT_SPEEDTEST_PORT}" != "24443" ]; then
+    sed -i "/listen/ s/24443/${AGENT_SPEEDTEST_PORT}/" /etc/nginx/netopt-speedtest-server.conf
+    echo "entrypoint: LAN speed test page on port ${AGENT_SPEEDTEST_PORT}"
+fi
 
 # Self-signed TLS opt-out (AGENT_SPEEDTEST_TLS=0): serve the speed test listener as
 # plain http instead - for sites already behind their own reverse proxy / TLS, or
@@ -17,7 +25,7 @@ if [ "${AGENT_SPEEDTEST_TLS:-1}" = "0" ]; then
         -e 's/^\([[:space:]]*listen[[:space:]][^;]*\) ssl\([^;]*;\)/\1\2/' \
         -e '/^[[:space:]]*ssl_/d' \
         /etc/nginx/netopt-speedtest-server.conf
-    echo "entrypoint: AGENT_SPEEDTEST_TLS=0 - LAN speed test serving plain http on 3000"
+    echo "entrypoint: AGENT_SPEEDTEST_TLS=0 - LAN speed test serving plain http on 24443"
 else
     # Generate a persisted self-signed cert for the LAN speed test's TLS listener if it
     # doesn't exist yet. TLS makes the OpenSpeedTest page a secure context so the browser

--- a/docker/agent/nginx.conf
+++ b/docker/agent/nginx.conf
@@ -1,7 +1,7 @@
 # OpenSpeedTest served by nginx on the on-site agent. The transfer legs
 # (/downloading via sendfile, /upload) run here so the agent saturates 10 GbE on
 # modest hardware; result posts + the results link proxy to the agent's loopback
-# relay (127.0.0.1:3001), which forwards them to the central server with the site
+# relay (127.0.0.1:18042), which forwards them to the central server with the site
 # slug and the real client IP. LAN tests are same-origin; the /wan/ flow's
 # post-back from the external test page is cross-origin, so the relay answers
 # with CORS headers.
@@ -40,14 +40,14 @@ server {
     # Result posts + the "view results" link relay through the agent's loopback
     # listener (site slug + real client IP forwarded on to the central server).
     location /api/public/speedtest/ {
-        proxy_pass http://127.0.0.1:3001;
+        proxy_pass http://127.0.0.1:18042;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 20m;
     }
 
     location = /client-speedtest {
-        proxy_pass http://127.0.0.1:3001;
+        proxy_pass http://127.0.0.1:18042;
         proxy_set_header Host $host;
     }
 
@@ -71,7 +71,7 @@ server {
     # WAN test server, making this agent the page's referrer so results post
     # back to this origin with the real client LAN IP.
     location /wan/ {
-        proxy_pass http://127.0.0.1:3001;
+        proxy_pass http://127.0.0.1:18042;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $remote_addr;
     }

--- a/docker/agent/nginx.conf
+++ b/docker/agent/nginx.conf
@@ -1,14 +1,14 @@
 # OpenSpeedTest served by nginx on the on-site agent. The transfer legs
 # (/downloading via sendfile, /upload) run here so the agent saturates 10 GbE on
 # modest hardware; result posts + the results link proxy to the agent's loopback
-# relay (127.0.0.1:18042), which forwards them to the central server with the site
+# relay (127.0.0.1:24042), which forwards them to the central server with the site
 # slug and the real client IP. LAN tests are same-origin; the /wan/ flow's
 # post-back from the external test page is cross-origin, so the relay answers
 # with CORS headers.
 server {
     server_name _;
-    listen 3000 ssl reuseport;
-    listen [::]:3000 ssl reuseport;
+    listen 24443 ssl reuseport;
+    listen [::]:24443 ssl reuseport;
     # Self-signed TLS by default so the OpenSpeedTest page is a secure context - the
     # browser Geolocation API (GPS-tagged results) requires https, and it works over
     # the agent's LAN IP without a per-site reverse proxy. The cert is generated once
@@ -40,14 +40,14 @@ server {
     # Result posts + the "view results" link relay through the agent's loopback
     # listener (site slug + real client IP forwarded on to the central server).
     location /api/public/speedtest/ {
-        proxy_pass http://127.0.0.1:18042;
+        proxy_pass http://127.0.0.1:24042;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $remote_addr;
         client_max_body_size 20m;
     }
 
     location = /client-speedtest {
-        proxy_pass http://127.0.0.1:18042;
+        proxy_pass http://127.0.0.1:24042;
         proxy_set_header Host $host;
     }
 
@@ -71,7 +71,7 @@ server {
     # WAN test server, making this agent the page's referrer so results post
     # back to this origin with the real client LAN IP.
     location /wan/ {
-        proxy_pass http://127.0.0.1:18042;
+        proxy_pass http://127.0.0.1:24042;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $remote_addr;
     }
@@ -86,7 +86,7 @@ server {
         add_header Cache-Control 'no-store, no-cache, max-age=0, no-transform';
         client_body_buffer_size 35m;
         client_max_body_size 50m;
-        # The public :3000 listener is now TLS; the sink that consumes the upload
+        # The public :24443 listener is now TLS; the sink that consumes the upload
         # body lives on a plaintext loopback listener (server block below) so the
         # self-proxy stays cheap HTTP rather than looping back through TLS.
         proxy_pass http://127.0.0.1:3002/upload-sink;
@@ -119,7 +119,7 @@ server {
 
 # Plaintext loopback sink for the upload leg. The /upload location proxies the POST
 # body here purely to read it (measuring upload throughput) then returns 200 - it must
-# be plaintext HTTP since the public :3000 listener is now TLS. Loopback-only, so it is
+# be plaintext HTTP since the public :24443 listener is now TLS. Loopback-only, so it is
 # never reachable from the network. client_max_body_size 0 lifts the body cap for the
 # discard (the client-facing /upload keeps its own 50m cap).
 server {

--- a/scripts/agent/install-docker.sh
+++ b/scripts/agent/install-docker.sh
@@ -13,7 +13,7 @@
 # Options:
 #   --server URL     Central server HTTPS address (required; same URL as the app)
 #   --token  TOKEN   One-time enrollment token (required on first install)
-#   --lan-speed-test Host the LAN speed test page (port 3000) and iperf3 (5201)
+#   --lan-speed-test Host the LAN speed test page (port 24443) and iperf3 (5201)
 #   --insecure       Accept a self-signed cert on the server's reverse proxy
 #   --dir PATH       Install directory (default: /opt/network-optimizer-agent)
 #   --uninstall      Stop and remove the agent container and install dir, then exit

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -394,7 +394,7 @@ else
 fi
 
 # nginx serves the OpenSpeedTest page + the throughput-critical transfer legs
-# (sendfile, 10 GbE); the agent's loopback relay (127.0.0.1:3001) forwards result
+# (sendfile, 10 GbE); the agent's loopback relay (127.0.0.1:18042) forwards result
 # posts to the central server. Only needed with --lan-speed-test.
 #
 # We run our OWN dedicated nginx master - its own config, webroot, pidfile, and
@@ -503,7 +503,7 @@ CFGJS
 [Unit]
 Description=Network Optimizer LAN speed test (nginx)
 # The speed test only matters when the agent is up (results relay through the
-# agent on 3001), so bind nginx's lifecycle to the agent: it starts after the
+# agent on 18042), so bind nginx's lifecycle to the agent: it starts after the
 # agent and stops whenever the agent stops or crashes. Mirrors the Docker
 # single-container model where the agent is PID 1 and nginx dies with it.
 After=network-online.target netopt-agent.service

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -64,6 +64,15 @@ if [ "$LAN_SPEED_TEST" != true ] && grep -q '"lanSpeedTest"[[:space:]]*:[[:space
     LAN_SPEED_TEST=true
 fi
 
+# Likewise the port: an install already serving on one keeps it unless this run names a different
+# one. Upgrading should not move a page that clients and firewall rules already know about, and an
+# agent enrolled before the port was configurable has the old 3000 recorded. Deleting that line from
+# agent.json is how an existing install adopts the current default.
+if [ "$SPEED_TEST_PORT" = "24443" ] && [ -f "${INSTALL_DIR}/agent.json" ]; then
+    EXISTING_PORT=$(sed -n 's/.*"lanSpeedTestPort"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p' "${INSTALL_DIR}/agent.json" | head -1)
+    [ -n "$EXISTING_PORT" ] && SPEED_TEST_PORT="$EXISTING_PORT"
+fi
+
 # --- Output helpers -----------------------------------------------------------
 # Colorized, structured output; colors collapse to empty when stdout isn't a
 # terminal (piped/redirected/logged), so captured output stays clean.

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -32,6 +32,7 @@ SERVER=""
 TOKEN=""
 LAN_SPEED_TEST=false
 SPEED_TEST_PORT=24443
+PORT_REQUESTED=false
 INSECURE=false
 UNINSTALL=false
 FORCE_NATIVE=false
@@ -46,7 +47,7 @@ while [ $# -gt 0 ]; do
         --server) SERVER="$2"; shift 2 ;;
         --token) TOKEN="$2"; shift 2 ;;
         --lan-speed-test) LAN_SPEED_TEST=true; shift ;;
-        --speed-test-port) SPEED_TEST_PORT="$2"; shift 2 ;;
+        --speed-test-port) SPEED_TEST_PORT="$2"; PORT_REQUESTED=true; shift 2 ;;
         --insecure) INSECURE=true; shift ;;
         --uninstall) UNINSTALL=true; shift ;;
         --force-native) FORCE_NATIVE=true; shift ;;
@@ -402,7 +403,7 @@ if grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
     # rewritten below either way, and the agent announces the port from here - so leaving this
     # alone would have the agent advertising a port it no longer serves, which is precisely the
     # mismatch the announcement exists to prevent.
-    if [ "$SPEED_TEST_PORT" != "24443" ]; then
+    if [ "$PORT_REQUESTED" = true ]; then
         if grep -q '"lanSpeedTestPort"' "$CONFIG"; then
             sed -i "s/\"lanSpeedTestPort\": *[0-9]*/\"lanSpeedTestPort\": ${SPEED_TEST_PORT}/" "$CONFIG"
         else
@@ -501,7 +502,7 @@ CFGJS
                 -e 's/^\([[:space:]]*listen[[:space:]][^;]*\) ssl\([^;]*;\)/\1\2/' \
                 -e '/^[[:space:]]*ssl_/d' \
                 "${INSTALL_DIR}/nginx-speedtest-server.conf"
-            note "AGENT_SPEEDTEST_TLS=0 - serving plain http on port 24443"
+            note "AGENT_SPEEDTEST_TLS=0 - serving plain http on port ${SPEED_TEST_PORT}"
         else
             # Persisted self-signed cert for the LAN speed test's TLS listener (secure context
             # for the browser Geolocation API / GPS-tagged results, no per-site reverse proxy).
@@ -591,7 +592,7 @@ UNIT
             # symlink from installs made before nginx was wanted by the agent.
             systemctl reenable --quiet netopt-speedtest-nginx.service
             START_SPEEDTEST_NGINX=1
-            ok "LAN speed test ready on port 24443 (starts with the agent)"
+            ok "LAN speed test ready on port ${SPEED_TEST_PORT} (starts with the agent)"
         else
             warn "nginx config test failed - the LAN speed test page won't serve."
             print_speedtest_apparmor_hint

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -14,7 +14,9 @@
 # Options:
 #   --server URL     Central server HTTPS address (required; same URL as the app)
 #   --token  TOKEN   One-time enrollment token (required on first install)
-#   --lan-speed-test Host the LAN speed test page (port 3000) and iperf3 (5201)
+#   --lan-speed-test Host the LAN speed test page (port 24443) and iperf3 (5201)
+#   --speed-test-port N  Serve the LAN speed test page on N instead of 24443. The agent tells the
+#                    server which port it uses, so in-app links follow automatically.
 #   --insecure       Accept a self-signed cert on the server's reverse proxy
 #   --force-native   Skip the UniFi gateway refusal (this installer targets a
 #                    separate box; on a UniFi OS gateway use install-agent-gateway.sh)
@@ -29,6 +31,7 @@ set -euo pipefail
 SERVER=""
 TOKEN=""
 LAN_SPEED_TEST=false
+SPEED_TEST_PORT=24443
 INSECURE=false
 UNINSTALL=false
 FORCE_NATIVE=false
@@ -43,6 +46,7 @@ while [ $# -gt 0 ]; do
         --server) SERVER="$2"; shift 2 ;;
         --token) TOKEN="$2"; shift 2 ;;
         --lan-speed-test) LAN_SPEED_TEST=true; shift ;;
+        --speed-test-port) SPEED_TEST_PORT="$2"; shift 2 ;;
         --insecure) INSECURE=true; shift ;;
         --uninstall) UNINSTALL=true; shift ;;
         --force-native) FORCE_NATIVE=true; shift ;;
@@ -385,6 +389,18 @@ step "Configuring the agent"
 # update the binary) never wipes the persisted agent key.
 if grep -q '"agentKey"' "$CONFIG" 2>/dev/null; then
     note "Existing enrollment found - keeping agent.json"
+    # ...except the speed test port, when this run asked for a different one. nginx's listener is
+    # rewritten below either way, and the agent announces the port from here - so leaving this
+    # alone would have the agent advertising a port it no longer serves, which is precisely the
+    # mismatch the announcement exists to prevent.
+    if [ "$SPEED_TEST_PORT" != "24443" ]; then
+        if grep -q '"lanSpeedTestPort"' "$CONFIG"; then
+            sed -i "s/\"lanSpeedTestPort\": *[0-9]*/\"lanSpeedTestPort\": ${SPEED_TEST_PORT}/" "$CONFIG"
+        else
+            sed -i "s/\"lanSpeedTest\": true/\"lanSpeedTest\": true,\n  \"lanSpeedTestPort\": ${SPEED_TEST_PORT}/" "$CONFIG"
+        fi
+        note "Speed test port set to ${SPEED_TEST_PORT} in agent.json"
+    fi
 else
     [ -n "$TOKEN" ] || err "--token is required for a first-time install"
     {
@@ -395,6 +411,9 @@ else
         printf '  "ignoreSslErrors": %s' "$INSECURE"
         if [ "$LAN_SPEED_TEST" = true ]; then
             printf ',\n  "lanSpeedTest": true'
+            # The agent announces this to the server, so in-app speed test links follow it.
+            [ "$SPEED_TEST_PORT" != "24443" ] && printf ',
+  "lanSpeedTestPort": %s' "$SPEED_TEST_PORT"
         fi
         printf '\n}\n'
     } > "$CONFIG"
@@ -402,7 +421,7 @@ else
 fi
 
 # nginx serves the OpenSpeedTest page + the throughput-critical transfer legs
-# (sendfile, 10 GbE); the agent's loopback relay (127.0.0.1:18042) forwards result
+# (sendfile, 10 GbE); the agent's loopback relay (127.0.0.1:24042) forwards result
 # posts to the central server. Only needed with --lan-speed-test.
 #
 # We run our OWN dedicated nginx master - its own config, webroot, pidfile, and
@@ -454,6 +473,14 @@ CFGJS
         curl -fsSL "$RAW/docker/agent/nginx.conf" -o "${INSTALL_DIR}/nginx-speedtest-server.conf"
         sed -i "s#root /usr/share/nginx/html;#root ${WEBROOT};#" "${INSTALL_DIR}/nginx-speedtest-server.conf"
 
+        # Serve on a different port when asked. Only the public listener moves; the loopback
+        # relay stays where the agent binary expects it. The agent announces the port it was
+        # given, so the server's links follow without being told separately.
+        if [ "$SPEED_TEST_PORT" != "24443" ]; then
+            sed -i "/listen/ s/24443/${SPEED_TEST_PORT}/" "${INSTALL_DIR}/nginx-speedtest-server.conf"
+            note "LAN speed test page on port ${SPEED_TEST_PORT}"
+        fi
+
         if [ "${AGENT_SPEEDTEST_TLS:-1}" = "0" ]; then
             # Self-signed TLS opt-out (AGENT_SPEEDTEST_TLS=0 at install time): serve the
             # speed test listener as plain http - for sites already behind their own
@@ -465,7 +492,7 @@ CFGJS
                 -e 's/^\([[:space:]]*listen[[:space:]][^;]*\) ssl\([^;]*;\)/\1\2/' \
                 -e '/^[[:space:]]*ssl_/d' \
                 "${INSTALL_DIR}/nginx-speedtest-server.conf"
-            note "AGENT_SPEEDTEST_TLS=0 - serving plain http on port 3000"
+            note "AGENT_SPEEDTEST_TLS=0 - serving plain http on port 24443"
         else
             # Persisted self-signed cert for the LAN speed test's TLS listener (secure context
             # for the browser Geolocation API / GPS-tagged results, no per-site reverse proxy).
@@ -511,7 +538,7 @@ CFGJS
 [Unit]
 Description=Network Optimizer LAN speed test (nginx)
 # The speed test only matters when the agent is up (results relay through the
-# agent on 18042), so bind nginx's lifecycle to the agent: it starts after the
+# agent on 24042), so bind nginx's lifecycle to the agent: it starts after the
 # agent and stops whenever the agent stops or crashes. Mirrors the Docker
 # single-container model where the agent is PID 1 and nginx dies with it.
 After=network-online.target netopt-agent.service
@@ -555,7 +582,7 @@ UNIT
             # symlink from installs made before nginx was wanted by the agent.
             systemctl reenable --quiet netopt-speedtest-nginx.service
             START_SPEEDTEST_NGINX=1
-            ok "LAN speed test ready on port 3000 (starts with the agent)"
+            ok "LAN speed test ready on port 24443 (starts with the agent)"
         else
             warn "nginx config test failed - the LAN speed test page won't serve."
             print_speedtest_apparmor_hint

--- a/scripts/agent/install-native.sh
+++ b/scripts/agent/install-native.sh
@@ -52,6 +52,14 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# An install that already serves the LAN speed test keeps serving it, whether or not the flag was
+# repeated on this run. Without this, re-running to update the binary quietly stopped refreshing the
+# nginx config while agent.json (deliberately preserved) kept the speed test switched on - so the two
+# could end up disagreeing about the loopback relay port, and results would silently stop posting.
+if [ "$LAN_SPEED_TEST" != true ] && grep -q '"lanSpeedTest"[[:space:]]*:[[:space:]]*true' "${INSTALL_DIR}/agent.json" 2>/dev/null; then
+    LAN_SPEED_TEST=true
+fi
+
 # --- Output helpers -----------------------------------------------------------
 # Colorized, structured output; colors collapse to empty when stdout isn't a
 # terminal (piped/redirected/logged), so captured output stays clean.

--- a/src/NetworkOptimizer.Agent/Iperf3Runner.cs
+++ b/src/NetworkOptimizer.Agent/Iperf3Runner.cs
@@ -50,7 +50,11 @@ public static class Iperf3Runner
                 }
 
                 Console.WriteLine("iperf3 server running (default port 5201)");
-                _ = CaptureResultsAsync(process.StandardOutput, relayResult, ct);
+                // iperf3 -J reports a refusal to start on STDOUT as {"error": "..."} rather than on
+                // stderr, so the only account of why it would not start arrives through the same
+                // stream as the results. Kept here so the exit can be explained with it.
+                var stdoutError = new ErrorSink();
+                var stdout = CaptureResultsAsync(process.StandardOutput, relayResult, stdoutError, ct);
                 // Kept rather than drained: when iperf3 refuses to start, its reason is the only
                 // thing that distinguishes "someone else already has 5201" from a real fault, and
                 // discarding it left an exit code and nothing to act on.
@@ -67,8 +71,9 @@ public static class Iperf3Runner
                     continue;
                 }
 
+                await stdout;
                 var detail = await stderr;
-                var reason = string.IsNullOrWhiteSpace(detail) ? $"exit code {process.ExitCode}" : detail!.Trim();
+                var reason = FirstNonEmpty(stdoutError.Message, detail) ?? $"exit code {process.ExitCode}";
 
                 if (DateTime.UtcNow - startedAt > HealthyRun)
                 {
@@ -120,6 +125,32 @@ public static class Iperf3Runner
         }
     }
 
+    /// <summary>Holds the last error iperf3 wrote to stdout, for explaining an exit.</summary>
+    private sealed class ErrorSink
+    {
+        public string? Message;
+    }
+
+    private static string? FirstNonEmpty(params string?[] candidates) =>
+        candidates.FirstOrDefault(c => !string.IsNullOrWhiteSpace(c))?.Trim();
+
+    /// <summary>The "error" text of an iperf3 JSON object, or null if it has none.</summary>
+    private static string? ErrorTextOf(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("error", out var error)
+                ? error.GetString()
+                : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static TimeSpan BackoffFor(int failures)
     {
         var seconds = FirstRetry.TotalSeconds * Math.Pow(2, Math.Max(0, failures - 1));
@@ -134,7 +165,7 @@ public static class Iperf3Runner
     /// Brace-counts <c>iperf3 -s -J</c> stdout to isolate each completed test's JSON object and
     /// relays it, mirroring the central <c>Iperf3ServerService</c>'s capture exactly.
     /// </summary>
-    private static async Task CaptureResultsAsync(StreamReader reader, Func<string, CancellationToken, Task>? relayResult, CancellationToken ct)
+    private static async Task CaptureResultsAsync(StreamReader reader, Func<string, CancellationToken, Task>? relayResult, ErrorSink errors, CancellationToken ct)
     {
         var accumulator = new JsonObjectAccumulator();
         try
@@ -149,6 +180,8 @@ public static class Iperf3Runner
                     // non-result to the server on every restart, which answered 404 each time.
                     if (relayResult != null && IsTestResult(json))
                         _ = relayResult(json, ct);
+                    else
+                        errors.Message = ErrorTextOf(json) ?? errors.Message;
                 });
             }
         }

--- a/src/NetworkOptimizer.Agent/Iperf3Runner.cs
+++ b/src/NetworkOptimizer.Agent/Iperf3Runner.cs
@@ -21,6 +21,8 @@ public static class Iperf3Runner
     // A server that stayed up this long was working; the next failure starts a fresh backoff rather
     // than inheriting the delay from whatever went wrong before it.
     private static readonly TimeSpan HealthyRun = TimeSpan.FromMinutes(1);
+    // Long enough for a bind to fail, short enough not to delay a healthy start noticeably.
+    private static readonly TimeSpan StartupGrace = TimeSpan.FromSeconds(2);
 
     public static async Task RunAsync(Func<string, CancellationToken, Task>? relayResult, CancellationToken ct)
     {
@@ -49,7 +51,10 @@ public static class Iperf3Runner
                     return;
                 }
 
-                Console.WriteLine("iperf3 server running (default port 5201)");
+                // Announced only once it has survived a moment. Saying it the instant the process
+                // starts claimed a server was running every ten seconds on a host where it could
+                // never bind - the one line in the log that was reliably untrue.
+                var announced = false;
                 // iperf3 -J reports a refusal to start on STDOUT as {"error": "..."} rather than on
                 // stderr, so the only account of why it would not start arrives through the same
                 // stream as the results. Kept here so the exit can be explained with it.
@@ -59,10 +64,18 @@ public static class Iperf3Runner
                 // thing that distinguishes "someone else already has 5201" from a real fault, and
                 // discarding it left an exit code and nothing to act on.
                 var stderr = CaptureLastLineAsync(process.StandardError, ct);
-                await process.WaitForExitAsync(ct);
+
+                var exited = process.WaitForExitAsync(ct);
+                if (await Task.WhenAny(exited, Task.Delay(StartupGrace, ct)) != exited)
+                {
+                    Console.WriteLine("iperf3 server running (default port 5201)");
+                    announced = true;
+                    await exited;
+                }
 
                 if (process.ExitCode == 0)
                 {
+                    if (announced) Console.WriteLine("iperf3 server stopped, restarting");
                     // A clean exit is a stop we did not ask for (a signal, usually). Start again,
                     // but not instantly - an immediate loop here would spin.
                     failures = 0;

--- a/src/NetworkOptimizer.Agent/Iperf3Runner.cs
+++ b/src/NetworkOptimizer.Agent/Iperf3Runner.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Text.Json;
 using NetworkOptimizer.AgentProtocol;
 using NetworkOptimizer.Core.Helpers;
 
@@ -15,11 +16,21 @@ namespace NetworkOptimizer.Agent;
 /// </summary>
 public static class Iperf3Runner
 {
+    private static readonly TimeSpan FirstRetry = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan MaxRetry = TimeSpan.FromMinutes(5);
+    // A server that stayed up this long was working; the next failure starts a fresh backoff rather
+    // than inheriting the delay from whatever went wrong before it.
+    private static readonly TimeSpan HealthyRun = TimeSpan.FromMinutes(1);
+
     public static async Task RunAsync(Func<string, CancellationToken, Task>? relayResult, CancellationToken ct)
     {
+        var failures = 0;
+        string? lastReason = null;
+
         while (!ct.IsCancellationRequested)
         {
             Process? process = null;
+            var startedAt = DateTime.UtcNow;
             try
             {
                 // Shared server args (-s -p {port} -J) so the emitted per-test JSON matches what
@@ -40,9 +51,50 @@ public static class Iperf3Runner
 
                 Console.WriteLine("iperf3 server running (default port 5201)");
                 _ = CaptureResultsAsync(process.StandardOutput, relayResult, ct);
-                _ = DrainAsync(process.StandardError, ct);
+                // Kept rather than drained: when iperf3 refuses to start, its reason is the only
+                // thing that distinguishes "someone else already has 5201" from a real fault, and
+                // discarding it left an exit code and nothing to act on.
+                var stderr = CaptureLastLineAsync(process.StandardError, ct);
                 await process.WaitForExitAsync(ct);
-                Console.Error.WriteLine($"iperf3 exited with code {process.ExitCode}, restarting in 10 seconds");
+
+                if (process.ExitCode == 0)
+                {
+                    // A clean exit is a stop we did not ask for (a signal, usually). Start again,
+                    // but not instantly - an immediate loop here would spin.
+                    failures = 0;
+                    lastReason = null;
+                    await Task.Delay(FirstRetry, ct);
+                    continue;
+                }
+
+                var detail = await stderr;
+                var reason = string.IsNullOrWhiteSpace(detail) ? $"exit code {process.ExitCode}" : detail!.Trim();
+
+                if (DateTime.UtcNow - startedAt > HealthyRun)
+                {
+                    failures = 0;
+                    lastReason = null;
+                }
+                failures++;
+
+                var delay = BackoffFor(failures);
+                // Say it once. This loop ran forever at a fixed ten seconds, so a port that was
+                // never going to free up produced an identical pair of lines every ten seconds for
+                // as long as the agent lived.
+                if (reason != lastReason)
+                {
+                    lastReason = reason;
+                    Console.Error.WriteLine(IsPortInUse(reason)
+                        ? "iperf3 could not take port 5201 - something else on this host is already "
+                          + $"serving it. LAN iperf3 tests will not run until that stops. ({reason})"
+                        : $"iperf3 exited: {reason}");
+                    Console.Error.WriteLine($"Retrying every {delay.TotalSeconds:0}s"
+                        + (delay < MaxRetry ? $", backing off to {MaxRetry.TotalMinutes:0} minutes" : "")
+                        + " until it starts.");
+                }
+
+                await Task.Delay(delay, ct);
+                continue;
             }
             catch (OperationCanceledException)
             {
@@ -63,10 +115,20 @@ public static class Iperf3Runner
                 process?.Dispose();
             }
 
-            try { await Task.Delay(TimeSpan.FromSeconds(10), ct); }
+            try { await Task.Delay(BackoffFor(++failures), ct); }
             catch (OperationCanceledException) { return; }
         }
     }
+
+    private static TimeSpan BackoffFor(int failures)
+    {
+        var seconds = FirstRetry.TotalSeconds * Math.Pow(2, Math.Max(0, failures - 1));
+        return TimeSpan.FromSeconds(Math.Min(seconds, MaxRetry.TotalSeconds));
+    }
+
+    private static bool IsPortInUse(string reason) =>
+        reason.Contains("Address already in use", StringComparison.OrdinalIgnoreCase)
+        || reason.Contains("unable to start listener", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Brace-counts <c>iperf3 -s -J</c> stdout to isolate each completed test's JSON object and
@@ -82,7 +144,10 @@ public static class Iperf3Runner
             {
                 accumulator.Feed(line, json =>
                 {
-                    if (relayResult != null)
+                    // A refusal to start is also a JSON object on stdout ({"error": "..."}), so the
+                    // brace-counter cannot tell it from a finished test. Relaying it posted a
+                    // non-result to the server on every restart, which answered 404 each time.
+                    if (relayResult != null && IsTestResult(json))
                         _ = relayResult(json, ct);
                 });
             }
@@ -93,17 +158,37 @@ public static class Iperf3Runner
         }
     }
 
-    private static async Task DrainAsync(StreamReader reader, CancellationToken ct)
+    /// <summary>A finished test carries an "end" section; iperf3's error objects carry "error".</summary>
+    private static bool IsTestResult(string json)
     {
         try
         {
-            while (!ct.IsCancellationRequested && await reader.ReadLineAsync(ct) != null)
+            using var doc = JsonDocument.Parse(json);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && !doc.RootElement.TryGetProperty("error", out _)
+                && doc.RootElement.TryGetProperty("end", out _);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static async Task<string?> CaptureLastLineAsync(StreamReader reader, CancellationToken ct)
+    {
+        string? last = null;
+        try
+        {
+            string? line;
+            while (!ct.IsCancellationRequested && (line = await reader.ReadLineAsync(ct)) != null)
             {
+                if (!string.IsNullOrWhiteSpace(line)) last = line;
             }
         }
         catch
         {
-            // Process ended or cancelled - nothing to drain.
+            // Process ended or cancelled - whatever we have is what we report.
         }
+        return last;
     }
 }

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -281,7 +281,7 @@ while (!cts.IsCancellationRequested)
         var drainTask = tunnel.DrainResultsAsync(resultBuffer, connectionCts.Token);
         try
         {
-            await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp, config.IgnoreSslErrors, cts.Token);
+            await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp, config.LanSpeedTestPort, config.IgnoreSslErrors, cts.Token);
             Console.Error.WriteLine("Tunnel closed by server, reconnecting...");
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -285,7 +285,8 @@ while (!cts.IsCancellationRequested)
             // serves none - a gateway install, or one where the server failed to start - has no
             // port to give, and claiming 3000 would advertise a listener that is not there.
             await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp,
-                speedTestServer != null ? config.LanSpeedTestPort : 0, config.IgnoreSslErrors, cts.Token);
+                speedTestServer != null ? config.LanSpeedTestPort : 0,
+                speedTestServer != null, config.IgnoreSslErrors, cts.Token);
             Console.Error.WriteLine("Tunnel closed by server, reconnecting...");
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -281,7 +281,11 @@ while (!cts.IsCancellationRequested)
         var drainTask = tunnel.DrainResultsAsync(resultBuffer, connectionCts.Token);
         try
         {
-            await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp, config.LanSpeedTestPort, config.IgnoreSslErrors, cts.Token);
+            // Announce the port only when a speed test server is actually up. An agent that
+            // serves none - a gateway install, or one where the server failed to start - has no
+            // port to give, and claiming 3000 would advertise a listener that is not there.
+            await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp,
+                speedTestServer != null ? config.LanSpeedTestPort : 0, config.IgnoreSslErrors, cts.Token);
             Console.Error.WriteLine("Tunnel closed by server, reconnecting...");
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -212,6 +212,11 @@ Task? watchdogTask = null;
 var spoolPath = Path.Combine(
     Path.GetDirectoryName(Path.GetFullPath(configPath)) ?? ".", "result-spool.bin");
 
+// How far back from a stop a result may have been corrupted by it: the longest a ping burst can
+// still be running when the signal lands. Generous rather than tight - losing a few seconds of
+// samples at a restart costs nothing next to a false loss spike that outlives it.
+var shutdownBoundary = TimeSpan.FromSeconds(5);
+
 // Best-effort spool of the unacked backlog for the next process to replay.
 // Called on graceful shutdown and by the async-I/O watchdog right before its
 // restart exit, so restarts don't cost the outage data the buffer exists for.
@@ -219,9 +224,20 @@ void SaveSpool()
 {
     if (resultBuffer is not { Count: > 0 })
         return;
+    // Anything measured in the last few seconds may have had its ping children killed underneath it
+    // by the same signal that is stopping us, which reads as loss it never saw. Drop that tail
+    // rather than persist it - see ResultBuffer.DropTail.
+    var poisoned = resultBuffer.DropTail(shutdownBoundary);
+    if (resultBuffer.Count == 0)
+    {
+        if (poisoned > 0)
+            Console.WriteLine($"Discarded {poisoned} result message(s) measured across the shutdown");
+        return;
+    }
     var count = resultBuffer.Count;
     resultBuffer.SaveTo(spoolPath);
-    Console.WriteLine($"Spooled {count} unsent result message(s) for the next start");
+    Console.WriteLine($"Spooled {count} unsent result message(s) for the next start"
+        + (poisoned > 0 ? $"; discarded {poisoned} measured across the shutdown" : ""));
 }
 
 if (!string.IsNullOrEmpty(config.TunnelUrl))

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -91,6 +91,16 @@ var version = Assembly.GetExecutingAssembly()
 // NO_AGENT_LAN_IP overrides auto-detection for deployments where it can't see the
 // real LAN address (e.g. Docker bridge mode instead of host, or multi-NIC hosts).
 var lanIpOverride = Environment.GetEnvironmentVariable("NO_AGENT_LAN_IP");
+
+// The port the speed test page is served on, for the announcement to the server. nginx is what
+// actually listens, and in a container the entrypoint moves that listener from an environment
+// variable - so the same variable has to reach the announcement, or the agent would report a port
+// nginx is no longer using. Native installs do not set the variable - they record the port in
+// agent.json instead, which is what the fallback reads.
+static int SpeedTestPagePort(NetworkOptimizer.Agent.AgentConfig cfg) =>
+    int.TryParse(Environment.GetEnvironmentVariable("AGENT_SPEEDTEST_PORT"), out var p) && p > 0
+        ? p
+        : cfg.LanSpeedTestPort;
 var lanIp = !string.IsNullOrWhiteSpace(lanIpOverride)
     ? lanIpOverride.Trim()
     : NetworkOptimizer.Core.Helpers.NetworkUtilities.DetectLocalIpFromInterfaces();
@@ -283,9 +293,9 @@ while (!cts.IsCancellationRequested)
         {
             // Announce the port only when a speed test server is actually up. An agent that
             // serves none - a gateway install, or one where the server failed to start - has no
-            // port to give, and claiming 3000 would advertise a listener that is not there.
+            // port to give, and claiming a port would advertise a listener that is not there.
             await tunnel.RunAsync(config.TunnelUrl, config.AgentKey!, version, lanIp,
-                speedTestServer != null ? config.LanSpeedTestPort : 0,
+                speedTestServer != null ? SpeedTestPagePort(config) : 0,
                 speedTestServer != null, config.IgnoreSslErrors, cts.Token);
             Console.Error.WriteLine("Tunnel closed by server, reconnecting...");
         }
@@ -383,7 +393,7 @@ namespace NetworkOptimizer.Agent
         string? TunnelUrl = null,
         string? ProbeSourceIp = null,
         bool LanSpeedTest = false,
-        int LanSpeedTestPort = 3000,
+        int LanSpeedTestPort = 24443,
         IReadOnlyList<string>? ProxyAllowedCidrs = null);
 
     public record EnrollmentResponse(string AgentKey, string SiteSlug, int? TunnelPort = null);

--- a/src/NetworkOptimizer.Agent/Program.cs
+++ b/src/NetworkOptimizer.Agent/Program.cs
@@ -93,10 +93,11 @@ var version = Assembly.GetExecutingAssembly()
 var lanIpOverride = Environment.GetEnvironmentVariable("NO_AGENT_LAN_IP");
 
 // The port the speed test page is served on, for the announcement to the server. nginx is what
-// actually listens, and in a container the entrypoint moves that listener from an environment
-// variable - so the same variable has to reach the announcement, or the agent would report a port
-// nginx is no longer using. Native installs do not set the variable - they record the port in
-// agent.json instead, which is what the fallback reads.
+// actually listens, so both have to resolve it the same way: the environment variable first (the
+// container's entrypoint moves nginx's listener from it), then whatever agent.json records, then
+// the built-in default. An agent enrolled before the port was configurable has the old 3000 in its
+// config and keeps serving it - upgrading should not move a port that clients and firewall rules
+// already know about. New installs get the current default instead.
 static int SpeedTestPagePort(NetworkOptimizer.Agent.AgentConfig cfg) =>
     int.TryParse(Environment.GetEnvironmentVariable("AGENT_SPEEDTEST_PORT"), out var p) && p > 0
         ? p

--- a/src/NetworkOptimizer.Agent/ProxyHandler.cs
+++ b/src/NetworkOptimizer.Agent/ProxyHandler.cs
@@ -63,9 +63,18 @@ public sealed class ProxyHandler
                 await SendOpenFailureAsync(open.ConnectionId, $"could not resolve '{open.Host}': {ex.Message}", ct);
                 return;
             }
+            // A name the resolver cannot answer for does not always throw: it can come back as the
+            // unspecified address (:: or 0.0.0.0), which is not a host anyone can dial. Left in, it
+            // reached the scope check and was refused there, reporting a policy problem for what is
+            // really a name this agent cannot resolve - and sending whoever read it looking in the
+            // wrong place entirely.
+            addresses = addresses.Where(a => !a.Equals(IPAddress.Any) && !a.Equals(IPAddress.IPv6Any)).ToArray();
             if (addresses.Length == 0)
             {
-                await SendOpenFailureAsync(open.ConnectionId, $"'{open.Host}' resolved to no addresses", ct);
+                var msg = $"could not resolve '{open.Host}' from this agent - use an address the "
+                    + "site's network can reach, or give the agent host a name server that knows it";
+                Console.Error.WriteLine($"Proxy dial DENIED: {open.Host}:{open.Port} (conn {open.ConnectionId}) - {msg}");
+                await SendOpenFailureAsync(open.ConnectionId, msg, ct);
                 return;
             }
         }

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -124,7 +124,12 @@ Downloads the self-contained binary (no .NET runtime or Docker), writes
 
 Both scripts accept:
 
-- `--lan-speed-test` - host the LAN speed test page (port 3000) and iperf3 (5201). The only feature that uses nginx.
+- `--lan-speed-test` - host the LAN speed test page (port 24443) and iperf3 (5201). The only feature that uses nginx.
+- `--speed-test-port N` - serve that page on `N` instead of 24443, for a host where 24443 is taken
+  or where you would rather use something else (443, if nothing else on the box wants it). Moves
+  nginx's listener and records the port in `agent.json`; the agent announces it to the server, so
+  in-app speed test links follow with no override needed. Docker equivalent: `AGENT_SPEEDTEST_PORT=N`
+  in the container environment.
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
 
@@ -224,15 +229,16 @@ The LAN speed test listener serves self-signed HTTPS by default (a secure
 context, so browser geolocation works for GPS-tagged results). Two supported
 deviations, and **both require updating the site's speed test URL override in
 the central app** (Settings > Multi-Site > the site's Configuration), because
-the app builds agent speed-test links as `https://<agent LAN IP>:3000` by
-default:
+the app builds agent speed-test links from the port the agent announces, defaulting to
+`https://<agent LAN IP>:24443`:
 
 - **Plain HTTP opt-out**: set `AGENT_SPEEDTEST_TLS=0` (an environment variable
   on the Docker container, or in the environment when running
-  `install-native.sh`) to skip cert generation and serve HTTP on port 3000 -
+  `install-native.sh`) to skip cert generation and serve HTTP on port 24443 -
   e.g. to avoid the self-signed trust prompt or shave TLS overhead on a
   high-throughput LAN. Then set the site's URL override to the matching
-  `http://<agent>:3000` address.
+  `http://<agent>:24443` address - the announcement carries the port but not the
+  scheme, and the app defaults to https.
 - **Your own reverse proxy / TLS in front of the agent**: point the site's URL
   override at the proxy's address (e.g. `https://speedtest.site.example.com`).
   The auto-detected agent LAN IP would otherwise bypass your proxy and hit the
@@ -533,7 +539,7 @@ the server's own prober), streaming results back for storage.
 ## LAN speed test serving
 
 Set `"lanSpeedTest": true` and the site's clients get an OpenSpeedTest page on
-port 3000. **nginx** serves the page and the throughput-critical download/upload
+port 24443 (`"lanSpeedTestPort"` to change it). **nginx** serves the page and the throughput-critical download/upload
 legs (sendfile, so it saturates 10 GbE on modest hardware where a .NET server
 would go CPU-bound) - the Docker image bundles it, and `install-native.sh`
 installs and configures it for the bare-metal install. The .NET agent keeps only

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -130,6 +130,17 @@ Both scripts accept:
   nginx's listener and records the port in `agent.json`; the agent announces it to the server, so
   in-app speed test links follow with no override needed. Docker equivalent: `AGENT_SPEEDTEST_PORT=N`
   in the container environment.
+
+Both nginx and the agent resolve the port the same way, so the listener and the announcement can
+never disagree: the environment variable if set, otherwise `"lanSpeedTestPort"` from `agent.json`,
+otherwise 24443. Two consequences worth knowing:
+
+- **An existing install keeps the port it is already serving.** The agent records its whole config
+  on enrollment, so agents set up before the page port was configurable have `3000` written there
+  and go on using it - an upgrade will not move a page that clients and firewall rules already know
+  about. Re-running the installer without `--speed-test-port` preserves it too.
+- **To adopt the current default, delete the `"lanSpeedTestPort"` line** from `agent.json` and
+  restart the agent. That is also the way out if an agent ever ends up on a port that does not work.
 - `--insecure` - accept a self-signed cert on the server's reverse proxy
 - `--dir PATH` - override the install directory
 
@@ -539,7 +550,7 @@ the server's own prober), streaming results back for storage.
 ## LAN speed test serving
 
 Set `"lanSpeedTest": true` and the site's clients get an OpenSpeedTest page on
-port 24443 (`"lanSpeedTestPort"` to change it). **nginx** serves the page and the throughput-critical download/upload
+port 24443, or whatever `"lanSpeedTestPort"` records (see above). **nginx** serves the page and the throughput-critical download/upload
 legs (sendfile, so it saturates 10 GbE on modest hardware where a .NET server
 would go CPU-bound) - the Docker image bundles it, and `install-native.sh`
 installs and configures it for the bare-metal install. The .NET agent keeps only

--- a/src/NetworkOptimizer.Agent/SpeedTestServer.cs
+++ b/src/NetworkOptimizer.Agent/SpeedTestServer.cs
@@ -24,10 +24,13 @@ public sealed class SpeedTestServer : IAsyncDisposable
     ///
     /// Was 3001, which Grafana takes by default - and an agent sharing a host with Grafana had its
     /// result posts proxied straight into Grafana, which answered 401. Loopback-only and internal,
-    /// so it is free to move somewhere nothing else wants: 18042 echoes the server's own 8042, sits
-    /// outside the Linux ephemeral range, and is registered to nothing.
+    /// so it is free to move somewhere nothing else wants: 24042 echoes the server's own 8042, sits
+    /// below the Linux ephemeral range so a boot-time bind cannot lose a race to an outbound
+    /// connection, and is registered to nothing. 18042 was the first pick and is out: UniFi OS
+    /// Server already listens on 18443, and neighbouring a product this runs alongside is the
+    /// mistake 3001 made.
     /// </summary>
-    public const int RelayPort = 18042;
+    public const int RelayPort = 24042;
 
     /// <summary>One WAN speed-test server the /wan/ router can redirect to.</summary>
     public sealed record WanServerEntry(string ServerId, string Url);

--- a/src/NetworkOptimizer.Agent/SpeedTestServer.cs
+++ b/src/NetworkOptimizer.Agent/SpeedTestServer.cs
@@ -19,8 +19,15 @@ namespace NetworkOptimizer.Agent;
 /// </summary>
 public sealed class SpeedTestServer : IAsyncDisposable
 {
-    /// <summary>Loopback port the relay binds; nginx proxies /api/public/speedtest/* here.</summary>
-    public const int RelayPort = 3001;
+    /// <summary>
+    /// Loopback port the relay binds; nginx proxies /api/public/speedtest/* here.
+    ///
+    /// Was 3001, which Grafana takes by default - and an agent sharing a host with Grafana had its
+    /// result posts proxied straight into Grafana, which answered 401. Loopback-only and internal,
+    /// so it is free to move somewhere nothing else wants: 18042 echoes the server's own 8042, sits
+    /// outside the Linux ephemeral range, and is registered to nothing.
+    /// </summary>
+    public const int RelayPort = 18042;
 
     /// <summary>One WAN speed-test server the /wan/ router can redirect to.</summary>
     public sealed record WanServerEntry(string ServerId, string Url);

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -116,7 +116,7 @@ public sealed class TunnelClient
     /// Connects and runs the tunnel until it drops or <paramref name="ct"/> is
     /// cancelled. Throws on connection failure so the caller can back off and retry.
     /// </summary>
-    public async Task RunAsync(string tunnelUrl, string agentKey, string version, string? lanIp, bool ignoreSslErrors, CancellationToken ct)
+    public async Task RunAsync(string tunnelUrl, string agentKey, string version, string? lanIp, int speedTestPort, bool ignoreSslErrors, CancellationToken ct)
     {
         // Belt-and-braces with the startup config validation: the tunnel carries
         // SNMP credentials and proxied console traffic, so cleartext is never OK.
@@ -168,7 +168,7 @@ public sealed class TunnelClient
 
             await call.RequestStream.WriteAsync(new AgentMessage
             {
-                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "" }
+                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "", SpeedTestPort = speedTestPort }
             }, helloCts.Token);
 
             if (!await call.ResponseStream.MoveNext(helloCts.Token) || call.ResponseStream.Current.Hello is not { } hello)

--- a/src/NetworkOptimizer.Agent/TunnelClient.cs
+++ b/src/NetworkOptimizer.Agent/TunnelClient.cs
@@ -116,7 +116,7 @@ public sealed class TunnelClient
     /// Connects and runs the tunnel until it drops or <paramref name="ct"/> is
     /// cancelled. Throws on connection failure so the caller can back off and retry.
     /// </summary>
-    public async Task RunAsync(string tunnelUrl, string agentKey, string version, string? lanIp, int speedTestPort, bool ignoreSslErrors, CancellationToken ct)
+    public async Task RunAsync(string tunnelUrl, string agentKey, string version, string? lanIp, int speedTestPort, bool servesSpeedTest, bool ignoreSslErrors, CancellationToken ct)
     {
         // Belt-and-braces with the startup config validation: the tunnel carries
         // SNMP credentials and proxied console traffic, so cleartext is never OK.
@@ -168,7 +168,7 @@ public sealed class TunnelClient
 
             await call.RequestStream.WriteAsync(new AgentMessage
             {
-                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "", SpeedTestPort = speedTestPort }
+                Hello = new AgentHello { AgentKey = agentKey, Version = version, LanIp = lanIp ?? "", SpeedTestPort = speedTestPort, ServesSpeedTest = servesSpeedTest }
             }, helloCts.Token);
 
             if (!await call.ResponseStream.MoveNext(helloCts.Token) || call.ResponseStream.Current.Hello is not { } hello)

--- a/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
+++ b/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
@@ -137,6 +137,11 @@ message AgentHello {
   // pointing clients at the wrong place. Absent or 0 is an older agent that does
   // not say - the server assumes 3000, which is what those agents serve.
   int32 speed_test_port = 4;
+  // Whether this agent serves a LAN speed test page at all. Explicitly optional so
+  // the server can tell "no" from "did not say": an agent predating this leaves it
+  // absent and the server falls back to deciding for itself, while a gateway
+  // install answers a definite no without being guessed at by its location.
+  optional bool serves_speed_test = 5;
 }
 
 message ServerHello {

--- a/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
+++ b/src/NetworkOptimizer.AgentProtocol/Protos/agent_tunnel.proto
@@ -132,6 +132,11 @@ message AgentHello {
   string agent_key = 1;
   string version = 2;
   string lan_ip = 3;
+  // Port this agent serves its LAN speed test page on. The server used to assume
+  // 3000, which meant the agent could never move off it without every server
+  // pointing clients at the wrong place. Absent or 0 is an older agent that does
+  // not say - the server assumes 3000, which is what those agents serve.
+  int32 speed_test_port = 4;
 }
 
 message ServerHello {

--- a/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
+++ b/src/NetworkOptimizer.AgentProtocol/ResultBuffer.cs
@@ -163,6 +163,38 @@ public sealed class ResultBuffer
     /// instead of losing it with the process. Deliberately synchronous file
     /// I/O: the async-engine watchdog calls this while async I/O is wedged.
     /// </summary>
+    /// <summary>
+    /// Drops entries enqueued within <paramref name="window"/> of now, newest first, and reports how
+    /// many went.
+    ///
+    /// For the shutdown boundary. systemd delivers SIGTERM to the whole control group, so the ping
+    /// children die at the same instant the agent starts stopping - a burst in flight then completes
+    /// with fewer replies than it sent and looks exactly like real loss. The cancellation check on
+    /// the probe path catches the common case, but not the race where the result is built before the
+    /// flag is observed, and once built it is an ordinary unsent message that the spool faithfully
+    /// preserves and replays. A blip planted this way is indistinguishable from a genuine one after
+    /// the fact.
+    ///
+    /// Dropping by time rather than by count is what keeps this safe: a server outage can leave a
+    /// long backlog, and taking a fixed number of messages off the tail would eat real samples. Only
+    /// the last few seconds can straddle the stop.
+    /// </summary>
+    public int DropTail(TimeSpan window)
+    {
+        lock (_lock)
+        {
+            var cutoff = DateTime.UtcNow - window;
+            var dropped = 0;
+            while (_entries.Last is { } last && last.Value.EnqueuedUtc >= cutoff)
+            {
+                _bytes -= last.Value.SizeBytes;
+                _entries.RemoveLast();
+                dropped++;
+            }
+            return dropped;
+        }
+    }
+
     public void SaveTo(string path)
     {
         lock (_lock)

--- a/src/NetworkOptimizer.Storage/Migrations/20260802040000_AddWanProfile.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260802040000_AddWanProfile.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802040000_AddWanProfile")]
+    partial class AddWanProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -2421,9 +2424,6 @@ namespace NetworkOptimizer.Storage.Migrations
                         .IsRequired()
                         .HasMaxLength(255)
                         .HasColumnType("TEXT");
-
-                    b.Property<bool>("RateProportionalDownloadBurst")
-                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SpeedtestEveningHour")
                         .HasColumnType("INTEGER");

--- a/src/NetworkOptimizer.Storage/Migrations/20260802040000_AddWanProfile.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260802040000_AddWanProfile.cs
@@ -1,0 +1,45 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWanProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WanProfiles",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    WanNetworkgroup = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    Interface = table.Column<string>(type: "TEXT", maxLength: 100, nullable: true),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 200, nullable: true),
+                    DownloadMbps = table.Column<double>(type: "REAL", nullable: true),
+                    UploadMbps = table.Column<double>(type: "REAL", nullable: true),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WanProfiles", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WanProfiles_WanNetworkgroup",
+                table: "WanProfiles",
+                column: "WanNetworkgroup",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "WanProfiles");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260802050000_SplitWanProfileInterfaces.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260802050000_SplitWanProfileInterfaces.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802050000_SplitWanProfileInterfaces")]
+    partial class SplitWanProfileInterfaces
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -2421,9 +2424,6 @@ namespace NetworkOptimizer.Storage.Migrations
                         .IsRequired()
                         .HasMaxLength(255)
                         .HasColumnType("TEXT");
-
-                    b.Property<bool>("RateProportionalDownloadBurst")
-                        .HasColumnType("INTEGER");
 
                     b.Property<int>("SpeedtestEveningHour")
                         .HasColumnType("INTEGER");

--- a/src/NetworkOptimizer.Storage/Migrations/20260802050000_SplitWanProfileInterfaces.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260802050000_SplitWanProfileInterfaces.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class SplitWanProfileInterfaces : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // One name could not serve both jobs: throughput is keyed on the physical port because
+            // VLAN sub-interface counters double, while SQM and PPPoE detection need the logical
+            // uplink. The existing value was the data path, so it keeps that meaning.
+            migrationBuilder.RenameColumn(
+                name: "Interface", table: "WanProfiles", newName: "DataPathInterface");
+
+            migrationBuilder.AddColumn<string>(
+                name: "CounterInterface", table: "WanProfiles", type: "TEXT", maxLength: 100, nullable: true);
+
+            // Stored WAN rates are keyed on gateway MAC + interface, so caching one without the
+            // other still leaves an offline site unable to read its own history.
+            migrationBuilder.AddColumn<string>(
+                name: "GatewayMac", table: "WanProfiles", type: "TEXT", maxLength: 50, nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "CounterInterface", table: "WanProfiles");
+            migrationBuilder.DropColumn(name: "GatewayMac", table: "WanProfiles");
+            migrationBuilder.RenameColumn(
+                name: "DataPathInterface", table: "WanProfiles", newName: "Interface");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringSettings.cs
@@ -77,7 +77,13 @@ public class MonitoringSettings
     public DateTime? LastSnmpDetection { get; set; }
     public DateTime? LastSnmpSuccess { get; set; }
 
-    // Access ISP context (set by the upstream wizard, used for first-mile labelling)
+    // Access ISP context (set by the upstream wizard, used for first-mile labelling).
+    //
+    // MOVE TO WanProfile: all three describe ONE WAN's first mile, but there is one set per site, so
+    // a second WAN cannot be described at all - a site with fiber and an LTE backup gets whichever
+    // the wizard looked at last. ISP Health and Monitoring are multi-WAN planned; WanProfile is the
+    // per-WAN home these belong in. Left here until each reader is taught to ask per WAN, so one
+    // place holds each fact rather than two disagreeing ones.
     public AccessTechnology AccessTechnology { get; set; } = AccessTechnology.Unknown;
 
     [MaxLength(50)]

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -68,6 +68,14 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<ApNeighborSighting> ApNeighborSightings { get; set; }
     public DbSet<Site> Sites { get; set; }
     public DbSet<WanContext> WanContexts { get; set; }
+
+    /// <summary>
+    /// What we have determined per WAN, starting with the expected ISP speeds read from the console.
+    /// The site's first per-WAN table: AccessTechnology and the WAN neighbor fields still sit on
+    /// MonitoringSettings, one set per site. ISP Health and Monitoring are multi-WAN planned, so a
+    /// new per-WAN fact belongs here rather than as another single-WAN field on the settings row.
+    /// </summary>
+    public DbSet<WanProfile> WanProfiles { get; set; }
     public DbSet<SiteAgent> SiteAgents { get; set; }
     public DbSet<LicenseKeyRecord> LicenseKeyRecords { get; set; }
     public DbSet<SiteLicenseAssignment> SiteLicenseAssignments { get; set; }
@@ -558,6 +566,12 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("ApNeighborSightings");
             entity.HasIndex(e => new { e.ApMac, e.Band, e.Bssid, e.Channel }).IsUnique();
             entity.HasIndex(e => e.LastSeenUtc);
+        });
+
+        modelBuilder.Entity<WanProfile>(entity =>
+        {
+            // One row per WAN: the console's own WAN group is the identity that survives a rename.
+            entity.HasIndex(e => e.WanNetworkgroup).IsUnique();
         });
     }
 }

--- a/src/NetworkOptimizer.Storage/Models/WanProfile.cs
+++ b/src/NetworkOptimizer.Storage/Models/WanProfile.cs
@@ -28,13 +28,35 @@ public class WanProfile
     [MaxLength(50)]
     public string WanNetworkgroup { get; set; } = string.Empty;
 
-    /// <summary>Interface name as reported when the speeds were read (eth4, ppp0). Diagnostic only.</summary>
+    /// <summary>
+    /// The data-path interface: the logical uplink the WAN payload rides - "eth4" plain, "eth4.100"
+    /// VLAN-tagged, "ppp0" for PPPoE. What SQM deploys on, and what PPPoE detection reads.
+    /// </summary>
     [MaxLength(100)]
-    public string? Interface { get; set; }
+    public string? DataPathInterface { get; set; }
+
+    /// <summary>
+    /// The interface whose counters represent this WAN's throughput. NOT the same as
+    /// <see cref="DataPathInterface"/> on a VLAN-tagged WAN: the sub-interface double-counts on some
+    /// kernels, so the physical port wins there, while ppp0/gre1 win over their physical port
+    /// because those carry exactly the WAN payload. See NetworkUtilities.PreferredWanCounterInterface,
+    /// which is what fills this - the two names are stored separately because using one for the
+    /// other's job silently reports the wrong throughput.
+    /// </summary>
+    [MaxLength(100)]
+    public string? CounterInterface { get; set; }
 
     /// <summary>The WAN's display name when the speeds were read. Diagnostic only.</summary>
     [MaxLength(200)]
     public string? Name { get; set; }
+
+    /// <summary>
+    /// The gateway whose port counters serve this WAN, as the throughput series are tagged. Cached
+    /// with the interface names because the pair is useless apart: querying stored WAN rates needs
+    /// both, and both otherwise come from a console read.
+    /// </summary>
+    [MaxLength(50)]
+    public string? GatewayMac { get; set; }
 
     /// <summary>Expected download in Mbps, null when the console reported none.</summary>
     public double? DownloadMbps { get; set; }

--- a/src/NetworkOptimizer.Storage/Models/WanProfile.cs
+++ b/src/NetworkOptimizer.Storage/Models/WanProfile.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// What we have determined about one WAN. This is the site's FIRST per-WAN table: everything of
+/// this kind lives on MonitoringSettings today - AccessTechnology, WanNeighborMac, WanNeighborOui -
+/// which stores per-WAN facts once per site and so cannot describe a second WAN at all. Those
+/// fields belong here and should move as each of their readers is taught to ask per WAN; they are
+/// deliberately not duplicated yet, so one place holds each fact.
+///
+/// ISP Health and Monitoring are multi-WAN planned. Keyed per WAN from the start rather than
+/// widened later, so a second WAN's row is already correct when multi-WAN scoring lands, and named
+/// broadly so the next per-WAN fact does not need another table.
+///
+/// The speeds are a cache of what the console said, never a user-editable setting: every successful
+/// console read overwrites the row, and <see cref="UpdatedAt"/> is what lets a report say a figure
+/// is remembered rather than current.
+/// </summary>
+public class WanProfile
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// UniFi's WAN group - "WAN", "WAN2". The stable identity across renames and interface changes,
+    /// so it is what the row is keyed on.
+    /// </summary>
+    [MaxLength(50)]
+    public string WanNetworkgroup { get; set; } = string.Empty;
+
+    /// <summary>Interface name as reported when the speeds were read (eth4, ppp0). Diagnostic only.</summary>
+    [MaxLength(100)]
+    public string? Interface { get; set; }
+
+    /// <summary>The WAN's display name when the speeds were read. Diagnostic only.</summary>
+    [MaxLength(200)]
+    public string? Name { get; set; }
+
+    /// <summary>Expected download in Mbps, null when the console reported none.</summary>
+    public double? DownloadMbps { get; set; }
+
+    /// <summary>Expected upload in Mbps, null when the console reported none.</summary>
+    public double? UploadMbps { get; set; }
+
+    /// <summary>When the console last confirmed these figures.</summary>
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1528,11 +1528,12 @@ from(bucket: ""{_bucket}"")
         DateTime from,
         DateTime to,
         TimeSpan? aggregateWindow = null,
+        int sampleIntervalSeconds = 5,
         CancellationToken ct = default)
     {
         if (!IsConfigured) await ReconfigureAsync(ct);
         if (!IsConfigured || wanIfNames.Count == 0) return Array.Empty<WanRatePoint>();
-        var window = aggregateWindow ?? PickAggregateWindow(to - from);
+        var window = aggregateWindow ?? PickAggregateWindow(to - from, sampleIntervalSeconds);
         var mac = NormalizeMac(deviceMac);
         var ifFilter = string.Join(" or ", wanIfNames.Select(n =>
             $@"r.if_name == ""{SanitizeFluxString(n)}"""));
@@ -2634,12 +2635,20 @@ from(bucket: ""{_longtermBucket}"")
                 yield return record;
     }
 
-    private static TimeSpan PickAggregateWindow(TimeSpan range)
+    /// <summary>
+    /// Bucket size for a range: about 150 points, floored so a short range cannot ask for buckets
+    /// finer than the data actually has.
+    ///
+    /// The floor defaults to 5 s, which was the sample interval when this was written. A caller
+    /// that knows its site's real interval passes it instead - otherwise a site polling faster has
+    /// the extra resolution averaged straight back out, and one polling slower gets buckets with
+    /// nothing in them.
+    /// </summary>
+    private static TimeSpan PickAggregateWindow(TimeSpan range, int floorSeconds = 5)
     {
-        // Target ~150 data points regardless of range. Floor at 5 s so short ranges
-        // don't produce sub-second windows that InfluxDB can't aggregate meaningfully.
         const int targetPoints = 150;
-        var windowSeconds = Math.Max(5, (int)(range.TotalSeconds / targetPoints));
+        var floor = Math.Max(1, floorSeconds);
+        var windowSeconds = Math.Max(floor, (int)(range.TotalSeconds / targetPoints));
         return TimeSpan.FromSeconds(windowSeconds);
     }
 

--- a/src/NetworkOptimizer.Storage/Services/SiteDatabasePaths.cs
+++ b/src/NetworkOptimizer.Storage/Services/SiteDatabasePaths.cs
@@ -13,6 +13,13 @@ public class SiteDatabasePaths
     /// <summary>Root folder holding one subfolder per non-default site.</summary>
     public string SitesRoot { get; }
 
+    /// <summary>
+    /// Slug of the default site. Site creation reserves it, so no managed site can ever take it -
+    /// which means a path request for it always means the main database, whatever the caller
+    /// believes about the flag.
+    /// </summary>
+    public const string DefaultSiteSlug = "main";
+
     public SiteDatabasePaths(string mainDbPath)
     {
         MainDbPath = mainDbPath;
@@ -24,7 +31,18 @@ public class SiteDatabasePaths
     /// <summary>Data folder for a non-default site, created on demand elsewhere.</summary>
     public string GetSiteDataDir(string slug) => Path.Combine(SitesRoot, slug);
 
-    /// <summary>Database file path for a site; the default site maps to the main database.</summary>
+    /// <summary>
+    /// Database file path for a site; the default site maps to the main database.
+    ///
+    /// The slug decides that as well as the flag. Callers that only ever handle managed sites pass
+    /// isDefault: false as a constant, which was correct until something started asking about the
+    /// default site through the same path - then it pointed at sites/main/network_optimizer.db, a
+    /// file that cannot exist, and the caller concluded the site was not provisioned. There is no
+    /// case where the default slug should resolve anywhere but the main database, so it no longer
+    /// depends on the caller getting the flag right.
+    /// </summary>
     public string GetSiteDbPath(string slug, bool isDefault) =>
-        isDefault ? MainDbPath : Path.Combine(GetSiteDataDir(slug), "network_optimizer.db");
+        isDefault || string.Equals(slug, DefaultSiteSlug, StringComparison.OrdinalIgnoreCase)
+            ? MainDbPath
+            : Path.Combine(GetSiteDataDir(slug), "network_optimizer.db");
 }

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -102,6 +102,7 @@
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/passkey.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/federated-login.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/site-context.js")"></script>
+    <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/collapse-reveal.js")"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/chart-defaults.js")"></script>
     <script src="_framework/blazor.web.js"></script>
     <script src="@FileVersionProvider.AddFileVersionToPath("/", "js/scrollRestoration.js")"></script>

--- a/src/NetworkOptimizer.Web/Components/Pages/AccountSecurity.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/AccountSecurity.razor
@@ -260,9 +260,6 @@
     private bool _mfaEnabled;
     private bool _roleRequiresMfa;
 
-    /// <summary>Whether this page has resolved the requirement from the roles at least once.</summary>
-    private bool _requirementChecked;
-
     /// <summary>
     /// Whether this account still owes the second factor its role requires. Recomputed on every
     /// render rather than captured at load: enrolling happens on this page, so a flag set in
@@ -318,11 +315,16 @@
             // kept being told they owed a factor they no longer did. Once we have looked for
             // ourselves and found no requirement, the stale parameter goes with it.
             var roleRequires = await Mfa.RoleRequiresMfaAsync(_user);
-            _roleRequiresMfa = roleRequires || (!_requirementChecked && Setup == "required");
-            if (_requirementChecked && !roleRequires && Setup == "required")
+            _roleRequiresMfa = roleRequires || Setup == "required";
+
+            // Consume it. The parameter is a one-shot handoff from whoever sent the user here, not a
+            // standing fact, and it cannot be revoked while it sits in the address bar - someone
+            // promoted to Operator and then put back to Viewer kept the URL and kept being told they
+            // owed a factor. Dropping it after it has been read leaves the roles as the only lasting
+            // source, so the next load - and a role change reloads this page - reflects the change.
+            if (Setup == "required")
                 Navigation.NavigateTo(
                     Navigation.GetUriWithQueryParameter("setup", (string?)null), replace: true);
-            _requirementChecked = true;
 
             _passkeyIsOnlyWayIn = _passkeys.Count > 0
                 && !_mfaEnabled

--- a/src/NetworkOptimizer.Web/Components/Pages/AccountSecurity.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/AccountSecurity.razor
@@ -260,6 +260,9 @@
     private bool _mfaEnabled;
     private bool _roleRequiresMfa;
 
+    /// <summary>Whether this page has resolved the requirement from the roles at least once.</summary>
+    private bool _requirementChecked;
+
     /// <summary>
     /// Whether this account still owes the second factor its role requires. Recomputed on every
     /// render rather than captured at load: enrolling happens on this page, so a flag set in
@@ -304,12 +307,22 @@
             _hasPassword = await Mfa.HasPasswordAsync(_user);
             _passkeys = await Passkeys.ListAsync(principal);
 
-            // The requirement, not how they arrived. Keyed on the query string alone, the guidance
-            // and the highlight vanished the moment someone reloaded or opened the page themselves -
-            // which is most of the times they will look at it while still owing a factor.
-            // The redirect that lands here carries setup=required, but the requirement itself is the
-            // thing worth asking about - it survives a reload and clears the moment a factor exists.
-            _roleRequiresMfa = Setup == "required" || await Mfa.RoleRequiresMfaAsync(_user);
+            // The requirement, not how they arrived. Asked of the role every time, so the guidance
+            // and the highlight survive a reload or someone opening the page themselves - which is
+            // most of the times they will look at it while still owing a factor.
+            //
+            // setup=required, which the sign-in and role-grant redirects carry, still counts on the
+            // FIRST pass: a caller may know the requirement before this page's own view of the roles
+            // does. It stops counting after that, because a query string cannot be revoked - someone
+            // sent here by a promotion to Operator and then put back to Viewer kept the URL, and so
+            // kept being told they owed a factor they no longer did. Once we have looked for
+            // ourselves and found no requirement, the stale parameter goes with it.
+            var roleRequires = await Mfa.RoleRequiresMfaAsync(_user);
+            _roleRequiresMfa = roleRequires || (!_requirementChecked && Setup == "required");
+            if (_requirementChecked && !roleRequires && Setup == "required")
+                Navigation.NavigateTo(
+                    Navigation.GetUriWithQueryParameter("setup", (string?)null), replace: true);
+            _requirementChecked = true;
 
             _passkeyIsOnlyWayIn = _passkeys.Count > 0
                 && !_mfaEnabled

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -3202,7 +3202,9 @@
     private async Task ScrollToAddFormAsync(string elementId)
     {
         await Task.Delay(300);
-        await JS.InvokeVoidAsync("noHighlightTarget", elementId, "center");
+        // The target wraps a .schedule-card, which rounds at --border-radius rather than the card
+        // radius the ring assumes, so it says so instead of ringing wider than the form it marks.
+        await JS.InvokeVoidAsync("noHighlightTarget", elementId, "center", "var(--border-radius)");
     }
 
     private void CancelEditLanSchedule()

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -3202,18 +3202,7 @@
     private async Task ScrollToAddFormAsync(string elementId)
     {
         await Task.Delay(300);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('{elementId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() {{ el.style.outline = ''; el.style.outlineOffset = ''; }}, 2000);
-                }}
-            }})();");
+        await JS.InvokeVoidAsync("noHighlightTarget", elementId, "center");
     }
 
     private void CancelEditLanSchedule()

--- a/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Audit.razor
@@ -46,7 +46,7 @@
                     <span>Connect to your UniFi Console to run security audits.</span>
                 }
             </div>
-            <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -43,7 +43,7 @@
                     <strong>Not Connected</strong>
                     <span>Unable to reach the UniFi Console. Signal polling is paused.</span>
                 </div>
-                <a href="/settings" class="btn btn-primary btn-sm">Check Settings</a>
+                <a href="/settings?tab=connection#console-connection" class="btn btn-primary btn-sm">Check Settings</a>
             </div>
         </div>
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -1225,18 +1225,7 @@
 
         // Give time for the DOM to update, then scroll
         await Task.Delay(100);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('result-{resultId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    // Brief highlight effect
-                    el.style.transition = 'background-color 0.3s';
-                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.3)';
-                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 1500);
-                }}
-            }})();
-        ");
+        await JS.InvokeVoidAsync("noHighlightRow", $"result-{resultId}");
     }
 
     private async Task LoadApMarkers()

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -1276,17 +1276,7 @@
         StateHasChanged();
 
         await Task.Delay(100);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('result-{resultId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    el.style.transition = 'background-color 0.3s';
-                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.3)';
-                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 1500);
-                }}
-            }})();
-        ");
+        await JS.InvokeVoidAsync("noHighlightRow", $"result-{resultId}");
     }
 
     #endregion

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -114,7 +114,7 @@
                         <span>Connect to your UniFi Console (Controller) to view network data.</span>
                     }
                 </div>
-                <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
+                <a href="/settings?tab=connection#console-connection" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
             </div>
         </div>
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -799,16 +799,22 @@
         </div>
     };
 
+    // Withheld while the console is down, unlike the Monitoring tab, which stays open so its
+    // timeline can be played back. This card is a live snapshot with nothing to scrub: it would
+    // render only to say the console is disconnected, which the page's own banner already says.
     private RenderFragment RenderLiveView => __builder =>
     {
-        <div class="card" id="live-view">
-            <a href="/monitoring?tab=live" class="card-header card-title-link" @onclick:stopPropagation>
-                <h2 class="card-title">Live View</h2>
-            </a>
-            <div class="card-body">
-                <LiveViewPanel MapMode="@GetLiveViewMapMode()" />
+        @if (ConnectionService.IsConnected || !ConnectionService.IsInitialized)
+        {
+            <div class="card" id="live-view">
+                <a href="/monitoring?tab=live" class="card-header card-title-link" @onclick:stopPropagation>
+                    <h2 class="card-title">Live View</h2>
+                </a>
+                <div class="card-body">
+                    <LiveViewPanel MapMode="@GetLiveViewMapMode()" />
+                </div>
             </div>
-        </div>
+        }
     };
 
     private string GetLiveViewMapMode()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2150,6 +2150,7 @@
                     await LoadTargetsAsync();
                     await LoadSnmpDeviceStatusesAsync();
                     await RefreshUpstreamReviewAsync();
+                    await RefreshSetupStatusAsync();
                     StateHasChanged();
                 });
             }
@@ -2171,6 +2172,64 @@
             }
         });
     }
+
+    /// <summary>
+    /// Keeps the Setup tab's status current while the page is open. Everything it reads is written
+    /// by something other than this circuit - the collection tier records InfluxDB reachability and
+    /// SNMP poll health, another admin can turn collection off, an agent can be enrolled or removed -
+    /// so without this the statuses are a page-load snapshot and fixing the underlying problem shows
+    /// nothing until a reload.
+    ///
+    /// Deliberately a database read and nothing more. Re-running SNMP detection would put a console
+    /// round trip (and a write) on a 15 second timer; the stored state already carries what the
+    /// poller found, and the Re-check button stays the way to ask the console again.
+    /// </summary>
+    private async Task RefreshSetupStatusAsync()
+    {
+        try
+        {
+            var settings = await SnmpDetection.GetOrCreateSettingsAsync();
+            _monitoringEnabled = settings.Enabled;
+
+            // A secondary site's connection is derived rather than stored, so its configured /
+            // reachable state comes from an active health check (RefreshInfluxStateAsync) that this
+            // poll deliberately does not run. Poll it only while setup is unfinished, which is when
+            // someone is waiting to see it complete, and leave a working site to the Test button.
+            if (SiteCtx.IsDefault)
+            {
+                _influxReachable = settings.InfluxDbReachable;
+                _influxError = settings.LastInfluxDbError;
+                _influxConfigured = !string.IsNullOrEmpty(settings.InfluxDbToken)
+                    && !string.IsNullOrEmpty(settings.InfluxDbUrl);
+            }
+            else if (!_influxConfigured)
+            {
+                await RefreshInfluxStateAsync(settings);
+            }
+
+            // The stored SNMP state drives which card the whole tab renders, so adopting a change
+            // mid-edit would tear a half-typed custom OID or interface form off the screen. Hold it
+            // until the editors are idle - the status lines above update either way. Skipped while a
+            // detection is running or after one failed here, so a fresh console error is not
+            // immediately overwritten by the older stored value.
+            if (!_detecting && _detectionError == null
+                && settings.SnmpDetectionState != _snmpState
+                && !SetupEditInFlight)
+            {
+                _snmpState = settings.SnmpDetectionState;
+            }
+
+            await LoadSiteAgentAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not refresh the Monitoring setup status");
+        }
+    }
+
+    /// <summary>Whether a Setup tab card is holding an edit that a re-layout would destroy.</summary>
+    private bool SetupEditInFlight =>
+        (_snmpDeviceCard?.HasUnsavedEdit ?? false) || (_miCard?.HasUnsavedEdit ?? false);
 
     private void LoadInfluxStateFromSettings(MonitoringSettings settings)
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -41,6 +41,9 @@
 @inject CellularModemService CellularModemService
 @inject StarlinkMonitorService StarlinkMonitor
 @inject MonitoringCollectionAgent CollectionAgent
+@inject AgentTunnelRegistry TunnelRegistry
+@inject NetworkOptimizer.Web.Services.IAgentEnrollmentService AgentEnrollment
+@inject NetworkOptimizer.Web.Services.ISiteManagementService SiteManagement
 @inject IspHealthService IspHealthService
 @inject NetworkOptimizer.Web.Services.Monitoring.FlakyTargetService FlakyTargets
 @inject NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapCache LanFlowMapCache
@@ -1583,20 +1586,24 @@
                     <div class="form-group">
                         <label class="form-label">Collection</label>
                         <div class="form-value">
-                            @if (_monitoringEnabled && _influxReachable == true)
-                            {
-                                <span class="status-indicator status-active"></span>
-                                <span>Agent running</span>
-                            }
-                            else if (_monitoringEnabled && _influxReachable != true)
-                            {
-                                <span class="status-indicator status-danger"></span>
-                                <span>Enabled, but InfluxDB unreachable</span>
-                            }
-                            else
+                            @if (!_monitoringEnabled)
                             {
                                 <span class="status-indicator status-inactive"></span>
                                 <span>Disabled</span>
+                            }
+                            else
+                            {
+                                <div>
+                                    <span class="status-indicator @(ServerCollecting ? "status-active" : "status-danger")"></span>
+                                    <span>Server: @ServerCollectionState</span>
+                                </div>
+                                @if (_siteAgent is not null)
+                                {
+                                    <div>
+                                        <span class="status-indicator @(TunnelRegistry.IsAgentLive(_siteAgent) ? "status-active" : "status-danger")"></span>
+                                        <span>On-site agent: @AgentCollectionState</span>
+                                    </div>
+                                }
                             }
                         </div>
                     </div>
@@ -1769,6 +1776,67 @@
     private string _activeTab = "setup";
 
     private bool _monitoringReady => _monitoringEnabled && _influxConfigured;
+
+    /// <summary>This site's agent, when it has one. Null on a server-polled site.</summary>
+    private SiteAgent? _siteAgent;
+
+    // A tier that has not completed a pass in this long has stopped, not slowed: the slowest tier
+    // runs on a 60s cadence and every tier stamps the same field.
+    private static readonly TimeSpan CollectionStaleAfter = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Whether collection is actually happening here. The server stands down from probing on every
+    /// non-default site, so on an agent site "collecting" is the agent's answer, not the server's.
+    /// </summary>
+    private bool ServerCollecting =>
+        _influxReachable == true
+        && CollectionAgent.LastCollectionUtc is DateTime last
+        && DateTime.UtcNow - last < CollectionStaleAfter;
+
+    private string ServerCollectionState =>
+        _influxReachable != true ? "enabled, but InfluxDB unreachable"
+        : !CollectionAgent.ServerProbesThisSite ? "syncing targets (this site is probed by its agent)"
+        : ServerCollecting ? "collecting"
+        : CollectionAgent.LastCollectionUtc is DateTime last
+            ? $"last collected {TimeFormatHelper.FormatRelativeTime(last).ToLowerInvariant()}"
+            : "not collecting";
+
+    private string AgentCollectionState
+    {
+        get
+        {
+            if (_siteAgent is null) return "";
+            var version = _siteAgent.LastVersion is null ? ""
+                : $", v{NetworkOptimizer.Core.Helpers.VersionUtilities.StripBuildMetadata(_siteAgent.LastVersion)}";
+            if (TunnelRegistry.IsAgentLive(_siteAgent)) return $"connected{version}";
+            if (_siteAgent.EnrolledAt is null) return "enrolled but never connected";
+            return _siteAgent.LastSeenAt is DateTime seen
+                ? $"last seen {TimeFormatHelper.FormatRelativeTime(seen).ToLowerInvariant()}{version}"
+                : $"not connected{version}";
+        }
+    }
+
+    /// <summary>
+    /// Loads this site's agent so the Collection status can report it. Best-effort: a registry that
+    /// will not answer leaves the agent line off rather than taking the Setup tab down with it.
+    /// </summary>
+    private async Task LoadSiteAgentAsync()
+    {
+        try
+        {
+            var site = (await SiteManagement.GetSitesAsync())
+                .FirstOrDefault(x => string.Equals(x.Slug, SiteCtx.Slug, StringComparison.OrdinalIgnoreCase));
+            if (site == null) return;
+            _siteAgent = (await AgentEnrollment.GetAgentsForSiteAsync(site.Id))
+                .Where(a => a.Enabled)
+                .OrderByDescending(a => a.LastSeenAt)
+                .FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not read the site's agent for the Collection status");
+        }
+    }
     private bool _cmHasDevices;
     private bool _ontHasDevices;
     private bool _cellularHasDevices;
@@ -2060,6 +2128,8 @@
 
         _activeTab = ResolveDefaultTab();
         _lastTabParam = TabParam ?? _activeTab;
+
+        await LoadSiteAgentAsync();
 
         await RefreshUpstreamReviewAsync();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -526,7 +526,9 @@
                                 <span class="host-truncate">@t.Name</span>
                                 <span class="lan-flaky-actions">
                                     <button class="btn btn-sm btn-secondary" @onclick="() => JumpToLatencyTargetAsync(t.Id)">Review in Latency Targets</button>
-                                    <button class="btn btn-sm btn-secondary" @onclick="() => DismissLanFlakyHintAsync(t)">Dismiss</button>
+                                    <SiteOperatorOnly>
+                                        <button class="btn btn-sm btn-secondary" @onclick="() => DismissLanFlakyHintAsync(t)">Dismiss</button>
+                                    </SiteOperatorOnly>
                                 </span>
                             </li>
                         }
@@ -3040,7 +3042,10 @@
         }
         catch (Exception ex)
         {
+            // Do NOT hide the row when the write did not happen: it would reappear on the next
+            // load, so the dismissal would read as having worked and then silently undone itself.
             Logger.LogWarning(ex, "Could not persist the LAN flaky-hint dismissal for target {TargetId}", target.Id);
+            return;
         }
         // _targets is loaded AsNoTracking, so reflect the dismissal in memory to drop the row
         // from the advisory immediately without waiting for a reload.

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -102,7 +102,12 @@
         </div>
     }
 }
-else
+
+@* The console being down does not take the history with it: the targets, SFP list and every chart
+   come from this site's own database and InfluxDB. So the banner above now sits over the page
+   instead of replacing it, and only the parts that genuinely need a live console are withheld. A
+   site whose gateway is gone can still be read. *@
+@if (ConnectionService.IsConnected || _monitoringReady)
 {
     <!-- Tab bar -->
     <div class="wifi-view-tabs-wrapper">
@@ -110,7 +115,8 @@ else
         <div class="wifi-view-tabs">
             <button class="wifi-view-tab @(_activeTab == "live" ? "active" : "")"
                     @onclick="@(() => SetActiveTab("live"))"
-                    disabled="@(!_monitoringReady)">
+                    disabled="@(!_monitoringReady || !ConnectionService.IsConnected)"
+                    data-tooltip="@(ConnectionService.IsConnected ? null : "Needs a live console connection")">
                 Live View
             </button>
             <button class="wifi-view-tab @(_activeTab == "isp-health" ? "active" : "")"
@@ -182,7 +188,7 @@ else
     </div>
 
     @* ──────────────── Tab: Live View ──────────────── *@
-    @if (_activeTab == "live" && _monitoringReady)
+    @if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected)
     {
         @* Too-long community shows even when the gateway is still polling - gateways
            often tolerate a long Community String while the switches silently drop. *@
@@ -1862,10 +1868,16 @@ else
         // site switch, where the tab is carried in the URL) falls through to the
         // default rather than opening a tab the site chose to hide.
         if (TabParam != null && ValidTabs.Contains(TabParam) && !IsHardwareTabHidden(TabParam.ToLowerInvariant()))
-            return TabParam.ToLowerInvariant();
+        {
+            var pinned = TabParam.ToLowerInvariant();
+            // Live View is the one tab a stored history cannot fill. Landing on it with the console
+            // down would answer a site-is-offline visit with the emptiest page we have.
+            if (pinned != "live" || ConnectionService.IsConnected)
+                return pinned;
+        }
         if (_influxReachable == false || _snmpState == SnmpDetectionState.PollFailing)
             return "setup";
-        return "live";
+        return ConnectionService.IsConnected ? "live" : "isp-health";
     }
 
     private async void SetActiveTab(string tab)
@@ -3627,28 +3639,27 @@ else
         // reset the flags. Reset them here so the connected render remounts cleanly;
         // the same path also tears the modules down when the console drops mid-session
         // (Blazor destroyed their DOM with the region swap).
+        //
+        // Only Live View's region swaps out now - the historical tabs stay rendered with the console
+        // down, which is the point of them. So this tears down the four live modules and nothing
+        // else, and no longer returns: the stat charts still need mounting while offline, and
+        // unmounting them here is what would leave a disconnected site staring at blank panels.
         if (!ConnectionService.IsConnected)
         {
-            if (_mapMounted || _map2dMounted || _wanLiveChartMounted || _portStatsMounted
-                || _latencyChartsMounted || _healthChartsMounted || _sfpChartsMounted
-                || _cellularChartsMounted || _starlinkChartsMounted || _cmChartsMounted || _ontChartsMounted)
+            if (_mapMounted || _map2dMounted || _wanLiveChartMounted || _portStatsMounted)
             {
                 _mapMounted = _map2dMounted = _wanLiveChartMounted = _portStatsMounted = false;
-                _latencyChartsMounted = _healthChartsMounted = _sfpChartsMounted = false;
-                _cellularChartsMounted = _starlinkChartsMounted = _cmChartsMounted = _ontChartsMounted = false;
                 try
                 {
                     await JS.InvokeVoidAsync("eval",
                         "window.__lanFlowMap?.unmount(); window.__lanFlowMap2d?.unmount();" +
-                        "window.__wanLiveChart?.unmount(); window.__portStatsTable?.unmount();" +
-                        "window.__latencyCharts?.unmount(); window.__healthCharts?.unmount();" +
-                        "window.__sfpCharts?.unmount(); window.__cellularCharts?.unmount();" +
-                        "window.__starlinkCharts?.unmount();" +
-                        "window.__cmCharts?.unmount(); window.__ontCharts?.unmount();");
+                        "window.__wanLiveChart?.unmount(); window.__portStatsTable?.unmount();");
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Could not unmount the Live View modules after the console dropped");
+                }
             }
-            return;
         }
 
         // Auto-expand the SNMP Devices table after the Live-tab banner jumps here.
@@ -3722,7 +3733,7 @@ else
         }
 
         // 3D map - Live tab only
-        if (_activeTab == "live" && _monitoringReady && !_mapMounted)
+        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_mapMounted)
         {
             _mapMounted = true;
             try
@@ -3765,7 +3776,7 @@ else
         }
 
         // 2D hierarchy map - Live tab only
-        if (_activeTab == "live" && _monitoringReady && !_map2dMounted)
+        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_map2dMounted)
         {
             _map2dMounted = true;
             try
@@ -3783,7 +3794,7 @@ else
         }
 
         // WAN live chart - Live tab only
-        if (_activeTab == "live" && _monitoringReady && !_wanLiveChartMounted)
+        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_wanLiveChartMounted)
         {
             _wanLiveChartMounted = true;
             try
@@ -3806,7 +3817,7 @@ else
         }
 
         // Port stats playback table - Live tab only
-        if (_activeTab == "live" && _monitoringReady && !_portStatsMounted)
+        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_portStatsMounted)
         {
             _portStatsMounted = true;
             try

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2888,18 +2888,7 @@
     private async Task ScrollToElementAsync(string elementId)
     {
         await Task.Delay(400);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('{elementId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'start' }});
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() {{ el.style.outline = ''; el.style.outlineOffset = ''; }}, 2000);
-                }}
-            }})();");
+        await JS.InvokeVoidAsync("noHighlightTarget", elementId);
     }
 
     private async Task OnBeforeInternalNavigation(LocationChangingContext context)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1593,13 +1593,13 @@
                             }
                             else
                             {
-                                <div>
+                                <div class="form-value-line">
                                     <span class="status-indicator @(ServerCollecting ? "status-active" : "status-danger")"></span>
                                     <span>Server: @ServerCollectionState</span>
                                 </div>
                                 @if (_siteAgent is not null)
                                 {
-                                    <div>
+                                    <div class="form-value-line">
                                         <span class="status-indicator @(TunnelRegistry.IsAgentLive(_siteAgent) ? "status-active" : "status-danger")"></span>
                                         <span>On-site agent: @AgentCollectionState</span>
                                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -27,6 +27,8 @@
 @inject MonitoringLiveStats LiveStats
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject SiteContextService SiteCtx
+@inject NetworkOptimizer.Web.Services.IMonitoringSettingsService MonitoringSettings
+@inject NetworkOptimizer.Web.Services.IMonitoringTargetService TargetService
 @inject Microsoft.JSInterop.IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 @inject NavigationManager NavigationManager
@@ -2101,21 +2103,7 @@ else
 
     private async Task ResetInfluxSetup()
     {
-        await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-        var settings = await db.MonitoringSettings.FirstOrDefaultAsync();
-        if (settings != null)
-        {
-            settings.Enabled = false;
-            settings.InfluxDbToken = "";
-            settings.InfluxDbUrl = "";
-            settings.InfluxDbOrg = "";
-            settings.InfluxDbBucket = "";
-            settings.InfluxDbLongtermBucket = "";
-            settings.InfluxDbReachable = null;
-            settings.LastInfluxDbError = null;
-            settings.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
-        }
+        await MonitoringSettings.ResetInfluxSetupAsync();
         _influxConfigured = false;
         _influxReachable = null;
         _influxError = null;
@@ -2207,8 +2195,6 @@ else
         NetworkOptimizer.Web.Services.Monitoring.DeviceHealthAlertEvaluator.DefaultDeviceTempHighC.ToString("0");
 
     // Blank/zero/negative entries mean "use the built-in default" (stored as null).
-    private static double? NormalizeTempThreshold(double? value) => value is > 0 ? value : null;
-
     private async Task SaveTempThresholdsAsync()
     {
         _savingTempThresholds = true;
@@ -2216,14 +2202,8 @@ else
         StateHasChanged();
         try
         {
-            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
-                ?? new MonitoringSettings();
-            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
-            settings.SwitchTempHighC = NormalizeTempThreshold(_switchTempThresholdInput);
-            settings.GatewayTempHighC = NormalizeTempThreshold(_gatewayTempThresholdInput);
-            settings.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            var settings = await MonitoringSettings.SaveTempThresholdsAsync(
+                _switchTempThresholdInput, _gatewayTempThresholdInput);
             _switchTempThresholdInput = settings.SwitchTempHighC;
             _gatewayTempThresholdInput = settings.GatewayTempHighC;
             _tempThresholdsSaved = true;
@@ -2277,21 +2257,16 @@ else
         StateHasChanged();
         try
         {
-            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
-                ?? new MonitoringSettings();
-            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
-            // Temperature must be positive; power thresholds may legitimately be
-            // negative (RX low) so a blank field (null) is the only "use default".
-            settings.PonTempHighC = NormalizeTempThreshold(_sfpPonTemp);
-            settings.PonRxPowerLowDbm = _sfpPonRx;
-            settings.PonTxPowerHighDbm = _sfpPonTx;
-            settings.AeTempHighC = NormalizeTempThreshold(_sfpAeTemp);
-            settings.AeRxPowerLowDbm = _sfpAeRx;
-            settings.AeTxPowerHighDbm = _sfpAeTx;
-            settings.SfpTempHighGenericC = NormalizeTempThreshold(_sfpGenericTemp);
-            settings.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            var settings = await MonitoringSettings.SaveSfpThresholdsAsync(new NetworkOptimizer.Web.Services.SfpThresholdEdit
+            {
+                PonTempHighC = _sfpPonTemp,
+                PonRxPowerLowDbm = _sfpPonRx,
+                PonTxPowerHighDbm = _sfpPonTx,
+                AeTempHighC = _sfpAeTemp,
+                AeRxPowerLowDbm = _sfpAeRx,
+                AeTxPowerHighDbm = _sfpAeTx,
+                SfpTempHighGenericC = _sfpGenericTemp
+            });
             LoadSfpThresholdInputs(settings);
             _sfpThresholdsSaved = true;
         }
@@ -2314,15 +2289,7 @@ else
         StateHasChanged();
         try
         {
-            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
-                ?? new MonitoringSettings();
-            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
-            // Temperature must be positive; a blank RX field (null) means "use default".
-            settings.PonTempHighC = NormalizeTempThreshold(_sfpPonTemp);
-            settings.PonRxPowerLowDbm = _sfpPonRx;
-            settings.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            var settings = await MonitoringSettings.SaveOntThresholdsAsync(_sfpPonTemp, _sfpPonRx);
             LoadSfpThresholdInputs(settings);
             _ontThresholdsSaved = true;
         }
@@ -2339,13 +2306,7 @@ else
         StateHasChanged();
         try
         {
-            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-            var settings = await db.MonitoringSettings.FirstOrDefaultAsync()
-                ?? new MonitoringSettings();
-            if (settings.Id == 0) db.MonitoringSettings.Add(settings);
-            settings.Enabled = enabled;
-            settings.UpdatedAt = DateTime.UtcNow;
-            await db.SaveChangesAsync();
+            await MonitoringSettings.SetEnabledAsync(enabled);
             _monitoringEnabled = enabled;
 
             if (_monitoringReady && _activeTab == "setup")
@@ -2968,15 +2929,12 @@ else
     {
         try
         {
-            await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-            var row = await db.MonitoringTargets.FindAsync(target.Id);
-            if (row != null)
-            {
-                row.LanFlakyHintDismissedAt = DateTime.UtcNow;
-                await db.SaveChangesAsync();
-            }
+            await TargetService.DismissLanFlakyHintAsync(target.Id);
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not persist the LAN flaky-hint dismissal for target {TargetId}", target.Id);
+        }
         // _targets is loaded AsNoTracking, so reflect the dismissal in memory to drop the row
         // from the advisory immediately without waiting for a reload.
         var local = _targets.FirstOrDefault(t => t.Id == target.Id);

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2841,35 +2841,13 @@
     private async Task ScrollToUpstreamDiscoveryAsync()
     {
         await Task.Delay(500);
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('upstream-discovery');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
-            })();");
+        await JS.InvokeVoidAsync("noHighlightTarget", "upstream-discovery");
     }
 
     private async Task ScrollToFlakyTargetsAsync()
     {
         await Task.Delay(500);
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('flaky-targets');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
-            })();");
+        await JS.InvokeVoidAsync("noHighlightTarget", "flaky-targets");
     }
 
     private async Task ScrollToSnmpDevicesAsync()
@@ -2878,18 +2856,7 @@
         // final position. Mirrors ScrollToUpstreamDiscoveryAsync, including the
         // brief highlight outline.
         await Task.Delay(400);
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('snmp-devices');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
-            })();");
+        await JS.InvokeVoidAsync("noHighlightTarget", "snmp-devices");
     }
 
     private async Task ScrollToMonitoringInterfacesAsync()
@@ -2897,18 +2864,7 @@
         // Mirror ScrollToSnmpDevicesAsync: wait for the expand animation, then scroll
         // to the Monitoring Interfaces card with the same brief highlight outline.
         await Task.Delay(400);
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('monitoring-interfaces');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
-            })();");
+        await JS.InvokeVoidAsync("noHighlightTarget", "monitoring-interfaces");
     }
 
     private async Task ScrollToSfpChartsAsync()

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -115,8 +115,8 @@
         <div class="wifi-view-tabs">
             <button class="wifi-view-tab @(_activeTab == "live" ? "active" : "")"
                     @onclick="@(() => SetActiveTab("live"))"
-                    disabled="@(!_monitoringReady || !ConnectionService.IsConnected)"
-                    data-tooltip="@(ConnectionService.IsConnected ? null : "Needs a live console connection")">
+                    disabled="@(!_monitoringReady)"
+                    data-tooltip="@(ConnectionService.IsConnected ? null : "Live values need a console; the timeline still plays back")">
                 Live View
             </button>
             <button class="wifi-view-tab @(_activeTab == "isp-health" ? "active" : "")"
@@ -188,7 +188,7 @@
     </div>
 
     @* ──────────────── Tab: Live View ──────────────── *@
-    @if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected)
+    @if (_activeTab == "live" && _monitoringReady)
     {
         @* Too-long community shows even when the gateway is still polling - gateways
            often tolerate a long Community String while the switches silently drop. *@
@@ -1869,15 +1869,11 @@
         // default rather than opening a tab the site chose to hide.
         if (TabParam != null && ValidTabs.Contains(TabParam) && !IsHardwareTabHidden(TabParam.ToLowerInvariant()))
         {
-            var pinned = TabParam.ToLowerInvariant();
-            // Live View is the one tab a stored history cannot fill. Landing on it with the console
-            // down would answer a site-is-offline visit with the emptiest page we have.
-            if (pinned != "live" || ConnectionService.IsConnected)
-                return pinned;
+            return TabParam.ToLowerInvariant();
         }
         if (_influxReachable == false || _snmpState == SnmpDetectionState.PollFailing)
             return "setup";
-        return ConnectionService.IsConnected ? "live" : "isp-health";
+        return "live";
     }
 
     private async void SetActiveTab(string tab)
@@ -3640,27 +3636,10 @@
         // the same path also tears the modules down when the console drops mid-session
         // (Blazor destroyed their DOM with the region swap).
         //
-        // Only Live View's region swaps out now - the historical tabs stay rendered with the console
-        // down, which is the point of them. So this tears down the four live modules and nothing
-        // else, and no longer returns: the stat charts still need mounting while offline, and
-        // unmounting them here is what would leave a disconnected site staring at blank panels.
-        if (!ConnectionService.IsConnected)
-        {
-            if (_mapMounted || _map2dMounted || _wanLiveChartMounted || _portStatsMounted)
-            {
-                _mapMounted = _map2dMounted = _wanLiveChartMounted = _portStatsMounted = false;
-                try
-                {
-                    await JS.InvokeVoidAsync("eval",
-                        "window.__lanFlowMap?.unmount(); window.__lanFlowMap2d?.unmount();" +
-                        "window.__wanLiveChart?.unmount(); window.__portStatsTable?.unmount();");
-                }
-                catch (Exception ex)
-                {
-                    Logger.LogDebug(ex, "Could not unmount the Live View modules after the console dropped");
-                }
-            }
-        }
+        // Nothing swaps out on a disconnect any more: every tab, Live View included, stays rendered
+        // so a site whose console is gone can still be read. The map and port stats are what replay
+        // the timeline, so tearing them down here is exactly what would empty the tab this comment
+        // used to justify emptying. Their live polling already returns early while disconnected.
 
         // Auto-expand the SNMP Devices table after the Live-tab banner jumps here.
         if (_pendingExpandSnmpCard && _activeTab == "setup" && _snmpDeviceCard != null)
@@ -3733,7 +3712,7 @@
         }
 
         // 3D map - Live tab only
-        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_mapMounted)
+        if (_activeTab == "live" && _monitoringReady && !_mapMounted)
         {
             _mapMounted = true;
             try
@@ -3776,7 +3755,7 @@
         }
 
         // 2D hierarchy map - Live tab only
-        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_map2dMounted)
+        if (_activeTab == "live" && _monitoringReady && !_map2dMounted)
         {
             _map2dMounted = true;
             try
@@ -3794,7 +3773,7 @@
         }
 
         // WAN live chart - Live tab only
-        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_wanLiveChartMounted)
+        if (_activeTab == "live" && _monitoringReady && !_wanLiveChartMounted)
         {
             _wanLiveChartMounted = true;
             try
@@ -3817,7 +3796,7 @@
         }
 
         // Port stats playback table - Live tab only
-        if (_activeTab == "live" && _monitoringReady && ConnectionService.IsConnected && !_portStatsMounted)
+        if (_activeTab == "live" && _monitoringReady && !_portStatsMounted)
         {
             _portStatsMounted = true;
             try

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -100,7 +100,7 @@
                         <span>Configure your UniFi Console connection in Settings to get started.</span>
                     }
                 </div>
-                <a href="/settings" class="btn btn-primary btn-sm">Settings</a>
+                <a href="/settings?tab=connection#console-connection" class="btn btn-primary btn-sm">Settings</a>
             </div>
         </div>
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2691,6 +2691,35 @@
                 }
             }
             catch { }
+
+            // Every historic query is keyed on these - WAN rates, the gateway's CPU/memory/temp,
+            // fabric ingress and egress - and they come from a console read, so an offline site
+            // scrubbed the timeline against keys it did not have and every card came back blank
+            // while the chart plotted. The remembered WAN profile holds exactly this pair.
+            //
+            // Only while the console is down: a connected console that reports no gateway keeps
+            // resolving to nothing, as before.
+            if (_gatewayMac == null && !ConnectionService.IsConnected)
+            {
+                try
+                {
+                    await using var wanDb = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
+                    var profile = await wanDb.WanProfiles.AsNoTracking()
+                        .Where(w => w.GatewayMac != null && w.CounterInterface != null)
+                        .OrderBy(w => w.WanNetworkgroup)
+                        .ThenByDescending(w => w.UpdatedAt)
+                        .FirstOrDefaultAsync();
+                    if (profile != null)
+                    {
+                        _gatewayMac = profile.GatewayMac!.Replace("-", ":").ToLowerInvariant();
+                        _gatewayWanIfNames = new List<string> { profile.CounterInterface! };
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogDebug(ex, "Could not read the remembered gateway and WAN interface for historic playback");
+                }
+            }
         }
         catch
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Optimize.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Optimize.razor
@@ -37,7 +37,7 @@
                     <span>Connect to your UniFi Console to analyze your network.</span>
                 }
             </div>
-            <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/PerformanceTweaks.razor
@@ -30,7 +30,7 @@
                 <strong>UniFi Connection Error</strong>
                 <span>@ConnectionService.LastError</span>
             </div>
-            <a href="/settings" class="btn btn-primary">Check Settings</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">Check Settings</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -38,6 +38,7 @@
 @inject IHttpClientFactory HttpClientFactory
 @inject NavigationManager NavigationManager
 @inject ISiteManagementService SiteManagement
+@inject SiteRegistryChangeNotifier SiteChangeNotifier
 @inject SiteSwitchService SiteSwitch
 @inject IAgentEnrollmentService AgentEnrollment
 @inject AgentServerUrlProvider AgentServerUrl
@@ -3948,8 +3949,31 @@
 
     private System.Threading.Timer? _agentPollTimer;
 
+    /// <summary>
+    /// The Sites table is a live list of who can reach what, and both halves of that change from
+    /// outside this circuit: a site removed by another admin, or this user's own membership
+    /// granted or revoked. The site switcher already rebuilds on the broadcast; this table did
+    /// not, so it kept showing a site until you navigated away and back.
+    /// </summary>
+    private async void OnSiteRegistryChanged()
+    {
+        try
+        {
+            await InvokeAsync(async () =>
+            {
+                await LoadMultiSiteSettings();
+                StateHasChanged();
+            });
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not refresh the Sites table after a site registry change");
+        }
+    }
+
     public void Dispose()
     {
+        SiteChangeNotifier.SitesChanged -= OnSiteRegistryChanged;
         _agentPollTimer?.Dispose();
     }
 
@@ -4843,6 +4867,7 @@
         await LoadMonitoringSettings();
         await LoadMapboxToken();
         await LoadMultiSiteSettings();
+        SiteChangeNotifier.SitesChanged += OnSiteRegistryChanged;
 
         if (_multiSiteEnabled)
             _currentSiteName = _sites.FirstOrDefault(s => s.Slug == SiteContext.Slug)?.Name ?? SiteContext.Slug;

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3628,7 +3628,7 @@
                                                                 <input type="checkbox" checked="@AgentCoversSite(site.Id)"
                                                                        disabled="@(!AgentsFor(site.Id).Any())"
                                                                        @onchange="e => ToggleAgentCoversSite(site, (bool)e.Value!)" />
-                                                                The agent collects for this site - probes, path discovery and SNMP run
+                                                                An agent collects for this site - probes, path discovery and SNMP run
                                                                 there instead of on this server. Turn on only if this server is off-site.
                                                             </label>
                                                             @if (AgentCoversSite(site.Id))

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3880,17 +3880,9 @@
         // Let the tab panel render before scrolling; same scroll-and-highlight
         // pattern as the Monitoring page.
         await Task.Delay(300);
+        await JS.InvokeVoidAsync("noHighlightTarget", anchor);
         await JS.InvokeVoidAsync("eval", @"
             (function() {
-                var el = document.getElementById('" + anchor + @"');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
                 if ('" + anchor + @"' === 'site-agent-setup') {
                     var inp = document.getElementById('site-name-input');
                     if (inp) inp.focus({ preventScroll: true });

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -122,12 +122,19 @@
                 </button>
             }
         </AuthorizeView>
-        @* Managing the set of sites is instance-wide, so it is not a site admin's tab either. *@
+        @* The tab is not instance-wide the way its title suggests: the site list is access-filtered
+           and every row authorizes for its own site, so a site's own admin gets that site's controls
+           and a row they only view carries nothing but Switch to Site. Offer it to anyone once
+           multi-site is on - /sites is RequireViewer and links straight here - and to an
+           instance-wide Admin always, since only they can turn multi-site on in the first place. *@
         <AuthorizeView Policy="@Policies.RequireAdmin" Context="multiSiteTab">
-            <button class="wifi-view-tab @(_activeTab == "multisite" ? "active" : "")"
-                    @onclick="@(() => SetActiveTab("multisite"))">
-                Multi-Site
-            </button>
+            <Authorized>@MultiSiteTabButton</Authorized>
+            <NotAuthorized>
+                @if (_multiSiteEnabled)
+                {
+                    @MultiSiteTabButton
+                }
+            </NotAuthorized>
         </AuthorizeView>
     </div>
     <button class="wifi-tabs-scroll-btn wifi-tabs-scroll-right" onclick="this.parentElement.querySelector('.wifi-view-tabs').scrollBy({left: 200, behavior: 'smooth'})">&#8250;</button>
@@ -3903,6 +3910,11 @@
     }
 
     // Multi-Site
+    private RenderFragment MultiSiteTabButton => @<button class="wifi-view-tab @(_activeTab == "multisite" ? "active" : "")"
+                                                          @onclick="@(() => SetActiveTab("multisite"))">
+        Multi-Site
+    </button>;
+
     private bool _multiSiteEnabled = false;
     private List<Site> _sites = new();
     private string _multiSiteMessage = "";

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -4440,8 +4440,12 @@
             .OrderByDescending(a => a.LastSeenAt)
             .Select(a => a.LanIp)
             .FirstOrDefault();
+        // The port the agent says it serves on, not an assumed one - otherwise the hint advertises a
+        // URL that differs from the one clients are actually sent to.
+        var port = TunnelRegistry.GetForSite(site.Slug).FirstOrDefault(c => c.SpeedTestPort > 0)?.SpeedTestPort
+            ?? SiteSpeedTestTargetResolver.AgentOpenSpeedTestPort;
         return lanIp != null
-            ? $"auto: https://{lanIp}:{SiteSpeedTestTargetResolver.AgentOpenSpeedTestPort} (agent's detected LAN IP)"
+            ? $"auto: https://{lanIp}:{port} (agent's detected LAN IP)"
             : "e.g. 192.168.1.50 or https://speed.example.com";
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3629,7 +3629,8 @@
                                                                        disabled="@(!AgentsFor(site.Id).Any())"
                                                                        @onchange="e => ToggleAgentCoversSite(site, (bool)e.Value!)" />
                                                                 An agent collects for this site - probes, path discovery and SNMP run
-                                                                there instead of on this server. Turn on only if this server is off-site.
+                                                                there instead of on this server. Turn on if this server is off-site, or
+                                                                you want a separate agent.
                                                             </label>
                                                             @if (AgentCoversSite(site.Id))
                                                             {

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3618,7 +3618,39 @@
                                                         }
                                                     </div>
 
-                                                    @if (!site.IsDefault)
+                                                    @if (site.IsDefault)
+                                                    {
+                                                        <div class="site-config-section">
+                                                            <div class="site-config-section-title">Settings</div>
+                                                            @* Only meaningful with an agent to hand the work to, so it cannot be
+                                                               switched on into a state where nothing collects at all. *@
+                                                            <label class="checkbox-toggle">
+                                                                <input type="checkbox" checked="@AgentCoversSite(site.Id)"
+                                                                       disabled="@(!AgentsFor(site.Id).Any())"
+                                                                       @onchange="e => ToggleAgentCoversSite(site, (bool)e.Value!)" />
+                                                                The agent collects for this site - probes, path discovery and SNMP run
+                                                                there instead of on this server. Turn on only if this server is off-site.
+                                                            </label>
+                                                            @if (AgentCoversSite(site.Id))
+                                                            {
+                                                                <label class="checkbox-toggle">
+                                                                    <input type="checkbox" checked="@ConsoleViaAgent(site.Id)"
+                                                                           @onchange="e => ToggleConsoleViaAgent(site, (bool)e.Value!)" />
+                                                                    Reach this site's UniFi Console through the agent tunnel - no VPN or
+                                                                    port-forward to the console needed. Applies on the next connect.
+                                                                </label>
+                                                                <label class="checkbox-toggle">
+                                                                    <input type="checkbox" checked="@SshViaAgent(site.Id)"
+                                                                           @onchange="e => ToggleSshViaAgent(site, (bool)e.Value!)" />
+                                                                    Reach this site's devices through the agent tunnel: SSH to the gateway
+                                                                    and devices, plus modem and ONT status pages. Enables gateway WAN speed
+                                                                    tests, LAN speed tests, and modem / ONT monitoring without VPN. Applies within
+                                                                    a minute.
+                                                                </label>
+                                                            }
+                                                        </div>
+                                                    }
+                                                    else
                                                     {
                                                         <div class="site-config-section">
                                                             <div class="site-config-section-title">Settings</div>
@@ -4287,6 +4319,7 @@
             {
                 await LoadConsoleViaAgentAsync(site);
                 await LoadSshViaAgentAsync(site);
+                await LoadAgentCoversSiteAsync(site);
                 await LoadClientSpeedTestTargetAsync(site);
                 _agentOnGateway[site.Id] = !site.IsDefault
                     && await OnGatewayDetector.IsAgentOnGatewayAsync(site.Slug);
@@ -4310,6 +4343,7 @@
     {
         await LoadConsoleViaAgentAsync(site);
         await LoadSshViaAgentAsync(site);
+        await LoadAgentCoversSiteAsync(site);
         await LoadClientSpeedTestTargetAsync(site);
         StateHasChanged();
     }
@@ -4321,6 +4355,21 @@
     {
         await SiteConfig.SetConsoleViaAgentAsync(site.Slug, value);
         _consoleViaAgent[site.Id] = value;
+    }
+
+    // "the agent collects for this site" flag, stored in the site's own database. Only offered for
+    // the default site: a secondary site's agent already collects, which is what having one means.
+    private readonly Dictionary<int, bool> _agentCoversSite = new();
+
+    private bool AgentCoversSite(int siteId) => _agentCoversSite.TryGetValue(siteId, out var enabled) && enabled;
+
+    private async Task LoadAgentCoversSiteAsync(Site site)
+        => _agentCoversSite[site.Id] = (await SiteConfig.GetAsync(site.Slug)).AgentCoversSite;
+
+    private async Task ToggleAgentCoversSite(Site site, bool value)
+    {
+        await SiteConfig.SetAgentCoversSiteAsync(site.Slug, value);
+        _agentCoversSite[site.Id] = value;
     }
 
     // Per-site "SSH via agent tunnel" flag (gateway + device SSH), stored in the site's own database

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3791,8 +3791,28 @@
         ["site-agent-setup"] = "multisite",
     };
 
-    private static string ResolveTab(string? param) =>
-        param != null && ValidTabs.Contains(param) ? param.ToLowerInvariant() : "connection";
+    // Instance-wide tabs: offered only on the default site, so a managed site is never shown a tab
+    // that renders nothing. Kept beside ResolveTab because they are the same rule read two ways -
+    // the markup decides whether to draw the button, this decides whether the URL may select it.
+    private static readonly HashSet<string> DefaultSiteOnlyTabs = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "application", "auditlog"
+    };
+
+    /// <summary>
+    /// The tab a URL selects, given the site being viewed. Switching sites carries the whole URL
+    /// across, so ?tab=auditlog followed the user onto a managed site where that tab does not exist:
+    /// no button was drawn, no panel was rendered, and Settings came up with nothing selected at all.
+    /// A tab the current site cannot show falls back to the first one, which every site has.
+    /// </summary>
+    private string ResolveTab(string? param)
+    {
+        if (param == null || !ValidTabs.Contains(param))
+            return "connection";
+
+        var tab = param.ToLowerInvariant();
+        return DefaultSiteOnlyTabs.Contains(tab) && !SiteContext.IsDefault ? "connection" : tab;
+    }
 
     private AuditLogPanel? _auditLogPanel;
 
@@ -4765,6 +4785,14 @@
         _activeTab = ResolveTab(TabParam);
         _lastTabParam = TabParam;
         _pendingAuditLoad = _activeTab == "auditlog";
+
+        // The address bar still names the tab we just refused. Rewrite it so a reload, a bookmark or
+        // a second site switch does not keep trying to open a tab this site does not have.
+        if (TabParam != null && !string.Equals(_activeTab, TabParam, StringComparison.OrdinalIgnoreCase))
+        {
+            NavigationManager.NavigateTo("/settings?tab=" + _activeTab, forceLoad: false, replace: true);
+            _lastTabParam = _activeTab;
+        }
 
         // Pre-release update notifications default ON (global/instance-wide); only an explicit "false" opts out.
         var prereleaseSetting = await SystemSettings.GetGlobalAsync("updates.include_prereleases");

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -2254,18 +2254,7 @@
 
         // Give time for the DOM to update, then scroll
         await Task.Delay(100);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('result-{resultId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    // Brief highlight effect
-                    el.style.transition = 'background-color 0.3s';
-                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.3)';
-                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 1500);
-                }}
-            }})();
-        ");
+        await JS.InvokeVoidAsync("noHighlightRow", $"result-{resultId}");
     }
 
     private async Task AnalyzeHistoricalPath(Iperf3Result result)

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -381,7 +381,7 @@
                 <div class="alert @(!string.IsNullOrEmpty(ConnectionService.LastError) ? "alert-danger" : "alert-warning")">
                     @if (!string.IsNullOrEmpty(ConnectionService.LastError))
                     {
-                        <strong>Connection Error:</strong> <text>@ConnectionService.LastError</text> <a href="/settings">Check Settings</a>
+                        <strong>Connection Error:</strong> <text>@ConnectionService.LastError</text> <a href="/settings?tab=connection#console-connection">Check Settings</a>
                     }
                     else
                     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -40,7 +40,7 @@
                 <strong>UniFi Connection Error</strong>
                 <span>@ConnectionService.LastError - WAN detection requires a working UniFi connection.</span>
             </div>
-            <a href="/settings" class="btn btn-primary">Check Settings</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">Check Settings</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/UpnpInspector.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/UpnpInspector.razor
@@ -40,7 +40,7 @@
                     <span>Connect to your UniFi Console to view UPnP mappings.</span>
                 }
             </div>
-            <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -17,6 +17,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject SpeedTestServiceRegistry SpeedTestRegistry
 @inject SiteContextService SiteContext
+@inject SiteAgentCoverage AgentCoverage
 @inject MonitoringReadinessService Readiness
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
@@ -689,11 +690,13 @@
 
     /// <summary>
     /// Whether the non-gateway run happens on the site's agent rather than on this server, which is
-    /// what the option is called and described as. True for a site the server cannot reach itself;
-    /// an agent that runs ON the gateway is not this case - that option is hidden entirely, because
-    /// the Gateway option already runs there.
+    /// what the option is called and described as. True for a site the server cannot reach itself,
+    /// and for the main site once its agent covers it - the run moves to the agent there too, so
+    /// the label has to move with it. An agent that runs ON the gateway is not this case: that
+    /// option is hidden entirely, because the Gateway option already runs there.
     /// </summary>
-    private bool RunsOnAgent => !SiteContext.IsDefault && !_agentOnGateway;
+    private bool _runsOnAgent;
+    private bool RunsOnAgent => _runsOnAgent;
     private bool _serverAvailable = true;
     private string? _serverUnavailableReason;
     private System.Threading.Timer? _agentStatusTimer;
@@ -962,6 +965,8 @@
         // one to use. When speed-test-capable gateway installs arrive, key this off
         // the agent's capability instead of its location.
         _agentOnGateway = agentOnline && await OnGatewayDetector.IsAgentOnGatewayAsync(SiteContext.Slug);
+        _runsOnAgent = !_agentOnGateway
+            && (!SiteContext.IsDefault || await AgentCoverage.CoversAsync(SiteContext.Slug));
         var agentRequired = !SiteContext.IsDefault && !agentOnline;
         var agentReason = _siteAgentOffline ? AgentOfflineReason : NoAgentReason;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -1783,17 +1783,7 @@
 
         // Give time for the DOM to update, then scroll
         await Task.Delay(100);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('result-{resultId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    el.style.transition = 'background-color 0.3s';
-                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.3)';
-                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 1500);
-                }}
-            }})();
-        ");
+        await JS.InvokeVoidAsync("noHighlightRow", $"result-{resultId}");
     }
 
     private static string FormatResultSummary(Iperf3Result result)

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -696,7 +696,14 @@
     /// option is hidden entirely, because the Gateway option already runs there.
     /// </summary>
     private bool _runsOnAgent;
-    private bool RunsOnAgent => _runsOnAgent;
+    // Resolving the vantage needs an await, so the first render happens before the answer is in and
+    // the label was painted "Server" before flipping to "Agent". The first frame now uses the
+    // cached coverage answer, which any recent read has already populated - so the flash only
+    // survives a cold cache, and never shows the wrong word twice.
+    private bool RunsOnAgent => _vantageResolved
+        ? _runsOnAgent
+        : !SiteContext.IsDefault || AgentCoverage.Covers(SiteContext.Slug);
+    private bool _vantageResolved;
     private bool _serverAvailable = true;
     private string? _serverUnavailableReason;
     private System.Threading.Timer? _agentStatusTimer;
@@ -967,6 +974,7 @@
         _agentOnGateway = agentOnline && await OnGatewayDetector.IsAgentOnGatewayAsync(SiteContext.Slug);
         _runsOnAgent = !_agentOnGateway
             && (!SiteContext.IsDefault || await AgentCoverage.CoversAsync(SiteContext.Slug));
+        _vantageResolved = true;
         var agentRequired = !SiteContext.IsDefault && !agentOnline;
         var agentReason = _siteAgentOffline ? AgentOfflineReason : NoAgentReason;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -1051,7 +1051,6 @@
         {
             var networks = await ConnectionService.GetNetworksAsync();
             var wanNetworks = networks.Where(n => n.IsWan && n.Enabled).ToList();
-            _hasMultipleWans = wanNetworks.Count > 1;
             _availableWans = wanNetworks
                 .Select(n => new WanOption(
                     n.WanNetworkgroup ?? "WAN",
@@ -1060,6 +1059,13 @@
 
             // Load WAN interfaces with physical names for gateway test
             _wanInterfaces = await SqmService.GetWanInterfacesFromControllerAsync();
+
+            // Whether traffic can actually be spread across WANs, from the gateway's real
+            // interfaces rather than the console's network list. A WAN network can be enabled with
+            // nothing attached to it, and counting those claimed load balancing on sites that have
+            // one working uplink. This is the same list the Gateway selector is built from, and the
+            // same source Adaptive SQM uses.
+            _hasMultipleWans = _wanInterfaces.Count > 1;
             _consoleDataLoaded = true;
         }
         catch { /* Non-critical */ }

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -141,7 +141,8 @@
                         }
                     </div>
                     <div class="wan-test-option-hint">
-                        Deploys a speed test binary to the gateway and runs it directly. Most accurate WAN measurement - no LAN overhead. For multi-gig connections, a Server-based test may be best.
+                        Deploys a speed test binary to the gateway and runs it directly. Most accurate WAN measurement - no LAN overhead.@if (!_agentOnGateway)
+                        {<text> For multi-gig connections, @(RunsOnAgent ? "an Agent-based" : "a Server-based") test may be best.</text>}
                     </div>
                     @if (!_gatewayAvailable && !_isRunning && !string.IsNullOrEmpty(_gatewayUnavailableReason))
                     {
@@ -169,7 +170,7 @@
                 {
                 <div class="wan-test-option @(_serverAvailable ? "" : "wan-test-option-unavailable")">
                     <div class="wan-test-option-header">
-                        <span class="wan-test-option-label">Server</span>
+                        <span class="wan-test-option-label">@(RunsOnAgent ? "On-site agent" : "Server")</span>
                         @if (!_serverAvailable && !_isRunning)
                         {
                             <span class="wan-test-option-badge" data-tooltip="@_serverUnavailableReason">Unavailable</span>
@@ -194,7 +195,7 @@
                             }
                             else
                             {
-                                <span>Run Test from Server</span>
+                                <span>Run Test from @(RunsOnAgent ? "Agent" : "Server")</span>
                             }
                         </button>
                         </SiteOperatorOnly>
@@ -206,11 +207,11 @@
                     <div class="wan-test-option-hint">
                         @if (_hasMultipleWans)
                         {
-                            <text>Tests from this server through the LAN. Traffic may be load-balanced across WAN interfaces.</text>
+                            <text>Tests from @(RunsOnAgent ? "the on-site agent" : "this server") through the LAN. Traffic may be load-balanced across WAN interfaces.</text>
                         }
                         else
                         {
-                            <text>Tests from this server through the LAN. Includes LAN traversal overhead.</text>
+                            <text>Tests from @(RunsOnAgent ? "the on-site agent" : "this server") through the LAN. Includes LAN traversal overhead.</text>
                         }
                     </div>
                 </div>
@@ -621,7 +622,7 @@
             {
                 <div class="empty-state">
                     <p>No WAN speed tests recorded yet.</p>
-                    <p class="form-help">Click "Run Test from Gateway" or "Run Test from Server" above to measure your internet connection speed.</p>
+                    <p class="form-help">Click "Run Test from Gateway" or "Run Test from @(RunsOnAgent ? "Agent" : "Server")" above to measure your internet connection speed.</p>
                 </div>
             }
         </div>
@@ -685,6 +686,14 @@
     // Both WAN tests run through that agent, so they can't run until it reconnects.
     private bool _siteAgentOffline;
     private bool _agentOnGateway;
+
+    /// <summary>
+    /// Whether the non-gateway run happens on the site's agent rather than on this server, which is
+    /// what the option is called and described as. True for a site the server cannot reach itself;
+    /// an agent that runs ON the gateway is not this case - that option is hidden entirely, because
+    /// the Gateway option already runs there.
+    /// </summary>
+    private bool RunsOnAgent => !SiteContext.IsDefault && !_agentOnGateway;
     private bool _serverAvailable = true;
     private string? _serverUnavailableReason;
     private System.Threading.Timer? _agentStatusTimer;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -43,7 +43,7 @@
                 <strong>UniFi Connection Error</strong>
                 <span>@ConnectionService.LastError - WAN detection requires a working UniFi connection.</span>
             </div>
-            <a href="/settings" class="btn btn-primary">Check Settings</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">Check Settings</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -46,7 +46,7 @@
                     <span>Connect to your UniFi Console to analyze Wi-Fi data.</span>
                 }
             </div>
-            <a href="/settings" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-primary">@(!string.IsNullOrEmpty(ConnectionService.LastError) ? "Check Settings" : "Connect Now")</a>
         </div>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/AlertsList.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/AlertsList.razor
@@ -17,7 +17,7 @@
         <div class="no-alerts">
             <div class="no-alerts-icon">!</div>
             <p>Connect to a UniFi Console to view alerts.</p>
-            <a href="/settings" class="btn btn-sm btn-primary">Go to Settings</a>
+            <a href="/settings?tab=connection#console-connection" class="btn btn-sm btn-primary">Go to Settings</a>
         </div>
     }
     else if (!ConnectionService.IsInitialized)

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -125,7 +125,7 @@
     .reboot-reason-icon {
         margin-left: auto;
         margin-right: 1rem;
-        margin-top: -1px;
+        margin-top: -0.5px;
         font-size: 0.85rem;
         color: var(--text-muted);
         cursor: help;

--- a/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/DeviceCard.razor
@@ -125,6 +125,7 @@
     .reboot-reason-icon {
         margin-left: auto;
         margin-right: 1rem;
+        margin-top: -1px;
         font-size: 0.85rem;
         color: var(--text-muted);
         cursor: help;

--- a/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
@@ -300,7 +300,7 @@
         if (!string.IsNullOrEmpty(_category)) query.Add($"category={Uri.EscapeDataString(_category)}");
         if (!string.IsNullOrEmpty(_outcome)) query.Add($"outcome={Uri.EscapeDataString(_outcome)}");
         if (!string.IsNullOrEmpty(_actor)) query.Add($"actor={Uri.EscapeDataString(_actor)}");
-        if (!string.IsNullOrEmpty(_site)) query.Add($"site={Uri.EscapeDataString(_site)}");
+        if (!string.IsNullOrEmpty(_site)) query.Add($"siteSlug={Uri.EscapeDataString(_site)}");
         var suffix = query.Count > 0 ? "?" + string.Join("&", query) : "";
         return $"/api/audit/export.{format}{suffix}";
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
@@ -81,7 +81,7 @@
                                 <td>
                                     @if (TargetLabel(e) is string label)
                                     {
-                                        <span data-tooltip="@e.TargetType">@label</span>
+                                        <span>@label</span>
                                     }
                                     else
                                     {
@@ -122,14 +122,78 @@
 
 @code {
     /// <summary>
+    /// Reader-facing names for the stored target type slugs, using each feature's own on-screen name
+    /// where it has one. Anything absent falls back to title-casing the slug, so a type added later
+    /// reads as words rather than as a raw identifier.
+    /// </summary>
+    private static readonly Dictionary<string, string> TargetTypeNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["monitoring_target"] = "Latency Target",
+        ["monitoring_settings"] = "Monitoring Settings",
+        ["monitoring_interface"] = "Monitoring Interface",
+        ["upstream_discovery"] = "Upstream Discovery",
+        ["tc_monitor"] = "SQM Monitor",
+        ["influx_org"] = "InfluxDB Organization",
+        ["influx_bucket"] = "InfluxDB Bucket",
+        ["influx_token"] = "InfluxDB Token",
+        ["wan_speedtest"] = "WAN Speed Test",
+        ["wan_speedtest_binary"] = "WAN Speed Test Binary",
+        ["lan_speedtest"] = "LAN Speed Test",
+        ["client_speedtest"] = "Client Speed Test",
+        ["gateway_speedtest"] = "Gateway Speed Test",
+        ["speedtest_device"] = "Speed Test Device",
+        ["alert"] = "Alert",
+        ["alert_rule"] = "Alert Rule",
+        ["alert_channel"] = "Notification Channel",
+        ["incident"] = "Incident",
+        ["schedule"] = "Schedule",
+        ["wan"] = "WAN",
+        ["wan_steering"] = "WAN Steering",
+        ["wan_steer_rule"] = "WAN Steering Rule",
+        ["perftweak"] = "Performance Tweak",
+        ["network_purpose"] = "Network Purpose",
+        ["config_archive"] = "Config Archive",
+        ["floor_plan"] = "Floor Plan",
+        ["planned_ap"] = "Planned AP",
+        ["ap_location"] = "AP Location",
+        ["mesh_ap"] = "Mesh AP",
+        ["spectrum_scan"] = "Spectrum Scan",
+        ["dashboard_layout"] = "Dashboard Layout",
+        ["site"] = "Site",
+        ["multi_site"] = "Multi-Site",
+        ["agent"] = "On-Site Agent",
+        ["auth_policy"] = "Authentication Policy",
+        ["license_key"] = "License Key",
+        ["setting"] = "Setting",
+        ["ssh_key"] = "SSH Key",
+        ["ssh_key_deployment"] = "SSH Key Deployment",
+        ["gateway_ssh"] = "Gateway SSH",
+        ["device_ssh"] = "Device SSH",
+        ["udm_boot"] = "UDM Boot Script",
+        ["security_audit"] = "Security Audit",
+        ["audit_issue"] = "Security Audit Issue",
+        ["threat_noise_filter"] = "Threat Intelligence Filter",
+    };
+
+    private static string TargetTypeName(string type) =>
+        TargetTypeNames.TryGetValue(type, out var name) ? name
+        : string.Join(' ', type.Split('_', StringSplitOptions.RemoveEmptyEntries)
+            .Select(word => char.ToUpperInvariant(word[0]) + word[1..]));
+
+    /// <summary>
     /// What the event acted on. Every audited action records this, and none of it was shown: the
     /// table said a monitoring target had been paused without saying which one. The name is what a
     /// reader recognizes, so it wins; the id is the fallback for an action that has no name to give.
+    /// The type leads, so "Test" reads as the Latency Target it was rather than as a bare word.
     /// </summary>
-    private static string? TargetLabel(AuditEvent e) =>
-        !string.IsNullOrEmpty(e.TargetName) ? e.TargetName
-        : !string.IsNullOrEmpty(e.TargetId) ? e.TargetId
-        : null;
+    private static string? TargetLabel(AuditEvent e)
+    {
+        var name = !string.IsNullOrEmpty(e.TargetName) ? e.TargetName : e.TargetId;
+        if (string.IsNullOrEmpty(e.TargetType))
+            return string.IsNullOrEmpty(name) ? null : name;
+        var type = TargetTypeName(e.TargetType);
+        return string.IsNullOrEmpty(name) ? type : $"{type}: {name}";
+    }
 
     private const int PageSize = 100;
     private static readonly string[] Categories =

--- a/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
@@ -38,7 +38,7 @@
             <button class="btn btn-primary btn-sm" @onclick="ApplyAsync">Filter</button>
             @if (HasFilter)
             {
-                <button class="btn btn-secondary btn-sm audit-filter-clear" @onclick="ClearFilterAsync"
+                <button type="button" class="audit-filter-clear" @onclick="ClearFilterAsync"
                         data-tooltip="Clear filter" aria-label="Clear filter">
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                          stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Identity/AuditLogPanel.razor
@@ -67,7 +67,7 @@
                 <table class="data-table">
                     <thead>
                         <tr>
-                            <th>Time (UTC)</th><th>Category</th><th>Action</th>
+                            <th>Time (UTC)</th><th>Category</th><th>Action</th><th>Target</th>
                             <th>Actor</th><th class="hide-mobile">Site ID</th><th>Outcome</th><th></th>
                         </tr>
                     </thead>
@@ -78,6 +78,16 @@
                                 <td>@e.TimestampUtc.ToString("yyyy-MM-dd HH:mm:ss")</td>
                                 <td>@e.Category</td>
                                 <td>@e.Action</td>
+                                <td>
+                                    @if (TargetLabel(e) is string label)
+                                    {
+                                        <span data-tooltip="@e.TargetType">@label</span>
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">-</span>
+                                    }
+                                </td>
                                 <td>@e.ActorName</td>
                                 <td class="hide-mobile">@(string.IsNullOrEmpty(e.SiteSlug) ? "-" : e.SiteSlug)</td>
                                 <td>
@@ -93,7 +103,7 @@
                             @if (_expanded == e.Id)
                             {
                                 <tr>
-                                    <td colspan="7"><pre class="detail-value">@e.DetailsJson</pre></td>
+                                    <td colspan="8"><pre class="detail-value">@e.DetailsJson</pre></td>
                                 </tr>
                             }
                         }
@@ -111,6 +121,16 @@
 </div>
 
 @code {
+    /// <summary>
+    /// What the event acted on. Every audited action records this, and none of it was shown: the
+    /// table said a monitoring target had been paused without saying which one. The name is what a
+    /// reader recognizes, so it wins; the id is the fallback for an action that has no name to give.
+    /// </summary>
+    private static string? TargetLabel(AuditEvent e) =>
+        !string.IsNullOrEmpty(e.TargetName) ? e.TargetName
+        : !string.IsNullOrEmpty(e.TargetId) ? e.TargetId
+        : null;
+
     private const int PageSize = 100;
     private static readonly string[] Categories =
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Identity/IdentityRolesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Identity/IdentityRolesCard.razor
@@ -228,17 +228,6 @@
         StateHasChanged();
 
         await Task.Delay(400);
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('identity-roles');
-                if (el) {
-                    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                    el.style.transition = 'outline-color 0.3s';
-                    el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-                    el.style.outlineOffset = '4px';
-                    el.style.borderRadius = '12px';
-                    setTimeout(function() { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-                }
-            })();");
+        await JS.InvokeVoidAsync("noHighlightTarget", "identity-roles");
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -5,6 +5,7 @@
 @using NetworkOptimizer.Web.Services.Identity
 @using Microsoft.EntityFrameworkCore
 @inject IInfluxDbProvisioningService Provisioner
+@inject ISiteInfluxProvisioningService SiteProvisioner
 @inject MonitoringInfluxRegistry InfluxRegistry
 @inject ICredentialProtectionService CredentialService
 @inject SiteContextService SiteContext
@@ -21,7 +22,7 @@
             </div>
             <div class="card-body">
                 <div class="empty-state">
-                    @if (_canProvision)
+                    @if (_canProvision || _canProvisionSite)
                     {
                         <span class="spinner"></span>
                         <p>Looking for InfluxDB on this network...</p>
@@ -291,8 +292,13 @@
         await ProvisionAsync();
     }
 
-    /// <summary>Whether this user could actually complete a provisioning step, resolved once on init.</summary>
+    /// <summary>Whether this user can establish the installation's InfluxDB - orgs, tokens, the
+    /// shared connection. Instance-wide Admin, because those are installation-wide decisions.</summary>
     private bool _canProvision;
+
+    /// <summary>Whether they can finish THIS site off an existing shared connection. Admin on this
+    /// site is enough: adding a site's own buckets decides nothing for the installation.</summary>
+    private bool _canProvisionSite;
 
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
 
@@ -303,10 +309,15 @@
         // looking - and a Viewer got two denied audit entries per visit (prerender, then the
         // circuit), swallowed by the catch below and therefore invisible except in the log. Ask
         // first: someone who could not finish the wizard has no business starting it.
-        _canProvision = AuthState is null
-            || (await Authz.AuthorizeAsync((await AuthState).User, Policies.RequireAdmin)).Succeeded;
+        var user = AuthState is null ? null : (await AuthState).User;
+        _canProvision = user is null || (await Authz.AuthorizeAsync(user, Policies.RequireAdmin)).Succeeded;
+        _canProvisionSite = _canProvision
+            || (await Authz.AuthorizeAsync(user!, SiteContext.Slug, Policies.SiteAdmin)).Succeeded;
 
-        if (!IsDefaultSite && _canProvision)
+        // Site mode only needs the site's own admin - it adds this site's buckets to a connection
+        // that already exists. The full flow establishes that connection, so it keeps the
+        // instance-wide check.
+        if (!IsDefaultSite && _canProvisionSite)
             await TryEnterSiteModeAsync();
         if (!_siteMode && _canProvision)
             await DetectAgainAsync();
@@ -370,11 +381,11 @@
     private async Task<bool> TrySilentProvisionAsync()
     {
         if (string.IsNullOrEmpty(_sharedToken)) return false;
-        var orgId = await Provisioner.TryResolveOrgIdAsync(_sharedUrl, _sharedToken, _sharedOrgName);
+        var orgId = await SiteProvisioner.TryResolveOrgIdAsync(_sharedUrl, _sharedToken, _sharedOrgName);
         if (string.IsNullOrEmpty(orgId)) return false;
         try
         {
-            await Provisioner.EnsureBucketsAsync(_sharedUrl, _sharedToken, orgId, SitePrimaryBucket, SiteLongtermBucket);
+            await SiteProvisioner.EnsureBucketsAsync(_sharedUrl, _sharedToken, orgId, SitePrimaryBucket, SiteLongtermBucket);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -22,7 +22,7 @@
             </div>
             <div class="card-body">
                 <div class="empty-state">
-                    @if (_canProvision || _canProvisionSite)
+                    @if (!_noWorkPossible)
                     {
                         <span class="spinner"></span>
                         <p>Looking for InfluxDB on this network...</p>
@@ -300,6 +300,9 @@
     /// site is enough: adding a site's own buckets decides nothing for the installation.</summary>
     private bool _canProvisionSite;
 
+    /// <summary>No provisioning path is open to this caller, so the wizard has nothing to do.</summary>
+    private bool _noWorkPossible;
+
     [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
 
     protected override async Task OnInitializedAsync()
@@ -321,6 +324,12 @@
             await TryEnterSiteModeAsync();
         if (!_siteMode && _canProvision)
             await DetectAgainAsync();
+
+        // Nothing above ran, so nothing will ever move off Detecting: site mode was skipped or bowed
+        // out, and the full flow needs an instance-wide Admin this caller does not have. Say so
+        // rather than spinning forever - a site's admin can land here on the default site, or on a
+        // managed site before the shared connection exists, and the spinner reads as a broken page.
+        _noWorkPossible = _state == Step.Detecting && !_siteMode && !_canProvision;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -224,10 +224,16 @@
                     @if (_siteMode)
                     {
                         <text>This site's buckets are ready on the shared InfluxDB. You can now enable monitoring.</text>
+                        @* Only when they actually pasted one: the silent path never asks, so saying
+                           we are finished with a token they never gave would be nonsense. *@
+                        @if (_usedAllAccessToken)
+                        {
+                            <text> Network Optimizer is finished with your All Access token - future sites provision using the shared token, so you can delete it in InfluxDB if you don't need it elsewhere.</text>
+                        }
                     }
                     else
                     {
-                        <text>Buckets created and a scoped token has been saved. You can now enable monitoring.</text>
+                        <text>Buckets created and a scoped token has been saved. You can now enable monitoring. Network Optimizer is finished with your All Access token - it was never written to disk, and you can delete it in InfluxDB if you don't need it elsewhere.</text>
                     }
                 </div>
                 <div class="action-buttons">
@@ -255,6 +261,10 @@
     private InfluxDbProvisioningService.UrlProbeResult? _probe;
     private string _manualUrl = string.Empty;
     private string _adminToken = string.Empty;
+
+    /// <summary>Whether this run actually asked for and used an All Access token - the silent
+    /// site-mode path never does, so its completion copy must not claim otherwise.</summary>
+    private bool _usedAllAccessToken;
     private string? _authedAs;
     private List<InfluxDbProvisioningService.InfluxOrg> _orgs = new();
     private string? _selectedOrgId;
@@ -479,6 +489,7 @@
                 await mainDb.SaveChangesAsync();
             }
             _adminToken = string.Empty; // drop the admin token explicitly
+            _usedAllAccessToken = true;
             _sharedToken = orgScoped.Token;
 
             // Main and every existing site client pick up the upgraded token

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -21,8 +21,18 @@
             </div>
             <div class="card-body">
                 <div class="empty-state">
-                    <span class="spinner"></span>
-                    <p>Looking for InfluxDB on this network...</p>
+                    @if (_canProvision)
+                    {
+                        <span class="spinner"></span>
+                        <p>Looking for InfluxDB on this network...</p>
+                    }
+                    else
+                    {
+                        @* Setting this up needs the instance-wide Admin role, which a site's own
+                           admin need not hold. Say so: nothing is going to happen for them, and a
+                           spinner that never resolves reads as the page being broken. *@
+                        <p>Setting up InfluxDB requires an administrator for this installation.</p>
+                    }
                 </div>
             </div>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -95,7 +95,21 @@
                 </span>
             </div>
             <div class="card-body">
-                @if (_siteMode)
+                @if (!_canProvision)
+                {
+                    @* An All Access token is an installation-wide credential, and everything this
+                       step does with it - creating the org's buckets, upgrading the shared token -
+                       is gated on the instance-wide role. Asking a site's own admin for one sends
+                       them to fetch a credential they have no authority to hold, and refuses them
+                       after they have gone and got it. Say who can do this instead. *@
+                    <p class="section-description">
+                        This site's monitoring data will live in the shared InfluxDB, in buckets
+                        named <code>@SitePrimaryBucket</code> and <code>@SiteLongtermBucket</code>.
+                        Creating them needs an administrator for this installation - the shared
+                        connection is set up once and covers every site.
+                    </p>
+                }
+                else if (_siteMode)
                 {
                     <p class="section-description">
                         This site will store its monitoring data in the shared InfluxDB,
@@ -122,12 +136,15 @@
                     </p>
                 }
 
-                <div class="form-group">
-                    <label class="form-label">All Access API Token</label>
-                    <input type="password" class="form-control" @bind="_adminToken" @bind:event="oninput" placeholder="Paste your InfluxDB All Access API Token" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
-                </div>
+                @if (_canProvision)
+                {
+                    <div class="form-group">
+                        <label class="form-label">All Access API Token</label>
+                        <input type="password" class="form-control" @bind="_adminToken" @bind:event="oninput" placeholder="Paste your InfluxDB All Access API Token" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
+                    </div>
+                }
 
-                @if (_state == Step.PickOrg)
+                @if (_canProvision && _state == Step.PickOrg)
                 {
                     <div class="form-group">
                         @if (_orgs.Count == 0)
@@ -176,17 +193,22 @@
                     <div class="alert alert-@_messageClass">@_message</div>
                 }
 
-                <div class="action-buttons">
-                    @if (!_siteMode)
-                    {
-                        <button class="btn btn-secondary" @onclick="DetectAgainAsync" disabled="@_busy">Use a different URL</button>
-                    }
-                    <button class="btn btn-primary" @onclick="OnPrimaryActionAsync"
-                            disabled="@(_busy || !CanPrimaryAction)">
-                        @if (_busy) { <span class="spinner-sm"></span> <span>@PrimaryBusyLabel</span> }
-                        else { <span>@PrimaryLabel</span> }
-                    </button>
-                </div>
+                @* No actions for someone who cannot complete any of them - every button here ends
+                   in an instance-wide gated call. *@
+                @if (_canProvision)
+                {
+                    <div class="action-buttons">
+                        @if (!_siteMode)
+                        {
+                            <button class="btn btn-secondary" @onclick="DetectAgainAsync" disabled="@_busy">Use a different URL</button>
+                        }
+                        <button class="btn btn-primary" @onclick="OnPrimaryActionAsync"
+                                disabled="@(_busy || !CanPrimaryAction)">
+                            @if (_busy) { <span class="spinner-sm"></span> <span>@PrimaryBusyLabel</span> }
+                            else { <span>@PrimaryLabel</span> }
+                        </button>
+                    </div>
+                }
             </div>
         </div>
         break;

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -502,6 +502,7 @@
         }
         catch (Exception ex)
         {
+            Logger.LogError(ex, "InfluxDB provisioning failed for site {Slug}", SiteContext.Slug);
             _message = $"Provisioning failed: {ex.Message}";
             _messageClass = "danger";
         }
@@ -670,6 +671,7 @@
         }
         catch (Exception ex)
         {
+            Logger.LogError(ex, "InfluxDB provisioning failed for site {Slug}", SiteContext.Slug);
             _message = $"Provisioning failed: {ex.Message}";
             _messageClass = "danger";
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/InfluxSetupWizard.razor
@@ -1,12 +1,16 @@
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Storage.Services
 @using NetworkOptimizer.Web.Services
+@using Microsoft.AspNetCore.Components.Authorization
+@using NetworkOptimizer.Web.Services.Identity
 @using Microsoft.EntityFrameworkCore
 @inject IInfluxDbProvisioningService Provisioner
 @inject MonitoringInfluxRegistry InfluxRegistry
 @inject ICredentialProtectionService CredentialService
 @inject SiteContextService SiteContext
 @inject SiteDbContextFactory SiteDbFactory
+@inject Microsoft.AspNetCore.Authorization.IAuthorizationService Authz
+@inject ILogger<InfluxSetupWizard> Logger
 
 @switch (_state)
 {
@@ -277,11 +281,24 @@
         await ProvisionAsync();
     }
 
+    /// <summary>Whether this user could actually complete a provisioning step, resolved once on init.</summary>
+    private bool _canProvision;
+
+    [CascadingParameter] private Task<AuthenticationState>? AuthState { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
-        if (!IsDefaultSite)
+        // Provisioning is Admin-gated at the service. Site mode opens by ATTEMPTING a silent bucket
+        // creation, so every Monitoring load on a managed site ran an Admin-only call as whoever was
+        // looking - and a Viewer got two denied audit entries per visit (prerender, then the
+        // circuit), swallowed by the catch below and therefore invisible except in the log. Ask
+        // first: someone who could not finish the wizard has no business starting it.
+        _canProvision = AuthState is null
+            || (await Authz.AuthorizeAsync((await AuthState).User, Policies.RequireAdmin)).Succeeded;
+
+        if (!IsDefaultSite && _canProvision)
             await TryEnterSiteModeAsync();
-        if (!_siteMode)
+        if (!_siteMode && _canProvision)
             await DetectAgainAsync();
     }
 
@@ -349,8 +366,9 @@
         {
             await Provisioner.EnsureBucketsAsync(_sharedUrl, _sharedToken, orgId, SitePrimaryBucket, SiteLongtermBucket);
         }
-        catch
+        catch (Exception ex)
         {
+            Logger.LogDebug(ex, "Silent bucket provisioning did not go through; falling back to the token prompt");
             return false;
         }
         await ReconfigureSiteClientAsync();

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -1,10 +1,9 @@
 @using NetworkOptimizer.Storage.Models
 @using Microsoft.EntityFrameworkCore
 @inject MonitoringLiveStats LiveStats
-@inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
-@inject NetworkOptimizer.Web.Services.Monitoring.AsnResolutionService AsnResolution
+@inject NetworkOptimizer.Web.Services.IMonitoringTargetService TargetService
 @inject Microsoft.JSInterop.IJSRuntime JS
 
 <div class="card">
@@ -133,7 +132,7 @@
                             <td style="white-space: nowrap;">
                                 <SiteOperatorOnly>
                                     <button class="btn btn-sm btn-secondary"
-                                        @onclick="() => ToggleTargetAsync(t.Id)"
+                                        @onclick="() => SetTargetEnabledAsync(t.Id, !t.Enabled)"
                                         title="@(t.Enabled ? "Pause probing" : "Resume probing")">
                                     @(t.Enabled ? "Pause" : "Resume")
                                 </button>
@@ -151,6 +150,10 @@
                     }
                 </tbody>
             </table>
+                @if (!string.IsNullOrEmpty(_targetError))
+                {
+                    <p class="alert alert-danger">@_targetError</p>
+                }
             </div>
             <p class="page-description" style="margin-top: 0.5rem;">
                 Removing a fabric or default WAN target will trigger it to be re-created
@@ -262,9 +265,6 @@
     // from inside the site, so adding is gated. The default site always probes locally.
     private bool CanAddTargets => SiteCtx.IsDefault || ExecutorFactory.ServerVantageIsAgent;
 
-    // Targets are per-site data: route through the current site's database.
-    private NetworkOptimizerDbContext CreateDb() => SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
-
     private bool _collapsed = true;
     private bool _showAddTarget;
     private bool _addingTarget;
@@ -275,6 +275,7 @@
     private int _newTargetPort = 443;
     private int _newTargetInterval = 10;
     private string? _addTargetError;
+    private string? _targetError;
 
     private void ToggleCollapse() => _collapsed = !_collapsed;
 
@@ -302,160 +303,67 @@
             }})();");
     }
 
-    private async Task ToggleTargetAsync(int targetId)
+    private async Task SetTargetEnabledAsync(int targetId, bool enabled)
     {
-        try
-        {
-            await using var db = CreateDb();
-            var row = await db.MonitoringTargets.FindAsync(targetId);
-            if (row == null) return;
-            row.Enabled = !row.Enabled;
-            await db.SaveChangesAsync();
-            await OnTargetsChanged.InvokeAsync();
-        }
-        catch { }
+        await MutateAsync(() => TargetService.SetEnabledAsync(targetId, enabled));
     }
 
     private async Task DeleteTargetAsync(int targetId)
     {
-        try
-        {
-            await using var db = CreateDb();
-            var row = await db.MonitoringTargets.FindAsync(targetId);
-            if (row == null) return;
-            db.MonitoringTargets.Remove(row);
-            await db.SaveChangesAsync();
-            await OnTargetsChanged.InvokeAsync();
-        }
-        catch { }
+        await MutateAsync(() => TargetService.DeleteAsync(targetId));
     }
 
     private async Task UpdateIntervalAsync(int targetId, ChangeEventArgs e)
     {
         if (!int.TryParse(e.Value?.ToString(), out var interval)) return;
-        try
-        {
-            await using var db = CreateDb();
-            var row = await db.MonitoringTargets.FindAsync(targetId);
-            if (row == null) return;
-            row.PollIntervalSeconds = interval;
-            await db.SaveChangesAsync();
-            await OnTargetsChanged.InvokeAsync();
-        }
-        catch { }
+        await MutateAsync(() => TargetService.SetPollIntervalAsync(targetId, interval));
     }
 
     private async Task UpdateWanContextAsync(int targetId, ChangeEventArgs e)
     {
-        var raw = e.Value?.ToString();
-        int? contextId = int.TryParse(raw, out var parsed) ? parsed : null;
+        int? contextId = int.TryParse(e.Value?.ToString(), out var parsed) ? parsed : null;
+        await MutateAsync(() => TargetService.SetWanContextAsync(targetId, contextId));
+    }
+
+    /// <summary>
+    /// Runs a target edit and refreshes the list. A failure surfaces on the card rather than being
+    /// swallowed: these used to end in an empty catch, so a rejected or failed edit looked like a
+    /// row that simply declined to change.
+    /// </summary>
+    private async Task MutateAsync(Func<Task<bool>> edit)
+    {
+        _targetError = null;
         try
         {
-            await using var db = CreateDb();
-            var row = await db.MonitoringTargets.FindAsync(targetId);
-            if (row == null) return;
-            row.WanContextId = contextId;
-            await db.SaveChangesAsync();
+            await edit();
             await OnTargetsChanged.InvokeAsync();
         }
-        catch { }
+        catch (Exception ex)
+        {
+            _targetError = ex is NetworkOptimizer.Web.Services.Gates.AuthorizationDeniedException
+                ? "You do not have permission to change monitoring targets."
+                : $"Could not update the target: {ex.Message}";
+        }
     }
 
     private async Task AddTargetAsync()
     {
         _addTargetError = null;
-        var name = _newTargetName.Trim();
-        var address = _newTargetAddress.Trim();
-        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(address))
-        {
-            _addTargetError = "Name and address are required.";
-            return;
-        }
-        if (name.Length > 200 || address.Length > 200)
-        {
-            _addTargetError = "Name and address must be under 200 characters.";
-            return;
-        }
-        if (!System.Net.IPAddress.TryParse(address, out _)
-            && !System.Text.RegularExpressions.Regex.IsMatch(address, @"^[a-zA-Z0-9][a-zA-Z0-9.\-]*$"))
-        {
-            _addTargetError = "Address must be a valid IP or hostname.";
-            return;
-        }
-
         _addingTarget = true;
         StateHasChanged();
         try
         {
-            var targetType = Enum.TryParse<MonitoringTargetType>(_newTargetType, out var tt) ? tt : MonitoringTargetType.Custom;
-            var probeMode = _newTargetProbeMode == "Tcp" ? NetworkOptimizer.Core.Enums.ProbeMode.Tcp : NetworkOptimizer.Core.Enums.ProbeMode.Icmp;
-            var targetId = $"custom-{Guid.NewGuid():N}"[..24];
-
-            int? asnNumber = null;
-            string? asnName = null;
-            if (targetType is MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp)
+            await TargetService.AddAsync(new NetworkOptimizer.Web.Services.NewMonitoringTarget
             {
-                var ip = address;
-                if (!System.Net.IPAddress.TryParse(address, out _))
-                {
-                    try
-                    {
-                        var entries = await System.Net.Dns.GetHostAddressesAsync(address);
-                        ip = entries.FirstOrDefault()?.ToString();
-                    }
-                    catch { ip = null; }
-                }
-                if (ip != null)
-                {
-                    var asn = await AsnResolution.ResolveAsync(ip);
-                    if (asn != null)
-                    {
-                        asnNumber = asn.Asn;
-                        // Apply the same industry-suffix cleanup auto-discovery uses
-                        // (UpstreamTracerService.CleanAsnName), so a manually-added transit hop
-                        // stores "Level 3", not "Level 3 Parent" / "Lumen", matching discovery.
-                        asnName = NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(asn.Name);
-                    }
-                }
-            }
-
-            // Manual Transit/Access ISP adds are user-provided upstream hops the tracer didn't
-            // find. Tag them UserProvided so upstream change-detection treats them as curated
-            // (never flags them as "removed", never re-suggests them as "added") while ISP
-            // Health still grades them by TargetType. Generic customs stay unmethoded (null).
-            var discoveryMethod = targetType is MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp
-                ? (DiscoveryMethod?)DiscoveryMethod.UserProvided
-                : null;
-
-            await using var db = CreateDb();
-            var entity = new MonitoringTarget
-            {
-                TargetId = targetId,
-                Name = name,
-                Address = address,
-                TargetType = targetType,
-                ProbeMode = probeMode,
-                Port = probeMode == NetworkOptimizer.Core.Enums.ProbeMode.Tcp ? _newTargetPort : null,
-                PollIntervalSeconds = _newTargetInterval,
-                PingCount = 5,
-                Enabled = true,
-                AutoDiscovered = false,
-                DiscoveryMethod = discoveryMethod,
-                VantagePoint = "server",
-                CreatedAt = DateTime.UtcNow,
-                AsnNumber = asnNumber,
-                AsnName = asnName
-            };
-            db.MonitoringTargets.Add(entity);
-            await db.SaveChangesAsync();
-
-            // Trace-on-save: an Internet/Custom target only absolves the ISP/transit hops it crosses
-            // once it has trace ancestry. Kick off an immediate trace so it can act as a witness now,
-            // instead of waiting for the next upstream discovery cycle. Resolve the "server" vantage
-            // executor here (synchronously, current site context) so external agent sites trace over
-            // the on-site agent tunnel and there's no scoped-context race in the fire-and-forget.
-            if (targetType is MonitoringTargetType.InternetService or MonitoringTargetType.Custom)
-                _ = TraceOnSaveForAncestryAsync(ExecutorFactory.GetServer(), entity.Id, address, SiteCtx.Slug, SiteCtx.IsDefault);
+                Name = _newTargetName,
+                Address = _newTargetAddress,
+                TargetType = Enum.TryParse<MonitoringTargetType>(_newTargetType, out var tt) ? tt : MonitoringTargetType.Custom,
+                ProbeMode = _newTargetProbeMode == "Tcp"
+                    ? NetworkOptimizer.Core.Enums.ProbeMode.Tcp
+                    : NetworkOptimizer.Core.Enums.ProbeMode.Icmp,
+                Port = _newTargetPort,
+                PollIntervalSeconds = _newTargetInterval
+            });
 
             _showAddTarget = false;
             _newTargetName = "";
@@ -465,6 +373,10 @@
             _newTargetPort = 443;
             _newTargetInterval = 10;
             await OnTargetsChanged.InvokeAsync();
+        }
+        catch (NetworkOptimizer.Web.Services.MonitoringTargetValidationException ex)
+        {
+            _addTargetError = ex.Message;
         }
         catch (Exception ex)
         {
@@ -476,17 +388,6 @@
         }
     }
 
-    /// <summary>
-    /// Traces a just-added Internet/Custom target over the site's server/agent vantage and persists
-    /// its hop ancestry as an UpstreamDiscovery row, so ISP Health can immediately use it as a
-    /// routes-through witness. Best-effort; fire-and-forget (reads no component state).
-    /// </summary>
-    private async Task TraceOnSaveForAncestryAsync(NetworkOptimizer.Monitoring.Probes.IProbeExecutor executor,
-        int targetId, string address, string slug, bool isDefault)
-    {
-        await using var db = SiteDb.CreateForSite(slug, isDefault);
-        await NetworkOptimizer.Web.Services.Monitoring.TargetAncestry.TraceAndPersistAsync(executor, db, targetId, address);
-    }
 
     private static string TargetTypeBadgeClass(MonitoringTargetType type) => type switch
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -291,16 +291,7 @@
         StateHasChanged();
         // Let the expand animation start and the row render before scrolling to it.
         await Task.Delay(350);
-        await JS.InvokeVoidAsync("eval", $@"
-            (function() {{
-                var el = document.getElementById('latency-target-{targetId}');
-                if (el) {{
-                    el.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
-                    el.style.transition = 'background-color 0.3s';
-                    el.style.backgroundColor = 'rgba(59, 130, 246, 0.18)';
-                    setTimeout(function() {{ el.style.backgroundColor = ''; }}, 2000);
-                }}
-            }})();");
+        await JS.InvokeVoidAsync("noHighlightRow", $"latency-target-{targetId}");
     }
 
     private async Task SetTargetEnabledAsync(int targetId, bool enabled)

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -165,7 +165,7 @@
         @if (!CanAddTargets)
         {
             <p class="page-description" style="margin-top: 0.75rem;">
-                <a href="/settings?tab=multisite#site-agent-setup">Deploy an on-site agent</a> to
+                <a href="/settings?tab=multisite#multi-site">Deploy an on-site agent</a> to
                 this site to add latency targets - the agent probes them from inside the site's
                 network.
             </p>

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -165,8 +165,9 @@
         @if (!CanAddTargets)
         {
             <p class="page-description" style="margin-top: 0.75rem;">
-                Deploy an on-site agent to this site to add latency targets - the agent probes
-                them from inside the site's network.
+                <a href="/settings?tab=multisite#site-agent-setup">Deploy an on-site agent</a> to
+                this site to add latency targets - the agent probes them from inside the site's
+                network.
             </p>
         }
         else if (_showAddTarget)

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -57,7 +57,7 @@
                     @foreach (var t in Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name))
                     {
                         var latest = LiveStats.GetTargetStats(t.TargetId);
-                        <tr id="latency-target-@t.Id" style="@(t.Enabled ? "" : "opacity: 0.55;")">
+                        <tr id="latency-target-@t.Id" class="@(t.Enabled ? "" : "latency-target-paused")">
                             <td>
                                 <span class="status-badge @TargetTypeBadgeClass(t.TargetType)">
                                     @t.TargetType.ToDisplayName()

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -308,7 +308,7 @@ else
                                     {
                                         @if (issue.LinkUrl!.StartsWith("#"))
                                         {
-                                            <a href="javascript:void(0)" onclick="document.getElementById('@(issue.LinkUrl.TrimStart('#'))').scrollIntoView({ behavior: 'smooth', block: 'start' });" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
+                                            <a href="javascript:void(0)" onclick="window.noIspJumpTo('@(issue.LinkUrl.TrimStart('#'))');" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
                                         }
                                         else
                                         {
@@ -832,6 +832,22 @@ else
         </div>
     </div>
 }
+
+@* One jump behavior for the panel: a finding's Open link and a hop's event count both scroll to
+   their section and mark it with the standard card highlight, so the two cannot drift apart. *@
+<script suppress-error="BL9992">
+    window.noIspJumpTo = function (id) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        // The same outline every other deep link in Monitoring uses (see Monitoring.razor's
+        // scroll-and-highlight helpers) so arriving somewhere always looks the same.
+        el.style.transition = 'outline-color 0.3s';
+        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
+        el.style.outlineOffset = '4px';
+        setTimeout(function () { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
+    };
+</script>
 
 @code {
     private const int NetworkPreviewCount = 5;
@@ -1480,14 +1496,7 @@ else
     /// Jumps to Path &amp; Congestion Events. The event count on a hop or network row is only useful
     /// next to the events it counts, and they sit far enough down the page to be worth a shortcut.
     /// </summary>
-    private async Task ScrollToEventsAsync()
-    {
-        await JS.InvokeVoidAsync("eval", @"
-            (function() {
-                var el = document.getElementById('isp-events');
-                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-            })();");
-    }
+    private async Task ScrollToEventsAsync() => await JS.InvokeVoidAsync("noIspJumpTo", "isp-events");
 
     private async Task ToggleEventFilterAsync(EventCategory cat, MouseEventArgs e)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -439,7 +439,15 @@ else
                                     {
                                         <span class="isp-target-stat">
                                             <span class="isp-target-stat-label">@hopLimit.Value.Label</span>
-                                            <span class="isp-target-stat-value @ScoreTextClass(hopLimit.Value.Score)">@hopLimit.Value.Value</span>
+                                            @if (hopLimit.Value.Label == "Congestion")
+                                            {
+                                                <span class="isp-target-stat-value isp-events-jump @ScoreTextClass(hopLimit.Value.Score)"
+                                                      data-tooltip="Show these events" @onclick="ScrollToEventsAsync">@hopLimit.Value.Value</span>
+                                            }
+                                            else
+                                            {
+                                                <span class="isp-target-stat-value @ScoreTextClass(hopLimit.Value.Score)">@hopLimit.Value.Value</span>
+                                            }
                                         </span>
                                     }
                                     @if (target.ReachDeltaMs is > 0.15)
@@ -607,7 +615,15 @@ else
                                 {
                                     <div class="isp-asn-stat">
                                         <span class="detail-label">@asnLimit.Value.Label</span>
-                                        <span class="detail-value @ScoreTextClass(asnLimit.Value.Score)">@asnLimit.Value.Value</span>
+                                        @if (asnLimit.Value.Label == "Congestion")
+                                        {
+                                            <span class="detail-value isp-events-jump @ScoreTextClass(asnLimit.Value.Score)"
+                                                  data-tooltip="Show these events" @onclick="ScrollToEventsAsync">@asnLimit.Value.Value</span>
+                                        }
+                                        else
+                                        {
+                                            <span class="detail-value @ScoreTextClass(asnLimit.Value.Score)">@asnLimit.Value.Value</span>
+                                        }
                                     </div>
                                 }
                                 @if (asn.ReachDeltaMs.HasValue)
@@ -754,7 +770,7 @@ else
         </div>
     }
 
-    <div class="card isp-health-card">
+    <div class="card isp-health-card" id="isp-events">
         <div class="card-header isp-events-header">
             <h2 class="card-title">Path &amp; Congestion Events (@EventsWindowLabel(r))</h2>
             <div class="time-range-selector isp-event-filter">
@@ -1460,6 +1476,23 @@ else
 
     // Ctrl+Click (Cmd+Click on macOS) bypasses the solo/restore semantics and just toggles the one
     // category, so a single category can be hidden straight from the all-on state.
+    /// <summary>
+    /// Jumps to Path &amp; Congestion Events. The event count on a hop or network row is only useful
+    /// next to the events it counts, and they sit far enough down the page to be worth a shortcut.
+    /// </summary>
+    private async Task ScrollToEventsAsync()
+    {
+        await JS.InvokeVoidAsync("eval", @"
+            (function() {
+                var el = document.getElementById('isp-events');
+                if (!el) return;
+                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                el.style.transition = 'background-color 0.3s';
+                el.style.backgroundColor = 'rgba(59, 130, 246, 0.18)';
+                setTimeout(function() { el.style.backgroundColor = ''; }, 2000);
+            })();");
+    }
+
     private async Task ToggleEventFilterAsync(EventCategory cat, MouseEventArgs e)
     {
         if (e.CtrlKey || e.MetaKey)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -308,7 +308,7 @@ else
                                     {
                                         @if (issue.LinkUrl!.StartsWith("#"))
                                         {
-                                            <a href="javascript:void(0)" onclick="window.noIspJumpTo('@(issue.LinkUrl.TrimStart('#'))');" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
+                                            <a href="javascript:void(0)" onclick="window.noHighlightTarget('@(issue.LinkUrl.TrimStart('#'))');" style="margin-left: 0.4rem;">@(issue.LinkText ?? "Open")</a>
                                         }
                                         else
                                         {
@@ -835,20 +835,6 @@ else
 
 @* One jump behavior for the panel: a finding's Open link and a hop's event count both scroll to
    their section and mark it with the standard card highlight, so the two cannot drift apart. *@
-<script suppress-error="BL9992">
-    window.noIspJumpTo = function (id) {
-        var el = document.getElementById(id);
-        if (!el) return;
-        el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        // The same outline every other deep link in Monitoring uses (see Monitoring.razor's
-        // scroll-and-highlight helpers) so arriving somewhere always looks the same.
-        el.style.transition = 'outline-color 0.3s';
-        el.style.outline = '2px solid rgba(59, 130, 246, 0.5)';
-        el.style.outlineOffset = '4px';
-        setTimeout(function () { el.style.outline = ''; el.style.outlineOffset = ''; }, 2000);
-    };
-</script>
-
 @code {
     private const int NetworkPreviewCount = 5;
 
@@ -1496,7 +1482,7 @@ else
     /// Jumps to Path &amp; Congestion Events. The event count on a hop or network row is only useful
     /// next to the events it counts, and they sit far enough down the page to be worth a shortcut.
     /// </summary>
-    private async Task ScrollToEventsAsync() => await JS.InvokeVoidAsync("noIspJumpTo", "isp-events");
+    private async Task ScrollToEventsAsync() => await JS.InvokeVoidAsync("noHighlightTarget", "isp-events");
 
     private async Task ToggleEventFilterAsync(EventCategory cat, MouseEventArgs e)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -442,7 +442,7 @@ else
                                             @if (hopLimit.Value.Label == "Congestion")
                                             {
                                                 <span class="isp-target-stat-value isp-events-jump @ScoreTextClass(hopLimit.Value.Score)"
-                                                      data-tooltip="Show these events" @onclick="ScrollToEventsAsync">@hopLimit.Value.Value</span>
+                                                      data-tooltip="Show these events" data-tooltip-hover @onclick="ScrollToEventsAsync">@hopLimit.Value.Value</span>
                                             }
                                             else
                                             {
@@ -618,7 +618,7 @@ else
                                         @if (asnLimit.Value.Label == "Congestion")
                                         {
                                             <span class="detail-value isp-events-jump @ScoreTextClass(asnLimit.Value.Score)"
-                                                  data-tooltip="Show these events" @onclick="ScrollToEventsAsync">@asnLimit.Value.Value</span>
+                                                  data-tooltip="Show these events" data-tooltip-hover @onclick="ScrollToEventsAsync">@asnLimit.Value.Value</span>
                                         }
                                         else
                                         {
@@ -1485,11 +1485,7 @@ else
         await JS.InvokeVoidAsync("eval", @"
             (function() {
                 var el = document.getElementById('isp-events');
-                if (!el) return;
-                el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                el.style.transition = 'background-color 0.3s';
-                el.style.backgroundColor = 'rgba(59, 130, 246, 0.18)';
-                setTimeout(function() { el.style.backgroundColor = ''; }, 2000);
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
             })();");
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -473,6 +473,14 @@
     private static MonitoringInterface NewInterface() => new() { Name = "modem0", SubnetPrefix = 24, SnatEnabled = true, WatchdogIntervalMinutes = 5 };
 
     /// <summary>
+    /// Whether the form is holding work the user would lose - an edit of an existing interface, or a
+    /// new one they have started filling in. The page checks this before adopting a polled status
+    /// change that would re-render this card away.
+    /// </summary>
+    public bool HasUnsavedEdit =>
+        !_collapsed && (_editingOriginal != null || !string.IsNullOrWhiteSpace(_editing.TargetIp) || _saving);
+
+    /// <summary>
     /// Test-visible (internal, see NetworkOptimizer.Web.csproj InternalsVisibleTo) so the
     /// Disabled-copy can be verified without a Blazor component-test harness.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -10,6 +10,7 @@
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteSwitchService SiteSwitch
+@inject SiteContextService SiteCtx
 @inject ISiteConfigurationService SiteConfig
 @implements IDisposable
 
@@ -250,13 +251,27 @@
                 <h3 class="site-wizard-title">@_site.Name is ready</h3>
                 <p class="section-description">
                     The site's database is provisioned@(_connected ? ", its UniFi Console is connected" : "")@(_agentToken != null ? ", and its agent token is issued" : "").
-                    Switch to the site to @(_connected ? "" : "connect its UniFi Console, then ")configure monitoring, speed tests,
-                    and everything else, exactly like a single-site install.
+                    @NextStepSentence
                 </p>
             </div>
         </div>
         <div class="action-buttons">
-            <button type="button" class="btn btn-primary" @onclick="SwitchToSiteAsync">Switch to @_site.Name</button>
+            @* Telling someone to switch to the site they are already on is the one instruction that
+               cannot be followed, so when this is the current site the action points at the actual
+               next step instead: monitoring once the console is connected, the console itself when
+               it is not. *@
+            @if (!OnCreatedSite)
+            {
+                <button type="button" class="btn btn-primary" @onclick="SwitchToSiteAsync">Switch to @_site.Name</button>
+            }
+            else if (_connected)
+            {
+                <a class="btn btn-primary" href="/monitoring">Go to Monitoring</a>
+            }
+            else
+            {
+                <a class="btn btn-primary" href="/settings#console-connection">Connect UniFi Console</a>
+            }
             <button type="button" class="btn btn-secondary" @onclick="ResetAsync">Add Another Site</button>
         </div>
     }
@@ -558,6 +573,26 @@
             setting.UpdatedAt = DateTime.UtcNow;
         }
     }
+
+    /// <summary>
+    /// Whether the finished site is the one already being viewed. Reachable through
+    /// <see cref="StartAgentSetupFor"/>, which re-enters the wizard for a site that already exists -
+    /// including the one currently selected.
+    /// </summary>
+    private bool OnCreatedSite =>
+        _site != null && string.Equals(_site.Slug, SiteCtx.Slug, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// What to do next, which depends on where the reader already is. Written out in full rather
+    /// than assembled from fragments: this is curated copy, and it should be legible as sentences.
+    /// </summary>
+    private string NextStepSentence => (OnCreatedSite, _connected) switch
+    {
+        (true, true) => "Configure monitoring, speed tests, and everything else here, exactly like a single-site install.",
+        (true, false) => "Connect its UniFi Console, then configure monitoring, speed tests, and everything else here, exactly like a single-site install.",
+        (false, true) => "Switch to the site to configure monitoring, speed tests, and everything else, exactly like a single-site install.",
+        (false, false) => "Switch to the site to connect its UniFi Console, then configure monitoring, speed tests, and everything else, exactly like a single-site install.",
+    };
 
     private async Task SwitchToSiteAsync()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -74,6 +74,7 @@
             <div class="form-group">
                 <div class="input-with-button">
                     <input type="text" id="site-name-input" class="form-control" @bind="_name" @bind:event="oninput"
+                           @onkeydown="SiteNameKeyDownAsync"
                            placeholder="Site name (e.g. Lake House)" autocomplete="off" data-1p-ignore data-lpignore="true" data-bwignore />
                     <button type="button" class="btn btn-primary btn-sm" @onclick="CreateSiteAsync"
                             disabled="@(_busy || string.IsNullOrWhiteSpace(_name))">
@@ -343,6 +344,17 @@
         _message = "";
         _messageClass = "";
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Enter creates the site, matching the button beside the field. Guarded on the same conditions
+    /// the button is disabled by, so a stray Enter on an empty field or mid-create does nothing.
+    /// </summary>
+    private async Task SiteNameKeyDownAsync(KeyboardEventArgs e)
+    {
+        if (e.Key != "Enter" || _busy || string.IsNullOrWhiteSpace(_name))
+            return;
+        await CreateSiteAsync();
     }
 
     private async Task CreateSiteAsync()

--- a/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
@@ -252,6 +252,13 @@
     private bool _testingOid;
     private TestOidResult? _testResult;
 
+    /// <summary>
+    /// Whether the custom OID form is holding work the user would lose. The page checks this before
+    /// adopting a polled status change that would re-render this card away.
+    /// </summary>
+    public bool HasUnsavedEdit =>
+        _showAddForm && (!string.IsNullOrWhiteSpace(_editOid) || !string.IsNullOrWhiteSpace(_editFieldName));
+
     protected override async Task OnParametersSetAsync()
     {
         // Nudge users who haven't touched custom OIDs yet: auto-expand the first device so the

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -471,6 +471,7 @@
     window.noUpstreamPin = (function () {
         var release = null;
         var goTop = false;
+        var frozen = false;
 
         // Glide rather than jump, matching the app-wide card expand. That one looks smooth because a
         // CSS transition feeds it a few pixels per frame; here the content arrives in chunks of
@@ -487,6 +488,7 @@
             stop();
             if (!document.getElementById(id)) return;
             goTop = false;
+            frozen = false;
 
             var scrollerOf = function (node) {
                 for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
@@ -531,6 +533,13 @@
             var frame = function () {
                 var cur = document.getElementById(id);
                 if (!cur) { stop(); return; }
+
+                // Hold position while the terminal render lands. It is the largest one of the run -
+                // the whole review UI arrives at once - and following it drags the view to the
+                // bottom of results we are about to leave, so the landing that follows reads as a
+                // long scroll back up rather than a single move.
+                if (frozen) { raf = requestAnimationFrame(frame); return; }
+
                 var sc = scrollerOf(cur);
                 var delta = correction(cur, sc);
 
@@ -568,6 +577,7 @@
                 window.removeEventListener('keydown', onKey, true);
                 release = null;
                 goTop = false;
+                frozen = false;
             };
             raf = requestAnimationFrame(frame);
         }
@@ -580,10 +590,15 @@
         // let go. A scroll of the reader's own still stops immediately via stop().
         function finish() {
             if (!release) return;
+            // Stop following FIRST. The run finishing is not the same as the card having finished
+            // growing: the render carrying the terminal state is the one that adds the review UI,
+            // and chasing it is what put the view below the results in the first place.
+            frozen = true;
             setTimeout(function () {
-                // Switch the running loop's target to the card's top and let it ease there; it
-                // stops itself once it arrives. Setting the flag rather than jumping is what keeps
-                // the final move as smooth as the following that preceded it.
+                // Layout has settled. Switch the loop's target to the card's top and let it ease
+                // there; it stops itself once it arrives. Setting the flag rather than jumping is
+                // what keeps the final move as smooth as the following that preceded it.
+                frozen = false;
                 goTop = true;
             }, 400);
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -38,7 +38,7 @@
             <div class="alert alert-info" style="margin-bottom: 0;">
                 <strong>Deploy an on-site agent first.</strong>
                 Upstream discovery traces the path from inside this site's network, so it needs a
-                connected agent at the site. Enroll one from <a href="/settings">Settings</a>, then
+                connected agent at the site. Enroll one from <a href="/settings?tab=multisite#site-agent-setup">Settings</a>, then
                 run discovery here.
             </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -492,26 +492,14 @@
                 var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
                 var drift = cur.getBoundingClientRect().top - paneTop;
 
-                // Two phases, because one rule cannot serve the whole run.
+                // Hold the TOP, always. An earlier version switched to following the bottom once the
+                // card outgrew the pane, which at the end of a run left the view parked at the
+                // bottom of a very long card - the opposite of what pinning means.
                 //
-                // While the card still fits the pane, hold its TOP: the whole thing is on screen and
-                // the reader watches it fill. Once discovery has grown it taller than the pane,
-                // holding the top would park the newest sections below the fold - which is exactly
-                // what happens at the end of a long run - so follow the BOTTOM instead, keeping the
-                // freshest content in view like a log tail.
-                //
-                // No spacer either way. Adding one below this card pushed the Latency targets panel
-                // off screen, and adding it to the pane wrote to layout every page shares; the
-                // write is simply allowed to clamp when there is nowhere further to go.
-                var r = cur.getBoundingClientRect();
-                var fits = r.height <= sc.clientHeight;
-                if (fits) {
-                    if (Math.abs(drift) > 2) sc.scrollTop += drift;
-                } else {
-                    var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
-                    var below = r.bottom - paneBottom;
-                    if (below > 2) sc.scrollTop += below;
-                }
+                // No spacer either. Adding one below this card pushed the Latency targets panel off
+                // screen, and adding it to the pane wrote to layout every page shares; the write is
+                // simply allowed to clamp when there is nowhere further to go.
+                if (Math.abs(drift) > 2) sc.scrollTop += drift;
             };
 
             lastKeep = keep;

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -470,11 +470,23 @@
 <script suppress-error="BL9992">
     window.noUpstreamPin = (function () {
         var release = null;
-        var lastTop = null;
+        var goTop = false;
+
+        // Glide rather than jump, matching the app-wide card expand. That one looks smooth because a
+        // CSS transition feeds it a few pixels per frame; here the content arrives in chunks of
+        // several hundred pixels at a time, so applying the whole correction in one frame is exactly
+        // the snap this replaces. Easing a fraction of what remains each frame reads as the view
+        // following the work, and re-targets for free every time another section lands.
+        var EASE = 0.18;
+        var SETTLED = 1;
+        // A correction that cannot move (already at the top or bottom of the scroller) would
+        // otherwise ease forever against a clamp.
+        var MAX_STALLED_FRAMES = 12;
 
         function start(id) {
             stop();
             if (!document.getElementById(id)) return;
+            goTop = false;
 
             var scrollerOf = function (node) {
                 for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
@@ -484,42 +496,57 @@
                 return document.scrollingElement || document.documentElement;
             };
 
-            var keep = function () {
-                var cur = document.getElementById(id);
-                if (!cur) { stop(); return; }
-                var sc = scrollerOf(cur);
+            // How far the view is from where it should be right now, or 0 when it is close enough.
+            var correction = function (cur, sc) {
                 var isDoc = sc === document.scrollingElement || sc === document.documentElement;
                 var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
-                var drift = cur.getBoundingClientRect().top - paneTop;
+                var r = cur.getBoundingClientRect();
+                var drift = r.top - paneTop;
+
+                // AT THE END: land on the TOP, not wherever the follow had got to. Following the
+                // edge is right while sections are still arriving; at the end it parks you past all
+                // the detail you came for, so the last move is to the start of the card.
+                if (goTop) return Math.abs(drift) > 2 ? drift : 0;
 
                 // WHILE RUNNING: show the newest work. If the card still fits the pane, holding its
                 // top does that already; once it is taller, follow the bottom edge so each section
-                // appears as it lands. Landing on the top at the END is handled by finish(), which
-                // is the one moment you want the whole result from its start rather than its tail.
+                // appears as it lands.
                 //
                 // No spacer either way. Adding one below this card pushed the Latency targets panel
                 // off screen, and adding it to the pane wrote to layout every page shares; the
                 // write is simply allowed to clamp when there is nowhere further to go.
-                var r = cur.getBoundingClientRect();
-                if (r.height <= sc.clientHeight) {
-                    if (Math.abs(drift) > 2) sc.scrollTop += drift;
-                } else {
-                    var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
-                    var below = r.bottom - paneBottom;
-                    if (below > 2) sc.scrollTop += below;
-                }
+                if (r.height <= sc.clientHeight) return Math.abs(drift) > 2 ? drift : 0;
+                var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
+                var below = r.bottom - paneBottom;
+                return below > 2 ? below : 0;
             };
 
-            lastTop = function () {
+            var raf = 0;
+            var stalled = 0;
+            var frame = function () {
                 var cur = document.getElementById(id);
-                if (!cur) return;
+                if (!cur) { stop(); return; }
                 var sc = scrollerOf(cur);
-                var isDoc = sc === document.scrollingElement || sc === document.documentElement;
-                var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
-                var drift = cur.getBoundingClientRect().top - paneTop;
-                if (Math.abs(drift) > 2) sc.scrollTop += drift;
+                var delta = correction(cur, sc);
+
+                if (Math.abs(delta) <= SETTLED) {
+                    stalled = 0;
+                    // Nothing left to do and nothing more coming: the run is over.
+                    if (goTop) { stop(); return; }
+                } else {
+                    var step = delta * EASE;
+                    // Cover the last pixel or two outright rather than crawling at them.
+                    if (Math.abs(step) < 0.5) step = delta;
+                    var before = sc.scrollTop;
+                    sc.scrollTop += step;
+                    if (sc.scrollTop === before && ++stalled >= MAX_STALLED_FRAMES) {
+                        if (goTop) { stop(); return; }
+                    } else if (sc.scrollTop !== before) {
+                        stalled = 0;
+                    }
+                }
+                raf = requestAnimationFrame(frame);
             };
-            var timer = setInterval(keep, 300);
             // Wheel, touch and the scrolling keys are unambiguous intent; a scroll event would also
             // catch our own corrections.
             var give = function () { stop(); };
@@ -530,14 +557,14 @@
             window.addEventListener('keydown', onKey, true);
 
             release = function () {
-                clearInterval(timer);
+                if (raf) cancelAnimationFrame(raf);
                 window.removeEventListener('wheel', give);
                 window.removeEventListener('touchmove', give);
                 window.removeEventListener('keydown', onKey, true);
                 release = null;
-                lastTop = null;
+                goTop = false;
             };
-            keep();
+            raf = requestAnimationFrame(frame);
         }
 
         function stop() { if (release) release(); }
@@ -549,11 +576,10 @@
         function finish() {
             if (!release) return;
             setTimeout(function () {
-                // Land on the TOP, not wherever the follow had got to. Following the edge is right
-                // while sections are still arriving; at the end it parks you past all the detail
-                // you came for, so the last move is to the start of the card.
-                if (lastTop) lastTop();
-                stop();
+                // Switch the running loop's target to the card's top and let it ease there; it
+                // stops itself once it arrives. Setting the flag rather than jumping is what keeps
+                // the final move as smooth as the following that preceded it.
+                goTop = true;
             }, 400);
         }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -549,7 +549,18 @@
     {
         if (!_canOperate) return;
         _justSaved = false;
-        await Discovery.StartAsync();
+        // Discovery adds sections to this card for a minute or so; keep its top in view rather than
+        // making the reader follow them down the page. Released when it finishes, or sooner if they
+        // scroll for themselves.
+        try { await JS.InvokeVoidAsync("noAnchorTop", "upstream-discovery"); } catch { }
+        try
+        {
+            await Discovery.StartAsync();
+        }
+        finally
+        {
+            try { await JS.InvokeVoidAsync("noAnchorRelease"); } catch { }
+        }
         _state = Tracer.State;
         StateHasChanged();
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -38,7 +38,7 @@
             <div class="alert alert-info" style="margin-bottom: 0;">
                 <strong>Deploy an on-site agent first.</strong>
                 Upstream discovery traces the path from inside this site's network, so it needs a
-                connected agent at the site. Enroll one from <a href="/settings?tab=multisite#site-agent-setup">Settings</a>, then
+                connected agent at the site. Enroll one from <a href="/settings?tab=multisite#multi-site">Settings</a>, then
                 run discovery here.
             </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -3,6 +3,7 @@
 @using NetworkOptimizer.Web.Services.Monitoring
 @implements IDisposable
 @inject UpstreamTracerService Tracer
+@inject NetworkOptimizer.Web.Services.IUpstreamDiscoveryService Discovery
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
@@ -548,7 +549,7 @@
     {
         if (!_canOperate) return;
         _justSaved = false;
-        await Tracer.StartDiscoveryAsync();
+        await Discovery.StartAsync();
         _state = Tracer.State;
         StateHasChanged();
     }
@@ -556,7 +557,7 @@
     private async Task CommitAsync()
     {
         if (!_canOperate) return;
-        await Tracer.CommitResultsAsync();
+        await Discovery.CommitAsync();
         _state = Tracer.State;
         _justSaved = true;
         await OnSaved.InvokeAsync();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -491,12 +491,26 @@
                 var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
                 var drift = cur.getBoundingClientRect().top - paneTop;
 
-                // No spacer of any kind. Adding one below this card pushed the Latency targets panel
-                // that follows it clean off the screen, and adding it to the pane wrote to layout
-                // every page shares. It was only ever needed while the card is short - and a short
-                // card is fully visible anyway - so the write is simply allowed to clamp. Once
-                // discovery grows the card past the pane height, the top reaches on its own.
-                if (Math.abs(drift) > 2) sc.scrollTop += drift;
+                // Two phases, because one rule cannot serve the whole run.
+                //
+                // While the card still fits the pane, hold its TOP: the whole thing is on screen and
+                // the reader watches it fill. Once discovery has grown it taller than the pane,
+                // holding the top would park the newest sections below the fold - which is exactly
+                // what happens at the end of a long run - so follow the BOTTOM instead, keeping the
+                // freshest content in view like a log tail.
+                //
+                // No spacer either way. Adding one below this card pushed the Latency targets panel
+                // off screen, and adding it to the pane wrote to layout every page shares; the
+                // write is simply allowed to clamp when there is nowhere further to go.
+                var r = cur.getBoundingClientRect();
+                var fits = r.height <= sc.clientHeight;
+                if (fits) {
+                    if (Math.abs(drift) > 2) sc.scrollTop += drift;
+                } else {
+                    var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
+                    var below = r.bottom - paneBottom;
+                    if (below > 2) sc.scrollTop += below;
+                }
             };
 
             var timer = setInterval(keep, 300);

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -4,6 +4,7 @@
 @implements IDisposable
 @inject UpstreamTracerService Tracer
 @inject NetworkOptimizer.Web.Services.IUpstreamDiscoveryService Discovery
+@inject ILogger<UpstreamTracerPanel> Logger
 @inject NetworkOptimizer.Storage.Services.SiteDbContextFactory SiteDb
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
@@ -552,14 +553,28 @@
         // Discovery adds sections to this card for a minute or so; keep its top in view rather than
         // making the reader follow them down the page. Released when it finishes, or sooner if they
         // scroll for themselves.
-        try { await JS.InvokeVoidAsync("noAnchorTop", "upstream-discovery"); } catch { }
+        try
+        {
+            await JS.InvokeVoidAsync("noAnchorTop", "upstream-discovery");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not pin the discovery card while it runs");
+        }
         try
         {
             await Discovery.StartAsync();
         }
         finally
         {
-            try { await JS.InvokeVoidAsync("noAnchorRelease"); } catch { }
+            try
+            {
+                await JS.InvokeVoidAsync("noAnchorRelease");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not release the discovery card pin");
+            }
         }
         _state = Tracer.State;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -517,8 +517,13 @@
                 // write is simply allowed to clamp when there is nowhere further to go.
                 if (r.height <= sc.clientHeight) return Math.abs(drift) > 2 ? drift : 0;
                 var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
+                // Both directions. A section that measures tall while it is building and settles
+                // shorter a frame later leaves the view parked past the end of the card, and a
+                // downward-only follow has no way back - it reads as scrolling below the results and
+                // staying there until the run ends. Correcting upward too means an overshoot is
+                // undone as soon as the layout settles, which is the frame after it happens.
                 var below = r.bottom - paneBottom;
-                return below > 2 ? below : 0;
+                return Math.abs(below) > 2 ? below : 0;
             };
 
             var raf = 0;

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -483,7 +483,6 @@
                 return document.scrollingElement || document.documentElement;
             };
 
-            var spaced = -1;
             var keep = function () {
                 var cur = document.getElementById(id);
                 if (!cur) { stop(); return; }
@@ -492,15 +491,11 @@
                 var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
                 var drift = cur.getBoundingClientRect().top - paneTop;
 
-                // The card is last on the page, so its top cannot reach the pane's top until there
-                // is something below it - the browser clamps the write and nothing moves. Make up
-                // the shortfall with margin on the card itself: it does not paint, and it goes away
-                // with the element, so it can never be stranded on anything shared.
-                var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
-                if (shortfall !== spaced) {
-                    spaced = shortfall;
-                    cur.style.marginBottom = shortfall ? shortfall + 'px' : '';
-                }
+                // No spacer of any kind. Adding one below this card pushed the Latency targets panel
+                // that follows it clean off the screen, and adding it to the pane wrote to layout
+                // every page shares. It was only ever needed while the card is short - and a short
+                // card is fully visible anyway - so the write is simply allowed to clamp. Once
+                // discovery grows the card past the pane height, the top reaches on its own.
                 if (Math.abs(drift) > 2) sc.scrollTop += drift;
             };
 
@@ -519,8 +514,6 @@
                 window.removeEventListener('wheel', give);
                 window.removeEventListener('touchmove', give);
                 window.removeEventListener('keydown', onKey, true);
-                var cur = document.getElementById(id);
-                if (cur) cur.style.marginBottom = '';
                 release = null;
             };
             keep();

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -462,6 +462,76 @@
     </div>
 </div>
 
+
+@* Scroll behavior for THIS card only. Deliberately not in shared JS: it is a niche affordance for a
+   long-running discovery, and when it lived alongside the app-wide helpers it reached into the
+   scroller every page shares and broke an unrelated jump. Defined here, it ships with the panel and
+   nothing else can call it. *@
+<script suppress-error="BL9992">
+    window.noUpstreamPin = (function () {
+        var release = null;
+
+        function start(id) {
+            stop();
+            if (!document.getElementById(id)) return;
+
+            var scrollerOf = function (node) {
+                for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
+                    var oy = getComputedStyle(n).overflowY;
+                    if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
+                }
+                return document.scrollingElement || document.documentElement;
+            };
+
+            var spaced = -1;
+            var keep = function () {
+                var cur = document.getElementById(id);
+                if (!cur) { stop(); return; }
+                var sc = scrollerOf(cur);
+                var isDoc = sc === document.scrollingElement || sc === document.documentElement;
+                var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
+                var drift = cur.getBoundingClientRect().top - paneTop;
+
+                // The card is last on the page, so its top cannot reach the pane's top until there
+                // is something below it - the browser clamps the write and nothing moves. Make up
+                // the shortfall with margin on the card itself: it does not paint, and it goes away
+                // with the element, so it can never be stranded on anything shared.
+                var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
+                if (shortfall !== spaced) {
+                    spaced = shortfall;
+                    cur.style.marginBottom = shortfall ? shortfall + 'px' : '';
+                }
+                if (Math.abs(drift) > 2) sc.scrollTop += drift;
+            };
+
+            var timer = setInterval(keep, 300);
+            // Wheel, touch and the scrolling keys are unambiguous intent; a scroll event would also
+            // catch our own corrections.
+            var give = function () { stop(); };
+            var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };
+            var onKey = function (e) { if (keys[e.key]) give(); };
+            window.addEventListener('wheel', give, { passive: true });
+            window.addEventListener('touchmove', give, { passive: true });
+            window.addEventListener('keydown', onKey, true);
+
+            release = function () {
+                clearInterval(timer);
+                window.removeEventListener('wheel', give);
+                window.removeEventListener('touchmove', give);
+                window.removeEventListener('keydown', onKey, true);
+                var cur = document.getElementById(id);
+                if (cur) cur.style.marginBottom = '';
+                release = null;
+            };
+            keep();
+        }
+
+        function stop() { if (release) release(); }
+
+        return { start: start, stop: stop };
+    })();
+</script>
+
 @code {
     [Parameter] public bool ForceExpand { get; set; }
     [Parameter] public EventCallback OnSaved { get; set; }
@@ -557,7 +627,7 @@
         {
             try
             {
-                await JS.InvokeVoidAsync("noAnchorRelease");
+                await JS.InvokeVoidAsync("noUpstreamPin.stop");
             }
             catch (Exception ex)
             {
@@ -575,7 +645,7 @@
         // scroll for themselves.
         try
         {
-            await JS.InvokeVoidAsync("noAnchorTop", "upstream-discovery");
+            await JS.InvokeVoidAsync("noUpstreamPin.start", "upstream-discovery");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -470,6 +470,7 @@
 <script suppress-error="BL9992">
     window.noUpstreamPin = (function () {
         var release = null;
+        var lastKeep = null;
 
         function start(id) {
             stop();
@@ -513,6 +514,7 @@
                 }
             };
 
+            lastKeep = keep;
             var timer = setInterval(keep, 300);
             // Wheel, touch and the scrolling keys are unambiguous intent; a scroll event would also
             // catch our own corrections.
@@ -529,13 +531,26 @@
                 window.removeEventListener('touchmove', give);
                 window.removeEventListener('keydown', onKey, true);
                 release = null;
+                lastKeep = null;
             };
             keep();
         }
 
         function stop() { if (release) release(); }
 
-        return { start: start, stop: stop };
+        // The run finishing is not the same as the card having finished growing: the render that
+        // carries the terminal state is the one that adds the review UI, so stopping on it leaves
+        // that last, largest addition unfollowed. Give the layout a moment, follow once more, then
+        // let go. A scroll of the reader's own still stops immediately via stop().
+        function finish() {
+            if (!release) return;
+            setTimeout(function () {
+                if (lastKeep) lastKeep();
+                stop();
+            }, 400);
+        }
+
+        return { start: start, stop: stop, finish: finish };
     })();
 </script>
 
@@ -634,7 +649,7 @@
         {
             try
             {
-                await JS.InvokeVoidAsync("noUpstreamPin.stop");
+                await JS.InvokeVoidAsync("noUpstreamPin.finish");
             }
             catch (Exception ex)
             {

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -470,7 +470,7 @@
 <script suppress-error="BL9992">
     window.noUpstreamPin = (function () {
         var release = null;
-        var lastKeep = null;
+        var lastTop = null;
 
         function start(id) {
             stop();
@@ -492,17 +492,33 @@
                 var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
                 var drift = cur.getBoundingClientRect().top - paneTop;
 
-                // Hold the TOP, always. An earlier version switched to following the bottom once the
-                // card outgrew the pane, which at the end of a run left the view parked at the
-                // bottom of a very long card - the opposite of what pinning means.
+                // WHILE RUNNING: show the newest work. If the card still fits the pane, holding its
+                // top does that already; once it is taller, follow the bottom edge so each section
+                // appears as it lands. Landing on the top at the END is handled by finish(), which
+                // is the one moment you want the whole result from its start rather than its tail.
                 //
-                // No spacer either. Adding one below this card pushed the Latency targets panel off
-                // screen, and adding it to the pane wrote to layout every page shares; the write is
-                // simply allowed to clamp when there is nowhere further to go.
-                if (Math.abs(drift) > 2) sc.scrollTop += drift;
+                // No spacer either way. Adding one below this card pushed the Latency targets panel
+                // off screen, and adding it to the pane wrote to layout every page shares; the
+                // write is simply allowed to clamp when there is nowhere further to go.
+                var r = cur.getBoundingClientRect();
+                if (r.height <= sc.clientHeight) {
+                    if (Math.abs(drift) > 2) sc.scrollTop += drift;
+                } else {
+                    var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
+                    var below = r.bottom - paneBottom;
+                    if (below > 2) sc.scrollTop += below;
+                }
             };
 
-            lastKeep = keep;
+            lastTop = function () {
+                var cur = document.getElementById(id);
+                if (!cur) return;
+                var sc = scrollerOf(cur);
+                var isDoc = sc === document.scrollingElement || sc === document.documentElement;
+                var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
+                var drift = cur.getBoundingClientRect().top - paneTop;
+                if (Math.abs(drift) > 2) sc.scrollTop += drift;
+            };
             var timer = setInterval(keep, 300);
             // Wheel, touch and the scrolling keys are unambiguous intent; a scroll event would also
             // catch our own corrections.
@@ -519,7 +535,7 @@
                 window.removeEventListener('touchmove', give);
                 window.removeEventListener('keydown', onKey, true);
                 release = null;
-                lastKeep = null;
+                lastTop = null;
             };
             keep();
         }
@@ -533,7 +549,10 @@
         function finish() {
             if (!release) return;
             setTimeout(function () {
-                if (lastKeep) lastKeep();
+                // Land on the TOP, not wherever the follow had got to. Following the edge is right
+                // while sections are still arriving; at the end it parks you past all the detail
+                // you came for, so the last move is to the start of the card.
+                if (lastTop) lastTop();
                 stop();
             }, 400);
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -546,6 +546,26 @@
         catch { _needsReview = false; }
     }
 
+    /// <summary>
+    /// Lets the card pin go once the run has settled. StartAsync returns while the run is still
+    /// going, so the release cannot live beside it - this fires on the render that carries the
+    /// terminal state instead.
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (_state.Step is TracerStep.Done or TracerStep.ReviewingResults or TracerStep.Failed)
+        {
+            try
+            {
+                await JS.InvokeVoidAsync("noAnchorRelease");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not release the discovery card pin");
+            }
+        }
+    }
+
     private async Task StartAsync()
     {
         if (!_canOperate) return;
@@ -561,21 +581,11 @@
         {
             Logger.LogDebug(ex, "Could not pin the discovery card while it runs");
         }
-        try
-        {
-            await Discovery.StartAsync();
-        }
-        finally
-        {
-            try
-            {
-                await JS.InvokeVoidAsync("noAnchorRelease");
-            }
-            catch (Exception ex)
-            {
-                Logger.LogDebug(ex, "Could not release the discovery card pin");
-            }
-        }
+        // Deliberately NOT released here. StartAsync returns as soon as the run is under way, not
+        // when it finishes, so releasing in a finally killed the pin about a tick after it started -
+        // one correction, then nothing, with no scroll from the reader to explain it. The pin ends
+        // when the run reaches a terminal step (below), or the moment they scroll for themselves.
+        await Discovery.StartAsync();
         _state = Tracer.State;
         StateHasChanged();
     }

--- a/src/NetworkOptimizer.Web/Endpoints/AuditLogEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/AuditLogEndpoints.cs
@@ -37,7 +37,11 @@ public static class AuditLogEndpoints
             ToUtc = DateTime.TryParse(q["to"], out var t) ? t.ToUniversalTime() : null,
             Category = NullIfEmpty(q["category"]),
             Actor = NullIfEmpty(q["actor"]),
-            SiteSlug = NullIfEmpty(q["site"]),
+            // NOT "site": that name belongs to the app's per-tab site pin, and site-context.js
+            // stamps it onto every /api/ anchor at click time. Reading it here turned Export into
+            // "export the current site only", silently dropping every event that has no site of its
+            // own - which is most of them, so the file came back as just the newest handful.
+            SiteSlug = NullIfEmpty(q["siteSlug"]),
             Outcome = NullIfEmpty(q["outcome"]),
         };
     }

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -133,8 +133,25 @@ public static class MonitoringChartEndpoints
                 }
             }
 
+            // Bucket to the site's own sample interval. The chart is only as fine as the data
+            // behind it, and averaging several samples into one bucket throws away resolution a
+            // faster-polling site is paying for. Read from this site's settings, not assumed.
+            var sampleIntervalSeconds = 5;
+            try
+            {
+                await using var sdb = siteDb.CreateForSite(siteContext.Slug, siteContext.IsDefault);
+                var ms = await sdb.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+                if (ms != null) sampleIntervalSeconds = Math.Max(1, ms.FastPollIntervalSeconds);
+            }
+            catch (Exception ex)
+            {
+                loggerFactory.CreateLogger("MonitoringChartEndpoints").LogDebug(ex,
+                    "Could not read the sample interval; the chart buckets at the default");
+            }
+
             var wanTask = !string.IsNullOrEmpty(gatewayMac) && wanIfNames?.Count > 0
-                ? influx.QueryGatewayWanRatesAsync(gatewayMac, wanIfNames, queryFrom, queryTo, ct: ct)
+                ? influx.QueryGatewayWanRatesAsync(gatewayMac, wanIfNames, queryFrom, queryTo,
+                    sampleIntervalSeconds: sampleIntervalSeconds, ct: ct)
                 : Task.FromResult<IReadOnlyList<MonitoringInfluxClient.WanRatePoint>>(Array.Empty<MonitoringInfluxClient.WanRatePoint>());
             var targets = await liveStats.GetIspTransitTargetsAsync(ct);
             var targetIds = targets.Select(t => t.TargetId).ToList();
@@ -169,7 +186,9 @@ public static class MonitoringChartEndpoints
                 };
             }).ToList();
 
-            return Results.Ok(new { points });
+            // The client polls live samples on its own timer; handing it the interval lets that
+            // timer track the site rather than a constant that was right for a 5s tier.
+            return Results.Ok(new { points, sampleIntervalSeconds });
         });
 
         group.MapGet("/api/monitoring/chart-data", async (

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -69,6 +69,7 @@ public static class MonitoringChartEndpoints
             UniFiConnectionService connectionService,
             NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDb,
             SiteContextService siteContext,
+            ILoggerFactory loggerFactory,
             DateTime? from,
             DateTime? to,
             CancellationToken ct) =>
@@ -119,11 +120,17 @@ public static class MonitoringChartEndpoints
                         .FirstOrDefaultAsync(ct);
                     if (profile != null)
                     {
-                        gatewayMac ??= profile.GatewayMac;
+                        // Assign rather than ??=: the entry condition allows an EMPTY string, which
+                        // ??= would keep. Normalized to match the other reader and the writer.
+                        gatewayMac = profile.GatewayMac!.Replace("-", ":").ToLowerInvariant();
                         wanIfNames = new List<string> { profile.CounterInterface! };
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    loggerFactory.CreateLogger("MonitoringChartEndpoints").LogDebug(ex,
+                        "Could not read the remembered WAN profile; the chart falls back to an empty series");
+                }
             }
 
             var wanTask = !string.IsNullOrEmpty(gatewayMac) && wanIfNames?.Count > 0

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -67,6 +67,8 @@ public static class MonitoringChartEndpoints
             MonitoringInfluxClient influx,
             MonitoringLiveStats liveStats,
             UniFiConnectionService connectionService,
+            NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDb,
+            SiteContextService siteContext,
             DateTime? from,
             DateTime? to,
             CancellationToken ct) =>
@@ -94,6 +96,35 @@ public static class MonitoringChartEndpoints
                 wanIfNames = gw?.WanInterfaceNames;
             }
             catch { }
+
+            // The stored rates are keyed on gateway MAC + counter interface, and both normally come
+            // from the console - so an offline site skipped the query entirely and read as having no
+            // history, when the history is sitting in InfluxDB. Fall back to the remembered WAN
+            // profile, which records exactly that pair.
+            //
+            // ONLY while the console is down, so nothing about the online path changes: a connected
+            // console that returns no gateway still yields an empty series as before, and eth0,
+            // eth6.100 and ppp0 keep resolving live. CounterInterface, not the data path - a VLAN
+            // sub-interface's counters double, which is why the two are stored apart.
+            if ((string.IsNullOrEmpty(gatewayMac) || wanIfNames is not { Count: > 0 })
+                && !connectionService.IsConnected)
+            {
+                try
+                {
+                    await using var db = siteDb.CreateForSite(siteContext.Slug, siteContext.IsDefault);
+                    var profile = await db.WanProfiles.AsNoTracking()
+                        .Where(w => w.GatewayMac != null && w.CounterInterface != null)
+                        .OrderBy(w => w.WanNetworkgroup)
+                        .ThenByDescending(w => w.UpdatedAt)
+                        .FirstOrDefaultAsync(ct);
+                    if (profile != null)
+                    {
+                        gatewayMac ??= profile.GatewayMac;
+                        wanIfNames = new List<string> { profile.CounterInterface! };
+                    }
+                }
+                catch { }
+            }
 
             var wanTask = !string.IsNullOrEmpty(gatewayMac) && wanIfNames?.Count > 0
                 ? influx.QueryGatewayWanRatesAsync(gatewayMac, wanIfNames, queryFrom, queryTo, ct: ct)

--- a/src/NetworkOptimizer.Web/Endpoints/SnmpEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SnmpEndpoints.cs
@@ -25,6 +25,7 @@ public static class SnmpEndpoints
             SiteContextService siteContext,
             ICredentialProtectionService credentialProtection,
             AgentSnmpQueryService agentSnmpQuery,
+            SiteAgentCoverage agentCoverage,
             ILoggerFactory loggerFactory,
             CancellationToken ct) =>
         {
@@ -32,7 +33,7 @@ public static class SnmpEndpoints
             if (string.IsNullOrWhiteSpace(request.DeviceMac) || string.IsNullOrWhiteSpace(request.Oid))
                 return Results.BadRequest(new TestOidResponse { ErrorMessage = "Device MAC and OID are required." });
 
-            var hasAgent = !siteContext.IsDefault && agentSnmpQuery.HasAgentForSite(siteContext.Slug);
+            var hasAgent = agentCoverage.AgentCovers(siteContext.Slug, agentSnmpQuery.HasAgentForSite(siteContext.Slug));
             oidLog.LogDebug(
                 "OID test: site={Slug} isDefault={IsDefault} hasAgent={HasAgent} mac={Mac} oid={Oid}",
                 siteContext.Slug, siteContext.IsDefault, hasAgent, request.DeviceMac, request.Oid);

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -79,18 +79,33 @@ var loggerConfig = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}");
 
-// Add file logging for Windows (in the logs folder under install directory)
-if (OperatingSystem.IsWindows())
+// File logging, in the logs folder under the install directory. Every platform, not just Windows:
+// in a container the console is the only record, and it goes with the container - so an upgrade,
+// or any recreate, destroyed the logs covering whatever prompted it. Docker compose already mounts
+// this folder to the host for exactly this purpose; nothing was ever written to it.
 {
     var logFolder = Path.Combine(AppContext.BaseDirectory, "logs");
-    Directory.CreateDirectory(logFolder);
-    var logPath = Path.Combine(logFolder, "networkoptimizer-.log");
+    try
+    {
+        Directory.CreateDirectory(logFolder);
+        var logPath = Path.Combine(logFolder, "networkoptimizer-.log");
 
-    loggerConfig.WriteTo.File(
-        logPath,
-        rollingInterval: RollingInterval.Day,
-        retainedFileCountLimit: 7,
-        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}");
+        loggerConfig.WriteTo.File(
+            logPath,
+            rollingInterval: RollingInterval.Day,
+            // Rolls on size as well as by day, and keeps a bounded number of files: debug logging
+            // on a busy install writes fast, and a log that fills the disk is worse than no log.
+            fileSizeLimitBytes: 20 * 1024 * 1024,
+            rollOnFileSizeLimit: true,
+            retainedFileCountLimit: 7,
+            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}");
+    }
+    catch (Exception ex)
+    {
+        // A read-only or unwritable install directory must not stop the app starting; the console
+        // sink is already attached and keeps working.
+        Console.Error.WriteLine($"File logging disabled - could not use {logFolder}: {ex.Message}");
+    }
 }
 
 Log.Logger = loggerConfig.CreateLogger();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -109,7 +109,7 @@ builder.Services.AddSingleton<NetworkOptimizer.Storage.Services.ICredentialProte
 // instance per site. Scoped resolution (components, request handlers, per-site
 // scopes) forwards to the current site's instance; singletons and background
 // code inject the registry directly.
-builder.Services.AddSingleton<SiteConnectionRegistry>();
+builder.Services.AddSiteScopedRegistry<SiteConnectionRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<SiteConnectionRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 builder.Services.AddSingleton<IUniFiClientProvider>(sp => sp.GetRequiredService<SiteConnectionRegistry>().GetDefault());
@@ -316,7 +316,7 @@ builder.Services.AddSingleton<SshClientService>();
 // pages): consults the site's devices.via_agent flag and rewrites host:port to
 // an agent tunnel proxy endpoint when enabled.
 builder.Services.AddSingleton<SiteTunnelRouting>();
-builder.Services.AddSingleton<GatewaySshRegistry>();
+builder.Services.AddSiteScopedRegistry<GatewaySshRegistry>();
 builder.Services.AddScoped<IGatewaySshService>(sp => sp.GetRequiredService<GatewaySshRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 
@@ -329,7 +329,7 @@ builder.Services.AddScoped<IUdmBootService, UdmBootService>();
 // device credentials + per-device configs from that site's DB). Scoped resolution
 // forwards to the current site's instance; singleton consumers inject the
 // registry and pin GetDefault() or GetFor(slug).
-builder.Services.AddSingleton<UniFiSshRegistry>();
+builder.Services.AddSiteScopedRegistry<UniFiSshRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<UniFiSshRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 
@@ -350,7 +350,7 @@ builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHttpProvider>()
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
-builder.Services.AddSingleton<ModemMonitorRegistry>();
+builder.Services.AddSiteScopedRegistry<ModemMonitorRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ModemMonitorRegistry>());
 builder.Services.AddScoped(sp => sp.GetRequiredService<ModemMonitorRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).CableModem);
@@ -391,7 +391,7 @@ builder.Services.AddMutatingService<IGatewaySpeedTestService, GatewaySpeedTestSe
 // (path analyzer + topology snapshots + client speed test service). Scoped
 // resolution forwards to the current site's instance so pages show that site's
 // results; the public results endpoint routes by slug parameter.
-builder.Services.AddSingleton<SpeedTestServiceRegistry>();
+builder.Services.AddSiteScopedRegistry<SpeedTestServiceRegistry>();
 builder.Services.AddMutatingService<IClientSpeedTestService>(sp => sp.GetRequiredService<SpeedTestServiceRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug).ClientSpeedTest);
 
@@ -508,7 +508,7 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<NetworkOptimizer.A
 // WAN data usage tracking is per site: the registry owns one WanDataUsageService per
 // site (its console + its DB), the default starting with the app and non-default sites
 // reconciled in. Scoped resolution forwards to the current site's collector.
-builder.Services.AddSingleton<WanDataUsageRegistry>();
+builder.Services.AddSiteScopedRegistry<WanDataUsageRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<WanDataUsageRegistry>());
 builder.Services.AddScoped(sp => sp.GetRequiredService<WanDataUsageRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
@@ -567,13 +567,13 @@ builder.Services.AddScoped<MonitoringReadinessService>();
 // default site's included. Scoped resolution forwards to the current site's
 // client so chart endpoints and pages read that site's buckets; singleton
 // consumers inject the registry and pin GetDefault().
-builder.Services.AddSingleton<MonitoringInfluxRegistry>();
+builder.Services.AddSiteScopedRegistry<MonitoringInfluxRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<MonitoringInfluxRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 // Per-site live monitoring caches, same forwarding shape: pages/endpoints get
 // the current site's instance, singleton collectors pin the default, and the
 // agent result sink records into the owning site's instance.
-builder.Services.AddSingleton<MonitoringLiveStatsRegistry>();
+builder.Services.AddSiteScopedRegistry<MonitoringLiveStatsRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<MonitoringLiveStatsRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.WanSummaryCache>();
@@ -583,7 +583,7 @@ builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.DeviceTra
 // Per-site device reboot trackers: uptime samples go in - from the collection tier where it is
 // running, and from DeviceRebootObserver regardless - and the dashboard reads the reason behind
 // each device's current boot back out.
-builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.RebootReason.DeviceRebootRegistry>();
+builder.Services.AddSiteScopedRegistry<NetworkOptimizer.Web.Services.Monitoring.RebootReason.DeviceRebootRegistry>();
 // Observes device uptime from the console alone, so reboot reasons resolve whether or not
 // monitoring is collecting anything.
 builder.Services.AddHostedService<NetworkOptimizer.Web.Services.Monitoring.RebootReason.DeviceRebootObserver>();
@@ -592,7 +592,7 @@ builder.Services.AddScoped(sp => sp.GetRequiredService<NetworkOptimizer.Web.Serv
 // ISP Health is per site: the registry owns one IspHealthService (with its own
 // PhysicalLinkResolver, report cache, and compute state) per site; scoped
 // resolution forwards to the current site's instance.
-builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.IspHealth.IspHealthRegistry>();
+builder.Services.AddSiteScopedRegistry<NetworkOptimizer.Web.Services.Monitoring.IspHealth.IspHealthRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<NetworkOptimizer.Web.Services.Monitoring.IspHealth.IspHealthRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 // Scoped - forwards to the current site's Influx client and database.
@@ -603,13 +603,13 @@ builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.AsnResolu
 // in-memory state machines keyed by target id / MAC, which repeat across sites, so
 // each site gets its own bundle. Local collection loops and the agent tunnel sink
 // both evaluate through the owning site's instances.
-builder.Services.AddSingleton<MonitoringAlertRegistry>();
+builder.Services.AddSiteScopedRegistry<MonitoringAlertRegistry>();
 // (The cable modem, ONT, and cellular alert evaluators are per site via
 // MonitoringAlertRegistry.)
 // Upstream tracer is per site (isolated discovery state in each site's DB, traceroute
 // from the site's own vantage). Scoped resolution forwards to the current site's tracer;
 // the background re-discovery iterates sites via the registry.
-builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerRegistry>();
+builder.Services.AddSiteScopedRegistry<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 builder.Services.AddMutatingService<IInfluxDbProvisioningService, InfluxDbProvisioningService>();
@@ -632,7 +632,7 @@ builder.Services.AddScoped<NetworkOptimizer.Web.Services.Monitoring.GatewayDiagn
 // (default always runs; non-default sites start/stop on site enable/disable). Scoped
 // resolution forwards to the current site's instance so the Setup dashboard reads
 // per-device SNMP status for the site it is showing.
-builder.Services.AddSingleton<MonitoringCollectionRegistry>();
+builder.Services.AddSiteScopedRegistry<MonitoringCollectionRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<MonitoringCollectionRegistry>());
 builder.Services.AddScoped(sp => sp.GetRequiredService<MonitoringCollectionRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
@@ -643,7 +643,7 @@ builder.Services.AddHostedService<NetworkOptimizer.Web.Services.Monitoring.Upstr
 // forwarding hands each request the current site's instance, so a secondary
 // site's rebuild can no longer overwrite the main site's map snapshot. Service
 // is Scoped so it can consume scoped deps.
-builder.Services.AddSingleton<NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapCacheRegistry>();
+builder.Services.AddSiteScopedRegistry<NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapCacheRegistry>();
 builder.Services.AddScoped(sp => sp.GetRequiredService<NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapCacheRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 builder.Services.AddScoped<NetworkOptimizer.Web.Services.LanFlowMap.LanFlowMapService>();
@@ -745,7 +745,7 @@ builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IChannelMemoryRep
         sp,
         sp.GetRequiredService<SiteContextService>().Slug,
         sp.GetRequiredService<SiteContextService>().IsDefault));
-builder.Services.AddSingleton<ChannelMemoryRegistry>();
+builder.Services.AddSiteScopedRegistry<ChannelMemoryRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ChannelMemoryRegistry>());
 
 // Add ApexCharts for Wi-Fi Optimizer visualizations

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -678,6 +678,12 @@ builder.Services.AddMutatingService<ISshKeyDeploymentService, SshKeyDeploymentSe
 // is session-lived, so the compute still runs about once per session.
 builder.Services.AddScoped<ModuleUpdateNotificationService>();
 builder.Services.AddMutatingService<IMonitoringInterfaceDeploymentService, MonitoringInterfaceDeploymentService>();
+// Curating the site's monitoring configuration from the Monitoring page: the Latency targets card's
+// target edits, the Setup tab's enable and alert thresholds, and Upstream path discovery. These ran
+// as direct DbContext writes in the components, so none of them were audited.
+builder.Services.AddMutatingService<IMonitoringTargetService, MonitoringTargetService>();
+builder.Services.AddMutatingService<IMonitoringSettingsService, MonitoringSettingsService>();
+builder.Services.AddMutatingService<IUpstreamDiscoveryService, UpstreamDiscoveryService>();
 
 // Register WiFi Optimizer rules and engine
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, NetworkOptimizer.WiFi.Rules.IoTSsidSeparationRule>();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -613,6 +613,10 @@ builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.UpstreamT
 builder.Services.AddScoped(sp => sp.GetRequiredService<NetworkOptimizer.Web.Services.Monitoring.UpstreamTracerRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));
 builder.Services.AddMutatingService<IInfluxDbProvisioningService, InfluxDbProvisioningService>();
+// The same implementation behind a site-scoped gate, for the one thing a Site Admin should be able
+// to finish alone: adding their own site's buckets to a shared connection that already exists.
+builder.Services.AddMutatingService<ISiteInfluxProvisioningService>(
+    sp => ActivatorUtilities.CreateInstance<InfluxDbProvisioningService>(sp));
 // Probe-execution layer: the server-side LocalProbeExecutor is the default vantage. SSH
 // vantages (gateway/switch/AP) are constructed per-device via SshProbeExecutor later.
 builder.Services.AddSingleton<NetworkOptimizer.Monitoring.Probes.LocalProbeExecutor>();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -79,33 +79,18 @@ var loggerConfig = new LoggerConfiguration()
     .Enrich.FromLogContext()
     .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}");
 
-// File logging, in the logs folder under the install directory. Every platform, not just Windows:
-// in a container the console is the only record, and it goes with the container - so an upgrade,
-// or any recreate, destroyed the logs covering whatever prompted it. Docker compose already mounts
-// this folder to the host for exactly this purpose; nothing was ever written to it.
+// Add file logging for Windows (in the logs folder under install directory)
+if (OperatingSystem.IsWindows())
 {
     var logFolder = Path.Combine(AppContext.BaseDirectory, "logs");
-    try
-    {
-        Directory.CreateDirectory(logFolder);
-        var logPath = Path.Combine(logFolder, "networkoptimizer-.log");
+    Directory.CreateDirectory(logFolder);
+    var logPath = Path.Combine(logFolder, "networkoptimizer-.log");
 
-        loggerConfig.WriteTo.File(
-            logPath,
-            rollingInterval: RollingInterval.Day,
-            // Rolls on size as well as by day, and keeps a bounded number of files: debug logging
-            // on a busy install writes fast, and a log that fills the disk is worse than no log.
-            fileSizeLimitBytes: 20 * 1024 * 1024,
-            rollOnFileSizeLimit: true,
-            retainedFileCountLimit: 7,
-            outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}");
-    }
-    catch (Exception ex)
-    {
-        // A read-only or unwritable install directory must not stop the app starting; the console
-        // sink is already attached and keeps working.
-        Console.Error.WriteLine($"File logging disabled - could not use {logFolder}: {ex.Message}");
-    }
+    loggerConfig.WriteTo.File(
+        logPath,
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 7,
+        outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}");
 }
 
 Log.Logger = loggerConfig.CreateLogger();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -316,6 +316,9 @@ builder.Services.AddSingleton<SshClientService>();
 // pages): consults the site's devices.via_agent flag and rewrites host:port to
 // an agent tunnel proxy endpoint when enabled.
 builder.Services.AddSingleton<SiteTunnelRouting>();
+// Whether a site's agent collects instead of this server. Singleton: consulted by the
+// per-site collection loops and the probe executor factory, and it caches per slug.
+builder.Services.AddSingleton<SiteAgentCoverage>();
 builder.Services.AddSiteScopedRegistry<GatewaySshRegistry>();
 builder.Services.AddScoped<IGatewaySshService>(sp => sp.GetRequiredService<GatewaySshRegistry>()
     .GetFor(sp.GetRequiredService<SiteContextService>().Slug));

--- a/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentEnrollmentService.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
@@ -24,6 +24,7 @@ public class AgentEnrollmentService : IAgentEnrollmentService
 
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _mainDbFactory;
     private readonly AgentTunnelRegistry _tunnelRegistry;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly ILogger<AgentEnrollmentService> _logger;
     private readonly Authorization.ISiteAccessFilter _siteAccess;
 
@@ -31,11 +32,13 @@ public class AgentEnrollmentService : IAgentEnrollmentService
         IDbContextFactory<NetworkOptimizerDbContext> mainDbFactory,
         AgentTunnelRegistry tunnelRegistry,
         Authorization.ISiteAccessFilter siteAccess,
+        SiteAgentCoverage agentCoverage,
         ILogger<AgentEnrollmentService> logger)
     {
         _siteAccess = siteAccess;
         _mainDbFactory = mainDbFactory;
         _tunnelRegistry = tunnelRegistry;
+        _agentCoverage = agentCoverage;
         _logger = logger;
     }
 
@@ -267,13 +270,16 @@ public class AgentEnrollmentService : IAgentEnrollmentService
 
     /// <summary>
     /// The LAN IP of an enrolled, enabled, online agent for the given site slug,
-    /// or null when the site has no such agent (default site, no agent, agent
-    /// offline, or its LAN IP is not yet known). Used to point site clients at the
-    /// on-site agent for LAN speed tests.
+    /// or null when the site has no such agent (no agent, agent offline, or its LAN IP is not yet
+    /// known). Used to point site clients at the on-site agent for LAN speed tests. The default
+    /// site answers null unless it is configured for its agent to cover it - otherwise clients
+    /// would be sent to an agent for a network this server is already on.
     /// </summary>
     public async Task<string?> GetOnlineAgentLanIpAsync(string siteSlug)
     {
-        if (string.IsNullOrWhiteSpace(siteSlug) || siteSlug == SiteManagementService.DefaultSiteSlug)
+        if (string.IsNullOrWhiteSpace(siteSlug))
+            return null;
+        if (siteSlug == SiteManagementService.DefaultSiteSlug && !_agentCoverage.Covers(siteSlug))
             return null;
 
         await using var db = await _mainDbFactory.CreateDbContextAsync();

--- a/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
@@ -40,6 +40,11 @@ public class AgentOnGatewayDetector
     private readonly NetworkOptimizer.Storage.Services.SiteDbContextFactory _siteDbFactory;
     private readonly ILogger<AgentOnGatewayDetector> _logger;
     private readonly ConcurrentDictionary<string, (bool OnGateway, DateTime At)> _cache = new();
+    // The agent address the last detection compared against the gateway's. Kept so callers that
+    // need it - anything asking "is this target the box the agent runs on" - can have it from here
+    // rather than asking the enrollment service again, which is gated and unusable from background
+    // work without a system scope.
+    private readonly ConcurrentDictionary<string, string> _agentIp = new();
     private readonly ConcurrentDictionary<string, Task> _refreshing = new();
 
     public AgentOnGatewayDetector(
@@ -102,6 +107,14 @@ public class AgentOnGatewayDetector
         return _cache.TryGetValue(siteSlug, out var fresh) && fresh.OnGateway;
     }
 
+    /// <summary>
+    /// The address the site's agent reported at the last detection, or null if none has completed.
+    /// Only meaningful alongside <see cref="IsAgentOnGatewayAsync"/> saying true, where it is the
+    /// gateway's own address - which is to say, the one target that agent must not probe.
+    /// </summary>
+    public string? LastKnownAgentIp(string siteSlug) =>
+        _agentIp.TryGetValue(siteSlug, out var ip) ? ip : null;
+
     /// <summary>One in-flight refresh per site; result lands in the cache, and first-time callers await the returned task.</summary>
     private Task StartOrJoinRefresh(string siteSlug) =>
         _refreshing.GetOrAdd(siteSlug, slug => Task.Run(async () =>
@@ -159,6 +172,7 @@ public class AgentOnGatewayDetector
 
         var onGateway = gatewayIps.Contains(agentIp!, StringComparer.OrdinalIgnoreCase);
         _cache[siteSlug] = (onGateway, DateTime.UtcNow);
+        _agentIp[siteSlug] = agentIp!;
         await PersistAsync(siteSlug, onGateway);
     }
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -110,6 +110,8 @@ public class AgentProbeResultSink
         ICredentialProtectionService credentialProtection,
         MonitoringCollectionRegistry collectionRegistry,
         SiteAgentCoverage agentCoverage,
+        AgentOnGatewayDetector onGatewayDetector,
+        IAgentEnrollmentService enrollment,
         ILogger<AgentProbeResultSink> logger)
     {
         _siteDbFactory = siteDbFactory;
@@ -122,11 +124,15 @@ public class AgentProbeResultSink
         _credentialProtection = credentialProtection;
         _collectionRegistry = collectionRegistry;
         _agentCoverage = agentCoverage;
+        _onGatewayDetector = onGatewayDetector;
+        _enrollment = enrollment;
         _logger = logger;
     }
 
     private readonly MonitoringCollectionRegistry _collectionRegistry;
     private readonly SiteAgentCoverage _agentCoverage;
+    private readonly AgentOnGatewayDetector _onGatewayDetector;
+    private readonly IAgentEnrollmentService _enrollment;
 
     /// <summary>Called once per connection after the hello exchange, and by the periodic refresh.</summary>
     public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct)
@@ -260,9 +266,25 @@ public class AgentProbeResultSink
                 .ToListAsync(ct);
             var contextsById = await db.WanContexts.AsNoTracking().ToDictionaryAsync(c => c.Id, ct);
 
+            // An agent running ON the gateway cannot usefully probe it: the target is the box the
+            // probe runs on, so every reply is loopback - 0 ms and no loss - which reads as a
+            // perfectly healthy gateway precisely when it might not be. Skipped for this agent at
+            // push time rather than disabled in the database, so the target stays as the user left
+            // it and any other vantage keeps measuring it.
+            var selfAddress = await _onGatewayDetector.IsAgentOnGatewayAsync(connection.SiteSlug)
+                ? await _enrollment.GetOnlineAgentLanIpAsync(connection.SiteSlug)
+                : null;
+            var skippedSelf = 0;
+
             var config = new ProbeConfig();
             foreach (var target in targets)
             {
+                if (!string.IsNullOrEmpty(selfAddress)
+                    && string.Equals(target.Address, selfAddress, StringComparison.OrdinalIgnoreCase))
+                {
+                    skippedSelf++;
+                    continue;
+                }
                 // Targets in an agent-assigned WAN context go only to that agent
                 // (typically a probe-only instance bound behind the right WAN);
                 // unassigned targets go to every agent as extra vantage points.
@@ -284,8 +306,9 @@ public class AgentProbeResultSink
             }
 
             connection.TrySend(new ServerMessage { ProbeConfig = config });
-            _logger.LogInformation("Pushed {Count} probe target(s) to agent {Id} (site {Slug})",
-                config.Targets.Count, connection.AgentId, connection.SiteSlug);
+            _logger.LogInformation("Pushed {Count} probe target(s) to agent {Id} (site {Slug}){Skipped}",
+                config.Targets.Count, connection.AgentId, connection.SiteSlug,
+                skippedSelf > 0 ? $" - {skippedSelf} skipped: the agent runs on that target" : "");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -271,8 +271,13 @@ public class AgentProbeResultSink
             // perfectly healthy gateway precisely when it might not be. Skipped for this agent at
             // push time rather than disabled in the database, so the target stays as the user left
             // it and any other vantage keeps measuring it.
+            // The address comes from the detector, which already resolved it while deciding. Asking
+            // the enrollment service directly looked equivalent and was not: it is a gated service,
+            // this runs on the tunnel's background path with no caller context, and the gate threw -
+            // taking the whole push with it, so the site got no targets at all and its monitoring
+            // read as total loss.
             var selfAddress = await _onGatewayDetector.IsAgentOnGatewayAsync(connection.SiteSlug)
-                ? await _enrollment.GetOnlineAgentLanIpAsync(connection.SiteSlug)
+                ? _onGatewayDetector.LastKnownAgentIp(connection.SiteSlug)
                 : null;
             var skippedSelf = 0;
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -231,6 +231,13 @@ public class AgentProbeResultSink
             // restart, since the console comes up on its own as soon as the tunnel does - so the
             // push was skipped exactly when it was wanted and SNMP lagged probes by a full refresh
             // cycle on every reconnect.
+            // ReconnectAsync returns once the console is ROUTED through the tunnel, not once it has
+            // authenticated - so IsConnected is still false for a moment afterwards and an
+            // immediate push defers for exactly the reason it was retried. Give it a short while to
+            // finish coming up; if it takes longer than this, the periodic refresh has it.
+            for (var i = 0; i < 10 && !siteConnection.IsConnected; i++)
+                await Task.Delay(TimeSpan.FromSeconds(1), CancellationToken.None);
+
             if (siteConnection.IsConnected)
                 await PushSnmpConfigAsync(connection, CancellationToken.None);
         }

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -134,8 +134,13 @@ public class AgentProbeResultSink
     private readonly AgentOnGatewayDetector _onGatewayDetector;
     private readonly IAgentEnrollmentService _enrollment;
 
-    /// <summary>Called once per connection after the hello exchange, and by the periodic refresh.</summary>
-    public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct)
+    /// <summary>
+    /// Called once per connection after the hello exchange, and again by the periodic refresh.
+    /// <paramref name="initialConnect"/> separates the two: the console reconnect below belongs to a
+    /// genuine connect and must not run on every refresh, or each cycle re-pushes a config that is
+    /// already current.
+    /// </summary>
+    public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct, bool initialConnect = false)
     {
         await PushProbeConfigAsync(connection, ct);
         await PushSnmpConfigAsync(connection, ct);
@@ -146,7 +151,8 @@ public class AgentProbeResultSink
         // before the tunnel is up, exhaust its short retry window, and stay
         // disconnected until a manual reconnect. Now that the tunnel is up,
         // reconnect it - fire-and-forget so we never block the tunnel read loop.
-        _ = ReconnectConsoleIfViaAgentAsync(connection);
+        if (initialConnect)
+            _ = ReconnectConsoleIfViaAgentAsync(connection);
     }
 
     /// <summary>
@@ -214,15 +220,7 @@ public class AgentProbeResultSink
                 return;
 
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
-            // Whether the console was down when this call began decides everything below. This
-            // method also runs on the 60s config refresh, so a console that is already up means
-            // there is nothing to reconnect and nothing deferred to catch up - the periodic push
-            // has it. Acting anyway sent a second, identical SNMP config every minute.
-            var consoleWasDown = !siteConnection.IsConnected;
-            if (!consoleWasDown)
-                return;
-
-            if (await siteConnection.IsConsoleViaAgentAsync())
+            if (!siteConnection.IsConnected && await siteConnection.IsConsoleViaAgentAsync())
             {
                 _logger.LogInformation(
                     "Agent tunnel up for site {Slug}; reconnecting its console via the tunnel", connection.SiteSlug);

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -214,7 +214,15 @@ public class AgentProbeResultSink
                 return;
 
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
-            if (!siteConnection.IsConnected && await siteConnection.IsConsoleViaAgentAsync())
+            // Whether the console was down when this call began decides everything below. This
+            // method also runs on the 60s config refresh, so a console that is already up means
+            // there is nothing to reconnect and nothing deferred to catch up - the periodic push
+            // has it. Acting anyway sent a second, identical SNMP config every minute.
+            var consoleWasDown = !siteConnection.IsConnected;
+            if (!consoleWasDown)
+                return;
+
+            if (await siteConnection.IsConsoleViaAgentAsync())
             {
                 _logger.LogInformation(
                     "Agent tunnel up for site {Slug}; reconnecting its console via the tunnel", connection.SiteSlug);

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -109,6 +109,7 @@ public class AgentProbeResultSink
         MonitoringAlertRegistry alertRegistry,
         ICredentialProtectionService credentialProtection,
         MonitoringCollectionRegistry collectionRegistry,
+        SiteAgentCoverage agentCoverage,
         ILogger<AgentProbeResultSink> logger)
     {
         _siteDbFactory = siteDbFactory;
@@ -120,10 +121,12 @@ public class AgentProbeResultSink
         _alertRegistry = alertRegistry;
         _credentialProtection = credentialProtection;
         _collectionRegistry = collectionRegistry;
+        _agentCoverage = agentCoverage;
         _logger = logger;
     }
 
     private readonly MonitoringCollectionRegistry _collectionRegistry;
+    private readonly SiteAgentCoverage _agentCoverage;
 
     /// <summary>Called once per connection after the hello exchange, and by the periodic refresh.</summary>
     public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct)
@@ -331,15 +334,17 @@ public class AgentProbeResultSink
     /// Builds and pushes the site's SNMP monitoring config: credentials from
     /// the site's MonitoringSettings, device list from the site's console
     /// connection, filtered and addressed by the same SnmpDeviceRules the
-    /// local collection agent uses. Default-site agents never get SNMP config
-    /// - the server's own collection agent already polls those devices.
+    /// local collection agent uses. A default-site agent gets SNMP config only when the site is
+    /// configured for its agent to cover it - otherwise the server's own collection agent is still
+    /// polling those devices and pushing a second poller would double every sample.
     /// </summary>
     public async Task PushSnmpConfigAsync(AgentTunnelConnection connection, CancellationToken ct)
     {
-        if (connection.SiteSlug == SiteManagementService.DefaultSiteSlug) return;
+        var isDefault = connection.SiteSlug == SiteManagementService.DefaultSiteSlug;
+        if (isDefault && !await _agentCoverage.CoversAsync(connection.SiteSlug)) return;
         try
         {
-            await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault: false);
+            await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault);
             var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
 
             // Before building the push, re-detect the SNMP config from the site's console

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -214,16 +214,23 @@ public class AgentProbeResultSink
                 return;
 
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
-            if (siteConnection.IsConnected || !await siteConnection.IsConsoleViaAgentAsync())
-                return;
-            _logger.LogInformation(
-                "Agent tunnel up for site {Slug}; reconnecting its console via the tunnel", connection.SiteSlug);
-            await siteConnection.ReconnectAsync();
+            if (!siteConnection.IsConnected && await siteConnection.IsConsoleViaAgentAsync())
+            {
+                _logger.LogInformation(
+                    "Agent tunnel up for site {Slug}; reconnecting its console via the tunnel", connection.SiteSlug);
+                await siteConnection.ReconnectAsync();
+            }
 
-            // The initial SNMP push in OnAgentConnectedAsync was deferred because the
-            // console wasn't connected yet (it reaches the console through this same
-            // tunnel). Now that it's up, re-push so the agent gets the full device list
-            // immediately instead of waiting for the next periodic refresh.
+            // The initial SNMP push in OnAgentConnectedAsync was deferred because the console
+            // wasn't connected yet (it reaches the console through this same tunnel). Now that it
+            // is, re-push so the agent gets the full device list immediately instead of waiting for
+            // the next periodic refresh.
+            //
+            // Reached whether or not the console needed reconnecting here. It used to sit behind an
+            // early return that also covered "already connected" - the ordinary case after a server
+            // restart, since the console comes up on its own as soon as the tunnel does - so the
+            // push was skipped exactly when it was wanted and SNMP lagged probes by a full refresh
+            // cycle on every reconnect.
             if (siteConnection.IsConnected)
                 await PushSnmpConfigAsync(connection, CancellationToken.None);
         }

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -188,12 +188,18 @@ public class AgentTunnelProxyService : IDisposable
             {
                 _logger.LogDebug("Proxy open {Host}:{Port} via agent {AgentId} failed: {Error}",
                     listener.TargetHost, listener.TargetPort, agent.AgentId, openError);
+                // Whoever dialed the loopback listener only ever sees it close, so the agent's
+                // reason has to be left where they can find it. SSH.NET, for one, reports the
+                // hang-up as a missing protocol banner and buries the actual cause entirely.
+                _lastOpenFailure[listener.LocalPort] =
+                    ($"{listener.TargetHost}:{listener.TargetPort} via the site's agent - {openError}", DateTime.UtcNow);
                 CloseConnection(connection, notifyAgent: false);
                 return;
             }
 
             // The tunnel answered, so clear any open breaker for this site.
             _openBreaker.TryRemove(listener.SiteSlug, out _);
+            _lastOpenFailure.TryRemove(listener.LocalPort, out _);
 
             // Local reads -> tunnel, with backpressure. The agent-to-local
             // direction is written by the tunnel read loop via OnProxyDataAsync.
@@ -222,6 +228,27 @@ public class AgentTunnelProxyService : IDisposable
     }
 
     /// <summary>Agent answered a ProxyOpen.</summary>
+    // Why the last open on a loopback listener failed, so a caller holding nothing but a closed
+    // socket can say something useful. Short-lived on purpose: an old reason attached to an
+    // unrelated later failure would be worse than no reason at all.
+    private readonly ConcurrentDictionary<int, (string Reason, DateTime At)> _lastOpenFailure = new();
+    private static readonly TimeSpan FailureReasonTtl = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// The agent's own reason for refusing or failing the last open on this loopback port, if it
+    /// was recent. Null when the port is not one of ours, or nothing has failed on it lately.
+    /// </summary>
+    public string? RecentOpenFailure(int localPort)
+    {
+        if (!_lastOpenFailure.TryGetValue(localPort, out var failure)) return null;
+        if (DateTime.UtcNow - failure.At > FailureReasonTtl)
+        {
+            _lastOpenFailure.TryRemove(localPort, out _);
+            return null;
+        }
+        return failure.Reason;
+    }
+
     public void OnProxyOpenResult(ProxyOpenResult result)
     {
         if (_connections.TryGetValue(result.ConnectionId, out var connection))

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -137,6 +137,14 @@ public sealed class AgentTunnelConnection
         LastMessageAt = DateTime.UtcNow;
     }
 
+    /// <summary>
+    /// Port this agent serves its LAN speed test page on, as announced in its hello. Zero for an
+    /// agent old enough not to say, which the callers read as the 3000 those agents serve. Lives on
+    /// the connection rather than the agent row because it only means anything while the agent is
+    /// connected - a target is never composed for an offline one.
+    /// </summary>
+    public int SpeedTestPort { get; internal set; }
+
     public int AgentId { get; }
     public string SiteSlug { get; }
     public string AgentName { get; }

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelRegistry.cs
@@ -145,6 +145,12 @@ public sealed class AgentTunnelConnection
     /// </summary>
     public int SpeedTestPort { get; internal set; }
 
+    /// <summary>
+    /// Whether this agent serves a LAN speed test page, as it stated in its hello. Null for an
+    /// agent that does not say, which leaves the server to work it out as it always has.
+    /// </summary>
+    public bool? ServesSpeedTest { get; internal set; }
+
     public int AgentId { get; }
     public string SiteSlug { get; }
     public string AgentName { get; }

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -99,6 +99,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
         await _enrollment.HeartbeatAsync(hello.AgentKey, hello.Version, hello.LanIp);
 
         var connection = _registry.Register(agent.Id, siteSlug, agent.Name);
+        connection.SpeedTestPort = hello.SpeedTestPort;
         _logger.LogInformation("Agent {Name} (id {Id}) opened tunnel for site {Slug}", agent.Name, agent.Id, siteSlug);
 
         // The pump and refresh loops must stop when the read loop ends for any

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -131,7 +131,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
             refreshTask = RefreshProbeConfigLoopAsync(connection, streamCts.Token);
             livenessTask = WatchLivenessAsync(connection, streamCts.Token);
 
-            await _probeResultSink.OnAgentConnectedAsync(connection, ct);
+            await _probeResultSink.OnAgentConnectedAsync(connection, ct, initialConnect: true);
 
             while (await requestStream.MoveNext(ct))
             {

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelService.cs
@@ -100,6 +100,7 @@ public class AgentTunnelService : AgentTunnel.AgentTunnelBase
 
         var connection = _registry.Register(agent.Id, siteSlug, agent.Name);
         connection.SpeedTestPort = hello.SpeedTestPort;
+        connection.ServesSpeedTest = hello.HasServesSpeedTest ? hello.ServesSpeedTest : null;
         _logger.LogInformation("Agent {Name} (id {Id}) opened tunnel for site {Slug}", agent.Name, agent.Id, siteSlug);
 
         // The pump and refresh loops must stop when the read loop ends for any

--- a/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
+++ b/src/NetworkOptimizer.Web/Services/AppVersionInfo.cs
@@ -22,7 +22,7 @@ public static class AppVersionInfo
     /// "Update agent" callout for enrolled agents reporting an older version
     /// than this, and over-bumping nags agents into pointless upgrades.
     /// </summary>
-    public const string LatestAgentVersion = "2.5.2";
+    public const string LatestAgentVersion = "2.5.3";
 
     /// <summary>Full informational version (e.g. "1.4.2" or "0.0.0-alpha.0.12").</summary>
     public static string Informational { get; }

--- a/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
@@ -96,7 +96,13 @@ public sealed class AuditQueryService : IAuditQueryService
         if (f.ToUtc is not null) q = q.Where(e => e.TimestampUtc <= f.ToUtc);
         if (!string.IsNullOrEmpty(f.Category)) q = q.Where(e => e.Category == f.Category);
         if (!string.IsNullOrEmpty(f.Outcome)) q = q.Where(e => e.Outcome == f.Outcome);
-        if (!string.IsNullOrEmpty(f.SiteSlug)) q = q.Where(e => e.SiteSlug == f.SiteSlug);
+        // Only the typed side is normalized: slugs are stored lowercase, so lowering the column too
+        // would run a function per row and give up the index for a case that cannot occur.
+        if (!string.IsNullOrEmpty(f.SiteSlug))
+        {
+            var slug = f.SiteSlug.ToLowerInvariant();
+            q = q.Where(e => e.SiteSlug == slug);
+        }
         if (!string.IsNullOrEmpty(f.Actor)) q = q.Where(e => e.ActorName != null && e.ActorName.Contains(f.Actor));
         return q;
     }

--- a/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
@@ -103,7 +103,14 @@ public sealed class AuditQueryService : IAuditQueryService
             var slug = f.SiteSlug.ToLowerInvariant();
             q = q.Where(e => e.SiteSlug == slug);
         }
-        if (!string.IsNullOrEmpty(f.Actor)) q = q.Where(e => e.ActorName != null && e.ActorName.Contains(f.Actor));
+        // Both sides here, unlike the slug above: actor names are whatever the identity provider
+        // gave us, so neither end has a guaranteed case. Contains translates to instr() on SQLite,
+        // which is case-sensitive - searching "Kira" found nothing for a user stored as "kira".
+        if (!string.IsNullOrEmpty(f.Actor))
+        {
+            var actor = f.Actor.ToLowerInvariant();
+            q = q.Where(e => e.ActorName != null && e.ActorName.ToLower().Contains(actor));
+        }
         return q;
     }
 

--- a/src/NetworkOptimizer.Web/Services/ChannelMemoryRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelMemoryRegistry.cs
@@ -11,7 +11,7 @@ namespace NetworkOptimizer.Web.Services;
 /// its site's channel history/neighbor sightings and polls its site's console. Same
 /// ownership pattern as MonitoringCollectionRegistry / WanDataUsageRegistry.
 /// </summary>
-public class ChannelMemoryRegistry : BackgroundService
+public class ChannelMemoryRegistry : BackgroundService, ISiteScopedRegistry
 {
     private static readonly TimeSpan ReconcileInterval = TimeSpan.FromSeconds(30);
 
@@ -109,6 +109,16 @@ public class ChannelMemoryRegistry : BackgroundService
         foreach (var slug in toStop)
             await StopInstanceAsync(slug, ct);
     }
+
+    /// <inheritdoc />
+    /// <remarks>The reconcile pass would drop a removed site eventually; this stops it now, before
+    /// the site's database and clients go away underneath the loop.</remarks>
+    public Func<ValueTask>? EvictSite(string slug)
+        => async () =>
+        {
+            await StopInstanceAsync(slug, CancellationToken.None);
+            _instances.TryRemove(slug, out _);
+        };
 
     private async Task StartInstanceAsync(string slug, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Web/Services/GatewaySpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewaySpeedTestService.cs
@@ -379,7 +379,7 @@ public class GatewaySpeedTestService : IGatewaySpeedTestService
     private async Task<(bool success, string output)> RunIperf3ClientAsync(
         string host, int port, int duration, int parallel, bool reverse)
     {
-        if (!_siteContext.IsDefault && await _tunnelRouting.IsViaAgentAsync(_siteContext.Slug))
+        if (await _tunnelRouting.IsViaAgentAsync(_siteContext.Slug))
         {
             _logger.LogDebug("Routing gateway iperf3 client to agent for site {Slug} against {Host}:{Port} (reverse={Reverse})",
                 _siteContext.Slug, host, port, reverse);

--- a/src/NetworkOptimizer.Web/Services/GatewaySpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewaySpeedTestService.cs
@@ -24,6 +24,7 @@ public class GatewaySpeedTestService : IGatewaySpeedTestService
     private readonly SiteDbContextFactory _siteDbFactory;
     private readonly SiteContextService _siteContext;
     private readonly SiteTunnelRouting _tunnelRouting;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly AgentIperf3Service _agentIperf3;
     private readonly AgentEnrollmentService _agentEnrollment;
 
@@ -40,6 +41,7 @@ public class GatewaySpeedTestService : IGatewaySpeedTestService
         SiteDbContextFactory siteDbFactory,
         SiteContextService siteContext,
         SiteTunnelRouting tunnelRouting,
+        SiteAgentCoverage agentCoverage,
         AgentIperf3Service agentIperf3,
         AgentEnrollmentService agentEnrollment,
         Licensing.LicenseStateService licenseState)
@@ -54,6 +56,7 @@ public class GatewaySpeedTestService : IGatewaySpeedTestService
         // path analysis resolves against the current site's topology.
         _pathAnalyzer = speedTestRegistry.GetFor(_siteContext.Slug).PathAnalyzer;
         _tunnelRouting = tunnelRouting;
+        _agentCoverage = agentCoverage;
         _agentIperf3 = agentIperf3;
         _agentEnrollment = agentEnrollment;
     }
@@ -509,7 +512,8 @@ public class GatewaySpeedTestService : IGatewaySpeedTestService
             // agent's reported LAN IP is the operator-correctable address the site
             // already advertises for speed test targets (NO_AGENT_LAN_IP), so when
             // the server endpoint wasn't found, retry the trace anchored there.
-            if (!_siteContext.IsDefault && !path.IsValid && path.ErrorMessage == NetworkPath.ServerPositionNotFoundError)
+            if ((!_siteContext.IsDefault || await _agentCoverage.CoversAsync(_siteContext.Slug))
+                && !path.IsValid && path.ErrorMessage == NetworkPath.ServerPositionNotFoundError)
             {
                 var agentLanIp = await _agentEnrollment.GetOnlineAgentLanIpAsync(_siteContext.Slug);
                 if (!string.IsNullOrEmpty(agentLanIp) && agentLanIp != localIp)

--- a/src/NetworkOptimizer.Web/Services/GatewaySshRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewaySshRegistry.cs
@@ -12,7 +12,7 @@ namespace NetworkOptimizer.Web.Services;
 /// ownership pattern as SiteConnectionRegistry. Instances hold no connections
 /// (SSH sessions are per-command), so nothing needs disposal.
 /// </summary>
-public class GatewaySshRegistry
+public class GatewaySshRegistry : ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<string, GatewaySshService> _instances = new();
@@ -29,4 +29,11 @@ public class GatewaySshRegistry
 
     /// <summary>The default site's gateway SSH service.</summary>
     public GatewaySshService GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/IMonitoringSettingsService.cs
+++ b/src/NetworkOptimizer.Web/Services/IMonitoringSettingsService.cs
@@ -1,0 +1,67 @@
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// The site's monitoring settings as the Monitoring - Setup forms edit them: the master enable and
+/// the device temperature, SFP DDM and ONT alert thresholds. These were direct DbContext writes in
+/// the page, so turning monitoring off or moving an alert threshold left no audit trail at all.
+///
+/// Site-scoped, Operator: the same reach the forms' own SiteOperatorOnly gate grants, now enforced
+/// where the write happens rather than by whether a button was rendered.
+/// </summary>
+[MutatingService(SiteScoped = true)]
+public interface IMonitoringSettingsService
+{
+    /// <summary>Turns the site's monitoring collection on or off.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
+    Task<MonitoringSettings> SetEnabledAsync(bool enabled, CancellationToken ct = default);
+
+    /// <summary>
+    /// Clears the site's InfluxDB connection and disables collection, returning Monitoring to its
+    /// unconfigured state. Admin: it discards the stored token and endpoint, matching the role the
+    /// rest of the InfluxDB provisioning surface requires.
+    /// </summary>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
+    Task ResetInfluxSetupAsync(CancellationToken ct = default);
+
+    /// <summary>Saves the switch and gateway temperature alert thresholds.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
+    Task<MonitoringSettings> SaveTempThresholdsAsync(double? switchHighC, double? gatewayHighC,
+        CancellationToken ct = default);
+
+    /// <summary>Saves the full SFP DDM alert threshold set (PON, active ethernet, and generic).</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
+    Task<MonitoringSettings> SaveSfpThresholdsAsync(SfpThresholdEdit edit, CancellationToken ct = default);
+
+    /// <summary>
+    /// Saves the ONT alert thresholds. These are the shared PON optical thresholds, so this also
+    /// drives the PON row under SFP Alert Thresholds and the gateway SFP DDM alerts.
+    /// </summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
+    Task<MonitoringSettings> SaveOntThresholdsAsync(double? ponTempHighC, double? ponRxPowerLowDbm,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// The SFP Alert Thresholds form's values. Temperatures are normalized (a non-positive entry means
+/// "use the default"); power thresholds are not, since a negative RX low is legitimate and only a
+/// blank field means default.
+/// </summary>
+public sealed record SfpThresholdEdit
+{
+    public double? PonTempHighC { get; init; }
+    public double? PonRxPowerLowDbm { get; init; }
+    public double? PonTxPowerHighDbm { get; init; }
+    public double? AeTempHighC { get; init; }
+    public double? AeRxPowerLowDbm { get; init; }
+    public double? AeTxPowerHighDbm { get; init; }
+    public double? SfpTempHighGenericC { get; init; }
+}

--- a/src/NetworkOptimizer.Web/Services/IMonitoringSettingsService.cs
+++ b/src/NetworkOptimizer.Web/Services/IMonitoringSettingsService.cs
@@ -16,7 +16,10 @@ namespace NetworkOptimizer.Web.Services;
 public interface IMonitoringSettingsService
 {
     /// <summary>Turns the site's monitoring collection on or off.</summary>
-    [RequireRole(Roles.Operator)]
+    /// <remarks>Admin, matching the SiteAdminOnly wrapper the Enable/Disable buttons have always
+    /// had: the gate is the boundary, so granting Operator here would widen it past what the UI
+    /// reserved for Site Admins.</remarks>
+    [RequireRole(Roles.Admin)]
     [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_settings")]
     Task<MonitoringSettings> SetEnabledAsync(bool enabled, CancellationToken ct = default);
 

--- a/src/NetworkOptimizer.Web/Services/IMonitoringTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/IMonitoringTargetService.cs
@@ -1,0 +1,68 @@
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Curating the site's latency targets: the Latency targets card's add, delete, pause/resume,
+/// interval and WAN context edits. These ran as direct DbContext writes inside the card, which
+/// left them outside the gate (design doc 06, gate 9) and so unaudited - a target could be paused
+/// or deleted with nothing recorded. Routing them through a gated interface gives each one an
+/// audit envelope and an enforced role, rather than relying on the card not rendering the button.
+///
+/// Site-scoped: a target belongs to the site in context, and Operator on THAT site is what the
+/// card's own SiteOperatorOnly gate means.
+/// </summary>
+[MutatingService(SiteScoped = true)]
+public interface IMonitoringTargetService
+{
+    /// <summary>Adds a manually-created target, resolving its ASN and tracing it for ancestry.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<MonitoringTarget> AddAsync(NewMonitoringTarget spec, CancellationToken ct = default);
+
+    /// <summary>Deletes a target. False when it no longer exists.</summary>
+    /// <remarks>Admin, not Operator: removing a target is the card's one SiteAdminOnly action.</remarks>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+
+    /// <summary>Pauses or resumes probing of a target. False when it no longer exists.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> SetEnabledAsync(int id, bool enabled, CancellationToken ct = default);
+
+    /// <summary>Changes how often a target is probed. False when it no longer exists.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> SetPollIntervalAsync(int id, int seconds, CancellationToken ct = default);
+
+    /// <summary>Dismisses the LAN flaky-target advisory for a target. False when it no longer exists.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> DismissLanFlakyHintAsync(int id, CancellationToken ct = default);
+
+    /// <summary>Reassigns which WAN a target is probed over. False when it no longer exists.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> SetWanContextAsync(int id, int? wanContextId, CancellationToken ct = default);
+}
+
+/// <summary>What the Latency targets card collects for a new target, before defaults are applied.</summary>
+public sealed record NewMonitoringTarget
+{
+    public required string Name { get; init; }
+    public required string Address { get; init; }
+    public MonitoringTargetType TargetType { get; init; } = MonitoringTargetType.Custom;
+    public ProbeMode ProbeMode { get; init; } = ProbeMode.Icmp;
+    public int Port { get; init; } = 443;
+    public int PollIntervalSeconds { get; init; } = 10;
+}
+
+/// <summary>Thrown when a new target fails validation, so the card can show the reason inline.</summary>
+public sealed class MonitoringTargetValidationException : Exception
+{
+    public MonitoringTargetValidationException(string message) : base(message) { }
+}

--- a/src/NetworkOptimizer.Web/Services/ISiteConfigurationService.cs
+++ b/src/NetworkOptimizer.Web/Services/ISiteConfigurationService.cs
@@ -7,7 +7,7 @@ using NetworkOptimizer.Web.Services.Gates;
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>The per-site settings the Multi-Site table edits, read in one pass.</summary>
-public sealed record SiteConfiguration(bool ConsoleViaAgent, bool DevicesViaAgent, string? ClientSpeedTestTarget);
+public sealed record SiteConfiguration(bool ConsoleViaAgent, bool DevicesViaAgent, bool AgentCoversSite, string? ClientSpeedTestTarget);
 
 /// <summary>
 /// The tunnel routing and speed-test target a site runs with. These were written straight from the
@@ -37,6 +37,15 @@ public interface ISiteConfigurationService
     [AuditAction(AuditActions.SiteChanged, TargetType = "site")]
     Task SetDevicesViaAgentAsync([SiteSlug] string siteSlug, bool enabled);
 
+    /// <summary>
+    /// Hands collection for this site to its on-site agent, standing this server down. Only
+    /// meaningful for the default site - a secondary site's agent already collects - and only takes
+    /// effect while an agent is actually enrolled.
+    /// </summary>
+    [RequireSiteRole(SiteRole.SiteAdmin)]
+    [AuditAction(AuditActions.SiteChanged, TargetType = "site")]
+    Task SetAgentCoversSiteAsync([SiteSlug] string siteSlug, bool enabled);
+
     /// <summary>Overrides where browsers reach this site's speed test pages. Null clears it.</summary>
     [RequireSiteRole(SiteRole.SiteAdmin)]
     [AuditAction(AuditActions.SiteChanged, TargetType = "site")]
@@ -47,8 +56,13 @@ public interface ISiteConfigurationService
 public sealed class SiteConfigurationService : ISiteConfigurationService
 {
     private readonly SiteDbContextFactory _siteDb;
+    private readonly SiteAgentCoverage _agentCoverage;
 
-    public SiteConfigurationService(SiteDbContextFactory siteDb) => _siteDb = siteDb;
+    public SiteConfigurationService(SiteDbContextFactory siteDb, SiteAgentCoverage agentCoverage)
+    {
+        _siteDb = siteDb;
+        _agentCoverage = agentCoverage;
+    }
 
     /// <inheritdoc />
     public async Task<SiteConfiguration> GetAsync(string siteSlug)
@@ -57,12 +71,14 @@ public sealed class SiteConfigurationService : ISiteConfigurationService
         var settings = await db.SystemSettings
             .Where(s => s.Key == UniFiConnectionService.ConsoleViaAgentKey
                      || s.Key == SiteTunnelRouting.DevicesViaAgentKey
+                     || s.Key == SiteAgentCoverage.AgentCoversSiteKey
                      || s.Key == SystemSettingKeys.ClientSpeedTestTargetOverride)
             .ToListAsync();
 
         return new SiteConfiguration(
             ReadFlag(settings, UniFiConnectionService.ConsoleViaAgentKey),
             ReadFlag(settings, SiteTunnelRouting.DevicesViaAgentKey),
+            ReadFlag(settings, SiteAgentCoverage.AgentCoversSiteKey),
             settings.FirstOrDefault(s => s.Key == SystemSettingKeys.ClientSpeedTestTargetOverride)?.Value);
     }
 
@@ -73,6 +89,15 @@ public sealed class SiteConfigurationService : ISiteConfigurationService
     /// <inheritdoc />
     public Task SetDevicesViaAgentAsync(string siteSlug, bool enabled)
         => WriteAsync(siteSlug, SiteTunnelRouting.DevicesViaAgentKey, enabled.ToString());
+
+    /// <inheritdoc />
+    public async Task SetAgentCoversSiteAsync(string siteSlug, bool enabled)
+    {
+        await WriteAsync(siteSlug, SiteAgentCoverage.AgentCoversSiteKey, enabled.ToString());
+        // The collection paths read this through a one-minute cache; a setting that decides whether
+        // the server collects at all should not wait that long to take effect.
+        _agentCoverage.Invalidate(siteSlug);
+    }
 
     /// <inheritdoc />
     public Task SetClientSpeedTestTargetAsync(string siteSlug, string? target)

--- a/src/NetworkOptimizer.Web/Services/ISiteInfluxProvisioningService.cs
+++ b/src/NetworkOptimizer.Web/Services/ISiteInfluxProvisioningService.cs
@@ -1,0 +1,35 @@
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Creating ONE site's buckets from an InfluxDB connection somebody else already established.
+///
+/// The same work as the matching methods on <see cref="IInfluxDbProvisioningService"/>, gated
+/// differently on purpose. That service is instance-wide: creating orgs, minting org-scoped tokens
+/// and writing the shared connection are decisions about the whole installation, so they ask for an
+/// instance-wide Admin. Adding a site's own prefixed buckets with a shared credential that is
+/// already org-scoped is not such a decision - it is that site's setup, and its own admin should be
+/// able to finish it. Asking one question for both meant a Site Admin could reach the wizard and
+/// never complete it.
+///
+/// Site-scoped, so <see cref="Roles.Admin"/> here is satisfied by Admin ON THAT SITE. It is
+/// deliberately the narrow path: if the shared token turns out not to be able to create buckets,
+/// this fails and the wizard falls back to the all-access token prompt, which is an
+/// installation-wide decision and stays with the instance-wide service.
+/// </summary>
+[MutatingService(SiteScoped = true)]
+public interface ISiteInfluxProvisioningService
+{
+    /// <summary>Resolves an org id by name, or null when the token cannot see it.</summary>
+    [RequireRole(Roles.Viewer)]
+    Task<string?> TryResolveOrgIdAsync(string url, string token, string orgName, CancellationToken ct = default);
+
+    /// <summary>Creates this site's fast and long-term buckets if they do not exist.</summary>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "influx_bucket")]
+    Task<InfluxDbProvisioningService.BucketProvisionResult> EnsureBucketsAsync(
+        string url, string token, string orgId, string primaryBucket, string longtermBucket,
+        CancellationToken ct = default);
+}

--- a/src/NetworkOptimizer.Web/Services/ISiteScopedRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/ISiteScopedRegistry.cs
@@ -1,0 +1,44 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// A registry that keeps one long-lived instance per site slug.
+///
+/// Removing a site has to empty every one of them. The instances capture that site's console
+/// connection, gateway SSH session, InfluxDB client and database path when they are created, so a
+/// registry that keeps its entry hands the dead objects of a removed site to whatever is created
+/// under the same slug next - which is exactly what a re-created test site is. Upstream path
+/// discovery failed that way: the tracer still held the removed site's console client, which
+/// answered every device request with nothing.
+///
+/// Eviction and teardown are separate on purpose. The instances hold each other - the ISP Health
+/// service holds the site's InfluxDB client, the tracer holds its connection and SSH services - so
+/// disposing one while another registry still hands out its holder turns a stale object into an
+/// ObjectDisposedException on the next background pass. Every registry evicts first; only then does
+/// the caller run the teardowns.
+/// </summary>
+public interface ISiteScopedRegistry
+{
+    /// <summary>
+    /// Drops the site's instance from this registry, returning a callback that tears it down, or
+    /// null when there was nothing registered or nothing to tear down. The caller runs the
+    /// callbacks only after every registry has evicted the site.
+    /// </summary>
+    Func<ValueTask>? EvictSite(string slug);
+}
+
+/// <summary>
+/// Registers a per-site registry as both its own type and <see cref="ISiteScopedRegistry"/>, so
+/// site removal sweeps it without anyone having to remember to add it to a list. Registering the
+/// singleton by hand and forgetting the second line is how a registry ends up leaking removed
+/// sites, so always use this.
+/// </summary>
+public static class SiteScopedRegistryRegistration
+{
+    public static IServiceCollection AddSiteScopedRegistry<T>(this IServiceCollection services)
+        where T : class, ISiteScopedRegistry
+    {
+        services.AddSingleton<T>();
+        services.AddSingleton<ISiteScopedRegistry>(sp => sp.GetRequiredService<T>());
+        return services;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/IUpstreamDiscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/IUpstreamDiscoveryService.cs
@@ -1,0 +1,28 @@
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// The two operator actions on Upstream path discovery: running a discovery, and committing the
+/// hops it proposes as monitoring targets. Both went straight to the per-site tracer from the
+/// panel, so a discovery run - and, more to the point, the target set it writes on commit - left
+/// nothing in the Audit Log.
+///
+/// A thin gate in front of <see cref="Monitoring.UpstreamTracerService"/> rather than an interface
+/// over it: the panel reads the tracer's live State throughout, and only these two calls mutate
+/// anything, so wrapping the whole surface would buy nothing.
+/// </summary>
+[MutatingService(SiteScoped = true)]
+public interface IUpstreamDiscoveryService
+{
+    /// <summary>Traces the upstream path and proposes targets for review.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "upstream_discovery")]
+    Task StartAsync(CancellationToken ct = default);
+
+    /// <summary>Commits the reviewed discovery, writing its hops as monitoring targets.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "upstream_discovery")]
+    Task CommitAsync(CancellationToken ct = default);
+}

--- a/src/NetworkOptimizer.Web/Services/InfluxDbProvisioningService.cs
+++ b/src/NetworkOptimizer.Web/Services/InfluxDbProvisioningService.cs
@@ -18,7 +18,7 @@ namespace NetworkOptimizer.Web.Services;
 /// UIs need to render specific error states (URL unreachable vs. bad token vs. lacking
 /// permissions) and a thrown exception would force the UI to parse messages.
 /// </summary>
-public class InfluxDbProvisioningService : IInfluxDbProvisioningService
+public class InfluxDbProvisioningService : IInfluxDbProvisioningService, ISiteInfluxProvisioningService
 {
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<InfluxDbProvisioningService> _logger;

--- a/src/NetworkOptimizer.Web/Services/Iperf3SpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/Iperf3SpeedTestService.cs
@@ -858,7 +858,8 @@ public class Iperf3SpeedTestService : IIperf3SpeedTestService
             // agent's reported LAN IP is the operator-correctable address the site
             // already advertises for speed test targets (NO_AGENT_LAN_IP), so when
             // the server endpoint wasn't found, retry the trace anchored there.
-            if (!_isDefault && !path.IsValid && path.ErrorMessage == NetworkPath.ServerPositionNotFoundError)
+            if ((!_isDefault || await _serviceProvider.GetRequiredService<SiteAgentCoverage>().CoversAsync(_siteSlug))
+                && !path.IsValid && path.ErrorMessage == NetworkPath.ServerPositionNotFoundError)
             {
                 var agentLanIp = await _serviceProvider.GetRequiredService<AgentEnrollmentService>()
                     .GetOnlineAgentLanIpAsync(_siteSlug);

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCacheRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapCacheRegistry.cs
@@ -10,7 +10,7 @@ namespace NetworkOptimizer.Web.Services.LanFlowMap;
 /// rebuild queried its empty Influx client). Scoped resolution forwards to the
 /// current site's cache, so each site keeps its own snapshot and build lock.
 /// </summary>
-public class LanFlowMapCacheRegistry
+public class LanFlowMapCacheRegistry : ISiteScopedRegistry
 {
     private readonly ConcurrentDictionary<string, LanFlowMapCache> _caches = new(StringComparer.OrdinalIgnoreCase);
 
@@ -19,4 +19,11 @@ public class LanFlowMapCacheRegistry
 
     /// <summary>The default site's map cache.</summary>
     public LanFlowMapCache GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _caches.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/ModemMonitorRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/ModemMonitorRegistry.cs
@@ -17,7 +17,7 @@ namespace NetworkOptimizer.Web.Services;
 /// resolution forwards to the current site's bundle so the Monitoring page,
 /// stats panels, and chart endpoints show the site being viewed.
 /// </summary>
-public class ModemMonitorRegistry : BackgroundService
+public class ModemMonitorRegistry : BackgroundService, ISiteScopedRegistry
 {
     /// <summary>One site's modem monitors.</summary>
     public sealed record SiteModemMonitors(
@@ -118,6 +118,19 @@ public class ModemMonitorRegistry : BackgroundService
             bundle.Starlink.DisposeOwned();
         }
     }
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+        => _instances.TryRemove(slug, out var bundle)
+            ? () =>
+            {
+                bundle.CableModem.DisposeOwned();
+                bundle.Ont.DisposeOwned();
+                bundle.Cellular.DisposeOwned();
+                bundle.Starlink.DisposeOwned();
+                return ValueTask.CompletedTask;
+            }
+            : null;
 
     private async Task ReconcileAsync(CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthRegistry.cs
@@ -10,7 +10,7 @@ namespace NetworkOptimizer.Web.Services.Monitoring.IspHealth;
 /// resolution forwards to the current site's instance, same pattern as
 /// MonitoringInfluxRegistry / MonitoringCollectionRegistry.
 /// </summary>
-public class IspHealthRegistry
+public class IspHealthRegistry : ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<string, IspHealthService> _instances = new(StringComparer.OrdinalIgnoreCase);
@@ -30,4 +30,11 @@ public class IspHealthRegistry
 
     /// <summary>The default site's ISP Health service.</summary>
     public IspHealthService GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1606,7 +1606,11 @@ public class IspHealthService
                 row = new WanProfile { WanNetworkgroup = wan.NetworkGroup! };
                 db.WanProfiles.Add(row);
             }
-            row.Interface = wan.Interface;
+            // The DATA-PATH interface, not the WAN's ifname: they diverge on PPPoE (ppp0 vs the
+            // physical eth) and every consumer of this field wants the data path - the throughput
+            // series are keyed on it, and PPPoE is detected from its name. Caching the ifname would
+            // hand an offline PPPoE site the physical interface and quietly drop its overlay.
+            row.Interface = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct) ?? wan.Interface;
             row.Name = wan.Name;
             row.DownloadMbps = down;
             row.UploadMbps = up;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -654,12 +654,20 @@ public class IspHealthService
         // report leaves _cached untouched, so the next read recomputes. Empty list rather than a
         // missing gateway: a site behind a third-party router has no gateway and must still score.
         var discoveredDevices = await _connectionService.GetDiscoveredDevicesAsync(ct);
-        if (discoveredDevices.Count == 0)
+        // Only suspect while the console CLAIMS to be up: a connected console serving nothing is
+        // the transient this guard was written for. A console that is plainly down is not a
+        // half-loaded one - it is a site someone is trying to look at after the fact, and the
+        // expected speeds it used to supply now come from the remembered WAN profile. Deferring
+        // there would refuse every offline site, which is the case the history exists for.
+        if (discoveredDevices.Count == 0 && _connectionService.IsConnected)
         {
             _logger.LogWarning("ISP Health: the console returned no devices, so its data is not yet trustworthy; " +
                 "deferring rather than caching a report computed without the console-derived inputs");
             return new ComputeOutcome(IspHealthStatus.AwaitingConnection, null, new List<AsnSeries>());
         }
+        if (discoveredDevices.Count == 0)
+            _logger.LogDebug("ISP Health: computing without the console (site offline); expected speeds come from " +
+                "the remembered WAN profile and device-derived detail is omitted");
 
         var profile = IspHealthProfiles.GetProfile(technology);
         if (profile == null)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1542,32 +1542,38 @@ public class IspHealthService
         if (down == null || up == null)
         {
             await using var db = await CreateSiteDbAsync(ct);
-            var sqmWan = await db.SqmWanConfigurations.AsNoTracking()
-                .OrderBy(c => c.WanNumber)
+
+            // What the console told us before it went away. This ranks ABOVE the Adaptive SQM
+            // figure: it is a reading from the authoritative source that is merely out of date,
+            // where the SQM value is a shaping target someone typed in - what to rate-limit to,
+            // not what the ISP confirmed the line does.
+            //
+            // With no console we cannot ask which WAN is primary, so prefer the first WAN group and
+            // fall back to the most recently confirmed row. Multi-WAN scoring picks its own WAN here.
+            var remembered = await db.WanProfiles.AsNoTracking()
+                .OrderBy(w => w.WanNetworkgroup)
+                .ThenByDescending(w => w.UpdatedAt)
                 .FirstOrDefaultAsync(ct);
-            if (sqmWan != null)
+            if (remembered != null)
             {
-                down ??= sqmWan.NominalDownloadMbps;
-                up ??= sqmWan.NominalUploadMbps;
-                source ??= "Adaptive SQM settings";
+                down ??= remembered.DownloadMbps;
+                up ??= remembered.UploadMbps;
+                if (down != null || up != null)
+                    source ??= "UniFi Network (last known)";
+                wan ??= new WanIdentity(remembered.Name, remembered.WanNetworkgroup, remembered.Interface);
             }
 
-            // Last rung: what the console told us before it went away. With the console down we
-            // cannot ask which WAN is primary, so prefer the first WAN group and fall back to the
-            // most recently confirmed row. Multi-WAN scoring will pick its own WAN here instead.
+            // Truly inferred, so it goes last: only reached when the console has never told us.
             if (down == null || up == null)
             {
-                var remembered = await db.WanProfiles.AsNoTracking()
-                    .OrderBy(w => w.WanNetworkgroup)
-                    .ThenByDescending(w => w.UpdatedAt)
+                var sqmWan = await db.SqmWanConfigurations.AsNoTracking()
+                    .OrderBy(c => c.WanNumber)
                     .FirstOrDefaultAsync(ct);
-                if (remembered != null)
+                if (sqmWan != null)
                 {
-                    down ??= remembered.DownloadMbps;
-                    up ??= remembered.UploadMbps;
-                    if (down != null || up != null)
-                        source ??= "UniFi Network (last known)";
-                    wan ??= new WanIdentity(remembered.Name, remembered.WanNetworkgroup, remembered.Interface);
+                    down ??= sqmWan.NominalDownloadMbps;
+                    up ??= sqmWan.NominalUploadMbps;
+                    source ??= "Adaptive SQM settings";
                 }
             }
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1316,7 +1316,10 @@ public class IspHealthService
     {
         try
         {
-            var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct);
+            // Through the resolver, not the console directly: PPPoE is read off the interface NAME,
+            // and the remembered profile holds that name, so an offline site keeps its overlay
+            // instead of silently grading a PPPoE line against its medium's raw thresholds.
+            var dataPath = await GetPrimaryWanInterfaceAsync(ct);
             if (string.IsNullOrEmpty(dataPath))
             {
                 _logger.LogWarning("ISP Health could not resolve the primary WAN's data-path interface; " +
@@ -1618,13 +1621,41 @@ public class IspHealthService
 
     private static readonly TimeSpan SqmProbeDuration = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// The primary WAN's data-path interface. Falls back to the remembered WAN profile so an
+    /// offline site still resolves it - the interface is what the throughput series are keyed on,
+    /// so without it a site with plenty of stored history reads as having none.
+    ///
+    /// Multi-WAN planned: this returns the primary only, and picks the first WAN group when there
+    /// is no console to ask. Per-WAN scoring resolves its own WAN's interface from its own row.
+    /// </summary>
     private async Task<string?> GetPrimaryWanInterfaceAsync(CancellationToken ct)
     {
         try
         {
-            return await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct);
+            var live = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct);
+            if (!string.IsNullOrEmpty(live)) return live;
         }
-        catch { return null; }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the primary WAN interface from the console");
+        }
+
+        try
+        {
+            await using var db = await CreateSiteDbAsync(ct);
+            return await db.WanProfiles.AsNoTracking()
+                .Where(w => w.Interface != null)
+                .OrderBy(w => w.WanNetworkgroup)
+                .ThenByDescending(w => w.UpdatedAt)
+                .Select(w => w.Interface)
+                .FirstOrDefaultAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the remembered primary WAN interface");
+            return null;
+        }
     }
 
     private async Task<List<(DateTime Start, DateTime End)>> BuildSqmProbeExclusionsAsync(

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1382,7 +1382,7 @@ public class IspHealthService
             if (mac == null || ifNames == null || ifNames.Count == 0)
                 return new List<ThroughputSample>();
 
-            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, to, aggregate, ct);
+            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, to, aggregate, ct: ct);
             return rates.Select(r => new ThroughputSample(r.Time, r.DownloadBps, r.UploadBps)).ToList();
         }
         catch (Exception ex)
@@ -1439,7 +1439,7 @@ public class IspHealthService
             var from = windowEnd.AddDays(-_options.UsageFingerprintLookbackDays);
             // Active usage is sustained (streaming, calls, uploads); a 5-min mean is plenty to catch
             // it and keeps the lookback series small.
-            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, windowEnd, TimeSpan.FromMinutes(5), ct);
+            var rates = await _influx.QueryGatewayWanRatesAsync(mac, ifNames, from, windowEnd, TimeSpan.FromMinutes(5), ct: ct);
             if (rates.Count == 0) return null;
 
             var tz = TimeZoneInfo.Local;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1547,7 +1547,7 @@ public class IspHealthService
         // away still be graded, and it is stored per WAN because plan speeds belong to a WAN:
         // scoring reads the primary today, and multi-WAN scoring is planned, at which point each
         // WAN's row is already here.
-        if (wan?.NetworkGroup is { Length: > 0 } && (down != null || up != null))
+        if (wan?.NetworkGroup is { Length: > 0 })
             await RememberWanSpeedsAsync(wan, down, up, ct);
 
         if (down == null || up == null)
@@ -1610,9 +1610,23 @@ public class IspHealthService
             // and what PPPoE is read from; the counter interface is what throughput is keyed on, and
             // on a VLAN-tagged WAN that is the PHYSICAL port - the sub-interface's counters double.
             // Storing one and using it for the other's job silently reports the wrong throughput.
-            var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct) ?? wan.Interface;
+            // Keep the previous data path when the device read comes back empty on an otherwise
+            // successful console read: overwriting it with the physical port would make a later
+            // offline PPPoE check grade the line without its overlay, which is what splitting these
+            // two columns exists to prevent.
+            var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct)
+                ?? row.DataPathInterface ?? wan.Interface;
             row.DataPathInterface = dataPath;
             row.CounterInterface = NetworkUtilities.PreferredWanCounterInterface(wan.Interface, dataPath);
+
+            // Stored WAN rates are keyed on gateway MAC AND interface, so every offline fallback
+            // filters on this being present - without it they match no row and silently do nothing.
+            // Normalized here so readers cannot disagree about the form.
+            var gatewayMac = (await _connectionService.GetDiscoveredDevicesAsync(ct))
+                .FirstOrDefault(d => d.Type == NetworkOptimizer.Core.Enums.DeviceType.Gateway
+                    || d.HardwareType == NetworkOptimizer.Core.Enums.DeviceType.Gateway)?.Mac;
+            if (!string.IsNullOrEmpty(gatewayMac))
+                row.GatewayMac = gatewayMac.Replace("-", ":").ToLowerInvariant();
             row.Name = wan.Name;
             row.DownloadMbps = down;
             row.UploadMbps = up;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -84,7 +84,31 @@ public class IspHealthService
     /// an unscored Speed vs Plan factor. Gates every compute entry point; a managed site's
     /// connection simply comes up later (over its agent tunnel) than the home site's.
     /// </summary>
-    private bool CanCompute => _connectionService.IsConnected;
+    // A remembered WAN profile is enough to grade a site whose console is unreachable - the scored
+    // inputs are latency and throughput history out of InfluxDB, and the console only supplied the
+    // expected speeds. Resolved per compute rather than cached: a site that has never had a
+    // successful console read still has nothing to score against.
+    private bool CanCompute => _connectionService.IsConnected || _hasRememberedWanSpeeds;
+
+    private bool _hasRememberedWanSpeeds;
+
+    /// <summary>
+    /// Whether any WAN has speeds remembered from an earlier console read. Refreshed on each compute
+    /// so a site that gains its first successful read starts computing without a restart.
+    /// </summary>
+    private async Task RefreshRememberedWanSpeedsAsync(CancellationToken ct)
+    {
+        try
+        {
+            await using var db = await CreateSiteDbAsync(ct);
+            _hasRememberedWanSpeeds = await db.WanProfiles
+                .AnyAsync(w => w.DownloadMbps != null || w.UploadMbps != null, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not check for remembered WAN speeds");
+        }
+    }
 
     /// <summary>Context for the database holding this instance's site data.</summary>
     private async Task<NetworkOptimizerDbContext> CreateSiteDbAsync(CancellationToken ct)
@@ -236,8 +260,15 @@ public class IspHealthService
         if (!mustRecompute && cached != null && DateTime.UtcNow - cached.ComputedAt < _options.CacheTtl)
             return cached;
 
-        // Defer computing until the console connection is up (expected ISP speeds come from
-        // it). Serve any existing report; otherwise publish AwaitingConnection for the funnels.
+        // The console supplies the expected ISP speeds, so a site that has never had a successful
+        // read has nothing to score against and still waits. One that has cannot be held back by an
+        // unreachable console: the scored inputs are history out of InfluxDB, and an offline site is
+        // exactly when someone wants to look at it. Checked here rather than cached at startup so a
+        // site gains computing on its first successful read without a restart.
+        if (!_connectionService.IsConnected)
+            await RefreshRememberedWanSpeedsAsync(ct);
+
+        // Serve any existing report; otherwise publish AwaitingConnection for the funnels.
         // Keep _recomputePending set so the recompute happens once the connection lands.
         if (!CanCompute)
         {
@@ -1501,6 +1532,13 @@ public class IspHealthService
             _logger.LogDebug(ex, "ISP Health could not read UniFi WAN provider capabilities");
         }
 
+        // Remember what the console said, per WAN. This is what lets a site whose console has gone
+        // away still be graded, and it is stored per WAN because plan speeds belong to a WAN:
+        // scoring reads the primary today, and multi-WAN scoring is planned, at which point each
+        // WAN's row is already here.
+        if (wan?.NetworkGroup is { Length: > 0 } && (down != null || up != null))
+            await RememberWanSpeedsAsync(wan, down, up, ct);
+
         if (down == null || up == null)
         {
             await using var db = await CreateSiteDbAsync(ct);
@@ -1513,8 +1551,55 @@ public class IspHealthService
                 up ??= sqmWan.NominalUploadMbps;
                 source ??= "Adaptive SQM settings";
             }
+
+            // Last rung: what the console told us before it went away. With the console down we
+            // cannot ask which WAN is primary, so prefer the first WAN group and fall back to the
+            // most recently confirmed row. Multi-WAN scoring will pick its own WAN here instead.
+            if (down == null || up == null)
+            {
+                var remembered = await db.WanProfiles.AsNoTracking()
+                    .OrderBy(w => w.WanNetworkgroup)
+                    .ThenByDescending(w => w.UpdatedAt)
+                    .FirstOrDefaultAsync(ct);
+                if (remembered != null)
+                {
+                    down ??= remembered.DownloadMbps;
+                    up ??= remembered.UploadMbps;
+                    if (down != null || up != null)
+                        source ??= "UniFi Network (last known)";
+                    wan ??= new WanIdentity(remembered.Name, remembered.WanNetworkgroup, remembered.Interface);
+                }
+            }
         }
         return (down, up, source, smartQueues, wan);
+    }
+
+    /// <summary>
+    /// Stores this WAN's expected speeds so they outlive the console connection. One row per WAN
+    /// group; a rename changes the display name, not the identity.
+    /// </summary>
+    private async Task RememberWanSpeedsAsync(WanIdentity wan, double? down, double? up, CancellationToken ct)
+    {
+        try
+        {
+            await using var db = await CreateSiteDbAsync(ct);
+            var row = await db.WanProfiles.FirstOrDefaultAsync(w => w.WanNetworkgroup == wan.NetworkGroup, ct);
+            if (row == null)
+            {
+                row = new WanProfile { WanNetworkgroup = wan.NetworkGroup! };
+                db.WanProfiles.Add(row);
+            }
+            row.Interface = wan.Interface;
+            row.Name = wan.Name;
+            row.DownloadMbps = down;
+            row.UploadMbps = up;
+            row.UpdatedAt = DateTime.UtcNow;
+            await db.SaveChangesAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not remember the expected speeds for WAN {Wan}", wan.NetworkGroup);
+        }
     }
 
     private static readonly TimeSpan SqmProbeDuration = TimeSpan.FromSeconds(30);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -1571,7 +1571,7 @@ public class IspHealthService
                 up ??= remembered.UploadMbps;
                 if (down != null || up != null)
                     source ??= "UniFi Network (last known)";
-                wan ??= new WanIdentity(remembered.Name, remembered.WanNetworkgroup, remembered.Interface);
+                wan ??= new WanIdentity(remembered.Name, remembered.WanNetworkgroup, remembered.CounterInterface);
             }
 
             // Truly inferred, so it goes last: only reached when the console has never told us.
@@ -1606,11 +1606,13 @@ public class IspHealthService
                 row = new WanProfile { WanNetworkgroup = wan.NetworkGroup! };
                 db.WanProfiles.Add(row);
             }
-            // The DATA-PATH interface, not the WAN's ifname: they diverge on PPPoE (ppp0 vs the
-            // physical eth) and every consumer of this field wants the data path - the throughput
-            // series are keyed on it, and PPPoE is detected from its name. Caching the ifname would
-            // hand an offline PPPoE site the physical interface and quietly drop its overlay.
-            row.Interface = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct) ?? wan.Interface;
+            // Both names, because they are not interchangeable. The data path is what SQM deploys on
+            // and what PPPoE is read from; the counter interface is what throughput is keyed on, and
+            // on a VLAN-tagged WAN that is the PHYSICAL port - the sub-interface's counters double.
+            // Storing one and using it for the other's job silently reports the wrong throughput.
+            var dataPath = await _connectionService.GetPrimaryWanDataPathInterfaceAsync(ct) ?? wan.Interface;
+            row.DataPathInterface = dataPath;
+            row.CounterInterface = NetworkUtilities.PreferredWanCounterInterface(wan.Interface, dataPath);
             row.Name = wan.Name;
             row.DownloadMbps = down;
             row.UploadMbps = up;
@@ -1645,14 +1647,20 @@ public class IspHealthService
             _logger.LogDebug(ex, "Could not read the primary WAN interface from the console");
         }
 
+        // ONLY when the console is down. A connected console that answers with nothing keeps
+        // answering nothing, exactly as before: eth0, eth6.100 and ppp0 all resolve live on that
+        // path, and substituting a remembered name there would change an online result on the
+        // strength of a stale row. The cache exists for the site with no console to ask.
+        if (_connectionService.IsConnected) return null;
+
         try
         {
             await using var db = await CreateSiteDbAsync(ct);
             return await db.WanProfiles.AsNoTracking()
-                .Where(w => w.Interface != null)
+                .Where(w => w.DataPathInterface != null)
                 .OrderBy(w => w.WanNetworkgroup)
                 .ThenByDescending(w => w.UpdatedAt)
-                .Select(w => w.Interface)
+                .Select(w => w.DataPathInterface)
                 .FirstOrDefaultAsync(ct);
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/ProbeExecutorFactory.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/ProbeExecutorFactory.cs
@@ -27,6 +27,7 @@ public class ProbeExecutorFactory
     private readonly SiteContextService _siteContext;
     private readonly SiteTunnelRouting _tunnelRouting;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly ILogger<ProbeExecutorFactory> _logger;
 
     public ProbeExecutorFactory(
@@ -39,6 +40,7 @@ public class ProbeExecutorFactory
         AgentProbeService agentProbe,
         SiteContextService siteContext,
         SiteTunnelRouting tunnelRouting,
+        SiteAgentCoverage agentCoverage,
         ILoggerFactory loggerFactory,
         ILogger<ProbeExecutorFactory> logger)
     {
@@ -51,6 +53,7 @@ public class ProbeExecutorFactory
         _agentProbe = agentProbe;
         _siteContext = siteContext;
         _tunnelRouting = tunnelRouting;
+        _agentCoverage = agentCoverage;
         _loggerFactory = loggerFactory;
         _logger = logger;
     }
@@ -58,12 +61,13 @@ public class ProbeExecutorFactory
     /// <summary>
     /// The "server" vantage. On a secondary site with an online agent that's the on-site
     /// agent host (the central server can't reach the site's network) - it runs the
-    /// identical LocalProbeExecutor over the tunnel. Falls back to the local server on the
-    /// default site or when no agent is online.
+    /// identical LocalProbeExecutor over the tunnel. The default site resolves the same way
+    /// once it is configured for its agent to cover it; otherwise, and whenever no agent is
+    /// online, this is the local server.
     /// </summary>
     public IProbeExecutor GetServer()
     {
-        if (!_siteContext.IsDefault && _agentProbe.HasAgentForSite(_siteContext.Slug))
+        if (ServerVantageIsAgent)
             return new AgentProbeExecutor(_agentProbe, _siteContext.Slug,
                 _loggerFactory.CreateLogger<AgentProbeExecutor>());
         return _local;
@@ -71,7 +75,7 @@ public class ProbeExecutorFactory
 
     /// <summary>Whether the "server" vantage resolves to the on-site agent for the current site.</summary>
     public bool ServerVantageIsAgent =>
-        !_siteContext.IsDefault && _agentProbe.HasAgentForSite(_siteContext.Slug);
+        _agentCoverage.AgentCovers(_siteContext.Slug, _agentProbe.HasAgentForSite(_siteContext.Slug));
 
     /// <summary>
     /// Build an executor that runs probes from the chosen UniFi device via SSH. Returns

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootRegistry.cs
@@ -7,7 +7,7 @@ namespace NetworkOptimizer.Web.Services.Monitoring.RebootReason;
 /// samples; pages read the same instance for the reason behind a device's current boot. Same
 /// pattern as MonitoringLiveStatsRegistry: instances are in-memory caches, nothing to dispose.
 /// </summary>
-public class DeviceRebootRegistry
+public class DeviceRebootRegistry : ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly UniFiSshRegistry _deviceSshRegistry;
@@ -52,4 +52,11 @@ public class DeviceRebootRegistry
 
     /// <summary>The default site's tracker.</summary>
     public DeviceRebootTracker GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerRegistry.cs
@@ -15,7 +15,7 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// agent (running the same LocalProbeExecutor over the tunnel) on a secondary site, so the
 /// path originates on the site's own network with first-hop logic identical to home.
 /// </summary>
-public class UpstreamTracerRegistry
+public class UpstreamTracerRegistry : ISiteScopedRegistry
 {
     private readonly SiteConnectionRegistry _connections;
     private readonly GatewaySshRegistry _gatewaySsh;
@@ -82,4 +82,11 @@ public class UpstreamTracerRegistry
 
     /// <summary>The default site's tracer.</summary>
     public UpstreamTracerService GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerRegistry.cs
@@ -25,6 +25,7 @@ public class UpstreamTracerRegistry : ISiteScopedRegistry
     private readonly SiteDbContextFactory _siteDbFactory;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly AsnResolutionService _asnResolution;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly NetworkOptimizer.Audit.Services.IeeeOuiDatabase _ouiDb;
     private readonly ILoggerFactory _loggerFactory;
@@ -39,6 +40,7 @@ public class UpstreamTracerRegistry : ISiteScopedRegistry
         SiteDbContextFactory siteDbFactory,
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
         AsnResolutionService asnResolution,
+        SiteAgentCoverage agentCoverage,
         IServiceScopeFactory scopeFactory,
         NetworkOptimizer.Audit.Services.IeeeOuiDatabase ouiDb,
         ILoggerFactory loggerFactory)
@@ -51,6 +53,7 @@ public class UpstreamTracerRegistry : ISiteScopedRegistry
         _siteDbFactory = siteDbFactory;
         _dbFactory = dbFactory;
         _asnResolution = asnResolution;
+        _agentCoverage = agentCoverage;
         _scopeFactory = scopeFactory;
         _ouiDb = ouiDb;
         _loggerFactory = loggerFactory;
@@ -60,11 +63,18 @@ public class UpstreamTracerRegistry : ISiteScopedRegistry
     public UpstreamTracerService GetFor(string slug) => _instances.GetOrAdd(slug, s =>
     {
         var isDefault = s == SiteManagementService.DefaultSiteSlug;
-        // Default site traces from the local server; a secondary site traces from its
-        // on-site agent (analogous to the NO Server on the home LAN).
-        IProbeExecutor traceExecutor = isDefault
-            ? _localProbe
-            : new AgentProbeExecutor(_agentProbe, s, _loggerFactory.CreateLogger<AgentProbeExecutor>());
+        // A secondary site always traces from its on-site agent (analogous to the NO Server on the
+        // home LAN) - tracing it from here would attribute this server's path to that site. The
+        // default site traces locally unless it is configured for its agent to cover it, which is
+        // the off-site-server case.
+        //
+        // Resolved per run rather than baked in here: this registry caches one tracer per site for
+        // the life of the process, so a flag changed afterwards would otherwise never be seen.
+        var agentExecutor = new AgentProbeExecutor(_agentProbe, s, _loggerFactory.CreateLogger<AgentProbeExecutor>());
+        Func<IProbeExecutor> traceExecutor = () =>
+            !isDefault || _agentCoverage.AgentCovers(s, _agentProbe.HasAgentForSite(s))
+                ? agentExecutor
+                : _localProbe;
         return new UpstreamTracerService(
             s,
             isDefault,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -122,8 +122,15 @@ public class UpstreamTracerService
     /// <summary>Sub-80ms regionals that are "enough": once a probe round has found this many, later rounds are skipped.</summary>
     internal const int AwsEnoughRegionals = 6;
 
-    /// <summary>Max AWS regionals surfaced as path-end candidates (transit-eliciting first, then lowest RTT).</summary>
-    internal const int MaxAwsPathEndTargets = 5;
+    /// <summary>Max AWS regionals SURFACED as path-end candidates (transit-eliciting first, then lowest RTT).</summary>
+    internal const int MaxAwsPathEndTargets = 7;
+
+    /// <summary>
+    /// How many of those arrive pre-enabled. Surfacing is cheap - a row to tick - but every enabled
+    /// one becomes a probed target forever, and four path-ends through one provider already
+    /// characterize the path. The rest are offered rather than chosen.
+    /// </summary>
+    internal const int MaxAwsAutoEnabledTargets = 4;
 
     // A resolved AWS regional: the hostname (what we persist as the target address, since AWS rotates
     // the regional IPs and the hostname re-resolves to a live in-region IP each poll) and the concrete
@@ -1505,8 +1512,9 @@ public class UpstreamTracerService
             var amazon = await _asnResolution.ResolveAsync(_awsRegionals[0].Ip, ct);
             var amazonAsn = amazon?.Asn ?? 0;
             var amazonName = string.IsNullOrEmpty(amazon?.Name) ? "Amazon" : CleanAsnName(amazon.Name);
-            // The via (farthest transit) labels the row, decides pre-enable, and ranks the trim: a
-            // region is pre-checked only when its trace actually crosses transit.
+            // The via (farthest transit) labels the row and ranks the trim. It also gates pre-enable:
+            // a region is pre-checked only when its trace actually crosses transit, and only while
+            // the pre-enabled count is under its own cap.
             var rankedAws = _awsRegionals
                 .Select(r =>
                 {
@@ -1515,9 +1523,15 @@ public class UpstreamTracerService
                 })
                 .OrderByDescending(x => x.Via != null)
                 .ThenBy(x => x.Regional.RttMs)
-                .Take(MaxAwsPathEndTargets);
+                .Take(MaxAwsPathEndTargets)
+                .ToList();
+            // Pre-enable only the best few. The list is already ordered transit-eliciting first,
+            // then by RTT, so taking from the front enables the most useful of them.
+            var autoEnabled = 0;
             foreach (var (r, via, awsComplete) in rankedAws)
             {
+                var enable = via != null && autoEnabled < MaxAwsAutoEnabledTargets;
+                if (enable) autoEnabled++;
                 candidates.Add(new TransitAsnCandidate
                 {
                     AsnNumber = amazonAsn,
@@ -1528,7 +1542,7 @@ public class UpstreamTracerService
                     HopAddress = r.Hostname,
                     PathProxyTarget = r.Hostname,
                     RespondedTo = ProbeMode.Icmp,
-                    Enabled = via != null,
+                    Enabled = enable,
                     ViaAsnNumber = via?.Asn,
                     ViaAsnName = via?.Name,
                     ViaPathComplete = awsComplete

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1674,19 +1674,27 @@ public class UpstreamTracerService
     // spacing) to be auto-selected, so flaky, ICMP-deprioritized routers don't get monitored - and
     // so a curated transit witness (e.g. Level 3 4.2.2.2) must itself clear the gate before it is
     // attached. We always send 3; the required successes depend on the connection's access medium
-    // (Item B): air-interface mediums (WISP, cellular) and the unconfigured Unknown case allow one
-    // dropped reply (2/3); stable wired/fiber/LEO mediums demand 3/3.
+    // (Item B): air-interface mediums (WISP, cellular) allow one dropped reply (2/3), everything
+    // else demands 3/3.
     private const int ReachabilityPingCount = 3;
 
     /// <summary>
     /// Required successful pings (out of <see cref="ReachabilityPingCount"/>) for a candidate to be
     /// auto-selected, by the connection's access technology. WISP / cellular have inherent
-    /// air-interface transient loss, and Unknown is unconfigured, so we don't penalize them for a
-    /// single drop; everything else (including LEO, which is stable) demands all three.
+    /// air-interface transient loss, so a single drop does not disqualify a candidate there;
+    /// everything else (including LEO, which is stable) demands all three.
+    ///
+    /// Unknown demands all three too. It used to be lenient on the grounds that an unconfigured
+    /// link might turn out to be air-interface - but Unknown is the state of every FIRST run on a
+    /// WAN, which is precisely the run that decides which candidates get seeded as monitoring
+    /// targets. Relaxing the gate exactly when the least is known adopted flaky routers on the
+    /// strength of the run with the weakest evidence. Leniency now follows a deliberate statement
+    /// about the medium rather than the absence of one: someone on a WISP sets the technology and
+    /// re-runs.
     /// </summary>
     private static int RequiredReachabilitySuccesses(AccessTechnology tech) => tech switch
     {
-        AccessTechnology.FixedWireless or AccessTechnology.Cellular or AccessTechnology.Unknown => 2,
+        AccessTechnology.FixedWireless or AccessTechnology.Cellular => 2,
         _ => 3
     };
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -36,7 +36,10 @@ public class UpstreamTracerService
     private readonly NetworkOptimizer.Storage.Services.SiteDbContextFactory _siteDbFactory;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly AsnResolutionService _asnResolution;
-    private readonly IProbeExecutor _traceExecutor;
+    // Resolved per use, not captured: whether the site's agent covers it can change while the
+    // instance lives, and the registry caches one tracer per site for the life of the process.
+    private readonly Func<IProbeExecutor> _traceExecutorFactory;
+    private IProbeExecutor _traceExecutor => _traceExecutorFactory();
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly IspHealth.IspHealthService _ispHealth;
     private readonly NetworkOptimizer.Audit.Services.IeeeOuiDatabase _ouiDb;
@@ -257,7 +260,7 @@ public class UpstreamTracerService
         UniFiConnectionService connectionService,
         IGatewaySshService gatewaySsh,
         IspHealth.IspHealthService ispHealth,
-        IProbeExecutor traceExecutor,
+        Func<IProbeExecutor> traceExecutor,
         NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
         AsnResolutionService asnResolution,
@@ -270,7 +273,7 @@ public class UpstreamTracerService
         _connectionService = connectionService;
         _gatewaySsh = gatewaySsh;
         _ispHealth = ispHealth;
-        _traceExecutor = traceExecutor;
+        _traceExecutorFactory = traceExecutor;
         _siteDbFactory = siteDbFactory;
         _dbFactory = dbFactory;
         _asnResolution = asnResolution;

--- a/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
@@ -16,7 +16,7 @@ namespace NetworkOptimizer.Web.Services;
 /// SiteConnectionRegistry / MonitoringInfluxRegistry; instances are pure
 /// in-memory state, so nothing needs disposal.
 /// </summary>
-public class MonitoringAlertRegistry
+public class MonitoringAlertRegistry : ISiteScopedRegistry
 {
     /// <summary>One site's alert evaluators.</summary>
     public sealed record SiteAlertEvaluators(
@@ -57,4 +57,11 @@ public class MonitoringAlertRegistry
 
     /// <summary>The default site's evaluators.</summary>
     public SiteAlertEvaluators GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -45,6 +45,7 @@ public class MonitoringCollectionAgent : BackgroundService
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _dbFactory;
     private readonly SiteDbContextFactory _siteDbFactory;
     private readonly AgentTunnelRegistry _tunnelRegistry;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly UniFiConnectionService _connectionService;
     private readonly MonitoringInfluxClient _influx;
     private readonly MonitoringLiveStats _liveStats;
@@ -120,9 +121,10 @@ public class MonitoringCollectionAgent : BackgroundService
     /// <summary>
     /// Whether this site's probing happens here. The server stands down from probing on every
     /// non-default site (see the comment in FastTierCollectAsync) - the site's own agent probes
-    /// from inside instead - so a status display must not claim the server is collecting there.
+    /// from inside instead - and on the default site too once it is configured for its agent to
+    /// cover it. A status display must not claim the server is collecting where it is not.
     /// </summary>
-    public bool ServerProbesThisSite => _isDefault;
+    public bool ServerProbesThisSite => _isDefault && !AgentCoversCollection();
 
     /// <summary>
     /// Lets the Setup page's interactive re-check override the cached self-heal sighting
@@ -142,6 +144,7 @@ public class MonitoringCollectionAgent : BackgroundService
         IDbContextFactory<NetworkOptimizerDbContext> dbFactory,
         SiteDbContextFactory siteDbFactory,
         AgentTunnelRegistry tunnelRegistry,
+        SiteAgentCoverage agentCoverage,
         SiteConnectionRegistry siteConnections,
         MonitoringInfluxRegistry influxRegistry,
         MonitoringLiveStatsRegistry liveStatsRegistry,
@@ -160,6 +163,7 @@ public class MonitoringCollectionAgent : BackgroundService
         _dbFactory = dbFactory;
         _siteDbFactory = siteDbFactory;
         _tunnelRegistry = tunnelRegistry;
+        _agentCoverage = agentCoverage;
         _licenseState = licenseState;
         _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
         _isDefault = _siteSlug == SiteManagementService.DefaultSiteSlug;
@@ -196,11 +200,17 @@ public class MonitoringCollectionAgent : BackgroundService
     /// Whether a connected on-site agent is collecting for this site right now. The
     /// tunnel relay handles latency probing and SNMP polling from inside the site's
     /// network (where the server often has no reach), so the local loops for those
-    /// paths stand down while an agent is connected. Never true for the default site:
-    /// its agents are additional vantage points, not replacements for local collection.
+    /// paths stand down while an agent is connected.
+    ///
+    /// For the default site this is false unless the site is explicitly configured for its agent to
+    /// cover it: a default-site agent is an ADDITIONAL vantage point by default, not a replacement
+    /// for local collection, and that is what installs using one today rely on.
     /// </summary>
-    private bool AgentCoversCollection() =>
-        !_isDefault && (_tunnelRegistry.GetForSite(_siteSlug).Count > 0 || _siteAgentEnrolled);
+    private bool AgentCoversCollection()
+    {
+        var agentPresent = _tunnelRegistry.GetForSite(_siteSlug).Count > 0 || _siteAgentEnrolled;
+        return _agentCoverage.AgentCovers(_siteSlug, agentPresent);
+    }
 
     // A secondary site is agent-backed if it has an ENROLLED agent, even while that agent
     // is momentarily disconnected (app startup, agent reconnect). The NO Server can't reach
@@ -1422,9 +1432,9 @@ public class MonitoringCollectionAgent : BackgroundService
         // central server can't see the site's network: with an agent connected it double-probes
         // the WAN path instead of the site's own fabric/WAN view, and with no agent yet it would
         // log its own anycast RTT as the site's ISP latency. The site's agent probes its enabled
-        // targets from inside once deployed (AgentProbeResultSink). The default site keeps
-        // probing locally as before.
-        if (!_isDefault) return;
+        // targets from inside once deployed (AgentProbeResultSink). The default site keeps probing
+        // locally unless it too is covered by its agent, which is the off-site-server case.
+        if (!_isDefault || AgentCoversCollection()) return;
 
         await using var db = await CreateSiteDbAsync(ct);
         var targets = await db.MonitoringTargets

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -110,6 +110,21 @@ public class MonitoringCollectionAgent : BackgroundService
     public bool CommunityTooLongDetected { get; private set; }
 
     /// <summary>
+    /// When a collection tier last completed a pass. Monitoring - Setup reported "Agent running"
+    /// from the enabled flag and InfluxDB reachability alone, which says nothing about whether
+    /// anything is actually collecting - a wedged or crashed loop still read as running. Stamped by
+    /// every tier, so a value going stale means all of them stopped, not just one.
+    /// </summary>
+    public DateTime? LastCollectionUtc { get; private set; }
+
+    /// <summary>
+    /// Whether this site's probing happens here. The server stands down from probing on every
+    /// non-default site (see the comment in FastTierCollectAsync) - the site's own agent probes
+    /// from inside instead - so a status display must not claim the server is collecting there.
+    /// </summary>
+    public bool ServerProbesThisSite => _isDefault;
+
+    /// <summary>
     /// Lets the Setup page's interactive re-check override the cached self-heal sighting
     /// with its fresher console read. Without this, a user who shortens the community and
     /// hits Re-check still sees the too-long banner until the agent's next re-pull.
@@ -346,6 +361,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 {
                     interval = intervalSelector(settings);
                     await collect(settings, stoppingToken);
+                    LastCollectionUtc = DateTime.UtcNow;
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionRegistry.cs
@@ -15,7 +15,7 @@ namespace NetworkOptimizer.Web.Services;
 /// Monitoring page's SNMP status panel reads whichever site it is showing).
 /// Same ownership pattern as SiteConnectionRegistry / MonitoringInfluxRegistry.
 /// </summary>
-public class MonitoringCollectionRegistry : BackgroundService
+public class MonitoringCollectionRegistry : BackgroundService, ISiteScopedRegistry
 {
     private static readonly TimeSpan ReconcileInterval = TimeSpan.FromSeconds(30);
 
@@ -63,6 +63,14 @@ public class MonitoringCollectionRegistry : BackgroundService
         await StopInstanceAsync(slug, ct);
         _instances.TryRemove(slug, out _);
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The loop has to come down before anything it reads from is disposed, so the stop runs in
+    /// the teardown callback and this registry is swept first.
+    /// </remarks>
+    public Func<ValueTask>? EvictSite(string slug)
+        => () => new ValueTask(StopForSiteAsync(slug));
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxRegistry.cs
@@ -15,11 +15,13 @@ namespace NetworkOptimizer.Web.Services;
 public class MonitoringInfluxRegistry : IAsyncDisposable
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly ILogger<MonitoringInfluxRegistry> _logger;
     private readonly ConcurrentDictionary<string, MonitoringInfluxClient> _clients = new();
 
-    public MonitoringInfluxRegistry(IServiceProvider serviceProvider)
+    public MonitoringInfluxRegistry(IServiceProvider serviceProvider, ILogger<MonitoringInfluxRegistry> logger)
     {
         _serviceProvider = serviceProvider;
+        _logger = logger;
     }
 
     /// <summary>The Influx client for a site, created on first use.</summary>
@@ -39,11 +41,35 @@ public class MonitoringInfluxRegistry : IAsyncDisposable
     /// their connection from main at configure time, so reconfiguring only the default
     /// client would leave existing site clients on the stale connection until restart.
     /// Clients not yet created pick up the fresh settings on first use.
+    ///
+    /// Best-effort per client: reconfiguring reads that site's own database, so one site
+    /// whose database is unreadable must not abort the caller. This runs at the end of
+    /// InfluxDB provisioning, after the buckets and token already exist, and letting it
+    /// throw reported a failure for work that had in fact succeeded.
     /// </summary>
     public async Task ReconfigureAllAsync(CancellationToken ct = default)
     {
-        foreach (var client in _clients.Values)
-            await client.ReconfigureAsync(ct);
+        foreach (var (slug, client) in _clients)
+        {
+            try
+            {
+                await client.ReconfigureAsync(ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not reconfigure the InfluxDB client for site {Slug}", slug);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops a removed site's client. Without this the registry keeps an entry pointing at a
+    /// database file that no longer exists, and every later ReconfigureAllAsync trips over it.
+    /// </summary>
+    public async Task RemoveAsync(string slug)
+    {
+        if (_clients.TryRemove(slug, out var client))
+            await client.DisposeOwnedAsync();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/NetworkOptimizer.Web/Services/MonitoringInfluxRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringInfluxRegistry.cs
@@ -12,7 +12,7 @@ namespace NetworkOptimizer.Web.Services;
 /// the registry and pin GetDefault(). Same ownership pattern as
 /// SiteConnectionRegistry: the registry disposes what it creates.
 /// </summary>
-public class MonitoringInfluxRegistry : IAsyncDisposable
+public class MonitoringInfluxRegistry : IAsyncDisposable, ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<MonitoringInfluxRegistry> _logger;
@@ -62,15 +62,14 @@ public class MonitoringInfluxRegistry : IAsyncDisposable
         }
     }
 
-    /// <summary>
-    /// Drops a removed site's client. Without this the registry keeps an entry pointing at a
-    /// database file that no longer exists, and every later ReconfigureAllAsync trips over it.
-    /// </summary>
-    public async Task RemoveAsync(string slug)
-    {
-        if (_clients.TryRemove(slug, out var client))
-            await client.DisposeOwnedAsync();
-    }
+    /// <inheritdoc />
+    /// <remarks>
+    /// Teardown is deferred rather than done here on purpose: the site's ISP Health service and
+    /// collection agent hold this client, so disposing it while they are still registered turns
+    /// every later background pass into an ObjectDisposedException on its config lock.
+    /// </remarks>
+    public Func<ValueTask>? EvictSite(string slug)
+        => _clients.TryRemove(slug, out var client) ? () => client.DisposeOwnedAsync() : null;
 
     public async ValueTask DisposeAsync()
     {

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStatsRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStatsRegistry.cs
@@ -10,7 +10,7 @@ namespace NetworkOptimizer.Web.Services;
 /// pattern as SiteConnectionRegistry / MonitoringInfluxRegistry. Instances
 /// are pure in-memory caches, so the registry never needs to dispose them.
 /// </summary>
-public class MonitoringLiveStatsRegistry
+public class MonitoringLiveStatsRegistry : ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<string, MonitoringLiveStats> _instances = new();
@@ -29,4 +29,11 @@ public class MonitoringLiveStatsRegistry
 
     /// <summary>The default site's cache.</summary>
     public MonitoringLiveStats GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/MonitoringSettingsService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringSettingsService.cs
@@ -1,0 +1,139 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <inheritdoc />
+public class MonitoringSettingsService : IMonitoringSettingsService
+{
+    private readonly SiteDbContextFactory _siteDb;
+    private readonly SiteContextService _siteContext;
+    private readonly IAuditContext _audit;
+
+    public MonitoringSettingsService(SiteDbContextFactory siteDb, SiteContextService siteContext, IAuditContext audit)
+    {
+        _siteDb = siteDb;
+        _siteContext = siteContext;
+        _audit = audit;
+    }
+
+    /// <summary>A non-positive temperature threshold means "use the default", stored as null.</summary>
+    private static double? NormalizeTemp(double? value) => value is > 0 ? value : null;
+
+    /// <inheritdoc />
+    public Task<MonitoringSettings> SetEnabledAsync(bool enabled, CancellationToken ct = default) =>
+        SaveAsync(ct, s =>
+        {
+            var before = s.Enabled;
+            s.Enabled = enabled;
+            return before == enabled ? null : new { field = "Enabled", from = before, to = enabled };
+        });
+
+    /// <inheritdoc />
+    public async Task ResetInfluxSetupAsync(CancellationToken ct = default)
+    {
+        await using var db = _siteDb.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
+        if (settings == null)
+        {
+            _audit.SuppressNoChange();
+            return;
+        }
+
+        settings.Enabled = false;
+        settings.InfluxDbToken = "";
+        settings.InfluxDbUrl = "";
+        settings.InfluxDbOrg = "";
+        settings.InfluxDbBucket = "";
+        settings.InfluxDbLongtermBucket = "";
+        settings.InfluxDbReachable = null;
+        settings.LastInfluxDbError = null;
+        settings.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+
+        // No values in the detail: the cleared fields include the token.
+        _audit.SetDetails(new { influxSetupReset = true });
+    }
+
+    /// <inheritdoc />
+    public Task<MonitoringSettings> SaveTempThresholdsAsync(double? switchHighC, double? gatewayHighC,
+        CancellationToken ct = default) =>
+        SaveAsync(ct, s =>
+        {
+            var before = (s.SwitchTempHighC, s.GatewayTempHighC);
+            s.SwitchTempHighC = NormalizeTemp(switchHighC);
+            s.GatewayTempHighC = NormalizeTemp(gatewayHighC);
+            var after = (s.SwitchTempHighC, s.GatewayTempHighC);
+            return before == after ? null : new
+            {
+                switchTempHighC = new { from = before.SwitchTempHighC, to = after.SwitchTempHighC },
+                gatewayTempHighC = new { from = before.GatewayTempHighC, to = after.GatewayTempHighC }
+            };
+        });
+
+    /// <inheritdoc />
+    public Task<MonitoringSettings> SaveSfpThresholdsAsync(SfpThresholdEdit edit, CancellationToken ct = default) =>
+        SaveAsync(ct, s =>
+        {
+            var before = Snapshot(s);
+            // Temperature must be positive; power thresholds may legitimately be
+            // negative (RX low) so a blank field (null) is the only "use default".
+            s.PonTempHighC = NormalizeTemp(edit.PonTempHighC);
+            s.PonRxPowerLowDbm = edit.PonRxPowerLowDbm;
+            s.PonTxPowerHighDbm = edit.PonTxPowerHighDbm;
+            s.AeTempHighC = NormalizeTemp(edit.AeTempHighC);
+            s.AeRxPowerLowDbm = edit.AeRxPowerLowDbm;
+            s.AeTxPowerHighDbm = edit.AeTxPowerHighDbm;
+            s.SfpTempHighGenericC = NormalizeTemp(edit.SfpTempHighGenericC);
+            var after = Snapshot(s);
+            return before == after ? null : new { from = before, to = after };
+        });
+
+    /// <inheritdoc />
+    public Task<MonitoringSettings> SaveOntThresholdsAsync(double? ponTempHighC, double? ponRxPowerLowDbm,
+        CancellationToken ct = default) =>
+        SaveAsync(ct, s =>
+        {
+            var before = (s.PonTempHighC, s.PonRxPowerLowDbm);
+            // Temperature must be positive; a blank RX field (null) means "use default".
+            s.PonTempHighC = NormalizeTemp(ponTempHighC);
+            s.PonRxPowerLowDbm = ponRxPowerLowDbm;
+            var after = (s.PonTempHighC, s.PonRxPowerLowDbm);
+            return before == after ? null : new
+            {
+                ponTempHighC = new { from = before.PonTempHighC, to = after.PonTempHighC },
+                ponRxPowerLowDbm = new { from = before.PonRxPowerLowDbm, to = after.PonRxPowerLowDbm }
+            };
+        });
+
+    private static (double?, double?, double?, double?, double?, double?, double?) Snapshot(MonitoringSettings s) =>
+        (s.PonTempHighC, s.PonRxPowerLowDbm, s.PonTxPowerHighDbm,
+         s.AeTempHighC, s.AeRxPowerLowDbm, s.AeTxPowerHighDbm, s.SfpTempHighGenericC);
+
+    /// <summary>
+    /// Loads the site's settings row (creating it on first save), applies an edit, and records the
+    /// diff. A mutate that returns null changed nothing, so the row is left alone and the event is
+    /// suppressed - saving a form whose values are already stored should not read as a
+    /// configuration change.
+    /// </summary>
+    private async Task<MonitoringSettings> SaveAsync(CancellationToken ct, Func<MonitoringSettings, object?> mutate)
+    {
+        await using var db = _siteDb.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct) ?? new MonitoringSettings();
+        if (settings.Id == 0) db.MonitoringSettings.Add(settings);
+
+        var change = mutate(settings);
+        if (change == null && settings.Id != 0)
+        {
+            _audit.SuppressNoChange();
+            return settings;
+        }
+
+        settings.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync(ct);
+        _audit.SetDetails(change ?? new { created = true });
+        return settings;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
@@ -1,0 +1,248 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Gates;
+using NetworkOptimizer.Web.Services.Monitoring;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <inheritdoc />
+public class MonitoringTargetService : IMonitoringTargetService
+{
+    private static readonly Regex HostnamePattern = new(@"^[a-zA-Z0-9][a-zA-Z0-9.\-]*$", RegexOptions.Compiled);
+    private const int MaxFieldLength = 200;
+
+    private readonly SiteDbContextFactory _siteDb;
+    private readonly SiteContextService _siteContext;
+    private readonly AsnResolutionService _asnResolution;
+    private readonly ProbeExecutorFactory _executorFactory;
+    private readonly IAuditContext _audit;
+    private readonly ILogger<MonitoringTargetService> _logger;
+
+    public MonitoringTargetService(
+        SiteDbContextFactory siteDb,
+        SiteContextService siteContext,
+        AsnResolutionService asnResolution,
+        ProbeExecutorFactory executorFactory,
+        IAuditContext audit,
+        ILogger<MonitoringTargetService> logger)
+    {
+        _siteDb = siteDb;
+        _siteContext = siteContext;
+        _asnResolution = asnResolution;
+        _executorFactory = executorFactory;
+        _audit = audit;
+        _logger = logger;
+    }
+
+    private NetworkOptimizerDbContext CreateDb() => _siteDb.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+
+    /// <inheritdoc />
+    public async Task<MonitoringTarget> AddAsync(NewMonitoringTarget spec, CancellationToken ct = default)
+    {
+        var name = (spec.Name ?? "").Trim();
+        var address = (spec.Address ?? "").Trim();
+        if (string.IsNullOrEmpty(name) || string.IsNullOrEmpty(address))
+            throw new MonitoringTargetValidationException("Name and address are required.");
+        if (name.Length > MaxFieldLength || address.Length > MaxFieldLength)
+            throw new MonitoringTargetValidationException($"Name and address must be under {MaxFieldLength} characters.");
+        if (!IPAddress.TryParse(address, out _) && !HostnamePattern.IsMatch(address))
+            throw new MonitoringTargetValidationException("Address must be a valid IP or hostname.");
+
+        var (asnNumber, asnName) = await ResolveAsnAsync(spec.TargetType, address);
+
+        // Manual Transit/Access ISP adds are user-provided upstream hops the tracer didn't
+        // find. Tag them UserProvided so upstream change-detection treats them as curated
+        // (never flags them as "removed", never re-suggests them as "added") while ISP
+        // Health still grades them by TargetType. Generic customs stay unmethoded (null).
+        var discoveryMethod = spec.TargetType is MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp
+            ? (DiscoveryMethod?)DiscoveryMethod.UserProvided
+            : null;
+
+        var entity = new MonitoringTarget
+        {
+            TargetId = $"custom-{Guid.NewGuid():N}"[..24],
+            Name = name,
+            Address = address,
+            TargetType = spec.TargetType,
+            ProbeMode = spec.ProbeMode,
+            Port = spec.ProbeMode == ProbeMode.Tcp ? spec.Port : null,
+            PollIntervalSeconds = spec.PollIntervalSeconds,
+            PingCount = 5,
+            Enabled = true,
+            AutoDiscovered = false,
+            DiscoveryMethod = discoveryMethod,
+            VantagePoint = "server",
+            CreatedAt = DateTime.UtcNow,
+            AsnNumber = asnNumber,
+            AsnName = asnName
+        };
+
+        await using (var db = CreateDb())
+        {
+            db.MonitoringTargets.Add(entity);
+            await db.SaveChangesAsync(ct);
+        }
+
+        _audit.SetTarget(entity.TargetId, entity.Name);
+        _audit.SetDetails(new
+        {
+            address = entity.Address,
+            targetType = entity.TargetType.ToString(),
+            probeMode = entity.ProbeMode.ToString(),
+            entity.Port,
+            entity.PollIntervalSeconds,
+            entity.AsnNumber
+        });
+
+        // Trace-on-save: an Internet/Custom target only absolves the ISP/transit hops it crosses
+        // once it has trace ancestry. Kick off an immediate trace so it can act as a witness now,
+        // instead of waiting for the next upstream discovery cycle. Resolve the "server" vantage
+        // executor here (synchronously, current site context) so external agent sites trace over
+        // the on-site agent tunnel and there's no scoped-context race in the fire-and-forget.
+        if (spec.TargetType is MonitoringTargetType.InternetService or MonitoringTargetType.Custom)
+            _ = TraceOnSaveForAncestryAsync(_executorFactory.GetServer(), entity.Id, address,
+                _siteContext.Slug, _siteContext.IsDefault);
+
+        return entity;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> DeleteAsync(int id, CancellationToken ct = default)
+    {
+        await using var db = CreateDb();
+        var row = await db.MonitoringTargets.FindAsync(new object?[] { id }, ct);
+        if (row == null)
+        {
+            _audit.SuppressNoChange();
+            return false;
+        }
+
+        _audit.SetTarget(row.TargetId, row.Name);
+        _audit.SetDetails(new { deleted = true, address = row.Address, targetType = row.TargetType.ToString() });
+
+        db.MonitoringTargets.Remove(row);
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public Task<bool> SetEnabledAsync(int id, bool enabled, CancellationToken ct = default) =>
+        UpdateAsync(id, ct, row =>
+        {
+            if (row.Enabled == enabled) return null;
+            var before = row.Enabled;
+            row.Enabled = enabled;
+            return new { field = "Enabled", from = before, to = enabled };
+        });
+
+    /// <inheritdoc />
+    public Task<bool> SetPollIntervalAsync(int id, int seconds, CancellationToken ct = default) =>
+        UpdateAsync(id, ct, row =>
+        {
+            if (row.PollIntervalSeconds == seconds) return null;
+            var before = row.PollIntervalSeconds;
+            row.PollIntervalSeconds = seconds;
+            return new { field = "PollIntervalSeconds", from = before, to = seconds };
+        });
+
+    /// <inheritdoc />
+    public Task<bool> DismissLanFlakyHintAsync(int id, CancellationToken ct = default) =>
+        UpdateAsync(id, ct, row =>
+        {
+            if (row.LanFlakyHintDismissedAt != null) return null;
+            row.LanFlakyHintDismissedAt = DateTime.UtcNow;
+            return new { field = "LanFlakyHintDismissedAt", dismissed = true };
+        });
+
+    /// <inheritdoc />
+    public Task<bool> SetWanContextAsync(int id, int? wanContextId, CancellationToken ct = default) =>
+        UpdateAsync(id, ct, row =>
+        {
+            if (row.WanContextId == wanContextId) return null;
+            var before = row.WanContextId;
+            row.WanContextId = wanContextId;
+            return new { field = "WanContextId", from = before, to = wanContextId };
+        });
+
+    /// <summary>
+    /// Applies a single-field edit and records what actually changed. A mutate that returns null
+    /// made no change, so nothing is saved and the event is suppressed outright - re-selecting the
+    /// interval a target already has is not a configuration change, and an Audit Log full of
+    /// entries that changed nothing is the thing that makes the real ones hard to find.
+    /// </summary>
+    private async Task<bool> UpdateAsync(int id, CancellationToken ct, Func<MonitoringTarget, object?> mutate)
+    {
+        await using var db = CreateDb();
+        var row = await db.MonitoringTargets.FindAsync(new object?[] { id }, ct);
+        if (row == null)
+        {
+            _audit.SuppressNoChange();
+            return false;
+        }
+
+        var change = mutate(row);
+        if (change == null)
+        {
+            _audit.SuppressNoChange();
+            return true;
+        }
+
+        await db.SaveChangesAsync(ct);
+        _audit.SetTarget(row.TargetId, row.Name);
+        _audit.SetDetails(change);
+        return true;
+    }
+
+    private async Task<(int? AsnNumber, string? AsnName)> ResolveAsnAsync(MonitoringTargetType targetType, string address)
+    {
+        if (targetType is not (MonitoringTargetType.Transit or MonitoringTargetType.AccessIsp))
+            return (null, null);
+
+        var ip = address;
+        if (!IPAddress.TryParse(address, out _))
+        {
+            try
+            {
+                var entries = await Dns.GetHostAddressesAsync(address);
+                ip = entries.FirstOrDefault()?.ToString();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Could not resolve {Address} for ASN lookup; adding the target without one", address);
+                ip = null;
+            }
+        }
+        if (ip == null) return (null, null);
+
+        var asn = await _asnResolution.ResolveAsync(ip);
+        if (asn == null) return (null, null);
+
+        // Apply the same industry-suffix cleanup auto-discovery uses
+        // (UpstreamTracerService.CleanAsnName), so a manually-added transit hop
+        // stores "Level 3", not "Level 3 Parent" / "Lumen", matching discovery.
+        return (asn.Asn, NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(asn.Name));
+    }
+
+    /// <summary>
+    /// Traces a just-added Internet/Custom target over the site's server/agent vantage and persists
+    /// its hop ancestry as an UpstreamDiscovery row, so ISP Health can immediately use it as a
+    /// routes-through witness. Best-effort; fire-and-forget (reads no request state).
+    /// </summary>
+    private async Task TraceOnSaveForAncestryAsync(NetworkOptimizer.Monitoring.Probes.IProbeExecutor executor,
+        int targetId, string address, string slug, bool isDefault)
+    {
+        try
+        {
+            await using var db = _siteDb.CreateForSite(slug, isDefault);
+            await TargetAncestry.TraceAndPersistAsync(executor, db, targetId, address);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Trace-on-save for target {TargetId} failed; ancestry will fill in on the next discovery", targetId);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SiteAgentCoverage.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteAgentCoverage.cs
@@ -1,0 +1,102 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Whether a site's on-site agent does the collecting instead of this server.
+///
+/// For a secondary site that is simply what having an agent means: the server cannot reach the
+/// site's network, so the agent probes, polls SNMP and proxies the console. The default site is the
+/// server's own network, so its agents have always been ADDITIONAL vantage points rather than
+/// replacements - and that is shipped behavior for anyone using one that way today.
+///
+/// This flag is what lets the default site opt into the secondary-site arrangement, for the case
+/// Settings has long described: the server runs off-site and the network being monitored is
+/// somewhere else. It is deliberately explicit rather than inferred from an agent being enrolled -
+/// inferring it would silently stop server-side collection for every install already using a
+/// default-site agent as an extra vantage.
+///
+/// Nothing here decides anything on its own. Every gate combines it with an agent actually being
+/// enrolled (<see cref="AgentProbeService.HasAgentForSite"/>), so a flag set on a site with no
+/// agent changes nothing.
+/// </summary>
+public class SiteAgentCoverage
+{
+    /// <summary>Per-site setting key: this site's agent collects, this server stands down.</summary>
+    public const string AgentCoversSiteKey = "site.agent_covers_collection";
+
+    // Consulted on collection paths that run every few seconds, so cache it briefly rather than
+    // hitting SQLite each time - same treatment as the via-agent routing flag.
+    private static readonly TimeSpan FlagCacheExpiry = TimeSpan.FromMinutes(1);
+
+    private readonly IServiceProvider _serviceProvider;
+    private readonly ConcurrentDictionary<string, (bool Enabled, DateTime At)> _flags = new();
+
+    public SiteAgentCoverage(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    /// <summary>Whether the site is configured for its agent to cover collection.</summary>
+    public async Task<bool> CoversAsync(string slug)
+    {
+        if (string.IsNullOrEmpty(slug)) return false;
+        if (_flags.TryGetValue(slug, out var cached) && DateTime.UtcNow - cached.At < FlagCacheExpiry)
+            return cached.Enabled;
+        return await ReadAsync(slug);
+    }
+
+    /// <summary>
+    /// The cached answer, for the callers that cannot await - the probe executor factory resolves
+    /// a vantage from a synchronous property. A cache miss reads false and refreshes in the
+    /// background, so the worst case is one pass of today's behavior before the flag takes hold.
+    /// </summary>
+    public bool Covers(string slug)
+    {
+        if (string.IsNullOrEmpty(slug)) return false;
+        if (_flags.TryGetValue(slug, out var cached) && DateTime.UtcNow - cached.At < FlagCacheExpiry)
+            return cached.Enabled;
+        _ = Task.Run(() => ReadAsync(slug));
+        return false;
+    }
+
+    /// <summary>Drops the cached answer for a site, so the next read sees a change immediately.</summary>
+    public void Invalidate(string slug) => _flags.TryRemove(slug, out _);
+
+    /// <summary>
+    /// The question every gate actually asks: does the agent do this site's work rather than this
+    /// server? A secondary site needs only an agent, which is what having one has always meant
+    /// there. The default site needs the flag as well, so an agent enrolled as an extra vantage
+    /// keeps behaving exactly as it does today.
+    ///
+    /// Defined once because it is asked from eight places, and a copy that drifts is a site that
+    /// half stands down.
+    /// </summary>
+    public bool AgentCovers(string slug, bool agentPresent)
+        => agentPresent && (slug != SiteManagementService.DefaultSiteSlug || Covers(slug));
+
+    /// <inheritdoc cref="AgentCovers"/>
+    public async Task<bool> AgentCoversAsync(string slug, bool agentPresent)
+        => agentPresent && (slug != SiteManagementService.DefaultSiteSlug || await CoversAsync(slug));
+
+    private async Task<bool> ReadAsync(string slug)
+    {
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            scope.ServiceProvider.GetRequiredService<SiteContextService>().OverrideSite(slug);
+            var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+            var setting = await db.SystemSettings.FindAsync(AgentCoversSiteKey);
+            var enabled = bool.TryParse(setting?.Value, out var value) && value;
+            _flags[slug] = (enabled, DateTime.UtcNow);
+            return enabled;
+        }
+        catch
+        {
+            // A site mid-removal or mid-creation reads as "server keeps collecting", which is the
+            // behavior every install has today.
+            return false;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SiteConnectionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteConnectionRegistry.cs
@@ -9,7 +9,7 @@ namespace NetworkOptimizer.Web.Services;
 /// registration; singletons and background code inject this registry and use
 /// GetDefault() or GetFor(slug).
 /// </summary>
-public class SiteConnectionRegistry : IDisposable
+public class SiteConnectionRegistry : IDisposable, ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<string, UniFiConnectionService> _connections = new();
@@ -38,6 +38,18 @@ public class SiteConnectionRegistry : IDisposable
         if (_connections.TryRemove(slug, out var connection))
             connection.DisposeOwned();
     }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Teardown is deferred rather than done here: the site's tracer, speed test bundle and
+    /// gateway SSH service all hold this connection, so it must not be disposed until they have
+    /// been evicted too. <see cref="RemoveFor"/> stays for the disable path, where the site and
+    /// everything holding it remain in place.
+    /// </remarks>
+    public Func<ValueTask>? EvictSite(string slug)
+        => _connections.TryRemove(slug, out var connection)
+            ? () => { connection.DisposeOwned(); return ValueTask.CompletedTask; }
+            : null;
 
     public void Dispose()
     {

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -13,8 +13,12 @@ namespace NetworkOptimizer.Web.Services;
 /// </summary>
 public class SiteManagementService : ISiteManagementService
 {
-    /// <summary>Slug reserved for the default site (the pre-multi-site instance).</summary>
-    public const string DefaultSiteSlug = "main";
+    /// <summary>
+    /// Slug reserved for the default site (the pre-multi-site instance). Defined in the storage
+    /// layer, which needs it to resolve database paths, and mirrored here so the two cannot drift -
+    /// a mismatch would send the default site's data to a folder that should never exist.
+    /// </summary>
+    public const string DefaultSiteSlug = SiteDatabasePaths.DefaultSiteSlug;
 
     private readonly ISiteRepository _siteRepository;
     private readonly Authorization.IEffectiveSiteRoleResolver _siteRoles;

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -25,7 +25,7 @@ public class SiteManagementService : ISiteManagementService
     private readonly Licensing.LicenseStateService _licenseState;
     private readonly Licensing.LicenseActivationService _activation;
     private readonly SiteConnectionRegistry _siteConnections;
-    private readonly MonitoringInfluxRegistry _influxRegistry;
+    private readonly IEnumerable<ISiteScopedRegistry> _siteRegistries;
     private readonly MonitoringCollectionRegistry _collectionRegistry;
     private readonly SiteRegistryChangeNotifier _changeNotifier;
     private readonly ILogger<SiteManagementService> _logger;
@@ -41,7 +41,7 @@ public class SiteManagementService : ISiteManagementService
         Licensing.LicenseStateService licenseState,
         Licensing.LicenseActivationService activation,
         SiteConnectionRegistry siteConnections,
-        MonitoringInfluxRegistry influxRegistry,
+        IEnumerable<ISiteScopedRegistry> siteRegistries,
         MonitoringCollectionRegistry collectionRegistry,
         SiteRegistryChangeNotifier changeNotifier,
         Authorization.ISiteAccessFilter siteAccess,
@@ -57,7 +57,7 @@ public class SiteManagementService : ISiteManagementService
         _licenseState = licenseState;
         _activation = activation;
         _siteConnections = siteConnections;
-        _influxRegistry = influxRegistry;
+        _siteRegistries = siteRegistries;
         _collectionRegistry = collectionRegistry;
         _changeNotifier = changeNotifier;
         _logger = logger;
@@ -287,10 +287,7 @@ public class SiteManagementService : ISiteManagementService
         site.Enabled = false;
         await _siteRepository.UpdateAsync(site);
         await _collectionRegistry.StopForSiteAsync(site.Slug);
-        _siteConnections.RemoveFor(site.Slug);
-        // The Influx client caches this site's connection and is rebuilt from the site's own
-        // database; leaving it registered points it at a file that is about to be deleted.
-        await _influxRegistry.RemoveAsync(site.Slug);
+        await SweepSiteRegistriesAsync(site.Slug);
         DropTunnels(site.Slug, "site removed");
 
         await using (var db = await _mainDbFactory.CreateDbContextAsync())
@@ -321,6 +318,50 @@ public class SiteManagementService : ISiteManagementService
         _siteRoles.InvalidateAll();
         _changeNotifier.NotifySitesChanged();
         _logger.LogInformation("Removed site {Slug} (id {Id}) and its data", site.Slug, site.Id);
+    }
+
+    /// <summary>
+    /// Empties every per-site registry of a site being removed.
+    ///
+    /// Two passes, because the instances hold one another: the tracer holds the site's console
+    /// connection, the ISP Health service holds its InfluxDB client. Evicting and disposing in one
+    /// pass hands a live holder a disposed dependency - which is how a re-created site ended up
+    /// with an ObjectDisposedException on every ISP Health pass and a discovery run that saw an
+    /// empty device list. So: evict everything first, then tear down.
+    ///
+    /// Loop owners are torn down before the rest so a running collection pass cannot reach a
+    /// client that has just been disposed.
+    /// </summary>
+    private async Task SweepSiteRegistriesAsync(string slug)
+    {
+        var loopTeardowns = new List<Func<ValueTask>>();
+        var teardowns = new List<Func<ValueTask>>();
+
+        foreach (var registry in _siteRegistries)
+        {
+            try
+            {
+                var teardown = registry.EvictSite(slug);
+                if (teardown == null) continue;
+                (registry is BackgroundService ? loopTeardowns : teardowns).Add(teardown);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not evict site {Slug} from {Registry}", slug, registry.GetType().Name);
+            }
+        }
+
+        foreach (var teardown in loopTeardowns.Concat(teardowns))
+        {
+            try
+            {
+                await teardown();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Teardown for removed site {Slug} failed", slug);
+            }
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -224,8 +224,10 @@ public class SiteManagementService : ISiteManagementService
         if (!enabled)
         {
             await _collectionRegistry.StopForSiteAsync(site.Slug);
-            _siteConnections.RemoveFor(site.Slug);
+            // After the tunnel, not before: dropping an agent's tunnel runs the console's
+            // reconnect path, which rebuilds the very connection this is trying to drop.
             DropTunnels(site.Slug, "site disabled");
+            _siteConnections.RemoveFor(site.Slug);
         }
         // Re-enable needs no explicit start: the collection registry's reconcile
         // pass picks the site up within its cadence, and the next page view or
@@ -287,7 +289,9 @@ public class SiteManagementService : ISiteManagementService
         site.Enabled = false;
         await _siteRepository.UpdateAsync(site);
         await _collectionRegistry.StopForSiteAsync(site.Slug);
-        await SweepSiteRegistriesAsync(site.Slug);
+        // Loops first and only loops: they must be down before the database files go, and the
+        // passive registries deliberately wait until afterwards (see the second sweep below).
+        await SweepSiteRegistriesAsync(site.Slug, loopOwners: true);
         DropTunnels(site.Slug, "site removed");
 
         await using (var db = await _mainDbFactory.CreateDbContextAsync())
@@ -313,6 +317,15 @@ public class SiteManagementService : ISiteManagementService
                 site.Slug, site.Slug);
         }
 
+        // Only now, with the registry row and the database files gone, are the passive registries
+        // safe to empty. Evicting them earlier does not hold: anything that touches the slug in the
+        // meantime rebuilds the entry from the site's still-present database, and DropTunnels above
+        // does exactly that - dropping an agent's tunnel runs the console's reconnect path, which
+        // loads that site's saved UniFi configuration into a fresh connection service. The entry
+        // then outlived the site and was handed to the next site created under the same slug,
+        // carrying the removed site's console credentials with it.
+        await SweepSiteRegistriesAsync(site.Slug, loopOwners: false);
+
         // Free the site's license seat.
         await _licenseState.RecomputeAsync();
         _siteRoles.InvalidateAll();
@@ -332,12 +345,12 @@ public class SiteManagementService : ISiteManagementService
     /// Loop owners are torn down before the rest so a running collection pass cannot reach a
     /// client that has just been disposed.
     /// </summary>
-    private async Task SweepSiteRegistriesAsync(string slug)
+    private async Task SweepSiteRegistriesAsync(string slug, bool loopOwners)
     {
         var loopTeardowns = new List<Func<ValueTask>>();
         var teardowns = new List<Func<ValueTask>>();
 
-        foreach (var registry in _siteRegistries)
+        foreach (var registry in _siteRegistries.Where(r => r is BackgroundService == loopOwners))
         {
             try
             {
@@ -390,6 +403,12 @@ public class SiteManagementService : ISiteManagementService
 
         var slug = await GenerateUniqueSlugAsync(name);
         var site = new Site { Slug = slug, Name = name.Trim() };
+
+        // A slug is free to be reused once its site is gone, so a new site must not be able to
+        // inherit anything cached under that name. Removal sweeps the registries, but a slug can
+        // only be proven clean here: this is the moment the name starts meaning a different site.
+        await SweepSiteRegistriesAsync(slug, loopOwners: true);
+        await SweepSiteRegistriesAsync(slug, loopOwners: false);
 
         await ProvisionSiteDatabaseAsync(slug);
         await _siteRepository.AddAsync(site);

--- a/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteManagementService.cs
@@ -25,6 +25,7 @@ public class SiteManagementService : ISiteManagementService
     private readonly Licensing.LicenseStateService _licenseState;
     private readonly Licensing.LicenseActivationService _activation;
     private readonly SiteConnectionRegistry _siteConnections;
+    private readonly MonitoringInfluxRegistry _influxRegistry;
     private readonly MonitoringCollectionRegistry _collectionRegistry;
     private readonly SiteRegistryChangeNotifier _changeNotifier;
     private readonly ILogger<SiteManagementService> _logger;
@@ -40,6 +41,7 @@ public class SiteManagementService : ISiteManagementService
         Licensing.LicenseStateService licenseState,
         Licensing.LicenseActivationService activation,
         SiteConnectionRegistry siteConnections,
+        MonitoringInfluxRegistry influxRegistry,
         MonitoringCollectionRegistry collectionRegistry,
         SiteRegistryChangeNotifier changeNotifier,
         Authorization.ISiteAccessFilter siteAccess,
@@ -55,6 +57,7 @@ public class SiteManagementService : ISiteManagementService
         _licenseState = licenseState;
         _activation = activation;
         _siteConnections = siteConnections;
+        _influxRegistry = influxRegistry;
         _collectionRegistry = collectionRegistry;
         _changeNotifier = changeNotifier;
         _logger = logger;
@@ -285,6 +288,9 @@ public class SiteManagementService : ISiteManagementService
         await _siteRepository.UpdateAsync(site);
         await _collectionRegistry.StopForSiteAsync(site.Slug);
         _siteConnections.RemoveFor(site.Slug);
+        // The Influx client caches this site's connection and is rebuilt from the site's own
+        // database; leaving it registered points it at a file that is about to be deleted.
+        await _influxRegistry.RemoveAsync(site.Slug);
         DropTunnels(site.Slug, "site removed");
 
         await using (var db = await _mainDbFactory.CreateDbContextAsync())

--- a/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
@@ -14,6 +14,11 @@ namespace NetworkOptimizer.Web.Services;
 public class SiteSpeedTestTargetResolver
 {
     /// <summary>The agent's nginx speed-test listener (self-signed https).</summary>
+    /// <summary>
+    /// Where an agent serves its LAN speed test page when it does not say otherwise. Agents announce
+    /// their port in the tunnel hello now; this is what agents predating that announcement serve,
+    /// and it is what the server assumed unconditionally before.
+    /// </summary>
     public const int AgentOpenSpeedTestPort = 3000;
 
     /// <summary>
@@ -38,6 +43,7 @@ public class SiteSpeedTestTargetResolver
     private readonly AgentEnrollmentService _agentEnrollment;
     private readonly ISystemSettingsService _settings;
     private readonly AgentOnGatewayDetector _onGatewayDetector;
+    private readonly AgentTunnelRegistry _tunnelRegistry;
     private readonly SiteAgentCoverage _agentCoverage;
 
     public SiteSpeedTestTargetResolver(
@@ -45,13 +51,27 @@ public class SiteSpeedTestTargetResolver
         AgentEnrollmentService agentEnrollment,
         ISystemSettingsService settings,
         AgentOnGatewayDetector onGatewayDetector,
-        SiteAgentCoverage agentCoverage)
+        SiteAgentCoverage agentCoverage,
+        AgentTunnelRegistry tunnelRegistry)
     {
         _siteContext = siteContext;
         _agentEnrollment = agentEnrollment;
         _settings = settings;
         _onGatewayDetector = onGatewayDetector;
         _agentCoverage = agentCoverage;
+        _tunnelRegistry = tunnelRegistry;
+    }
+
+    /// <summary>
+    /// The port the site's connected agent says it serves its speed test page on, or the historic
+    /// 3000 when it does not say. Several agents on one site are possible, so the first that
+    /// announces a port wins - they serve the same page and a site with two disagreeing agents has
+    /// a bigger problem than which one a link points at.
+    /// </summary>
+    private int AgentSpeedTestPortFor(string slug)
+    {
+        var announced = _tunnelRegistry.GetForSite(slug).FirstOrDefault(c => c.SpeedTestPort > 0);
+        return announced?.SpeedTestPort ?? AgentOpenSpeedTestPort;
     }
 
     /// <summary>
@@ -99,7 +119,7 @@ public class SiteSpeedTestTargetResolver
         }
         else
         {
-            baseUrl = $"https://{effectiveTarget}:{AgentOpenSpeedTestPort}";
+            baseUrl = $"https://{effectiveTarget}:{AgentSpeedTestPortFor(_siteContext.Slug)}";
             host = effectiveTarget;
         }
 

--- a/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
@@ -38,17 +38,20 @@ public class SiteSpeedTestTargetResolver
     private readonly AgentEnrollmentService _agentEnrollment;
     private readonly ISystemSettingsService _settings;
     private readonly AgentOnGatewayDetector _onGatewayDetector;
+    private readonly SiteAgentCoverage _agentCoverage;
 
     public SiteSpeedTestTargetResolver(
         SiteContextService siteContext,
         AgentEnrollmentService agentEnrollment,
         ISystemSettingsService settings,
-        AgentOnGatewayDetector onGatewayDetector)
+        AgentOnGatewayDetector onGatewayDetector,
+        SiteAgentCoverage agentCoverage)
     {
         _siteContext = siteContext;
         _agentEnrollment = agentEnrollment;
         _settings = settings;
         _onGatewayDetector = onGatewayDetector;
+        _agentCoverage = agentCoverage;
     }
 
     /// <summary>
@@ -61,7 +64,10 @@ public class SiteSpeedTestTargetResolver
     /// </summary>
     public async Task<Result> ResolveAsync()
     {
-        if (_siteContext.IsDefault)
+        // The main site normally has no agent to point clients at - this server IS the site's
+        // speed test host. Once its agent covers the site, it is the host, exactly as on a
+        // secondary site.
+        if (_siteContext.IsDefault && !await _agentCoverage.CoversAsync(_siteContext.Slug))
             return new Result(null, null, null, UsesAgent: false, AgentOffline: false);
 
         var targetOverride = (await _settings.GetAsync(SystemSettingKeys.ClientSpeedTestTargetOverride))?.Trim();

--- a/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteSpeedTestTargetResolver.cs
@@ -100,10 +100,21 @@ public class SiteSpeedTestTargetResolver
         // wins (a separate box the operator knows about). When speed-test-capable
         // gateway installs arrive, replace this location check with the agent's
         // speed-test capability so the config can flow through.
-        if (string.IsNullOrEmpty(targetOverride) && agentLanIp != null
-            && await _onGatewayDetector.IsAgentOnGatewayAsync(_siteContext.Slug))
+        // The agent's own word first, where it gives one: an agent that says it serves no speed test
+        // has nothing to point clients at, whatever host it runs on - and an agent that says it DOES
+        // serve one is taken at its word even on a gateway, which is what a speed-test-capable
+        // gateway install needs. Only an agent that says nothing falls back to deciding by location.
+        var servesSpeedTest = _tunnelRegistry.GetForSite(_siteContext.Slug)
+            .Select(c => c.ServesSpeedTest)
+            .FirstOrDefault(v => v.HasValue);
+        // Location is still asked separately, because it is what the copy reports. An agent that
+        // simply serves no speed test is not necessarily on a gateway, and saying so would be wrong.
+        var onGateway = await _onGatewayDetector.IsAgentOnGatewayAsync(_siteContext.Slug);
+        var noSpeedTestHost = servesSpeedTest.HasValue ? !servesSpeedTest.Value : onGateway;
+
+        if (string.IsNullOrEmpty(targetOverride) && agentLanIp != null && noSpeedTestHost)
         {
-            return new Result(null, null, null, UsesAgent: false, AgentOffline: false, AgentOnGateway: true);
+            return new Result(null, null, null, UsesAgent: false, AgentOffline: false, AgentOnGateway: onGateway);
         }
 
         var effectiveTarget = !string.IsNullOrEmpty(targetOverride) ? targetOverride : agentLanIp;

--- a/src/NetworkOptimizer.Web/Services/SiteTunnelRouting.cs
+++ b/src/NetworkOptimizer.Web/Services/SiteTunnelRouting.cs
@@ -11,8 +11,9 @@ namespace NetworkOptimizer.Web.Services;
 /// instead of directly. When enabled, <see cref="RouteAsync"/> rewrites a
 /// host:port to a loopback endpoint from <see cref="AgentTunnelProxyService"/>;
 /// the agent dials the real target inside the site's network, and the caller's
-/// transport (SSH.NET, HttpClient) is unaware of the proxying. The default
-/// site is this server's own network and never routes via tunnel.
+/// transport (SSH.NET, HttpClient) is unaware of the proxying. The default site is normally this
+/// server's own network and routes directly; it can route via tunnel too, but only once it is
+/// explicitly configured for its agent to cover it (the off-site-server case).
 /// </summary>
 public class SiteTunnelRouting
 {
@@ -24,19 +25,24 @@ public class SiteTunnelRouting
     private static readonly TimeSpan FlagCacheExpiry = TimeSpan.FromMinutes(1);
 
     private readonly IServiceProvider _serviceProvider;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly ILogger<SiteTunnelRouting> _logger;
     private readonly ConcurrentDictionary<string, (bool Enabled, DateTime At)> _flags = new();
 
-    public SiteTunnelRouting(IServiceProvider serviceProvider, ILogger<SiteTunnelRouting> logger)
+    public SiteTunnelRouting(IServiceProvider serviceProvider, SiteAgentCoverage agentCoverage, ILogger<SiteTunnelRouting> logger)
     {
         _serviceProvider = serviceProvider;
+        _agentCoverage = agentCoverage;
         _logger = logger;
     }
 
     /// <summary>Whether the site's devices are configured to be reached through its agent tunnel.</summary>
     public async Task<bool> IsViaAgentAsync(string slug)
     {
-        if (string.IsNullOrEmpty(slug) || slug == SiteManagementService.DefaultSiteSlug)
+        if (string.IsNullOrEmpty(slug)) return false;
+        // The default site answers no without touching the database unless it has been handed to
+        // its agent - this is consulted per SSH command and per modem poll on every install.
+        if (slug == SiteManagementService.DefaultSiteSlug && !_agentCoverage.Covers(slug))
             return false;
         if (_flags.TryGetValue(slug, out var cached) && DateTime.UtcNow - cached.At < FlagCacheExpiry)
             return cached.Enabled;
@@ -65,7 +71,8 @@ public class SiteTunnelRouting
     /// </summary>
     public bool IsAgentOnline(string slug)
     {
-        if (string.IsNullOrEmpty(slug) || slug == SiteManagementService.DefaultSiteSlug)
+        if (string.IsNullOrEmpty(slug)) return false;
+        if (slug == SiteManagementService.DefaultSiteSlug && !_agentCoverage.Covers(slug))
             return false;
         var registry = _serviceProvider.GetService<AgentTunnelRegistry>();
         return registry != null && registry.GetForSite(slug).Count > 0;

--- a/src/NetworkOptimizer.Web/Services/SpeedTestServiceRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/SpeedTestServiceRegistry.cs
@@ -15,7 +15,7 @@ namespace NetworkOptimizer.Web.Services;
 /// inject this registry and pin GetDefault(). Same ownership pattern as
 /// SiteConnectionRegistry.
 /// </summary>
-public class SpeedTestServiceRegistry
+public class SpeedTestServiceRegistry : ISiteScopedRegistry
 {
     /// <summary>One site's speed test service bundle.</summary>
     public sealed record SiteSpeedTestServices(
@@ -73,4 +73,11 @@ public class SpeedTestServiceRegistry
 
     /// <summary>The default site's speed test bundle.</summary>
     public SiteSpeedTestServices GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/Ssh/SshClientService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/SshClientService.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text;
 using Renci.SshNet;
 using Renci.SshNet.Common;
@@ -11,10 +12,27 @@ namespace NetworkOptimizer.Web.Services.Ssh;
 public class SshClientService
 {
     private readonly ILogger<SshClientService> _logger;
+    private readonly AgentTunnelProxyService? _tunnelProxy;
 
-    public SshClientService(ILogger<SshClientService> logger)
+    public SshClientService(ILogger<SshClientService> logger, AgentTunnelProxyService? tunnelProxy = null)
     {
         _logger = logger;
+        _tunnelProxy = tunnelProxy;
+    }
+
+    /// <summary>
+    /// The reason a connection really failed. A host reached through its site's agent is dialed on a
+    /// loopback listener, and when the agent cannot open the far side the server simply closes that
+    /// socket - which SSH.NET reports as a missing protocol banner. That message describes the
+    /// symptom and hides the cause, so the agent's own reason replaces it when there is one.
+    /// </summary>
+    private string ExplainConnectionFailure(SshConnectionInfo connection, string sshNetMessage)
+    {
+        if (_tunnelProxy == null || !IPAddress.TryParse(connection.Host, out var ip) || !IPAddress.IsLoopback(ip))
+            return sshNetMessage;
+        return _tunnelProxy.RecentOpenFailure(connection.Port) is { } reason
+            ? $"could not reach {reason}"
+            : sshNetMessage;
     }
 
     /// <summary>
@@ -68,12 +86,13 @@ public class SshClientService
         }
         catch (SshConnectionException ex)
         {
-            _logger.LogError("SSH connection failed for {Host}: {Error}", connection.Host, ex.Message);
+            var explained = ExplainConnectionFailure(connection, ex.Message);
+            _logger.LogError("SSH connection failed for {Host}: {Error}", connection.Host, explained);
             return new SshCommandResult
             {
                 Success = false,
                 ExitCode = -1,
-                Error = $"Connection failed: {ex.Message}"
+                Error = $"Connection failed: {explained}"
             };
         }
         catch (SshOperationTimeoutException ex)
@@ -136,8 +155,9 @@ public class SshClientService
         }
         catch (SshConnectionException ex)
         {
-            _logger.LogWarning("SSH connection failed for {Host}: {Error}", connection.Host, ex.Message);
-            return (false, $"Connection failed: {ex.Message}");
+            var explained = ExplainConnectionFailure(connection, ex.Message);
+            _logger.LogWarning("SSH connection failed for {Host}: {Error}", connection.Host, explained);
+            return (false, $"Connection failed: {explained}");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/UniFiSshRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiSshRegistry.cs
@@ -11,7 +11,7 @@ namespace NetworkOptimizer.Web.Services;
 /// Instances hold no connections (SSH sessions are per-command), so nothing
 /// needs disposal.
 /// </summary>
-public class UniFiSshRegistry
+public class UniFiSshRegistry : ISiteScopedRegistry
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly ConcurrentDictionary<string, UniFiSshService> _instances = new();
@@ -28,4 +28,11 @@ public class UniFiSshRegistry
 
     /// <summary>The default site's device SSH service.</summary>
     public UniFiSshService GetDefault() => GetFor(SiteManagementService.DefaultSiteSlug);
+
+    /// <inheritdoc />
+    public Func<ValueTask>? EvictSite(string slug)
+    {
+        _instances.TryRemove(slug, out _);
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Web/Services/UpstreamDiscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/UpstreamDiscoveryService.cs
@@ -1,0 +1,54 @@
+using NetworkOptimizer.Web.Services.Gates;
+using NetworkOptimizer.Web.Services.Monitoring;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <inheritdoc />
+public class UpstreamDiscoveryService : IUpstreamDiscoveryService
+{
+    private readonly UpstreamTracerService _tracer;
+    private readonly IAuditContext _audit;
+
+    public UpstreamDiscoveryService(UpstreamTracerService tracer, IAuditContext audit)
+    {
+        _tracer = tracer;
+        _audit = audit;
+    }
+
+    /// <inheritdoc />
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        await _tracer.StartDiscoveryAsync(ct);
+
+        // Shape of the result, not its contents: how far it got and how much it found. The path
+        // itself (WAN address, first-mile neighbor) is discovery output the panel already shows,
+        // and is not what an audit trail is for.
+        var s = _tracer.State;
+        _audit.SetDetails(new
+        {
+            step = s.Step.ToString(),
+            accessHops = s.AccessHops.Count,
+            transitAsns = s.TransitAsns.Count,
+            pendingRemovals = s.PendingRemovalTransitAsns.Count,
+            failed = s.FailureMessage is not null
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task CommitAsync(CancellationToken ct = default)
+    {
+        // Counted before the commit: committing clears the review lists, so reading them
+        // afterwards would report every run as having applied nothing.
+        var s = _tracer.State;
+        var detail = new
+        {
+            accessHops = s.AccessHops.Count,
+            transitAsns = s.TransitAsns.Count,
+            removals = s.PendingRemovalTransitAsns.Count,
+            addedAsns = s.DiscoveryAddedAsns.Count
+        };
+
+        await _tracer.CommitResultsAsync(ct);
+        _audit.SetDetails(detail);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -25,6 +25,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
     private readonly IGatewaySshService _gatewaySsh;
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly SiteTunnelRouting _tunnelRouting;
+    private readonly SiteAgentCoverage _agentCoverage;
     private readonly AgentUwnService _agentUwn;
     private readonly AgentEnrollmentService _agentEnrollment;
 
@@ -52,6 +53,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         GatewaySshRegistry gatewaySshRegistry,
         IServiceScopeFactory scopeFactory,
         SiteTunnelRouting tunnelRouting,
+        SiteAgentCoverage agentCoverage,
         AgentUwnService agentUwn,
         AgentEnrollmentService agentEnrollment,
         NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
@@ -65,6 +67,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         _gatewaySsh = gatewaySshRegistry.GetFor(SiteSlug);
         _scopeFactory = scopeFactory;
         _tunnelRouting = tunnelRouting;
+        _agentCoverage = agentCoverage;
         _agentUwn = agentUwn;
         _agentEnrollment = agentEnrollment;
     }
@@ -303,7 +306,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         // from the on-site agent, so the trace source is the agent's LAN IP on that
         // site's topology (this server's HOST_IP is off-network there) - same
         // resolution the Client Speed Test uses for agent-relayed results.
-        var serverIp = IsDefaultSite
+        var serverIp = IsDefaultSite && !await _agentCoverage.CoversAsync(SiteSlug)
             ? _configuration["HOST_IP"]
             : await _agentEnrollment.GetOnlineAgentLanIpAsync(SiteSlug);
 

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -96,10 +96,11 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         Action<string, int, string?> report,
         CancellationToken cancellationToken)
     {
-        // A non-default site that is reached via its agent runs the binary at the
-        // site, so the measured WAN is the site's rather than this server's.
-        // CanRunForSiteAsync has already refused non-default sites without an agent.
-        if (!IsDefaultSite && await _tunnelRouting.IsViaAgentAsync(SiteSlug))
+        // A site reached via its agent runs the binary at the site, so the measured WAN is the
+        // site's rather than this server's. CanRunForSiteAsync has already refused non-default
+        // sites without an agent, and IsViaAgentAsync answers false for the default site unless it
+        // has been handed to its agent.
+        if (await _tunnelRouting.IsViaAgentAsync(SiteSlug))
             return await RunViaAgentAsync(report, cancellationToken);
 
         return await RunLocalAsync(report, cancellationToken);

--- a/src/NetworkOptimizer.Web/Services/WanDataUsageRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/WanDataUsageRegistry.cs
@@ -14,7 +14,7 @@ namespace NetworkOptimizer.Web.Services;
 /// instance (the Alerts page reads whichever site it is showing). Same ownership
 /// pattern as MonitoringCollectionRegistry.
 /// </summary>
-public class WanDataUsageRegistry : BackgroundService
+public class WanDataUsageRegistry : BackgroundService, ISiteScopedRegistry
 {
     private static readonly TimeSpan ReconcileInterval = TimeSpan.FromSeconds(30);
 
@@ -122,6 +122,16 @@ public class WanDataUsageRegistry : BackgroundService
         foreach (var slug in toStop)
             await StopInstanceAsync(slug, ct);
     }
+
+    /// <inheritdoc />
+    /// <remarks>The reconcile pass would drop a removed site eventually; this stops it now, before
+    /// the site's database and clients go away underneath the loop.</remarks>
+    public Func<ValueTask>? EvictSite(string slug)
+        => async () =>
+        {
+            await StopInstanceAsync(slug, CancellationToken.None);
+            _instances.TryRemove(slug, out _);
+        };
 
     private async Task StartInstanceAsync(string slug, CancellationToken ct)
     {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18277,6 +18277,10 @@ a.isp-outage-ack:hover {
 .card-highlight {
     outline: 2px solid transparent;
     outline-offset: 4px;
+    /* Card radius by default: half these targets are a bare wrapper div around a card, which has no
+       radius of its own, so the ring drew square corners around a rounded card. Not on the row
+       variant below - a row tints rather than rings, so it has nothing to round. */
+    border-radius: var(--border-radius-lg);
     transition: outline-color 0.9s ease-out;
 }
 
@@ -18287,6 +18291,17 @@ a.isp-outage-ack:hover {
 .card-highlight {
     outline-color: color-mix(in srgb, var(--highlight-color) 50%, transparent);
     transition: outline-color 0.25s ease-in;
+}
+
+/* Row variant: a ring around a table row fights its neighbours, so a row tints instead. Same
+   variable, same timing, so the two read as one behavior seen on different shapes. */
+.nav-highlight-row {
+    transition: background-color 0.9s ease-out;
+}
+
+.nav-highlight-row.nav-highlight-on {
+    background-color: color-mix(in srgb, var(--highlight-color) 30%, transparent);
+    transition: background-color 0.25s ease-in;
 }
 
 .isp-events-jump {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18277,7 +18277,6 @@ a.isp-outage-ack:hover {
 .card-highlight {
     outline: 2px solid transparent;
     outline-offset: 4px;
-    border-radius: 12px;
     transition: outline-color 0.9s ease-out;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18277,10 +18277,12 @@ a.isp-outage-ack:hover {
 .card-highlight {
     outline: 2px solid transparent;
     outline-offset: 4px;
-    /* Card radius by default: half these targets are a bare wrapper div around a card, which has no
-       radius of its own, so the ring drew square corners around a rounded card. Not on the row
-       variant below - a row tints rather than rings, so it has nothing to round. */
-    border-radius: var(--border-radius-lg);
+    /* Card radius by default, since most targets are a card or a bare wrapper around one, which has
+       no radius of its own and would otherwise ring square around rounded content. A target that is
+       not card-shaped - a sub-card form, a button - overrides it by passing a radius to the helper,
+       which sets --nav-highlight-radius on the element. Declared by the caller, never guessed at
+       from the children. Not on the row variant below: a row tints rather than rings. */
+    border-radius: var(--nav-highlight-radius, var(--border-radius-lg));
     transition: outline-color 0.9s ease-out;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2078,6 +2078,7 @@ a.stat-card-link:active {
 .isp-events-jump {
     cursor: pointer;
     text-decoration: underline dotted;
+    text-decoration-color: var(--text-muted);
     text-underline-offset: 3px;
 }
 
@@ -16912,13 +16913,13 @@ tr.stats-row-filtered {
 
 .isp-score-excellent { color: #24bc70; }
 .isp-score-good { color: #3b82f6; }
-.isp-score-fair { color: #f59e0b; }
+.isp-score-fair { color: var(--warning-color); }
 .isp-score-poor { color: #ef4444; }
 .isp-score-none { color: var(--text-muted); }
 
 .monitoring-stat-card .stat-value.isp-score-excellent { color: #24bc70; }
 .monitoring-stat-card .stat-value.isp-score-good { color: #3b82f6; }
-.monitoring-stat-card .stat-value.isp-score-fair { color: #f59e0b; }
+.monitoring-stat-card .stat-value.isp-score-fair { color: var(--warning-color); }
 .monitoring-stat-card .stat-value.isp-score-poor { color: #ef4444; }
 .monitoring-stat-card .stat-value.isp-score-none { color: var(--text-muted); }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18281,7 +18281,7 @@ a.isp-outage-ack:hover {
 
 .nav-highlight-on {
     outline-color: rgba(59, 130, 246, 0.5);
-    transition: outline-color 0.15s ease-in;
+    transition: outline-color 0.25s ease-in;
 }
 
 .isp-events-jump {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2075,6 +2075,12 @@ a.stat-card-link:active {
     opacity: 0.55;
 }
 
+.isp-events-jump {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-underline-offset: 2px;
+}
+
 .data-table thead {
     background: var(--bg-primary);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2078,7 +2078,7 @@ a.stat-card-link:active {
 .isp-events-jump {
     cursor: pointer;
     text-decoration: underline dotted;
-    text-underline-offset: 2px;
+    text-underline-offset: 3px;
 }
 
 .data-table thead {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18271,7 +18271,9 @@ a.isp-outage-ack:hover {
 .isp-events-jump {
     cursor: pointer;
     text-decoration: underline dotted;
-    text-decoration-color: var(--text-muted);
+    /* A dimmed version of the score color the value is carrying, not a flat grey: the count is
+       colored by its grade, so its underline should be a quieter shade of the same thing. */
+    text-decoration-color: color-mix(in srgb, currentColor 45%, transparent);
     text-underline-offset: 3px;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -15748,6 +15748,13 @@ tr.stats-row-filtered {
     gap: 0.5rem;
 }
 
+.form-value-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: 100%;
+}
+
 /* 3D LAN Flow Map (spec 5.7) */
 .lan-flow-map-body {
     padding: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -22,6 +22,7 @@
     --warning-color: #e79613;
     --danger-color: #ee6368;
     --info-color: #4797ff;
+    --good-color: #3b82f6;
 
     /* Purple/Violet - WiFi 6E, sponsorship */
     --purple-color: #a855f7;
@@ -2073,13 +2074,6 @@ a.stat-card-link:active {
 
 .latency-target-paused td:not(:last-child) {
     opacity: 0.55;
-}
-
-.isp-events-jump {
-    cursor: pointer;
-    text-decoration: underline dotted;
-    text-decoration-color: var(--text-muted);
-    text-underline-offset: 3px;
 }
 
 .data-table thead {
@@ -16911,16 +16905,16 @@ tr.stats-row-filtered {
     line-height: 1.4;
 }
 
-.isp-score-excellent { color: #24bc70; }
-.isp-score-good { color: #3b82f6; }
+.isp-score-excellent { color: var(--success-color); }
+.isp-score-good { color: var(--good-color); }
 .isp-score-fair { color: var(--warning-color); }
-.isp-score-poor { color: #ef4444; }
+.isp-score-poor { color: var(--danger-color); }
 .isp-score-none { color: var(--text-muted); }
 
-.monitoring-stat-card .stat-value.isp-score-excellent { color: #24bc70; }
-.monitoring-stat-card .stat-value.isp-score-good { color: #3b82f6; }
+.monitoring-stat-card .stat-value.isp-score-excellent { color: var(--success-color); }
+.monitoring-stat-card .stat-value.isp-score-good { color: var(--good-color); }
 .monitoring-stat-card .stat-value.isp-score-fair { color: var(--warning-color); }
-.monitoring-stat-card .stat-value.isp-score-poor { color: #ef4444; }
+.monitoring-stat-card .stat-value.isp-score-poor { color: var(--danger-color); }
 .monitoring-stat-card .stat-value.isp-score-none { color: var(--text-muted); }
 
 .isp-health-tile {
@@ -16932,10 +16926,10 @@ tr.stats-row-filtered {
         linear-gradient(160deg, rgba(43, 168, 154, 0.07), transparent 55%);
 }
 
-.isp-health-tile.isp-score-excellent { --tile-accent: #24bc70; }
-.isp-health-tile.isp-score-good { --tile-accent: #3b82f6; }
-.isp-health-tile.isp-score-fair { --tile-accent: #f59e0b; }
-.isp-health-tile.isp-score-poor { --tile-accent: #ef4444; }
+.isp-health-tile.isp-score-excellent { --tile-accent: var(--success-color); }
+.isp-health-tile.isp-score-good { --tile-accent: var(--good-color); }
+.isp-health-tile.isp-score-fair { --tile-accent: var(--warning-color); }
+.isp-health-tile.isp-score-poor { --tile-accent: var(--danger-color); }
 .isp-health-tile.isp-score-none { --tile-accent: var(--text-muted); }
 
 .isp-health-tile .stat-value.isp-tile-score {
@@ -18272,6 +18266,13 @@ a.isp-outage-ack:hover {
 
 .isp-factor-link:hover {
     color: var(--primary-hover);
+}
+
+.isp-events-jump {
+    cursor: pointer;
+    text-decoration: underline dotted;
+    text-decoration-color: var(--text-muted);
+    text-underline-offset: 3px;
 }
 
 body.kiosk-mode .hamburger-btn {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -23,6 +23,9 @@
     --danger-color: #ee6368;
     --info-color: #4797ff;
     --good-color: #3b82f6;
+    /* What "look here" is drawn in: the nav-to-card ring and a card held called out. Its own name
+       rather than borrowing a score color, so changing either cannot move the other. */
+    --highlight-color: var(--primary-color);
 
     /* Purple/Violet - WiFi 6E, sponsorship */
     --purple-color: #a855f7;
@@ -18283,7 +18286,7 @@ a.isp-outage-ack:hover {
    two cannot drift into different blues, which is what they had done. */
 .nav-highlight-on,
 .card-highlight {
-    outline-color: color-mix(in srgb, var(--good-color) 50%, transparent);
+    outline-color: color-mix(in srgb, var(--highlight-color) 50%, transparent);
     transition: outline-color 0.25s ease-in;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19865,11 +19865,21 @@ body.kiosk-mode .status-indicators {
     margin-left: auto;
 }
 
+/* An icon, not a button: it sits among the filter inputs to save the width a labelled control
+   would take, so it carries no button chrome. */
 .audit-filter-clear {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    padding-inline: 0.4rem;
+    padding: 0;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.audit-filter-clear:hover {
+    color: var(--text-secondary);
 }
 
 .audit-pager {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7343,9 +7343,7 @@ a.path-hop.hop-clickable:hover {
    the user to act on. .card carries no border, so this is a ring rather than a border-color: the
    same 3px primary halo the focus state uses, which is why it reads as deliberate rather than as a
    hairline stuck to the edge. */
-.card-highlight {
-    box-shadow: 0 0 0 3px rgba(5, 89, 201, 0.5);
-}
+
 
 /* The guidance sits at the top of the card body, where .alert's own top margin doubles the padding
    already there. */
@@ -18272,14 +18270,19 @@ a.isp-outage-ack:hover {
    on it, then fades out on its own. Every jump used to inline its own copy of this. The ring is
    painted with a transparent outline always present, so the color transition has something to
    animate from and the fade is not a hard cut. */
-.nav-highlight {
+.nav-highlight,
+.card-highlight {
     outline: 2px solid transparent;
     outline-offset: 4px;
     border-radius: 12px;
     transition: outline-color 0.9s ease-out;
 }
 
-.nav-highlight-on {
+/* .card-highlight is the same ring held on: a card that stays called out (MFA still to set up on
+   Account Security) rather than one being pointed at by a jump. Same treatment either way, so the
+   two cannot drift into different blues, which is what they had done. */
+.nav-highlight-on,
+.card-highlight {
     outline-color: rgba(59, 130, 246, 0.5);
     transition: outline-color 0.25s ease-in;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18283,7 +18283,7 @@ a.isp-outage-ack:hover {
    two cannot drift into different blues, which is what they had done. */
 .nav-highlight-on,
 .card-highlight {
-    outline-color: rgba(59, 130, 246, 0.5);
+    outline-color: color-mix(in srgb, var(--good-color) 50%, transparent);
     transition: outline-color 0.25s ease-in;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2071,6 +2071,10 @@ a.stat-card-link:active {
     min-width: 500px; /* Ensures table doesn't compress too much */
 }
 
+.latency-target-paused td:not(:last-child) {
+    opacity: 0.55;
+}
+
 .data-table thead {
     background: var(--bg-primary);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18268,6 +18268,22 @@ a.isp-outage-ack:hover {
     color: var(--primary-hover);
 }
 
+/* Arriving somewhere from a link elsewhere in Monitoring: the target rings itself so the eye lands
+   on it, then fades out on its own. Every jump used to inline its own copy of this. The ring is
+   painted with a transparent outline always present, so the color transition has something to
+   animate from and the fade is not a hard cut. */
+.nav-highlight {
+    outline: 2px solid transparent;
+    outline-offset: 4px;
+    border-radius: 12px;
+    transition: outline-color 0.9s ease-out;
+}
+
+.nav-highlight-on {
+    outline-color: rgba(59, 130, 246, 0.5);
+    transition: outline-color 0.15s ease-in;
+}
+
 .isp-events-jump {
     cursor: pointer;
     text-decoration: underline dotted;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -18264,7 +18264,7 @@ a.isp-outage-ack:hover {
 
 .isp-factor-link {
     color: var(--text-primary);
-    text-decoration: underline;
+    text-decoration: underline dotted;
     text-decoration-color: var(--text-muted);
     text-underline-offset: 3px;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.5.3.json
@@ -23,7 +23,7 @@
       "url": "/sqm",
       "selector": "[data-tour=\"sqm-download-burst\"]",
       "title": "Larger download burst",
-      "listLabel": "Downloads that fall short of your plan may have more to give",
+      "listLabel": "Adaptive SQM: Downloads that fall short of your plan may have more to give",
       "body": "If your downloads never quite reach your plan, **Larger download burst** may find the rest. Turn it on for your WAN and redeploy to try it.",
       "placement": "top",
       "requires": ["sqm-enabled"],

--- a/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
@@ -1,0 +1,58 @@
+// Expanding a card reveals content that is often below the fold, leaving the reader to scroll to
+// see what their own click just produced. This nudges the view so the newly revealed content is
+// visible.
+//
+// Deliberately conservative, because it runs app-wide on a shared pattern:
+//   - only on EXPAND, never on collapse
+//   - only ever scrolls DOWN, and never further than putting the card's top at the top of the pane,
+//     so the header you just clicked can never be pushed off screen
+//   - does nothing when the card already fits
+//   - reads layout and sets scrollTop; it never writes padding, margin, or classes, so it cannot
+//     leave anything behind on elements it does not own
+//
+// One delegated listener rather than per-component wiring: every collapsible in the app is a
+// .card-header-collapsible followed by an .expand-wrapper, so they all get this for free.
+(function () {
+    'use strict';
+
+    // The expand animates grid-template-rows over 0.25s; measure once it has settled.
+    var SETTLE_MS = 320;
+
+    function scrollerOf(node) {
+        for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
+            var oy = getComputedStyle(n).overflowY;
+            if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
+        }
+        return document.scrollingElement || document.documentElement;
+    }
+
+    function reveal(header) {
+        var wrapper = header.nextElementSibling;
+        // Collapsed, or not the pattern we expect - nothing to do.
+        if (!wrapper || !wrapper.classList.contains('expand-wrapper')) return;
+        if (!wrapper.classList.contains('expanded')) return;
+
+        var card = header.parentElement;
+        if (!card) return;
+
+        var sc = scrollerOf(card);
+        var isDoc = sc === document.scrollingElement || sc === document.documentElement;
+        var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
+        var paneBottom = isDoc ? window.innerHeight : sc.getBoundingClientRect().bottom;
+
+        var r = card.getBoundingClientRect();
+        var below = r.bottom - paneBottom;
+        if (below <= 2) return;
+
+        // Never past the card's own top: scrolling further would hide the header just clicked.
+        var headroom = Math.max(0, r.top - paneTop);
+        sc.scrollTop += Math.min(below, headroom);
+    }
+
+    document.addEventListener('click', function (e) {
+        var header = e.target.closest && e.target.closest('.card-header-collapsible');
+        if (!header) return;
+        // After the component has re-rendered and the transition has run.
+        setTimeout(function () { reveal(header); }, SETTLE_MS);
+    }, true);
+})();

--- a/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
@@ -46,7 +46,17 @@
 
         // Never past the card's own top: scrolling further would hide the header just clicked.
         var headroom = Math.max(0, r.top - paneTop);
-        sc.scrollTop += Math.min(below, headroom);
+        var by = Math.min(below, headroom);
+        if (by <= 0) return;
+
+        // Animated rather than jumped, so the reader keeps their place. scrollBy honors the pane's
+        // own scroll-behavior; the fallback covers a scroller that does not implement the options
+        // form, which would otherwise silently do nothing.
+        if (typeof sc.scrollBy === 'function') {
+            sc.scrollBy({ top: by, behavior: 'smooth' });
+        } else {
+            sc.scrollTop += by;
+        }
     }
 
     document.addEventListener('click', function (e) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
@@ -16,8 +16,8 @@
     'use strict';
 
     // The expand animates grid-template-rows over 0.25s; measure once it has settled.
-    var SETTLE_MS = 320;
-    var GLIDE_MS = 200;
+    // A touch longer than the 0.25s expand transition, so the last pixels are followed.
+    var FOLLOW_MS = 400;
 
     function scrollerOf(node) {
         for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
@@ -27,30 +27,19 @@
         return document.scrollingElement || document.documentElement;
     }
 
-    // Driven by hand rather than behavior:'smooth': the native curve has a fixed duration that
-    // reads as sluggish for a short hop like this. Long enough that the movement is visible - an
-    // instant jump looks like a glitch - and short enough not to be waited on.
-    function glide(sc, by) {
-        var from = sc.scrollTop;
-        var t0 = performance.now();
-        function step(now) {
-            var p = Math.min(1, (now - t0) / GLIDE_MS);
-            // easeInOutQuad
-            var e = p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2;
-            sc.scrollTop = from + by * e;
-            if (p < 1) requestAnimationFrame(step);
-        }
-        requestAnimationFrame(step);
-    }
-
-    function reveal(header) {
+    // Track the expansion as it happens rather than waiting for it to finish. The card grows over
+    // the transition, so following it frame by frame reads as one movement - the view opening with
+    // the panel - where measuring once at the end is a separate jump after the fact.
+    //
+    // Each frame moves by whatever is currently needed, which is small while the card is still
+    // growing, so no easing of our own is wanted: the transition supplies the pacing.
+    function step(header) {
         var wrapper = header.nextElementSibling;
-        // Collapsed, or not the pattern we expect - nothing to do.
-        if (!wrapper || !wrapper.classList.contains('expand-wrapper')) return;
-        if (!wrapper.classList.contains('expanded')) return;
+        if (!wrapper || !wrapper.classList.contains('expand-wrapper')) return false;
+        if (!wrapper.classList.contains('expanded')) return false;
 
         var card = header.parentElement;
-        if (!card) return;
+        if (!card) return false;
 
         var sc = scrollerOf(card);
         var isDoc = sc === document.scrollingElement || sc === document.documentElement;
@@ -59,20 +48,24 @@
 
         var r = card.getBoundingClientRect();
         var below = r.bottom - paneBottom;
-        if (below <= 2) return;
-
-        // Never past the card's own top: scrolling further would hide the header just clicked.
-        var headroom = Math.max(0, r.top - paneTop);
-        var by = Math.min(below, headroom);
-        if (by <= 0) return;
-
-        glide(sc, by);
+        if (below > 1) {
+            // Never past the card's own top: scrolling further would hide the header just clicked.
+            var headroom = Math.max(0, r.top - paneTop);
+            var by = Math.min(below, headroom);
+            if (by > 0) sc.scrollTop += by;
+        }
+        return true;
     }
 
     document.addEventListener('click', function (e) {
         var header = e.target.closest && e.target.closest('.card-header-collapsible');
         if (!header) return;
-        // After the component has re-rendered and the transition has run.
-        setTimeout(function () { reveal(header); }, SETTLE_MS);
+        // Blazor re-renders before the transition starts, so begin on the next frame and run for a
+        // little longer than the 0.25s expand to catch the final pixels.
+        var until = performance.now() + FOLLOW_MS;
+        requestAnimationFrame(function frame(now) {
+            if (!step(header)) return;
+            if (now < until) requestAnimationFrame(frame);
+        });
     }, true);
 })();

--- a/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
@@ -33,10 +33,14 @@
     //
     // Each frame moves by whatever is currently needed, which is small while the card is still
     // growing, so no easing of our own is wanted: the transition supplies the pacing.
+    // Returns false only when there is nothing to wait for. Not-yet-expanded is NOT that: Blazor
+    // has not re-rendered on the frame the click lands, so the class arrives a frame or two later -
+    // treating its absence as "done" made the loop quit before it ever started, which is why
+    // dropping the fixed delay appeared to disable this entirely.
     function step(header) {
         var wrapper = header.nextElementSibling;
         if (!wrapper || !wrapper.classList.contains('expand-wrapper')) return false;
-        if (!wrapper.classList.contains('expanded')) return false;
+        if (!wrapper.classList.contains('expanded')) return true;
 
         var card = header.parentElement;
         if (!card) return false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/collapse-reveal.js
@@ -17,6 +17,7 @@
 
     // The expand animates grid-template-rows over 0.25s; measure once it has settled.
     var SETTLE_MS = 320;
+    var GLIDE_MS = 200;
 
     function scrollerOf(node) {
         for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
@@ -24,6 +25,22 @@
             if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
         }
         return document.scrollingElement || document.documentElement;
+    }
+
+    // Driven by hand rather than behavior:'smooth': the native curve has a fixed duration that
+    // reads as sluggish for a short hop like this. Long enough that the movement is visible - an
+    // instant jump looks like a glitch - and short enough not to be waited on.
+    function glide(sc, by) {
+        var from = sc.scrollTop;
+        var t0 = performance.now();
+        function step(now) {
+            var p = Math.min(1, (now - t0) / GLIDE_MS);
+            // easeInOutQuad
+            var e = p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2;
+            sc.scrollTop = from + by * e;
+            if (p < 1) requestAnimationFrame(step);
+        }
+        requestAnimationFrame(step);
     }
 
     function reveal(header) {
@@ -49,14 +66,7 @@
         var by = Math.min(below, headroom);
         if (by <= 0) return;
 
-        // Animated rather than jumped, so the reader keeps their place. scrollBy honors the pane's
-        // own scroll-behavior; the fallback covers a scroller that does not implement the options
-        // form, which would otherwise silently do nothing.
-        if (typeof sc.scrollBy === 'function') {
-            sc.scrollBy({ top: by, behavior: 'smooth' });
-        } else {
-            sc.scrollTop += by;
-        }
+        glide(sc, by);
     }
 
     document.addEventListener('click', function (e) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -177,15 +177,21 @@
 // Scroll to a card and ring it briefly, the one behavior every in-page jump in Monitoring shares
 // (findings, advisories, an event count). Kept here because this file already loads app-wide and
 // the callers are spread across pages and components.
-window.noHighlightTarget = function (id, block) {
+function noHighlight(id, block, variant) {
     var el = document.getElementById(id);
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
-    el.classList.add('nav-highlight');
+    el.classList.add(variant);
     // Next frame, so the class that defines the transition is applied before the color changes -
     // set together, the browser has nothing to animate from.
     requestAnimationFrame(function () {
         el.classList.add('nav-highlight-on');
         setTimeout(function () { el.classList.remove('nav-highlight-on'); }, 1800);
     });
-};
+}
+
+// A card or section: ringed.
+window.noHighlightTarget = function (id, block) { noHighlight(id, block, 'nav-highlight'); };
+
+// A table row: tinted, because an offset ring around a row collides with the rows either side.
+window.noHighlightRow = function (id, block) { noHighlight(id, block || 'center', 'nav-highlight-row'); };

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -177,10 +177,10 @@
 // Scroll to a card and ring it briefly, the one behavior every in-page jump in Monitoring shares
 // (findings, advisories, an event count). Kept here because this file already loads app-wide and
 // the callers are spread across pages and components.
-window.noHighlightTarget = function (id) {
+window.noHighlightTarget = function (id, block) {
     var el = document.getElementById(id);
     if (!el) return;
-    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
     el.classList.add('nav-highlight');
     // Next frame, so the class that defines the transition is applied before the color changes -
     // set together, the browser has nothing to animate from.

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -237,11 +237,20 @@ window.noAnchorTop = function (id) {
         if (!cur) return false;
         var r = cur.getBoundingClientRect();
         var grew = r.bottom > lastBottom + 1;
+        var off = r.bottom > window.innerHeight;
+        // Report the actual numbers whenever it grows, so a run that does nothing says why rather
+        // than leaving us to guess which half of the condition failed.
+        if (grew) {
+            console.log('[anchor] grew: bottom=' + Math.round(r.bottom)
+                + ' top=' + Math.round(r.top)
+                + ' innerHeight=' + window.innerHeight
+                + ' offscreen=' + off
+                + ' -> ' + (off ? 'scrolling' : 'no scroll needed'));
+        }
         lastBottom = r.bottom;
-        // Only act when it has grown AND the new edge is off screen: otherwise a short card would
-        // be yanked around for no reason.
-        if (grew && r.bottom > window.innerHeight)
-            cur.scrollIntoView({ block: 'end', behavior: 'smooth' });
+        // Instant, not smooth: repeated smooth calls restart the animation and can net out to no
+        // movement at all. The highlight jumps that work in this layout use the instant form.
+        if (grew && off) cur.scrollIntoView({ block: 'end' });
         return true;
     };
     var timer = setInterval(function () {

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -173,3 +173,19 @@
         return originalFetch.call(this, input, init);
     };
 })();
+
+// Scroll to a card and ring it briefly, the one behavior every in-page jump in Monitoring shares
+// (findings, advisories, an event count). Kept here because this file already loads app-wide and
+// the callers are spread across pages and components.
+window.noHighlightTarget = function (id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    el.classList.add('nav-highlight');
+    // Next frame, so the class that defines the transition is applied before the color changes -
+    // set together, the browser has nothing to animate from.
+    requestAnimationFrame(function () {
+        el.classList.add('nav-highlight-on');
+        setTimeout(function () { el.classList.remove('nav-highlight-on'); }, 1800);
+    });
+};

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -208,3 +208,41 @@ window.noHighlightTarget = function (id, block, radius) { noHighlight(id, block,
 
 // A table row: tinted, because an offset ring around a row collides with the rows either side.
 window.noHighlightRow = function (id, block) { noHighlight(id, block || 'center', 'nav-highlight-row'); };
+
+// Keeps a long-running card's top pinned to the view while it grows - upstream discovery adds
+// sections for a minute or so, and without this the reader chases them down the page. Released the
+// moment the user scrolls for themselves: wheel, touch and the scrolling keys are unambiguous
+// intent, unlike a scroll event, which our own scrolling would also raise.
+var anchorRelease = null;
+
+window.noAnchorTop = function (id) {
+    window.noAnchorRelease();
+    var el = document.getElementById(id);
+    if (!el) return;
+
+    var keep = function () { el.scrollIntoView({ block: 'start' }); };
+    var timer = setInterval(function () {
+        if (!document.contains(el)) { window.noAnchorRelease(); return; }
+        keep();
+    }, 400);
+
+    var give = function () { window.noAnchorRelease(); };
+    var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };
+    var onKey = function (e) { if (keys[e.key]) give(); };
+    window.addEventListener('wheel', give, { passive: true });
+    window.addEventListener('touchmove', give, { passive: true });
+    window.addEventListener('keydown', onKey, true);
+
+    anchorRelease = function () {
+        clearInterval(timer);
+        window.removeEventListener('wheel', give);
+        window.removeEventListener('touchmove', give);
+        window.removeEventListener('keydown', onKey, true);
+        anchorRelease = null;
+    };
+    keep();
+};
+
+window.noAnchorRelease = function () {
+    if (anchorRelease) anchorRelease();
+};

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -178,7 +178,8 @@
 // (findings, advisories, an event count). Kept here because this file already loads app-wide and
 // the callers are spread across pages and components.
 function noHighlight(id, block, variant, radius) {
-    if (!document.getElementById(id)) return;
+    var el = document.getElementById(id);
+    if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
     // The caller says what shape it is pointing at; the default suits a card.
     if (radius) el.style.setProperty('--nav-highlight-radius', radius);
@@ -207,85 +208,3 @@ window.noHighlightTarget = function (id, block, radius) { noHighlight(id, block,
 
 // A table row: tinted, because an offset ring around a row collides with the rows either side.
 window.noHighlightRow = function (id, block) { noHighlight(id, block || 'center', 'nav-highlight-row'); };
-
-// Keeps a long-running card's top pinned to the view while it grows - upstream discovery adds
-// sections for a minute or so, and without this the reader chases them down the page. Released the
-// moment the user scrolls for themselves: wheel, touch and the scrolling keys are unambiguous
-// intent, unlike a scroll event, which our own scrolling would also raise.
-var anchorRelease = null;
-
-window.noAnchorTop = function (id) {
-    window.noAnchorRelease();
-    var el = document.getElementById(id);
-    if (!el) return;
-
-    // Re-resolved every tick rather than captured: the card re-renders as discovery adds sections,
-    // and Blazor can swap the element out. Holding the original node meant the pin let go the first
-    // time that happened - one scroll, then nothing, which is exactly what it looked like.
-    // PIN THE TOP: hold the card's top at the top of whatever actually scrolls, correcting every
-    // tick, until the reader scrolls for themselves. Earlier attempts measured against
-    // window.innerHeight, but this app scrolls .main-content / .page-content, not the document - so
-    // the numbers were about the wrong box. Find the real scroller and work in its coordinates.
-    var scrollerOf = function (node) {
-        for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
-            var oy = getComputedStyle(n).overflowY;
-            if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
-        }
-        return document.scrollingElement || document.documentElement;
-    };
-
-    var padded = -1;
-    var keep = function () {
-        var cur = document.getElementById(id);
-        if (!cur) {
-            // Gone - navigated away, or the tab re-rendered without it. Release rather than return:
-            // the pane is holding borrowed padding, and leaving it there strands a screen of empty
-            // space at the bottom of a scroller every page shares.
-            window.noAnchorRelease();
-            return;
-        }
-        var sc = scrollerOf(cur);
-        var isDoc = sc === document.scrollingElement || sc === document.documentElement;
-        var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
-        var drift = cur.getBoundingClientRect().top - paneTop;
-
-        // The card is the last thing on the page, so bringing its top to the pane's top means
-        // scrolling past the end of the document, which the browser clamps - until the card is
-        // taller than the pane there is nothing below it to scroll into view and the write silently
-        // does nothing. Make up the shortfall with margin ON THE CARD, never padding on the pane:
-        // the pane is shared by every page, and a niche affordance has no business leaving state
-        // there - stranding it once put a screen of blank space under an unrelated page. Margin
-        // does not paint, and it is removed with the card, so it cannot outlive this.
-        var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
-        if (shortfall !== padded) {
-            padded = shortfall;
-            cur.style.marginBottom = shortfall ? shortfall + 'px' : '';
-        }
-
-        if (Math.abs(drift) > 2) sc.scrollTop += drift;
-    };
-    var timer = setInterval(keep, 300);
-
-    var give = function () { window.noAnchorRelease(); };
-    var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };
-    var onKey = function (e) { if (keys[e.key]) give(); };
-    window.addEventListener('wheel', give, { passive: true });
-    window.addEventListener('touchmove', give, { passive: true });
-    window.addEventListener('keydown', onKey, true);
-
-    anchorRelease = function () {
-        clearInterval(timer);
-        // Give the card its own margin back.
-        var cur = document.getElementById(id);
-        if (cur) cur.style.marginBottom = '';
-        window.removeEventListener('wheel', give);
-        window.removeEventListener('touchmove', give);
-        window.removeEventListener('keydown', onKey, true);
-        anchorRelease = null;
-    };
-    keep();
-};
-
-window.noAnchorRelease = function () {
-    if (anchorRelease) anchorRelease();
-};

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -236,6 +236,8 @@ window.noAnchorTop = function (id) {
 
     var ticks = 0;
     var named = false;
+    var padded = -1;
+    var paddedPane = null;
     var keep = function () {
         var cur = document.getElementById(id);
         if (!cur) return false;
@@ -248,11 +250,27 @@ window.noAnchorTop = function (id) {
             console.log('[anchor] scroller=' + (isDoc ? 'document' : (sc.tagName + '.' + sc.className))
                 + ' scrollHeight=' + sc.scrollHeight + ' clientHeight=' + sc.clientHeight);
         }
+        // The card is the last thing on the page, so bringing its top to the pane's top means
+        // scrolling past the end of the document - which the browser clamps. Until the card is
+        // taller than the pane there is literally nothing below it to scroll into view, and the
+        // write silently does nothing. Give the pane exactly the shortfall as temporary space so
+        // the position becomes reachable; it shrinks to nothing as the card grows, and is removed
+        // when the pin lets go.
+        var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
+        if (shortfall !== padded) {
+            padded = shortfall;
+            sc.style.paddingBottom = shortfall ? shortfall + 'px' : '';
+            paddedPane = shortfall ? sc : null;
+        }
+
         if (Math.abs(drift) > 2) {
             var before = sc.scrollTop;
             sc.scrollTop = before + drift;
-            console.log('[anchor] drift=' + Math.round(drift)
-                + ' scrollTop ' + Math.round(before) + ' -> ' + Math.round(sc.scrollTop));
+            if (Math.round(sc.scrollTop) === Math.round(before) && Math.abs(drift) > 2) {
+                console.log('[anchor] clamped at ' + Math.round(before)
+                    + ' (max ' + Math.round(sc.scrollHeight - sc.clientHeight)
+                    + ', pad ' + shortfall + ') - drift ' + Math.round(drift));
+            }
         }
         return true;
     };
@@ -271,6 +289,8 @@ window.noAnchorTop = function (id) {
 
     anchorRelease = function () {
         clearInterval(timer);
+        // Hand the pane back the space we borrowed.
+        if (paddedPane) { paddedPane.style.paddingBottom = ''; paddedPane = null; }
         window.removeEventListener('wheel', give);
         window.removeEventListener('touchmove', give);
         window.removeEventListener('keydown', onKey, true);

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -178,8 +178,7 @@
 // (findings, advisories, an event count). Kept here because this file already loads app-wide and
 // the callers are spread across pages and components.
 function noHighlight(id, block, variant, radius) {
-    var el = document.getElementById(id);
-    if (!el) return;
+    if (!document.getElementById(id)) return;
     el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
     // The caller says what shape it is pointing at; the default suits a card.
     if (radius) el.style.setProperty('--nav-highlight-radius', radius);
@@ -220,17 +219,19 @@ window.noAnchorTop = function (id) {
     var el = document.getElementById(id);
     if (!el) return;
 
+    // Re-resolved every tick rather than captured: the card re-renders as discovery adds sections,
+    // and Blazor can swap the element out. Holding the original node meant the pin let go the first
+    // time that happened - one scroll, then nothing, which is exactly what it looked like.
     var ticks = 0;
-    var keep = function () { el.scrollIntoView({ block: 'start' }); };
+    var keep = function () {
+        var cur = document.getElementById(id);
+        if (cur) cur.scrollIntoView({ block: 'start' });
+        return !!cur;
+    };
     var timer = setInterval(function () {
-        if (!document.contains(el)) {
-            console.log('[anchor] target left the DOM after ' + ticks + ' ticks, releasing');
-            window.noAnchorRelease();
-            return;
-        }
         ticks++;
-        keep();
-    }, 400);
+        if (!keep()) console.log('[anchor] no element for ' + id + ' this tick (' + ticks + ')');
+    }, 300);
     console.log('[anchor] pinned ' + id);
 
     var give = function () { console.log('[anchor] released by user scroll'); window.noAnchorRelease(); };

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -220,13 +220,20 @@ window.noAnchorTop = function (id) {
     var el = document.getElementById(id);
     if (!el) return;
 
+    var ticks = 0;
     var keep = function () { el.scrollIntoView({ block: 'start' }); };
     var timer = setInterval(function () {
-        if (!document.contains(el)) { window.noAnchorRelease(); return; }
+        if (!document.contains(el)) {
+            console.log('[anchor] target left the DOM after ' + ticks + ' ticks, releasing');
+            window.noAnchorRelease();
+            return;
+        }
+        ticks++;
         keep();
     }, 400);
+    console.log('[anchor] pinned ' + id);
 
-    var give = function () { window.noAnchorRelease(); };
+    var give = function () { console.log('[anchor] released by user scroll'); window.noAnchorRelease(); };
     var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };
     var onKey = function (e) { if (keys[e.key]) give(); };
     window.addEventListener('wheel', give, { passive: true });

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -235,7 +235,6 @@ window.noAnchorTop = function (id) {
     };
 
     var padded = -1;
-    var paddedPane = null;
     var keep = function () {
         var cur = document.getElementById(id);
         if (!cur) {
@@ -253,13 +252,14 @@ window.noAnchorTop = function (id) {
         // The card is the last thing on the page, so bringing its top to the pane's top means
         // scrolling past the end of the document, which the browser clamps - until the card is
         // taller than the pane there is nothing below it to scroll into view and the write silently
-        // does nothing. Lend the pane exactly the shortfall so the position becomes reachable; it
-        // shrinks to nothing as the card grows, and is handed back when the pin releases.
+        // does nothing. Make up the shortfall with margin ON THE CARD, never padding on the pane:
+        // the pane is shared by every page, and a niche affordance has no business leaving state
+        // there - stranding it once put a screen of blank space under an unrelated page. Margin
+        // does not paint, and it is removed with the card, so it cannot outlive this.
         var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
         if (shortfall !== padded) {
             padded = shortfall;
-            sc.style.paddingBottom = shortfall ? shortfall + 'px' : '';
-            paddedPane = shortfall ? sc : null;
+            cur.style.marginBottom = shortfall ? shortfall + 'px' : '';
         }
 
         if (Math.abs(drift) > 2) sc.scrollTop += drift;
@@ -275,8 +275,9 @@ window.noAnchorTop = function (id) {
 
     anchorRelease = function () {
         clearInterval(timer);
-        // Hand the pane back the space we borrowed.
-        if (paddedPane) { paddedPane.style.paddingBottom = ''; paddedPane = null; }
+        // Give the card its own margin back.
+        var cur = document.getElementById(id);
+        if (cur) cur.style.marginBottom = '';
         window.removeEventListener('wheel', give);
         window.removeEventListener('touchmove', give);
         window.removeEventListener('keydown', onKey, true);

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -238,7 +238,13 @@ window.noAnchorTop = function (id) {
     var paddedPane = null;
     var keep = function () {
         var cur = document.getElementById(id);
-        if (!cur) return;
+        if (!cur) {
+            // Gone - navigated away, or the tab re-rendered without it. Release rather than return:
+            // the pane is holding borrowed padding, and leaving it there strands a screen of empty
+            // space at the bottom of a scroller every page shares.
+            window.noAnchorRelease();
+            return;
+        }
         var sc = scrollerOf(cur);
         var isDoc = sc === document.scrollingElement || sc === document.documentElement;
         var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -222,11 +222,27 @@ window.noAnchorTop = function (id) {
     // Re-resolved every tick rather than captured: the card re-renders as discovery adds sections,
     // and Blazor can swap the element out. Holding the original node meant the pin let go the first
     // time that happened - one scroll, then nothing, which is exactly what it looked like.
+    // Drive the owning scroller by hand rather than calling scrollIntoView. The app scrolls
+    // .main-content or .page-content, not the document, and scrollIntoView does not reliably move
+    // those - the tour driver hit the same thing and does its own scroller math for it.
+    var scrollerOf = function (node) {
+        for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
+            var oy = getComputedStyle(n).overflowY;
+            if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
+        }
+        return document.scrollingElement || document.documentElement;
+    };
     var ticks = 0;
     var keep = function () {
         var cur = document.getElementById(id);
-        if (cur) cur.scrollIntoView({ block: 'start' });
-        return !!cur;
+        if (!cur) return false;
+        var sc = scrollerOf(cur);
+        var isDoc = sc === document.scrollingElement || sc === document.documentElement;
+        var top = isDoc ? 0 : sc.getBoundingClientRect().top;
+        var delta = cur.getBoundingClientRect().top - top;
+        // Only correct real drift, so we are not fighting the browser over sub-pixel rounding.
+        if (Math.abs(delta) > 2) sc.scrollTop += delta;
+        return true;
     };
     var timer = setInterval(function () {
         ticks++;

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -222,33 +222,33 @@ window.noAnchorTop = function (id) {
     // Re-resolved every tick rather than captured: the card re-renders as discovery adds sections,
     // and Blazor can swap the element out. Holding the original node meant the pin let go the first
     // time that happened - one scroll, then nothing, which is exactly what it looked like.
-    // Drive the owning scroller by hand rather than calling scrollIntoView. The app scrolls
-    // .main-content or .page-content, not the document, and scrollIntoView does not reliably move
-    // those - the tour driver hit the same thing and does its own scroller math for it.
-    var scrollerOf = function (node) {
-        for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
-            var oy = getComputedStyle(n).overflowY;
-            if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
-        }
-        return document.scrollingElement || document.documentElement;
-    };
+    // FOLLOW the growing edge, do not pin the top. Pinning the top is what this did first, and it
+    // worked exactly as asked - one scroll, then nothing to do, because the card's top was already
+    // in place. That is the wrong goal: discovery makes the card taller than the screen, so the new
+    // sections land below the fold and the reader is left chasing them. Keeping the BOTTOM in view
+    // is what "I should not have to scroll" actually means here.
+    //
+    // scrollIntoView is the mechanism the highlight jumps already use successfully in this layout,
+    // so it is what this uses too rather than second-guessing which element scrolls.
     var ticks = 0;
+    var lastBottom = 0;
     var keep = function () {
         var cur = document.getElementById(id);
         if (!cur) return false;
-        var sc = scrollerOf(cur);
-        var isDoc = sc === document.scrollingElement || sc === document.documentElement;
-        var top = isDoc ? 0 : sc.getBoundingClientRect().top;
-        var delta = cur.getBoundingClientRect().top - top;
-        // Only correct real drift, so we are not fighting the browser over sub-pixel rounding.
-        if (Math.abs(delta) > 2) sc.scrollTop += delta;
+        var r = cur.getBoundingClientRect();
+        var grew = r.bottom > lastBottom + 1;
+        lastBottom = r.bottom;
+        // Only act when it has grown AND the new edge is off screen: otherwise a short card would
+        // be yanked around for no reason.
+        if (grew && r.bottom > window.innerHeight)
+            cur.scrollIntoView({ block: 'end', behavior: 'smooth' });
         return true;
     };
     var timer = setInterval(function () {
         ticks++;
         if (!keep()) console.log('[anchor] no element for ' + id + ' this tick (' + ticks + ')');
     }, 300);
-    console.log('[anchor] pinned ' + id);
+    console.log('[anchor] following ' + id);
 
     var give = function () { console.log('[anchor] released by user scroll'); window.noAnchorRelease(); };
     var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -177,10 +177,12 @@
 // Scroll to a card and ring it briefly, the one behavior every in-page jump in Monitoring shares
 // (findings, advisories, an event count). Kept here because this file already loads app-wide and
 // the callers are spread across pages and components.
-function noHighlight(id, block, variant) {
+function noHighlight(id, block, variant, radius) {
     var el = document.getElementById(id);
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
+    // The caller says what shape it is pointing at; the default suits a card.
+    if (radius) el.style.setProperty('--nav-highlight-radius', radius);
     el.classList.add(variant);
     // Next frame, so the class that defines the transition is applied before the color changes -
     // set together, the browser has nothing to animate from.
@@ -190,8 +192,9 @@ function noHighlight(id, block, variant) {
     });
 }
 
-// A card or section: ringed.
-window.noHighlightTarget = function (id, block) { noHighlight(id, block, 'nav-highlight'); };
+// A card or section: ringed. Pass a CSS length as `radius` for a target that is not card-shaped,
+// e.g. "var(--border-radius)" for a form or control inside a card.
+window.noHighlightTarget = function (id, block, radius) { noHighlight(id, block, 'nav-highlight', radius); };
 
 // A table row: tinted, because an offset ring around a row collides with the rows either side.
 window.noHighlightRow = function (id, block) { noHighlight(id, block || 'center', 'nav-highlight-row'); };

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -188,7 +188,17 @@ function noHighlight(id, block, variant, radius) {
     // set together, the browser has nothing to animate from.
     requestAnimationFrame(function () {
         el.classList.add('nav-highlight-on');
-        setTimeout(function () { el.classList.remove('nav-highlight-on'); }, 1800);
+        setTimeout(function () {
+            el.classList.remove('nav-highlight-on');
+            // Take the rest off once the fade has run, rather than leaving it on the element for
+            // good: the base class carries a transition and a radius override, so a highlighted
+            // table row would keep fading its hover afterwards and a wrapper would keep the
+            // corners the ring gave it.
+            setTimeout(function () {
+                el.classList.remove(variant);
+                el.style.removeProperty('--nav-highlight-radius');
+            }, 1000);
+        }, 1800);
     });
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -234,28 +234,21 @@ window.noAnchorTop = function (id) {
         return document.scrollingElement || document.documentElement;
     };
 
-    var ticks = 0;
-    var named = false;
     var padded = -1;
     var paddedPane = null;
     var keep = function () {
         var cur = document.getElementById(id);
-        if (!cur) return false;
+        if (!cur) return;
         var sc = scrollerOf(cur);
         var isDoc = sc === document.scrollingElement || sc === document.documentElement;
         var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
         var drift = cur.getBoundingClientRect().top - paneTop;
-        if (!named) {
-            named = true;
-            console.log('[anchor] scroller=' + (isDoc ? 'document' : (sc.tagName + '.' + sc.className))
-                + ' scrollHeight=' + sc.scrollHeight + ' clientHeight=' + sc.clientHeight);
-        }
+
         // The card is the last thing on the page, so bringing its top to the pane's top means
-        // scrolling past the end of the document - which the browser clamps. Until the card is
-        // taller than the pane there is literally nothing below it to scroll into view, and the
-        // write silently does nothing. Give the pane exactly the shortfall as temporary space so
-        // the position becomes reachable; it shrinks to nothing as the card grows, and is removed
-        // when the pin lets go.
+        // scrolling past the end of the document, which the browser clamps - until the card is
+        // taller than the pane there is nothing below it to scroll into view and the write silently
+        // does nothing. Lend the pane exactly the shortfall so the position becomes reachable; it
+        // shrinks to nothing as the card grows, and is handed back when the pin releases.
         var shortfall = Math.max(0, Math.round(sc.clientHeight - cur.getBoundingClientRect().height));
         if (shortfall !== padded) {
             padded = shortfall;
@@ -263,24 +256,11 @@ window.noAnchorTop = function (id) {
             paddedPane = shortfall ? sc : null;
         }
 
-        if (Math.abs(drift) > 2) {
-            var before = sc.scrollTop;
-            sc.scrollTop = before + drift;
-            if (Math.round(sc.scrollTop) === Math.round(before) && Math.abs(drift) > 2) {
-                console.log('[anchor] clamped at ' + Math.round(before)
-                    + ' (max ' + Math.round(sc.scrollHeight - sc.clientHeight)
-                    + ', pad ' + shortfall + ') - drift ' + Math.round(drift));
-            }
-        }
-        return true;
+        if (Math.abs(drift) > 2) sc.scrollTop += drift;
     };
-    var timer = setInterval(function () {
-        ticks++;
-        if (!keep()) console.log('[anchor] no element for ' + id + ' this tick (' + ticks + ')');
-    }, 300);
-    console.log('[anchor] pinning top of ' + id);
+    var timer = setInterval(keep, 300);
 
-    var give = function () { console.log('[anchor] released by user scroll'); window.noAnchorRelease(); };
+    var give = function () { window.noAnchorRelease(); };
     var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };
     var onKey = function (e) { if (keys[e.key]) give(); };
     window.addEventListener('wheel', give, { passive: true });

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -222,42 +222,45 @@ window.noAnchorTop = function (id) {
     // Re-resolved every tick rather than captured: the card re-renders as discovery adds sections,
     // and Blazor can swap the element out. Holding the original node meant the pin let go the first
     // time that happened - one scroll, then nothing, which is exactly what it looked like.
-    // FOLLOW the growing edge, do not pin the top. Pinning the top is what this did first, and it
-    // worked exactly as asked - one scroll, then nothing to do, because the card's top was already
-    // in place. That is the wrong goal: discovery makes the card taller than the screen, so the new
-    // sections land below the fold and the reader is left chasing them. Keeping the BOTTOM in view
-    // is what "I should not have to scroll" actually means here.
-    //
-    // scrollIntoView is the mechanism the highlight jumps already use successfully in this layout,
-    // so it is what this uses too rather than second-guessing which element scrolls.
+    // PIN THE TOP: hold the card's top at the top of whatever actually scrolls, correcting every
+    // tick, until the reader scrolls for themselves. Earlier attempts measured against
+    // window.innerHeight, but this app scrolls .main-content / .page-content, not the document - so
+    // the numbers were about the wrong box. Find the real scroller and work in its coordinates.
+    var scrollerOf = function (node) {
+        for (var n = node.parentElement; n && n !== document.body; n = n.parentElement) {
+            var oy = getComputedStyle(n).overflowY;
+            if ((oy === 'auto' || oy === 'scroll') && n.scrollHeight > n.clientHeight + 4) return n;
+        }
+        return document.scrollingElement || document.documentElement;
+    };
+
     var ticks = 0;
-    var lastBottom = 0;
+    var named = false;
     var keep = function () {
         var cur = document.getElementById(id);
         if (!cur) return false;
-        var r = cur.getBoundingClientRect();
-        var grew = r.bottom > lastBottom + 1;
-        var off = r.bottom > window.innerHeight;
-        // Report the actual numbers whenever it grows, so a run that does nothing says why rather
-        // than leaving us to guess which half of the condition failed.
-        if (grew) {
-            console.log('[anchor] grew: bottom=' + Math.round(r.bottom)
-                + ' top=' + Math.round(r.top)
-                + ' innerHeight=' + window.innerHeight
-                + ' offscreen=' + off
-                + ' -> ' + (off ? 'scrolling' : 'no scroll needed'));
+        var sc = scrollerOf(cur);
+        var isDoc = sc === document.scrollingElement || sc === document.documentElement;
+        var paneTop = isDoc ? 0 : sc.getBoundingClientRect().top;
+        var drift = cur.getBoundingClientRect().top - paneTop;
+        if (!named) {
+            named = true;
+            console.log('[anchor] scroller=' + (isDoc ? 'document' : (sc.tagName + '.' + sc.className))
+                + ' scrollHeight=' + sc.scrollHeight + ' clientHeight=' + sc.clientHeight);
         }
-        lastBottom = r.bottom;
-        // Instant, not smooth: repeated smooth calls restart the animation and can net out to no
-        // movement at all. The highlight jumps that work in this layout use the instant form.
-        if (grew && off) cur.scrollIntoView({ block: 'end' });
+        if (Math.abs(drift) > 2) {
+            var before = sc.scrollTop;
+            sc.scrollTop = before + drift;
+            console.log('[anchor] drift=' + Math.round(drift)
+                + ' scrollTop ' + Math.round(before) + ' -> ' + Math.round(sc.scrollTop));
+        }
         return true;
     };
     var timer = setInterval(function () {
         ticks++;
         if (!keep()) console.log('[anchor] no element for ' + id + ' this tick (' + ticks + ')');
     }, 300);
-    console.log('[anchor] following ' + id);
+    console.log('[anchor] pinning top of ' + id);
 
     var give = function () { console.log('[anchor] released by user scroll'); window.noAnchorRelease(); };
     var keys = { PageDown: 1, PageUp: 1, ArrowDown: 1, ArrowUp: 1, Home: 1, End: 1, ' ': 1 };

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -478,16 +478,24 @@ async function catchUpTick() {
     }
 }
 
-function restartBackfill() {
-    if (!backfillTimer) {
-        dbg('restartBackfill SKIPPED - no timer (chart paused or not mounted)');
-        return;
-    }
-    dbg(`restartBackfill - ${CATCHUP_TRIES} fills every ${CATCHUP_MS / 1000}s, then ${BACKFILL_MS / 1000}s`);
-    clearInterval(backfillTimer);
+// Arms the fills in catch-up mode. Called wherever polling starts, so it cannot depend on the
+// first live sample arriving after the timer exists - it did not, and the trigger was wasted on a
+// stale sample served before the agent had even connected.
+function startBackfillCatchUp() {
+    if (backfillTimer) clearInterval(backfillTimer);
+    dbg(`backfill armed - ${CATCHUP_TRIES} fills every ${CATCHUP_MS / 1000}s, then ${BACKFILL_MS / 1000}s`);
     catchUpLeft = CATCHUP_TRIES;
     backfillTimer = setInterval(catchUpTick, CATCHUP_MS);
-    catchUpTick();
+}
+
+// Live data resuming after a stall re-arms the same burst: the history for the gap only becomes
+// queryable once the server catches up, which is after the samples themselves start arriving.
+function restartBackfill() {
+    if (!backfillTimer) {
+        dbg('restartBackfill skipped - not polling');
+        return;
+    }
+    startBackfillCatchUp();
 }
 
 async function backfillHistory() {
@@ -640,7 +648,7 @@ export async function mount(containerId, opts) {
 
     pollTimer = setInterval(pollLive, interval);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
-    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+    startBackfillCatchUp();
 
     if (visHandler) document.removeEventListener('visibilitychange', visHandler);
     visHandler = async () => {
@@ -677,7 +685,7 @@ export function resume() {
     if (!chart || pollTimer) return;
     pollTimer = setInterval(pollLive, POLL_MS);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
-    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+    startBackfillCatchUp();
 }
 
 // Render the historic view at a given playhead time from the current buffer.
@@ -758,7 +766,7 @@ export async function seekTime(isoTimestamp) {
         updateChart();
         pollTimer = setInterval(pollLive, POLL_MS);
         scrollTimer = setInterval(updateChart, SCROLL_MS);
-        backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+        startBackfillCatchUp();
         return;
     }
     // Historic mode: stop polling, fetch window centered on timestamp

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -33,6 +33,10 @@ let elId = null;
 let visHandler = null;
 let mountGen = 0;
 let lastSampleTime = 0;
+// Whether a LIVE poll has landed this mount. Separate from lastSampleTime, which history and
+// backfill points also advance - so on any site with stored history it is never 0 by the time the
+// first live sample arrives, and keying the re-phase off it did nothing.
+let seenLiveSample = false;
 // Historic playback interpolation state (see seekTime).
 let histTimer = null;
 let histAt = 0;
@@ -402,7 +406,8 @@ async function pollLive() {
         // reconnecting). The backfill cadence was started at mount against a site that had nothing
         // to backfill, so its next tick sits at an arbitrary point in the 60s window. Restart it
         // from here so the first fill happens now rather than up to a minute into live data.
-        const dataJustStarted = lastSampleTime === 0;
+        const dataJustStarted = !seenLiveSample;
+        seenLiveSample = true;
         lastSampleTime = sampleTime;
         if (dataJustStarted) restartBackfill();
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
@@ -532,6 +537,7 @@ export async function mount(containerId, opts) {
     removeMouseTracking();
     buffer = [];
     lastSampleTime = 0;
+    seenLiveSample = false;
     const gen = ++mountGen;
     elId = containerId;
     const el = document.getElementById(containerId);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -398,7 +398,13 @@ async function pollLive() {
         // the line double back on itself.
         const sampleTime = d.sampleTime ? new Date(d.sampleTime).getTime() : Date.now();
         if (sampleTime <= lastSampleTime) return;
+        // First sample of this mount: data has just started flowing (an agent coming up, a console
+        // reconnecting). The backfill cadence was started at mount against a site that had nothing
+        // to backfill, so its next tick sits at an arbitrary point in the 60s window. Restart it
+        // from here so the first fill happens now rather than up to a minute into live data.
+        const dataJustStarted = lastSampleTime === 0;
         lastSampleTime = sampleTime;
+        if (dataJustStarted) restartBackfill();
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
         buffer.push({
             time: sampleTime,
@@ -417,6 +423,15 @@ async function pollLive() {
 // start) show up. Live mode + foreground only. The newest live samples - which
 // can be ahead of Influx ingestion - are kept ahead of the re-pulled history so
 // the live edge never flickers back.
+// Runs a fill now and re-phases the 60s cadence to this moment. Only meaningful while mounted;
+// pause() clears the timer and a later mount starts its own.
+function restartBackfill() {
+    if (!backfillTimer) return;
+    clearInterval(backfillTimer);
+    backfillHistory();
+    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+}
+
 async function backfillHistory() {
     if (!chart || !pollTimer || document.hidden) return;
     const gen = mountGen;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -387,7 +387,7 @@ async function loadHistory() {
         const resp = await fetch(
             `/api/monitoring/wan-live-chart-data?from=${from.toISOString()}&to=${to.toISOString()}`,
             { credentials: 'same-origin' });
-        if (!resp.ok) return;
+        if (!resp.ok) return 0;
         const data = await resp.json();
         buffer = (data.points || []).map(p => ({
             time: new Date(p.time).getTime(),
@@ -470,9 +470,16 @@ const CATCHUP_TRIES = 6;
 let catchUpLeft = 0;
 
 async function catchUpTick() {
-    await backfillHistory();
-    if (catchUpLeft > 0 && --catchUpLeft === 0 && backfillTimer) {
-        dbg('catch-up done - back to the ' + (BACKFILL_MS / 1000) + 's cadence');
+    // Stop as soon as a fill actually returns something: the burst exists only to bridge the wait
+    // until the server has the window queryable, and once it does there is nothing left to catch up
+    // on. Normally that is a single extra fill, not the whole burst - each one re-pulls the entire
+    // history window, so running them when they are not needed is pure waste.
+    const got = await backfillHistory();
+    if (!backfillTimer) return;
+    if (got > 0 || --catchUpLeft <= 0) {
+        dbg(got > 0 ? 'caught up - back to the normal cadence' : 'catch-up exhausted - normal cadence',
+            { fillsLeftUnused: Math.max(catchUpLeft, 0) });
+        catchUpLeft = 0;
         clearInterval(backfillTimer);
         backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
     }
@@ -501,7 +508,7 @@ function restartBackfill() {
 async function backfillHistory() {
     if (!chart || !pollTimer || document.hidden) {
         dbg('backfill skipped', { chart: !!chart, polling: !!pollTimer, hidden: document.hidden });
-        return;
+        return 0;
     }
     const startedAt = Date.now();
     const gen = mountGen;
@@ -521,9 +528,9 @@ async function backfillHistory() {
             rtt: p.rttMs,
             loss: p.lossPercent ?? 0,
         }));
-    } catch { return; }
+    } catch { return 0; }
     // Bail if the mount changed or we left live mode while fetching.
-    if (gen !== mountGen || !pollTimer) return;
+    if (gen !== mountGen || !pollTimer) return 0;
     const newestHist = points.length ? points[points.length - 1].time : 0;
     // The number that matters when the fill looks like it did nothing: zero points means the fill
     // ran BEFORE the server had that window queryable, so the data arrives on the next tick.
@@ -539,6 +546,7 @@ async function backfillHistory() {
         if (p.time > lastSampleTime) lastSampleTime = p.time;
     }
     updateChart();
+    return points.length;
 }
 
 // Upper-left mode cluster: play/pause + Historic badge, shown only while the

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -37,6 +37,26 @@ let lastSampleTime = 0;
 // backfill points also advance - so on any site with stored history it is never 0 by the time the
 // first live sample arrives, and keying the re-phase off it did nothing.
 let seenLiveSample = false;
+// Wall-clock of the last accepted live sample, and how long a stall has to last before data coming
+// back counts as "started flowing again". Keyed on a GAP rather than on the first sample of a mount
+// because the case that matters is the server restarting under a tab that stays open all the way
+// through: the chart never remounts, so any per-mount flag is already set and never re-arms.
+// Comfortably longer than the poll interval so ordinary jitter or one failed poll is not a resume.
+let lastLiveAt = 0;
+const RESUME_AFTER_MS = 20000;
+
+// Opt-in tracing for the backfill cadence, which is otherwise invisible: it is all client side and
+// the interesting part is WHEN each fill runs relative to the first live sample. Enable with
+//   localStorage.setItem('no-wan-chart-debug', '1')
+// and reload; clear it with removeItem. Off by default so nothing ships noise to users.
+const CHART_DEBUG = (() => {
+    try { return localStorage.getItem('no-wan-chart-debug') === '1'; } catch { return false; }
+})();
+const mountedAt = () => (chartMountedAt ? ((Date.now() - chartMountedAt) / 1000).toFixed(1) + 's' : 'n/a');
+let chartMountedAt = 0;
+function dbg(what, detail) {
+    if (CHART_DEBUG) console.log(`[wan-chart +${mountedAt()}] ${what}`, detail ?? '');
+}
 // Historic playback interpolation state (see seekTime).
 let histTimer = null;
 let histAt = 0;
@@ -406,10 +426,19 @@ async function pollLive() {
         // reconnecting). The backfill cadence was started at mount against a site that had nothing
         // to backfill, so its next tick sits at an arbitrary point in the 60s window. Restart it
         // from here so the first fill happens now rather than up to a minute into live data.
-        const dataJustStarted = !seenLiveSample;
+        const now = Date.now();
+        const stalledFor = lastLiveAt ? now - lastLiveAt : Infinity;
+        const dataJustStarted = !seenLiveSample || stalledFor > RESUME_AFTER_MS;
         seenLiveSample = true;
+        lastLiveAt = now;
         lastSampleTime = sampleTime;
-        if (dataJustStarted) restartBackfill();
+        if (dataJustStarted) {
+            dbg('live data started flowing', {
+                stalledForSec: stalledFor === Infinity ? 'first' : (stalledFor / 1000).toFixed(1),
+                sampleTime: new Date(sampleTime).toISOString(),
+            });
+            restartBackfill();
+        }
         const cutoff = Date.now() - HISTORY_MINUTES * 60000;
         buffer.push({
             time: sampleTime,
@@ -430,15 +459,43 @@ async function pollLive() {
 // the live edge never flickers back.
 // Runs a fill now and re-phases the 60s cadence to this moment. Only meaningful while mounted;
 // pause() clears the timer and a later mount starts its own.
+// Data starting to flow does not mean the history is queryable yet: the latency line appears first,
+// SNMP rates a couple of seconds later, and the server needs a moment more before a fill returns
+// anything. Firing one fill at that instant returns nothing and leaves the next attempt a full
+// BACKFILL_MS away, which is why this felt unchanged. Run a short burst of closely spaced fills
+// instead, then settle back to the normal cadence - whenever the data lands, a fill is at most
+// CATCHUP_MS behind it.
+const CATCHUP_MS = 10000;
+const CATCHUP_TRIES = 6;
+let catchUpLeft = 0;
+
+async function catchUpTick() {
+    await backfillHistory();
+    if (catchUpLeft > 0 && --catchUpLeft === 0 && backfillTimer) {
+        dbg('catch-up done - back to the ' + (BACKFILL_MS / 1000) + 's cadence');
+        clearInterval(backfillTimer);
+        backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+    }
+}
+
 function restartBackfill() {
-    if (!backfillTimer) return;
+    if (!backfillTimer) {
+        dbg('restartBackfill SKIPPED - no timer (chart paused or not mounted)');
+        return;
+    }
+    dbg(`restartBackfill - ${CATCHUP_TRIES} fills every ${CATCHUP_MS / 1000}s, then ${BACKFILL_MS / 1000}s`);
     clearInterval(backfillTimer);
-    backfillHistory();
-    backfillTimer = setInterval(backfillHistory, BACKFILL_MS);
+    catchUpLeft = CATCHUP_TRIES;
+    backfillTimer = setInterval(catchUpTick, CATCHUP_MS);
+    catchUpTick();
 }
 
 async function backfillHistory() {
-    if (!chart || !pollTimer || document.hidden) return;
+    if (!chart || !pollTimer || document.hidden) {
+        dbg('backfill skipped', { chart: !!chart, polling: !!pollTimer, hidden: document.hidden });
+        return;
+    }
+    const startedAt = Date.now();
     const gen = mountGen;
     const to = new Date();
     const from = new Date(to.getTime() - HISTORY_MINUTES * 60000);
@@ -460,6 +517,13 @@ async function backfillHistory() {
     // Bail if the mount changed or we left live mode while fetching.
     if (gen !== mountGen || !pollTimer) return;
     const newestHist = points.length ? points[points.length - 1].time : 0;
+    // The number that matters when the fill looks like it did nothing: zero points means the fill
+    // ran BEFORE the server had that window queryable, so the data arrives on the next tick.
+    dbg('backfill returned', {
+        points: points.length,
+        newestHist: newestHist ? new Date(newestHist).toISOString() : null,
+        tookMs: Date.now() - startedAt,
+    });
     const liveTail = buffer.filter(p => p.time > newestHist);
     const cutoff = Date.now() - HISTORY_MINUTES * 60000;
     buffer = points.concat(liveTail).filter(p => p.time >= cutoff).sort((a, b) => a.time - b.time);
@@ -538,6 +602,9 @@ export async function mount(containerId, opts) {
     buffer = [];
     lastSampleTime = 0;
     seenLiveSample = false;
+    lastLiveAt = 0;
+    chartMountedAt = Date.now();
+    dbg('mount', { backfillEverySec: BACKFILL_MS / 1000 });
     const gen = ++mountGen;
     elId = containerId;
     const el = document.getElementById(containerId);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -6,9 +6,13 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import * as flowData from './lan-flow-data.js?v=7';
 
 const HISTORY_MINUTES = 5;
-// Poll faster than the 5s SNMP fast tier so no sample is missed when the two
-// clocks drift out of phase; pollLive dedupes repeat reads via sampleTime.
+// Poll at twice the site's SNMP sample rate so no sample is missed when the two
+// clocks drift out of phase; pollLive dedupes repeat reads via sampleTime. The
+// rate is per-site and configurable, so it comes back with the chart data rather
+// than being assumed - at the 5s default tier this is the 2500ms it always was.
 const POLL_MS = 2500;
+const POLL_MS_MIN = 1000;
+const POLL_MS_MAX = 5000;
 // Window-scroll redraw cadence. At 250ms each step moves well under a pixel
 // on typical widths, so the chart slides instead of visibly ticking.
 const SCROLL_MS = 250;
@@ -44,6 +48,27 @@ let seenLiveSample = false;
 // Comfortably longer than the poll interval so ordinary jitter or one failed poll is not a resume.
 let lastLiveAt = 0;
 const RESUME_AFTER_MS = 20000;
+// This site's SNMP sample interval and the poll cadence derived from it. Every
+// chart fetch reports the interval, so a settings change is picked up on the next
+// backfill without a reload. An explicit pollMs from the caller still wins.
+let pollMs = POLL_MS;
+let pollMsOverride = null;
+
+// Adopt the interval a chart-data response reported. Restarts the live timer when
+// the cadence actually moved, so a site polling faster than the chart does stops
+// having samples fall between reads.
+function applySampleInterval(data) {
+    const seconds = data?.sampleIntervalSeconds;
+    if (!seconds || seconds <= 0) return;
+    const next = Math.min(POLL_MS_MAX, Math.max(POLL_MS_MIN, Math.round(seconds * 1000 / 2)));
+    if (next === pollMs) return;
+    dbg('sample interval changed', { seconds, pollMs: next });
+    pollMs = next;
+    if (pollTimer && !pollMsOverride) {
+        clearInterval(pollTimer);
+        pollTimer = setInterval(pollLive, pollMs);
+    }
+}
 
 // Opt-in tracing for the backfill cadence, which is otherwise invisible: it is all client side and
 // the interesting part is WHEN each fill runs relative to the first live sample. Enable with
@@ -389,6 +414,7 @@ async function loadHistory() {
             { credentials: 'same-origin' });
         if (!resp.ok) return 0;
         const data = await resp.json();
+        applySampleInterval(data);
         buffer = (data.points || []).map(p => ({
             time: new Date(p.time).getTime(),
             download: p.downloadBps,
@@ -521,6 +547,7 @@ async function backfillHistory() {
             { credentials: 'same-origin' });
         if (!resp.ok) return;
         const data = await resp.json();
+        applySampleInterval(data);
         points = (data.points || []).map(p => ({
             time: new Date(p.time).getTime(),
             download: p.downloadBps,
@@ -652,7 +679,8 @@ export async function mount(containerId, opts) {
     await pollLive();
     if (gen !== mountGen) return;
     updateChart();
-    const interval = opts?.pollMs || POLL_MS;
+    pollMsOverride = opts?.pollMs || null;
+    const interval = pollMsOverride || pollMs;
 
     pollTimer = setInterval(pollLive, interval);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
@@ -691,7 +719,7 @@ export function pause() {
 
 export function resume() {
     if (!chart || pollTimer) return;
-    pollTimer = setInterval(pollLive, POLL_MS);
+    pollTimer = setInterval(pollLive, pollMsOverride || pollMs);
     scrollTimer = setInterval(updateChart, SCROLL_MS);
     startBackfillCatchUp();
 }
@@ -772,7 +800,7 @@ export async function seekTime(isoTimestamp) {
         await loadHistory();
         if (liveGen !== seekGen) return; // seeked again while loading
         updateChart();
-        pollTimer = setInterval(pollLive, POLL_MS);
+        pollTimer = setInterval(pollLive, pollMsOverride || pollMs);
         scrollTimer = setInterval(updateChart, SCROLL_MS);
         startBackfillCatchUp();
         return;
@@ -800,6 +828,7 @@ export async function seekTime(isoTimestamp) {
         if (!resp.ok) return;
         const data = await resp.json();
         if (gen !== seekGen) return; // a newer seek (or return to live) superseded this one
+        applySampleInterval(data);
         buffer = (data.points || []).map(p => ({
             time: new Date(p.time).getTime(),
             download: p.downloadBps,

--- a/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
+++ b/tests/NetworkOptimizer.AgentProtocol.Tests/ResultBufferTests.cs
@@ -410,4 +410,32 @@ public class ResultBufferTests
             File.Delete(path);
         }
     }
+
+    [Fact]
+    public void DropTail_removes_only_results_enqueued_inside_the_window()
+    {
+        var buffer = new ResultBuffer();
+        buffer.Enqueue(ProbeMessage("just-measured"));
+
+        // Everything just enqueued is inside a generous window, so it all goes.
+        var dropped = buffer.DropTail(TimeSpan.FromSeconds(5));
+
+        dropped.Should().Be(1);
+        buffer.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void DropTail_keeps_a_backlog_older_than_the_window()
+    {
+        // The case that makes this safe: a server outage leaves a long backlog, and only the last
+        // few seconds can have been corrupted by the stop. A count-based tail would eat real data.
+        var buffer = new ResultBuffer();
+        for (var i = 0; i < 50; i++)
+            buffer.Enqueue(ProbeMessage($"outage-{i}"));
+
+        var dropped = buffer.DropTail(TimeSpan.Zero);
+
+        dropped.Should().Be(0);
+        buffer.Count.Should().Be(50);
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/AgentEnrollmentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/AgentEnrollmentServiceTests.cs
@@ -1,5 +1,6 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NetworkOptimizer.Storage.Models;
@@ -36,7 +37,11 @@ public class AgentEnrollmentServiceTests
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
             .Options;
         _factory = new TestDbFactory(options);
-        _service = new AgentEnrollmentService(_factory, _tunnelRegistry, new UnfilteredSiteAccess(), new Mock<ILogger<AgentEnrollmentService>>().Object);
+        // No service provider behind it: every coverage read fails closed to "the server still
+        // collects", which is what these tests assert against.
+        _service = new AgentEnrollmentService(_factory, _tunnelRegistry, new UnfilteredSiteAccess(),
+            new SiteAgentCoverage(new ServiceCollection().BuildServiceProvider()),
+            new Mock<ILogger<AgentEnrollmentService>>().Object);
     }
 
     private const string Slug = "lake-house";

--- a/tests/NetworkOptimizer.Web.Tests/Identity/ComponentDatabaseWriteTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Identity/ComponentDatabaseWriteTests.cs
@@ -23,8 +23,6 @@ public class ComponentDatabaseWriteTests
     {
         "FlakyTargetsCard.razor",
         "InfluxSetupWizard.razor",
-        "LatencyTargetsCard.razor",
-        "Monitoring.razor",
         "Settings.razor",
         "SfpModulesCard.razor",
         "SnmpDeviceStatusCard.razor",

--- a/tests/NetworkOptimizer.Web.Tests/Identity/MonitoringGatedServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Identity/MonitoringGatedServiceTests.cs
@@ -1,0 +1,208 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services;
+using NetworkOptimizer.Web.Services.Gates;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Identity;
+
+/// <summary>
+/// The monitoring edits that used to be direct DbContext writes inside the Latency targets card and
+/// the Monitoring page. What matters here is what reaches the audit envelope: an edit that changed
+/// something must describe it, and an edit that changed nothing must stay out of the log entirely.
+/// </summary>
+public class MonitoringGatedServiceTests : IDisposable
+{
+    private readonly string _dir;
+    private readonly SiteDbContextFactory _factory;
+    private readonly SiteContextService _siteContext;
+    private readonly AuditContext _audit = new();
+
+    public MonitoringGatedServiceTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "no-gated-monitoring-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_dir);
+        var paths = new SiteDatabasePaths(Path.Combine(_dir, "network_optimizer.db"));
+        _factory = new SiteDbContextFactory(paths);
+        _siteContext = new SiteContextService(new HttpContextAccessor(), paths);
+
+        using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        db.Database.Migrate();
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* temp dir; a leftover is harmless */ }
+        GC.SuppressFinalize(this);
+    }
+
+    private MonitoringTargetService Targets() => new(
+        _factory, _siteContext, asnResolution: null!, executorFactory: null!, _audit,
+        NullLogger<MonitoringTargetService>.Instance);
+
+    private MonitoringSettingsService Settings() => new(_factory, _siteContext, _audit);
+
+    private async Task<int> SeedTargetAsync(bool enabled = true, int interval = 10)
+    {
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var target = new MonitoringTarget
+        {
+            TargetId = "custom-seed",
+            Name = "Seed target",
+            Address = "192.0.2.10",
+            TargetType = MonitoringTargetType.Custom,
+            ProbeMode = ProbeMode.Icmp,
+            PollIntervalSeconds = interval,
+            PingCount = 5,
+            Enabled = enabled,
+            VantagePoint = "server",
+            CreatedAt = DateTime.UtcNow
+        };
+        db.MonitoringTargets.Add(target);
+        await db.SaveChangesAsync();
+        return target.Id;
+    }
+
+    [Fact]
+    public async Task Pausing_a_target_records_what_changed()
+    {
+        var id = await SeedTargetAsync(enabled: true);
+
+        (await Targets().SetEnabledAsync(id, false)).Should().BeTrue();
+
+        var (details, targetId, targetName, suppressed) = _audit.Drain();
+        details.Should().NotBeNull();
+        suppressed.Should().BeFalse();
+        targetId.Should().Be("custom-seed");
+        targetName.Should().Be("Seed target");
+
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        (await db.MonitoringTargets.FindAsync(id))!.Enabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Pausing_an_already_paused_target_writes_no_event()
+    {
+        var id = await SeedTargetAsync(enabled: false);
+
+        (await Targets().SetEnabledAsync(id, false)).Should().BeTrue();
+
+        _audit.Drain().Suppressed.Should().BeTrue("an edit that changed nothing writes no audit event at all");
+    }
+
+    [Fact]
+    public async Task Editing_a_target_that_is_gone_reports_it_rather_than_throwing()
+    {
+        (await Targets().SetEnabledAsync(4242, false)).Should().BeFalse();
+        _audit.Drain().Suppressed.Should().BeTrue("nothing was there to change");
+
+        (await Targets().DeleteAsync(4242)).Should().BeFalse();
+        _audit.Drain().Suppressed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Deleting_a_target_names_it_before_it_disappears()
+    {
+        var id = await SeedTargetAsync();
+
+        (await Targets().DeleteAsync(id)).Should().BeTrue();
+
+        var (details, targetId, targetName, suppressed) = _audit.Drain();
+        details.Should().NotBeNull();
+        targetId.Should().Be("custom-seed");
+        targetName.Should().Be("Seed target", "the row is gone by the time the envelope is written");
+
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        (await db.MonitoringTargets.FindAsync(id)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Changing_the_poll_interval_records_both_ends()
+    {
+        var id = await SeedTargetAsync(interval: 10);
+
+        await Targets().SetPollIntervalAsync(id, 30);
+
+        _audit.Drain().Details.Should().NotBeNull();
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        (await db.MonitoringTargets.FindAsync(id))!.PollIntervalSeconds.Should().Be(30);
+    }
+
+    [Theory]
+    [InlineData("", "192.0.2.1")]
+    [InlineData("Name", "")]
+    [InlineData("Name", "not a hostname!")]
+    public async Task A_target_that_fails_validation_is_rejected_before_anything_is_written(string name, string address)
+    {
+        var act = () => Targets().AddAsync(new NewMonitoringTarget { Name = name, Address = address });
+
+        await act.Should().ThrowAsync<MonitoringTargetValidationException>();
+
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        (await db.MonitoringTargets.CountAsync()).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task An_over_long_target_name_is_rejected()
+    {
+        var act = () => Targets().AddAsync(new NewMonitoringTarget
+        {
+            Name = new string('n', 201),
+            Address = "192.0.2.1"
+        });
+
+        await act.Should().ThrowAsync<MonitoringTargetValidationException>();
+    }
+
+    [Fact]
+    public async Task Saving_temperature_thresholds_records_the_change_and_normalizes_non_positive_values()
+    {
+        var settings = await Settings().SaveTempThresholdsAsync(switchHighC: 65, gatewayHighC: 0);
+
+        settings.SwitchTempHighC.Should().Be(65);
+        settings.GatewayTempHighC.Should().BeNull("a non-positive threshold means use the default");
+        _audit.Drain().Details.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Re_saving_the_same_thresholds_writes_no_event()
+    {
+        await Settings().SaveTempThresholdsAsync(switchHighC: 65, gatewayHighC: 70);
+        _audit.Drain();
+
+        await Settings().SaveTempThresholdsAsync(switchHighC: 65, gatewayHighC: 70);
+
+        _audit.Drain().Suppressed.Should().BeTrue("saving a form whose values are already stored changed nothing");
+    }
+
+    [Fact]
+    public async Task Resetting_the_influx_setup_clears_it_without_putting_the_token_in_the_log()
+    {
+        await Settings().SetEnabledAsync(true);
+        await using (var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault))
+        {
+            var row = await db.MonitoringSettings.FirstAsync();
+            row.InfluxDbToken = "a-secret-token";
+            row.InfluxDbUrl = "http://192.0.2.50:8086";
+            await db.SaveChangesAsync();
+        }
+        _audit.Drain();
+
+        await Settings().ResetInfluxSetupAsync();
+
+        await using var check = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var settings = await check.MonitoringSettings.FirstAsync();
+        settings.InfluxDbToken.Should().BeEmpty();
+        settings.Enabled.Should().BeFalse();
+
+        var details = _audit.Drain().Details;
+        details.Should().NotBeNull();
+        System.Text.Json.JsonSerializer.Serialize(details)
+            .Should().NotContain("a-secret-token", "the audit detail must never carry the cleared credentials");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/SiteScopedRegistryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SiteScopedRegistryTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// A registry that hands out one instance per site slug must be emptied when a site is removed,
+/// or the instance - holding that site's console connection, InfluxDB client and database path -
+/// is handed straight back to whatever is created under the same slug next. That is not a rare
+/// case: a removed-and-re-added test site hits it every time, and the symptoms are remote from the
+/// cause (Upstream path discovery reporting an empty device list, ISP Health throwing
+/// ObjectDisposedException on a client somebody else disposed).
+///
+/// The sweep works off <see cref="ISiteScopedRegistry"/>, so a registry that does not implement it
+/// is invisible to site removal. This test is the net for that.
+/// </summary>
+public class SiteScopedRegistryTests
+{
+    private static readonly Assembly WebAssembly = typeof(SiteManagementService).Assembly;
+
+    /// <summary>
+    /// Registries that key on something other than a site slug, so site removal has nothing to do
+    /// with them. Each entry is a reviewed decision rather than an omission.
+    /// </summary>
+    private static readonly HashSet<string> NotPerSite = new()
+    {
+        // Keyed by agent id / tunnel, torn down by DropTunnels on removal.
+        "AgentTunnelRegistry",
+    };
+
+    [Fact]
+    public void EveryPerSiteRegistryCanBeSwept()
+    {
+        var perSite = WebAssembly.GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && t.Name.EndsWith("Registry", StringComparison.Ordinal))
+            .Where(t => !NotPerSite.Contains(t.Name))
+            // The per-site shape: a GetFor(string) handing out one instance per slug.
+            .Where(t => t.GetMethod("GetFor", BindingFlags.Public | BindingFlags.Instance, new[] { typeof(string) }) != null)
+            .ToList();
+
+        // Without this the test passes by matching nothing at all - a rename of the shape it looks
+        // for would quietly retire the net rather than fail.
+        perSite.Should().HaveCountGreaterThan(10, "the per-site registries should still be found by this shape");
+
+        var offenders = perSite
+            .Where(t => !typeof(ISiteScopedRegistry).IsAssignableFrom(t))
+            .Select(t => t.Name)
+            .OrderBy(n => n)
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "a registry with a per-slug GetFor must implement ISiteScopedRegistry and be registered "
+            + "with AddSiteScopedRegistry, or removing a site leaves its instance behind for the next "
+            + "site created under the same slug");
+    }
+}


### PR DESCRIPTION
Three themes. Monitoring's writes now go through the gate engine, a site whose console is unreachable can be read instead of showing a banner where the page used to be, and a main site whose server runs off-site can hand its collection to its agent - which Settings has been telling people to do for a while without the plumbing to back it.

## Monitoring

### Setup, targets and thresholds

Adding, pausing, deleting and retiming a latency target, dismissing the LAN flaky-target advisory, turning collection on or off, saving the temperature and SFP/ONT alert thresholds, resetting the InfluxDB setup, and running or committing Upstream path discovery were all direct database writes inside the page. A page is not a mutating service, so none of them had an audit envelope: pausing or deleting a target left nothing in the Audit Log at all.

- **Every one of those actions is now audited** and authorizes the caller where the write happens, rather than relying on which wrapper surrounds the button. Roles match what the page already granted: Operator for the routine edits, Admin for deleting a target and for the InfluxDB reset, which discards the stored token.
- **An edit that changes nothing writes no event** - re-selecting the interval a target already has stays out of the log entirely.
- **Failed edits say so.** Pause and delete previously ended in an empty catch, so a rejected or failed edit looked like a row that simply declined to change.
- **A Site Admin can finish their own site's InfluxDB.** Provisioning asked one question for two different things, so a site's own admin could reach the setup wizard and never complete it. Establishing the installation's InfluxDB - the org, the org-scoped token, the shared connection - is an installation-wide decision and still requires an instance-wide Admin. Adding a site's own prefixed buckets to a connection that already exists is that site's setup, and now takes Admin on that site. If the shared credential turns out not to be able to create buckets, it still falls back to the all-access prompt, which stays instance-wide.
- **The setup status stays current while you watch it.** InfluxDB reachability, SNMP poll health, whether collection is running and whether the site has an agent are all written by something other than the open page, so they were a page-load snapshot: fixing the underlying problem showed nothing until a reload. They now refresh on the page's existing 15 second pass - a database read, not a console round trip, so nothing extra is asked of the console. A stored SNMP state change re-lays-out the whole tab, so it is held while a custom OID or Monitoring Interfaces edit is in flight rather than tearing the form away.
- **Collection status reports both collectors.** Monitoring - Setup read "Agent running" from the enabled flag and InfluxDB reachability alone, so a wedged collector or an agent that died an hour ago still read as running, and on an agent site it credited the server for work the server does not do. It now reports whether anything is actually collecting, and a site with an agent gets a second line carrying that agent's own state, since the two fail independently.

### Reading a site whose console is down

The console being unreachable replaced the whole page with a banner, which is the wrong answer for a site whose gateway has gone away: the targets and SFP list come from the site's own database and the charts come from InfluxDB, so none of it needed the console.

- **The banner sits over the page instead of replacing it.** ISP Health, the stat tabs and Live View all work from stored history.
- **Live View plays back.** Its timeline is built entirely from InfluxDB windows, so it reads an offline site as well as a connected one.
- **ISP Health grades an offline site.** It refused to compute without a console because that is where the expected ISP speeds come from. Successful reads are now remembered per WAN and used when there is no console to ask, labelled so the report shows the figure is remembered rather than current. A site that has never had a successful read still waits, since it has nothing to score against.
- **The WAN chart, gateway CPU/memory/temperature and fabric ingress/egress fill in.** All of them key their queries on the gateway MAC and WAN interface, which came from a console read.
- **The Dashboard Live View card is withheld** while the console is down. It is a live snapshot with no timeline to scrub - the opposite call from the Monitoring tab, which stays open precisely so its timeline can be played back.

Everything remembered is stored per WAN rather than per site, because plan speeds and interface names belong to a WAN. Scoring reads the primary today and multi-WAN is planned, so each WAN's row is already right when that lands. The counter interface and the data-path interface are separate: throughput is keyed on the physical port because a VLAN sub-interface's counters double, while SQM and PPPoE detection need the logical uplink, and using one for the other's job silently reports the wrong throughput. Every fallback reads the stored values only while the console is down, so a connected site resolves exactly as before.

### The main site's collection can move to an on-site agent

The main site is normally collected by the server itself, which assumes the server is on that network and can carry the work. Neither holds for a server running off-site or hosted in the cloud, and neither is required by anyone who would rather spread collection across their own servers. Settings has recommended adding an agent for the first case for a while, without the plumbing to back it: a main-site agent was an additional vantage point, and probes, path discovery, SNMP, device reachability and speed tests all stayed server-local behind hard-coded default-site gates. Anyone following that advice got a half-working site - the agent's latency samples went into the same charts as the server's own, from a network the server was not on.

- **A main site can now hand its collection to its agent.** A toggle in that site's Multi-Site row, disabled until an agent is enrolled so it cannot be switched on into a state where nothing collects at all. With it on, the agent runs the probes, path discovery traces from the site rather than from here, SNMP polling moves to the agent, and this server stands down from all of it.
- **The console and device tunnel toggles are offered for the main site once coverage is on.** Routing the primary console through a tunnel is right for an off-site server and wrong for every other install, so it is not offered until the site has said which it is.
- **Speed tests follow coverage too.** Four paths still assumed the main site is always this server's own network: the client speed-test target resolver returned nothing for the default site before looking at anything (so the UI never pointed clients at the main site's agent), the UWN WAN test anchored its path trace on `HOST_IP` rather than the agent's LAN IP, and the gateway and LAN tests skipped the agent-LAN-IP retry that the server-position-not-found case needs.
- **An agent on the gateway stops probing the gateway.** It was still sent the gateway's own latency/loss target, so it pinged the box it runs on: every reply loopback, no measurable latency, no loss - a perfectly healthy gateway at exactly the moment it might not be. Skipped for that agent when the config is pushed rather than disabled in the database, so the target stays as the user left it and any other vantage keeps measuring it.
- **WAN Speed Test names the vantage the test runs from.** On a site the server cannot reach, the non-gateway option runs on that site's agent - but it was labelled Server, with a hint reading "Tests from this server through the LAN". It now reads On-site agent and Run Test from Agent wherever that is what happens, including a main site whose agent covers it, and the Gateway hint's closing suggestion follows suit rather than recommending a Server-based test on a site where that button says Agent, or recommending one at all when the option is hidden.
- **Every gate asks one question.** `AgentCovers(slug, agentPresent)`: a secondary site needs only an agent, which is what having one has always meant there; the main site needs the flag as well. With the flag unset each of the eight gates reduces to exactly the expression it replaced, so an install without it takes an unchanged path, and an agent enrolled on the main site as an extra vantage keeps behaving as it does today. The flag is a `SystemSettings` row - no schema change.

### Upstream path discovery

- **An unknown access medium demands all three pings.** The reachability gate that decides which candidates are auto-selected let `Unknown` through on 2 of 3 replies, alongside WISP and cellular, on the grounds that an unconfigured link might turn out to be air-interface. But `Unknown` is the state of every first run on a WAN - nothing is stored yet, and the only thing that can resolve it mid-run is inferring a medium from the L2 neighbor's OUI vendor. So the gate relaxed exactly when the run knew the least, and that run is the one that seeds the monitoring targets. WISP and cellular keep 2/3 for their inherent air-interface loss; everything else, `Unknown` included, needs all three.

- **The card follows discovery smoothly and lands on the top.** It corrected the scroll on a fixed interval and applied each correction whole, so every section that landed arrived as a jump. It now eases a fraction of the remaining distance each frame, corrects upward as well as down (a section that measures tall while building and settles shorter used to leave the view parked past the end with no way back), and stops following the moment the run ends so the last, largest render does not drag the view to the bottom of results it is about to leave.

### Live View

- **The WAN Live Chart follows the site's SNMP poll rate.** It bucketed on a fixed 5 second floor and polled on a fixed 2.5 second timer, both written when 5 seconds was the only sample interval there was. A site polling faster had the extra resolution averaged straight back out, and samples landing between client polls were never fetched at all; a site polling slower got buckets with nothing in them. The chart data now carries the site's own interval, so the first load, the periodic backfill and a historic seek all bucket the same way, and the page re-times its polling to match without a reload. The interval is per site, so a faster main site and a default-rate secondary site each get their own. The other sixteen chart queries keep the 5 second floor.

### ISP Health

- **Score colors come from the palette.** Fair, good, excellent and poor were loose hexes; they now use `--warning-color`, a new `--good-color`, `--success-color` and `--danger-color`.
- **The event count is the way to the events.** Where a network card or hop row reports congestion as what is holding its grade down, the count now jumps to Path & Congestion Events and highlights it, rather than leaving you to scroll and work out which entries belonged to that hop.

## Settings - Audit Log

- **Every event says what it acted on.** A target type, id and name were recorded for every audited action and none of them were shown, so an entry said a monitoring target had been paused without saying which one. There is now a Target column reading "Latency Target: Test", falling back to the id for actions with no name to give.
- **Export CSV/JSON returns the whole log again.** It came back as the newest handful of rows: the per-tab site pin is stamped onto every `/api/` link at click time, and the export endpoint read that same parameter as its site filter, so clicking Export quietly meant "this site only" and dropped every event with no site of its own.
- **The filters match regardless of case.** Searching an actor as "Kira" found nothing for a user stored as "kira", and a capitalized Site ID returned an empty log rather than that site's events.
- **The clear-filter control is an icon again**, not a button. It sits among the filter inputs to save the width a labelled control would take, so the button chrome defeated the point.
- **A site-only tab no longer follows you to another site.** Switching sites carries the whole URL across, so `?tab=auditlog` landed on a managed site where that tab does not exist and Settings came up with nothing selected at all.

## Account Security

- **A revoked MFA requirement clears.** The redirects that send someone here carry `setup=required`, and the page treated that as a standing fact - so a user promoted to a role that requires MFA, then put back to one that does not, kept the URL and kept being told they owed a factor. The parameter is now read once and dropped from the address bar, leaving the roles as the only lasting source.

## Highlighting a card you were sent to

Every in-page jump inlined its own copy of scroll-then-highlight - ten of them across Monitoring, Alerts, Settings, Identity and the speed test pages - so they had drifted into two families, two blues, two durations, and in one case no highlight at all.

- **One behavior, one definition.** `window.noHighlightTarget(id, block, radius)` in `site-context.js`, which loads app-wide, backed by `.nav-highlight` in the stylesheet. It fades in and out rather than snapping.
- **Rows tint, cards ring.** An offset ring around a table row collides with the rows either side, so `noHighlightRow` tints from the same color instead. Same variable, same timing.
- **The radius is declared, not guessed.** It defaults to the card radius, since most targets are a card or a bare wrapper around one; a target shaped differently passes its own rather than anything inspecting children.
- **Prompts link to what they are about.** "Enroll one from Settings" on Upstream path discovery and Latency targets now land on Multi-Site Management, and the console-connection banners across the app land on the UniFi Console card rather than Settings generally.
- **Expanding a card scrolls its contents into view**, following the panel frame by frame as it opens rather than jumping afterwards. Expand only, down only, and never past the header you clicked.
- **Upstream path discovery keeps itself in view while it runs** - following each new section as it lands, then settling on the top of the card when the run ends, so you get the whole result rather than its tail. Any scroll of your own ends it. Confined to that panel, so it cannot affect anything else.
- **The MFA-required card on Account Security uses the same ring**, held on rather than fading, instead of a box-shadow in a different blue.

## Multi-Site

- **A re-created site no longer inherits the removed site's console connection.** Removal evicted the site's console connection and then dropped its agent tunnel - and dropping the tunnel runs the console's reconnect path, which builds a fresh connection service and loads that site's saved UniFi configuration from a database moments away from being deleted. The entry outlived the site, and because a freed slug is reused verbatim, the next site created under that name was handed the previous site's console credentials. The connection was held in memory only - nothing was written to the new site's database, and a restart cleared it - but it was reachable from a site it did not belong to. Eviction cannot be final while the data is still on disk, so the passive registries are swept after the registry row and the files are gone, and site creation sweeps the slug as well - creation is the moment a name starts meaning a different site. Disabling a site had the same ordering, dropping the connection and then bringing it straight back with the tunnel; same site, so no crossover, but a disabled site kept a live console connection.
- **Removing a site empties every per-site registry.** Fifteen registries hand out one long-lived instance per site slug, and removal emptied three of them. Those instances capture the site's console connection, gateway SSH, InfluxDB client and database path when they are built, so a slug created again after a removal was handed the previous site's dead objects. Upstream path discovery failed exactly that way - the tracer still held the removed site's console client, which answered every device request with nothing, so discovery stopped on "Empty device response from UniFi Console" and stayed broken until a restart. Removal now evicts every registry before it disposes anything, because the instances hold one another and disposing during eviction hands a live holder a disposed dependency. A new `ISiteScopedRegistry` carries this, `AddSiteScopedRegistry` makes it one line to register, and an architecture test fails the build for a registry with a per-slug lookup that does not implement it.
- **The Sites table follows changes made elsewhere.** It is a live list of who can reach what, and both halves change from outside the circuit looking at it: another admin removes a site, or this user's own membership is granted or revoked. Both already broadcast and the site switcher already rebuilt from it - this table never subscribed, so a site admin watching it saw a removed site stay until they navigated away and back.
- **The Multi-Site tab is visible to a site's own admin.** It was gated on instance-wide Admin, while the Sites page that links to it is viewer-level and the card itself authorizes per row - so a site admin could reach Multi-Site by link and never see the tab in Settings. It now appears for anyone once multi-site is on, and for an instance-wide Admin always, since only they can enable it.
- **InfluxDB setup no longer fails after a site is removed.** Provisioning ends by reconfiguring every registered client so existing sites pick up a changed shared connection, and it walked into the removed site's client - failing after the new site's buckets and org-scoped token had already been created. It reported failure for work that had succeeded, and each retry minted another token. Reconfiguring is now best-effort per client, and the wizard logs what it catches rather than reporting only to the screen.

## On-site agent

- **A hostname whose DNS answer includes an unspecified address is reachable again.** The proxy scope check is deliberately all-or-nothing: one out-of-scope address in a resolution refuses the whole dial, so a DNS answer cannot smuggle a target outside the site. It had never met a resolver that returns `::` *alongside* the real address - which refused the dial outright with a valid RFC1918 address sitting in the same answer, and reported it as an SSH protocol error. Unspecified addresses are dropped before the check; a public address still trips it exactly as before. Affects anything tunnel-routed and configured by name: gateway SSH, the console, modem and ONT pages.
- **An SSH failure through the tunnel says what the agent said.** The agent's reason was logged at Debug and the loopback socket closed, so SSH.NET reported a missing protocol banner with a link to the RFC on version exchange - the symptom, never the cause. The reason for the last failed open is now kept against the loopback port and preferred over SSH.NET's account. Sixty second lifetime, so an old reason is never attached to an unrelated later failure.
- **iperf3 that cannot take its port says so once.** A host already serving 5201 produced a fixed ten-second restart loop forever, logging an exit code and nothing else, plus a relay 404 each time. Its refusal to start arrives as JSON on stdout, which the brace-counter could not tell from a finished test, so every restart posted a non-result to the server. The reason is now reported in iperf3's own words, only objects carrying an `end` section are relayed, the retry backs off to five minutes, and the server is announced only once it has survived startup rather than on every doomed attempt.
- **Released agent images carry their version.** MinVer reads git tags and `.dockerignore` keeps `.git` out of the build context, so the agent image had no version to find - and unlike the main image it took no `VERSION` build-arg, so every published agent called itself `0.0.0-alpha.0`. The native binaries were unaffected.
- **The speed test ports move off crowded ones, and become configurable.** The page was on 3000 and the loopback relay on 3001 - Grafana's defaults, and the reason the single-site speed test picked 3005 years ago. An agent sharing a host with Grafana had its result posts proxied straight into Grafana, which answered 401. New installs now use 24443 and 24042: below the ephemeral range so a boot-time bind cannot lose a race, and clear of UniFi OS Server's 18443. An agent that already exists keeps the page port it is serving, because the agent writes its whole config back on enrollment and every agent enrolled so far has 3000 recorded - upgrading should not move a page its clients and firewall rules already know. nginx and the agent resolve the port identically (environment variable, then `agent.json`, then the default), so the announcement always matches the listener; removing the recorded port is how an existing install adopts the new default. The port is settable directly too, with `--speed-test-port` natively and `AGENT_SPEEDTEST_PORT` on the container.
- **The container rebuilds its nginx config from a template each start.** The entrypoint edited the live file in place, and a restart keeps the container filesystem - so a port or TLS change applied once could never be taken back by changing the setting, only by recreating the container.
- **Re-running the native installer keeps the speed test it was serving.** The nginx work sits behind `--lan-speed-test` and the flag defaults off, so re-running to update the binary - the documented upgrade path - skipped refreshing the config unless the flag was repeated, while `agent.json` (deliberately preserved) kept the speed test switched on.
- **A stop no longer plants a false loss spike.** systemd delivers SIGTERM to the whole control group, so a probe's ping children die at the same instant the agent starts stopping: the burst completes with fewer replies than it sent and is indistinguishable from real loss. The probe path's cancellation check catches the common case but not the race where the result is built before the flag is observed, and once built it is an ordinary unsent message that the spool preserves and replays. Results measured within five seconds of a stop are now dropped rather than spooled - by time rather than by count, because a server outage can leave a long backlog and protecting that backlog is what the spool is for. It is a race, so it lands on some stops and not others, which is what made it hard to attribute.
- **An agent on the gateway gets its probe config again.** Skipping the gateway's own target asked a gated service for the agent's address from the tunnel's background path, where there is no caller context, so the gate threw and took the whole push with it - leaving that site with no targets at all. The address now comes from the detector that had already resolved it.
- **SNMP config reaches a reconnecting agent without waiting for the next refresh.** An agent that dropped and came back kept polling whatever it still had until the periodic push came round, so a config changed while it was away, or an agent that returned with nothing, stayed wrong for a full cycle. It is now pushed on a genuine reconnect, and only once the console has finished connecting so the config is not built from a half-loaded state.
- **`LatestAgentVersion` moves to 2.5.3**, since the name-resolution fix is one an enrolled agent genuinely lacks.

## Fixes

- **The default site's database path no longer depends on the caller getting a flag right.** An agent relaying a speed test result for the main site got 404 "Site main is not provisioned", and topology snapshots for it were dropped for the same reason: the path was resolved with `isDefault` hardcoded false, so it looked for `sites/main/network_optimizer.db`, a file that cannot exist. The slug already settles this - creation reserves `main` - so it now decides, and a wrong flag cannot produce a wrong path. The slug constant moved to the storage layer that resolves paths, with the web layer referencing it, so the two cannot drift.
- **The load-balancing hint counts real WAN interfaces.** WAN Speed Test claimed traffic may be load-balanced whenever the console listed more than one enabled WAN network - and a WAN network can be enabled with nothing attached, so a site with one working uplink and a leftover configured one was told its results might be split. It counts the gateway's actual interfaces now, the same list the Gateway selector uses and the same source Adaptive SQM works from. The WAN assignment picker still offers every configured WAN, so a result can be reassigned to one that is no longer in use.
- **Monitoring on a managed site no longer provisions InfluxDB as whoever is looking.** Opening the page ran an Admin-only bucket call because site mode begins by attempting one; a viewer got two denied audit entries per visit, swallowed and visible only in the log.
- **Latency targets: a paused row dims its data, not its buttons.** The whole row carried the opacity, so Resume and Remove faded out with it - the two controls a paused row exists to offer.
- **The reboot reason icon** sat a pixel low against the uptime value beside it.
- **The WAN chart backfills promptly when data starts flowing.** Its 60 second cadence was phased from page load, so after a restart the first fill could land most of a minute after live data began. It now runs a short burst of closely spaced fills and stops on the first that returns data.

