### PR TITLE
Fix macOS ad hoc signing identity drift

### DIFF
--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -32,6 +32,7 @@ DATA_DIR="$HOME/Library/Application Support/NetworkOptimizer"
 LAUNCH_AGENT_DIR="$HOME/Library/LaunchAgents"
 LAUNCH_AGENT_FILE="net.ozarkconnect.networkoptimizer.plist"
 OLD_LAUNCH_AGENT_FILE="com.networkoptimizer.app.plist"  # For migration from older installs
+APP_BUNDLE_ID="${NETWORK_OPTIMIZER_BUNDLE_ID:-net.ozarkconnect.networkoptimizer}"
 
 # Detect architecture
 ARCH=$(uname -m)
@@ -324,7 +325,7 @@ echo ""
 echo "[4/9] Signing binaries..."
 cd "$INSTALL_DIR"
 find . -name '*.dylib' -exec codesign --force --sign - {} \;
-codesign --force --sign - NetworkOptimizer.Web
+codesign --force --sign - --identifier "$APP_BUNDLE_ID" NetworkOptimizer.Web
 echo "Verifying signature..."
 codesign -v NetworkOptimizer.Web
 

--- a/tests/NetworkOptimizer.Web.Tests/MacNativeInstallerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/MacNativeInstallerTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class MacNativeInstallerTests
+{
+    [Fact]
+    public void InstallerSignsTheAppWithAStableBundleIdentifier()
+    {
+        var script = ReadRepositoryFile("scripts/install-macos-native.sh");
+
+        script.Should().Contain(
+            "APP_BUNDLE_ID=\"${NETWORK_OPTIMIZER_BUNDLE_ID:-net.ozarkconnect.networkoptimizer}\"");
+        script.Should().Contain(
+            "codesign --force --sign - --identifier \"$APP_BUNDLE_ID\" NetworkOptimizer.Web");
+        script.Should().NotContain("codesign --force --sign - NetworkOptimizer.Web");
+    }
+
+    private static string ReadRepositoryFile(string relativePath)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "NetworkOptimizer.sln")))
+            directory = directory.Parent;
+
+        directory.Should().NotBeNull("the test must run from inside a NetworkOptimizer checkout");
+        return File.ReadAllText(Path.Combine(directory!.FullName, relativePath));
+    }
+}


### PR DESCRIPTION
## Problem

The native macOS installer ad hoc re-signs `NetworkOptimizer.Web` without an explicit identifier. That lets the executable's designated identity vary across rebuilt installs, so macOS privacy approvals can stop matching after an otherwise routine update.

## Fix

- sign the app with the stable default identifier `net.ozarkconnect.networkoptimizer`
- allow distributors to override it with `NETWORK_OPTIMIZER_BUNDLE_ID`
- leave dylib signing and the rest of the installer unchanged

## Validation

- added a regression test that checks the default, override, and exact `codesign --identifier` invocation
- `bash -n scripts/install-macos-native.sh`
- full Release `NetworkOptimizer.Web.Tests`: 1,281 passed

No application was installed or re-signed on a live host while validating this change.
