### PR TITLE
Keep local health checks on the local listener

### DIFF
--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1200,16 +1200,16 @@ if (!string.IsNullOrEmpty(canonicalHost))
 {
     app.Use(async (context, next) =>
     {
-        // The agent tunnel is gRPC, which cannot follow an HTTP redirect: a 302
+        // The health endpoint is consumed by local service supervisors, and the agent tunnel is
+        // gRPC, which cannot follow an HTTP redirect: a 302
         // here silently breaks the tunnel whenever a reverse proxy forwards the
         // gRPC path without presenting the canonical Host (e.g. Caddy proxying to
         // the https://localhost tunnel upstream sends Host: localhost, so the app
         // sees a non-canonical host and redirects the Connect stream to death -
         // while REST heartbeats still land and keep the agent showing online).
-        // gRPC is machine-to-machine and has no canonical-host concern, so never
-        // redirect it; let it through to the gRPC endpoint regardless of Host.
-        var contentType = context.Request.ContentType;
-        if (contentType != null && contentType.StartsWith("application/grpc", StringComparison.OrdinalIgnoreCase))
+        // These machine-to-machine endpoints have no canonical-host concern, so never redirect
+        // them; let them through regardless of Host.
+        if (CanonicalHostRedirectPolicy.ShouldBypass(context.Request))
         {
             await next();
             return;

--- a/src/NetworkOptimizer.Web/Services/CanonicalHostRedirectPolicy.cs
+++ b/src/NetworkOptimizer.Web/Services/CanonicalHostRedirectPolicy.cs
@@ -1,0 +1,18 @@
+namespace NetworkOptimizer.Web.Services;
+
+internal static class CanonicalHostRedirectPolicy
+{
+    /// <summary>
+    /// Machine-to-machine endpoints must remain reachable on the local listener even when the
+    /// browser-facing application redirects other requests to its configured canonical host.
+    /// </summary>
+    internal static bool ShouldBypass(HttpRequest request)
+    {
+        if (request.Path.Equals("/api/health", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return request.ContentType?.StartsWith(
+            "application/grpc",
+            StringComparison.OrdinalIgnoreCase) == true;
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/CanonicalHostRedirectPolicyTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CanonicalHostRedirectPolicyTests.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class CanonicalHostRedirectPolicyTests
+{
+    [Theory]
+    [InlineData("/api/health")]
+    [InlineData("/API/HEALTH")]
+    public void ShouldBypass_AllowsLocalHealthChecks(string path)
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = path;
+
+        CanonicalHostRedirectPolicy.ShouldBypass(context.Request).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldBypass_PreservesGrpcTunnelBypass()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/networkoptimizer.AgentService/Connect";
+        context.Request.ContentType = "application/grpc+proto";
+
+        CanonicalHostRedirectPolicy.ShouldBypass(context.Request).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldBypass_KeepsBrowserRoutesCanonical()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Path = "/dashboard";
+
+        CanonicalHostRedirectPolicy.ShouldBypass(context.Request).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Problem

When `HOST_NAME` or `REVERSE_PROXIED_HOST_NAME` is configured, the canonical-host middleware redirects `http://127.0.0.1:8042/api/health` to the public hostname. Local installers and process supervisors can then false-fail because the redirected route has different TLS, authentication, or reachability requirements.

`/api/health` is already an anonymous machine endpoint; it should report the local listener's health without depending on the browser-facing hostname.

## Fix

- bypass canonical-host redirects for the exact `/api/health` path
- retain the existing gRPC tunnel bypass
- keep every browser route subject to canonical-host enforcement

## Validation

- added coverage for lowercase and uppercase health paths, gRPC, and an ordinary browser route
- focused tests: 4 passed
- full Release `NetworkOptimizer.Web.Tests`: 1,284 passed

No running service or reverse proxy was changed while validating this fix.
