### PR TITLE
Allow separate OpenSpeedTest save and results URLs

### DIFF
--- a/docs/MACOS-INSTALLATION.md
+++ b/docs/MACOS-INSTALLATION.md
@@ -32,6 +32,8 @@ export TZ="America/Chicago"
 Additional environment variables can be added to `start.sh` - see [docker/.env.example](../docker/.env.example) for all available options including:
 - `HOST_NAME` - Hostname for canonical URL enforcement
 - `REVERSE_PROXIED_HOST_NAME` - Hostname when behind a reverse proxy (enables HTTPS)
+- `OPENSPEEDTEST_SAVE_DATA_URL` - Optional absolute HTTP(S) URL or root-relative path for submitting browser speed-test results
+- `OPENSPEEDTEST_CLIENT_RESULTS_URL` - Optional absolute HTTP(S) URL or root-relative path for viewing client results
 - `OPENSPEEDTEST_HTTPS` - Enable HTTPS for speed tests (required for geolocation)
 - `Logging__LogLevel__NetworkOptimizer` / `Logging__LogLevel__Default` - Logging verbosity (see [Enable Debug Logging](#enable-debug-logging))
 

--- a/src/NetworkOptimizer.Installer/SpeedTest/config.js.template
+++ b/src/NetworkOptimizer.Installer/SpeedTest/config.js.template
@@ -5,17 +5,19 @@
 
 // These will be replaced by the service at startup
 var saveData = {{SAVE_DATA}};
-var saveDataURL = "{{SAVE_DATA_URL}}";
+var saveDataURL = {{SAVE_DATA_URL}};
 var apiPath = "{{API_PATH}}";
+var clientResultsUrl = {{CLIENT_RESULTS_URL}};
 
 // If __DYNAMIC__, construct URL from browser location (same host, port 8042)
 if (saveDataURL === "__DYNAMIC__") {
     saveDataURL = window.location.protocol + "//" + window.location.hostname + ":8042" + apiPath;
 }
 
-// URL for viewing client speed test results (derived from saveDataURL)
-// Extract base URL by splitting on /api
-var clientResultsUrl = saveDataURL.split("/api")[0] + "/client-speedtest";
+// By default, view results on the same Network Optimizer origin that receives them.
+if (clientResultsUrl === "__FROM_SAVE_DATA_URL__") {
+    clientResultsUrl = saveDataURL.split("/api")[0] + "/client-speedtest";
+}
 
 // Fix for missing variable bug in OpenSpeedTest
 var OpenSpeedTestdb = "";

--- a/src/NetworkOptimizer.Web/Services/NginxHostedService.cs
+++ b/src/NetworkOptimizer.Web/Services/NginxHostedService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using NetworkOptimizer.Core.Helpers;
 
 namespace NetworkOptimizer.Web.Services;
@@ -89,13 +90,15 @@ public class NginxHostedService : IHostedService, IDisposable
         // Construct the save URL based on configuration
         const string apiPath = "/api/public/speedtest/results";
         var saveDataUrl = ConstructSaveDataUrl(config, apiPath);
+        var clientResultsUrl = ConstructClientResultsUrl(config);
 
         // Read template and replace placeholders (matches OpenSpeedTest format)
         var template = await File.ReadAllTextAsync(templatePath);
 
         var configJs = template
             .Replace("{{SAVE_DATA}}", "true")
-            .Replace("{{SAVE_DATA_URL}}", saveDataUrl)
+            .Replace("{{SAVE_DATA_URL}}", JsonSerializer.Serialize(saveDataUrl))
+            .Replace("{{CLIENT_RESULTS_URL}}", JsonSerializer.Serialize(clientResultsUrl))
             .Replace("{{API_PATH}}", apiPath);
 
         // Ensure output directory exists
@@ -106,7 +109,10 @@ public class NginxHostedService : IHostedService, IDisposable
         }
 
         await File.WriteAllTextAsync(outputPath, configJs);
-        _logger.LogInformation("Generated config.js with save URL: {SaveUrl}", saveDataUrl);
+        _logger.LogInformation(
+            "Generated config.js with save URL {SaveUrl} and client results URL {ClientResultsUrl}",
+            saveDataUrl,
+            clientResultsUrl);
     }
 
     private Task<Dictionary<string, string>> LoadConfigurationAsync()
@@ -126,6 +132,8 @@ public class NginxHostedService : IHostedService, IDisposable
                     LoadRegistryValue(config, key, "REVERSE_PROXIED_HOST_NAME");
                     LoadRegistryValue(config, key, "REVERSE_PROXIED_PORT");
                     LoadRegistryValue(config, key, "OPENSPEEDTEST_PORT");
+                    LoadRegistryValue(config, key, "OPENSPEEDTEST_SAVE_DATA_URL");
+                    LoadRegistryValue(config, key, "OPENSPEEDTEST_CLIENT_RESULTS_URL");
                 }
             }
             catch (Exception ex)
@@ -140,6 +148,8 @@ public class NginxHostedService : IHostedService, IDisposable
         OverrideFromConfiguration(config, "REVERSE_PROXIED_HOST_NAME");
         OverrideFromConfiguration(config, "REVERSE_PROXIED_PORT");
         OverrideFromConfiguration(config, "OPENSPEEDTEST_PORT");
+        OverrideFromConfiguration(config, "OPENSPEEDTEST_SAVE_DATA_URL");
+        OverrideFromConfiguration(config, "OPENSPEEDTEST_CLIENT_RESULTS_URL");
 
         return Task.FromResult(config);
     }
@@ -165,8 +175,14 @@ public class NginxHostedService : IHostedService, IDisposable
         }
     }
 
-    private string ConstructSaveDataUrl(Dictionary<string, string> config, string apiPath)
+    internal static string ConstructSaveDataUrl(IReadOnlyDictionary<string, string> config, string apiPath)
     {
+        if (config.TryGetValue("OPENSPEEDTEST_SAVE_DATA_URL", out var configuredUrl)
+            && !string.IsNullOrWhiteSpace(configuredUrl))
+        {
+            return ValidateConfiguredUrl(configuredUrl, "OPENSPEEDTEST_SAVE_DATA_URL");
+        }
+
         // Priority: REVERSE_PROXIED_HOST_NAME (https) > HOST_NAME (http) > HOST_IP (http) > __DYNAMIC__
         // IMPORTANT: Keep this logic in sync with docker/openspeedtest/entrypoint.sh (Docker deployment)
         config.TryGetValue("REVERSE_PROXIED_HOST_NAME", out var reverseProxy);
@@ -194,6 +210,33 @@ public class NginxHostedService : IHostedService, IDisposable
             // No explicit host configured - use dynamic URL (constructed client-side from browser location)
             return "__DYNAMIC__";
         }
+    }
+
+    internal static string ConstructClientResultsUrl(IReadOnlyDictionary<string, string> config)
+    {
+        if (config.TryGetValue("OPENSPEEDTEST_CLIENT_RESULTS_URL", out var configuredUrl)
+            && !string.IsNullOrWhiteSpace(configuredUrl))
+        {
+            return ValidateConfiguredUrl(configuredUrl, "OPENSPEEDTEST_CLIENT_RESULTS_URL");
+        }
+
+        return "__FROM_SAVE_DATA_URL__";
+    }
+
+    private static string ValidateConfiguredUrl(string value, string key)
+    {
+        var url = value.Trim();
+        if (url.StartsWith('/') && !url.StartsWith("//", StringComparison.Ordinal))
+            return url;
+
+        if (Uri.TryCreate(url, UriKind.Absolute, out var parsed)
+            && (parsed.Scheme == Uri.UriSchemeHttp || parsed.Scheme == Uri.UriSchemeHttps))
+        {
+            return url;
+        }
+
+        throw new InvalidOperationException(
+            $"{key} must be an absolute HTTP(S) URL or a root-relative path");
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Web.Tests/NginxHostedServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NginxHostedServiceTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class NginxHostedServiceTests
+{
+    [Fact]
+    public void ConstructUrls_UsesIndependentConfiguredRoutes()
+    {
+        var config = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["OPENSPEEDTEST_SAVE_DATA_URL"] = "/api/public/speedtest/results",
+            ["OPENSPEEDTEST_CLIENT_RESULTS_URL"] = "https://optimizer.example/client-speedtest"
+        };
+
+        NginxHostedService.ConstructSaveDataUrl(config, "/ignored")
+            .Should().Be("/api/public/speedtest/results");
+        NginxHostedService.ConstructClientResultsUrl(config)
+            .Should().Be("https://optimizer.example/client-speedtest");
+    }
+
+    [Fact]
+    public void ConstructUrls_PreservesExistingDefaults()
+    {
+        var config = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["REVERSE_PROXIED_HOST_NAME"] = "optimizer.example"
+        };
+
+        NginxHostedService.ConstructSaveDataUrl(config, "/api/public/speedtest/results")
+            .Should().Be("https://optimizer.example/api/public/speedtest/results");
+        NginxHostedService.ConstructClientResultsUrl(config)
+            .Should().Be("__FROM_SAVE_DATA_URL__");
+    }
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("//unexpected.example/results")]
+    [InlineData("relative/results")]
+    public void ConstructSaveDataUrl_RejectsUnsafeConfiguredValues(string value)
+    {
+        var config = new Dictionary<string, string>
+        {
+            ["OPENSPEEDTEST_SAVE_DATA_URL"] = value
+        };
+
+        var act = () => NginxHostedService.ConstructSaveDataUrl(config, "/api/results");
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
## Problem

The native OpenSpeedTest template assumes that result submissions and the Network Optimizer results page share one origin derived from `SAVE_DATA_URL`. Reverse-proxy deployments can legitimately serve the test UI on one host, submit results through a same-origin API route there, and show saved results on the Network Optimizer host.

Today those deployments have to rewrite the installed template after every update.

## Fix

- add optional `OPENSPEEDTEST_SAVE_DATA_URL` and `OPENSPEEDTEST_CLIENT_RESULTS_URL` settings
- preserve the current derived URLs when neither setting is present
- accept only absolute HTTP(S) URLs or root-relative paths
- JSON-encode generated JavaScript values rather than interpolating raw strings
- document the two settings for native macOS installs

## Validation

- tests cover independent routes, unchanged defaults, and rejection of unsafe URL shapes
- focused tests: 5 passed
- full Release `NetworkOptimizer.Web.Tests`: 1,285 passed

No deployed OpenSpeedTest files or proxy routes were changed while validating this fix.
