### PR TITLE
Install a verified Ookla CLI for adaptive SQM

### DIFF
--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -10,6 +10,11 @@ namespace NetworkOptimizer.Sqm;
 /// </summary>
 public class ScriptGenerator
 {
+    public const string ManagedSpeedtestPath = "/data/network-optimizer/bin/speedtest";
+    public const string ManagedSpeedtestArchiveRelease = "1.2.0";
+    public const string ManagedSpeedtestCliVersion = "1.2.0.84";
+    public const string ManagedSpeedtestBuildId = "ea6b6773cf";
+
     private readonly SqmConfiguration _config;
     private readonly string _name; // Normalized name for files (e.g., "wan1", "wan2")
     private readonly int _initialDelaySeconds; // Delay before first speedtest (for staggering multiple WANs)
@@ -75,6 +80,16 @@ public class ScriptGenerator
         sb.AppendLine("PING_SCRIPT=\"$SQM_DIR/${SQM_NAME}-ping.sh\"");
         sb.AppendLine("RESULT_FILE=\"$SQM_DIR/${SQM_NAME}-result.txt\"");
         sb.AppendLine("LOG_FILE=\"/var/log/sqm-${SQM_NAME}.log\"");
+        sb.AppendLine($"SPEEDTEST_BIN=\"{ManagedSpeedtestPath}\"");
+        sb.AppendLine($"SPEEDTEST_RELEASE=\"{ManagedSpeedtestArchiveRelease}\"");
+        sb.AppendLine($"SPEEDTEST_CLI_VERSION=\"{ManagedSpeedtestCliVersion}\"");
+        sb.AppendLine($"SPEEDTEST_BUILD_ID=\"{ManagedSpeedtestBuildId}\"");
+        sb.AppendLine();
+        sb.AppendLine("fail_boot() {");
+        sb.AppendLine("    echo \"[$(date)] ERROR: $*\" >> \"$LOG_FILE\"");
+        sb.AppendLine("    echo \"ERROR: $*\" >&2");
+        sb.AppendLine("    exit 1");
+        sb.AppendLine("}");
         sb.AppendLine();
         // Rotate log on boot/deploy: keep last 2000 lines (~1.5 days at 1 min ping interval)
         sb.AppendLine("# Rotate log to prevent unbounded growth");
@@ -90,19 +105,64 @@ public class ScriptGenerator
         sb.AppendLine("# Section 1: Install Dependencies");
         sb.AppendLine("# ============================================");
         sb.AppendLine();
-        sb.AppendLine("# Install official Ookla speedtest if not present");
-        sb.AppendLine("if ! which speedtest > /dev/null 2>&1; then");
-        sb.AppendLine("    echo \"Installing Ookla speedtest...\" >> $LOG_FILE");
-        sb.AppendLine("    # Remove UniFi's speedtest if present");
-        sb.AppendLine("    apt-get remove -y speedtest 2>/dev/null || true");
-        sb.AppendLine("    # Install official Speedtest by Ookla");
-        sb.AppendLine("    curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash");
-        sb.AppendLine("    apt-get install -y speedtest");
+        sb.AppendLine("# Install the reviewed Ookla build without changing UniFi-managed packages");
+        sb.AppendLine("for required_command in curl tar sha256sum; do");
+        sb.AppendLine("    command -v \"$required_command\" >/dev/null 2>&1 || fail_boot \"required command not found: $required_command\"");
+        sb.AppendLine("done");
+        sb.AppendLine("case \"$(uname -m)\" in");
+        sb.AppendLine("    aarch64|arm64)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"aarch64\"");
+        sb.AppendLine("        SPEEDTEST_ARCHIVE_SHA256=\"3953d231da3783e2bf8904b6dd72767c5c6e533e163d3742fd0437affa431bd3\"");
+        sb.AppendLine("        SPEEDTEST_BINARY_SHA256=\"d99fa13293f658b53eaa79fe81f4b210db39fdfc1e9698f33da3f234a6008df7\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    armv7l|armv7)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"armhf\"");
+        sb.AppendLine("        SPEEDTEST_ARCHIVE_SHA256=\"e45fcdebbd8a185553535533dd032d6b10bc8c64eee4139b1147b9c09835d08d\"");
+        sb.AppendLine("        SPEEDTEST_BINARY_SHA256=\"66ad57568664e6f8580e14ad67316a57038fd22b30548bef98531df4ebcc8956\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    x86_64|amd64)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"x86_64\"");
+        sb.AppendLine("        SPEEDTEST_ARCHIVE_SHA256=\"5690596c54ff9bed63fa3732f818a05dbc2db19ad36ed68f21ca5f64d5cfeeb7\"");
+        sb.AppendLine("        SPEEDTEST_BINARY_SHA256=\"31f1124c5ab8acdae6b9fe1741e704df420f9f2e7d429679fabe62075453c051\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    *) fail_boot \"unsupported gateway architecture: $(uname -m)\" ;;");
+        sb.AppendLine("esac");
+        sb.AppendLine("SPEEDTEST_URL=\"https://install.speedtest.net/app/cli/ookla-speedtest-${SPEEDTEST_RELEASE}-linux-${SPEEDTEST_ARCH}.tgz\"");
+        sb.AppendLine();
+        sb.AppendLine("speedtest_is_valid() {");
+        sb.AppendLine("    [ -f \"$SPEEDTEST_BIN\" ] && [ ! -L \"$SPEEDTEST_BIN\" ] && [ -x \"$SPEEDTEST_BIN\" ] \\");
+        sb.AppendLine("        && printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_BIN\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        && \"$SPEEDTEST_BIN\" --version 2>/dev/null | head -n 1 | grep -Fq \"Speedtest by Ookla ${SPEEDTEST_CLI_VERSION} (${SPEEDTEST_BUILD_ID})\"");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("if ! speedtest_is_valid; then");
+        sb.AppendLine("    echo \"[$(date)] Installing Ookla speedtest ${SPEEDTEST_CLI_VERSION}...\" >> \"$LOG_FILE\"");
+        sb.AppendLine("    SPEEDTEST_DIR=$(dirname \"$SPEEDTEST_BIN\")");
+        sb.AppendLine("    mkdir -p \"$SPEEDTEST_DIR\"");
+        sb.AppendLine("    SPEEDTEST_STAGE=$(mktemp -d \"${SPEEDTEST_DIR}/.speedtest-install.XXXXXX\") || fail_boot \"could not create speedtest staging directory\"");
+        sb.AppendLine("    cleanup_speedtest_stage() { rm -rf \"$SPEEDTEST_STAGE\"; }");
+        sb.AppendLine("    trap cleanup_speedtest_stage EXIT");
+        sb.AppendLine("    trap 'cleanup_speedtest_stage; exit 1' HUP INT TERM");
+        sb.AppendLine("    curl --fail --silent --show-error --location --proto '=https' --max-time 120 --max-filesize 4194304 \"$SPEEDTEST_URL\" -o \"$SPEEDTEST_STAGE/speedtest.tgz\" \\");
+        sb.AppendLine("        || fail_boot \"failed to download Ookla speedtest\"");
+        sb.AppendLine("    printf '%s  %s\\n' \"$SPEEDTEST_ARCHIVE_SHA256\" \"$SPEEDTEST_STAGE/speedtest.tgz\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        || fail_boot \"Ookla speedtest archive checksum mismatch\"");
+        sb.AppendLine("    tar -xzf \"$SPEEDTEST_STAGE/speedtest.tgz\" -C \"$SPEEDTEST_STAGE\" speedtest \\");
+        sb.AppendLine("        || fail_boot \"failed to extract Ookla speedtest\"");
+        sb.AppendLine("    [ -f \"$SPEEDTEST_STAGE/speedtest\" ] && [ ! -L \"$SPEEDTEST_STAGE/speedtest\" ] \\");
+        sb.AppendLine("        || fail_boot \"Ookla speedtest archive did not contain a regular binary\"");
+        sb.AppendLine("    chmod 0755 \"$SPEEDTEST_STAGE/speedtest\"");
+        sb.AppendLine("    printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_STAGE/speedtest\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        || fail_boot \"Ookla speedtest binary checksum mismatch\"");
+        sb.AppendLine("    mv -f \"$SPEEDTEST_STAGE/speedtest\" \"${SPEEDTEST_BIN}.new\"");
+        sb.AppendLine("    mv -f \"${SPEEDTEST_BIN}.new\" \"$SPEEDTEST_BIN\"");
+        sb.AppendLine("    speedtest_is_valid || fail_boot \"installed Ookla speedtest failed validation\"");
+        sb.AppendLine("    cleanup_speedtest_stage");
+        sb.AppendLine("    trap - EXIT HUP INT TERM");
         sb.AppendLine("fi");
         sb.AppendLine();
         // Refresh the package index once if either base dependency is missing, so a
-        // console with stale/empty apt lists can still resolve bc/jq. The Ookla block
-        // above gets its index refresh from the packagecloud script; these don't.
+        // console with stale/empty apt lists can still resolve bc/jq.
         sb.AppendLine("# Refresh package lists once if a base dependency is missing");
         sb.AppendLine("if ! which bc > /dev/null 2>&1 || ! which jq > /dev/null 2>&1; then");
         sb.AppendLine("    apt-get update");
@@ -253,6 +313,15 @@ public class ScriptGenerator
         sb.AppendLine($"LINK_SPEED_HEADROOM=\"0.98\"");
         sb.AppendLine($"RESULT_FILE=\"/data/sqm/{_name}-result.txt\"");
         sb.AppendLine($"LOG_FILE=\"/var/log/sqm-{_name}.log\"");
+        sb.AppendLine($"SPEEDTEST_BIN=\"{ManagedSpeedtestPath}\"");
+        sb.AppendLine($"SPEEDTEST_CLI_VERSION=\"{ManagedSpeedtestCliVersion}\"");
+        sb.AppendLine($"SPEEDTEST_BUILD_ID=\"{ManagedSpeedtestBuildId}\"");
+        sb.AppendLine("case \"$(uname -m)\" in");
+        sb.AppendLine("    aarch64|arm64) SPEEDTEST_BINARY_SHA256=\"d99fa13293f658b53eaa79fe81f4b210db39fdfc1e9698f33da3f234a6008df7\" ;;");
+        sb.AppendLine("    armv7l|armv7) SPEEDTEST_BINARY_SHA256=\"66ad57568664e6f8580e14ad67316a57038fd22b30548bef98531df4ebcc8956\" ;;");
+        sb.AppendLine("    x86_64|amd64) SPEEDTEST_BINARY_SHA256=\"31f1124c5ab8acdae6b9fe1741e704df420f9f2e7d429679fabe62075453c051\" ;;");
+        sb.AppendLine("    *) SPEEDTEST_BINARY_SHA256=\"unsupported\" ;;");
+        sb.AppendLine("esac");
         sb.AppendLine();
 
         // Baseline data
@@ -265,9 +334,12 @@ public class ScriptGenerator
         sb.AppendLine();
 
         // Check for speedtest
-        sb.AppendLine("# Check if speedtest is installed");
-        sb.AppendLine("if ! which speedtest > /dev/null 2>&1; then");
-        sb.AppendLine("    echo \"[$(date)] ERROR: speedtest not found\" >> $LOG_FILE");
+        sb.AppendLine("# Validate the exact managed speedtest build before changing TC rates");
+        sb.AppendLine("if [ \"$SPEEDTEST_BINARY_SHA256\" = \"unsupported\" ] \\");
+        sb.AppendLine("    || [ ! -f \"$SPEEDTEST_BIN\" ] || [ -L \"$SPEEDTEST_BIN\" ] || [ ! -x \"$SPEEDTEST_BIN\" ] \\");
+        sb.AppendLine("    || ! printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_BIN\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("    || ! \"$SPEEDTEST_BIN\" --version 2>/dev/null | head -n 1 | grep -Fq \"Speedtest by Ookla ${SPEEDTEST_CLI_VERSION} (${SPEEDTEST_BUILD_ID})\"; then");
+        sb.AppendLine("    echo \"[$(date)] ERROR: managed speedtest binary is missing or failed validation\" >> $LOG_FILE");
         sb.AppendLine("    exit 1");
         sb.AppendLine("fi");
         sb.AppendLine();
@@ -306,7 +378,7 @@ public class ScriptGenerator
             ? ""
             : $" --server-id={_config.PreferredSpeedtestServerId}";
         sb.AppendLine("# Run speedtest");
-        sb.AppendLine($"speedtest_output=$(speedtest --accept-license --accept-gdpr --format=json --interface=$INTERFACE{serverIdArg})");
+        sb.AppendLine($"speedtest_output=$(\"$SPEEDTEST_BIN\" --accept-license --accept-gdpr --format=json --interface=$INTERFACE{serverIdArg})");
         sb.AppendLine();
         sb.AppendLine("# Parse download speed (bytes/sec to Mbps)");
         sb.AppendLine("download_speed_bytes=$(echo \"$speedtest_output\" | jq .download.bandwidth)");

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -10,6 +10,17 @@ namespace NetworkOptimizer.Sqm;
 /// </summary>
 public class ScriptGenerator
 {
+    public const string ManagedSpeedtestPath = "/data/network-optimizer/bin/speedtest";
+    public const string ManagedSpeedtestArchiveRelease = "1.2.0";
+    public const string ManagedSpeedtestCliVersion = "1.2.0.84";
+    public const string ManagedSpeedtestBuildId = "ea6b6773cf";
+    public const string ManagedSpeedtestAarch64ArchiveSha256 = "3953d231da3783e2bf8904b6dd72767c5c6e533e163d3742fd0437affa431bd3";
+    public const string ManagedSpeedtestAarch64BinarySha256 = "d99fa13293f658b53eaa79fe81f4b210db39fdfc1e9698f33da3f234a6008df7";
+    public const string ManagedSpeedtestArmhfArchiveSha256 = "e45fcdebbd8a185553535533dd032d6b10bc8c64eee4139b1147b9c09835d08d";
+    public const string ManagedSpeedtestArmhfBinarySha256 = "66ad57568664e6f8580e14ad67316a57038fd22b30548bef98531df4ebcc8956";
+    public const string ManagedSpeedtestX86_64ArchiveSha256 = "5690596c54ff9bed63fa3732f818a05dbc2db19ad36ed68f21ca5f64d5cfeeb7";
+    public const string ManagedSpeedtestX86_64BinarySha256 = "31f1124c5ab8acdae6b9fe1741e704df420f9f2e7d429679fabe62075453c051";
+
     private readonly SqmConfiguration _config;
     private readonly string _name; // Normalized name for files (e.g., "wan1", "wan2")
     private readonly int _initialDelaySeconds; // Delay before first speedtest (for staggering multiple WANs)
@@ -75,6 +86,15 @@ public class ScriptGenerator
         sb.AppendLine("PING_SCRIPT=\"$SQM_DIR/${SQM_NAME}-ping.sh\"");
         sb.AppendLine("RESULT_FILE=\"$SQM_DIR/${SQM_NAME}-result.txt\"");
         sb.AppendLine("LOG_FILE=\"/var/log/sqm-${SQM_NAME}.log\"");
+        sb.AppendLine($"SPEEDTEST_BIN=\"{ManagedSpeedtestPath}\"");
+        sb.AppendLine($"SPEEDTEST_RELEASE=\"{ManagedSpeedtestArchiveRelease}\"");
+        sb.AppendLine($"SPEEDTEST_CLI_VERSION=\"{ManagedSpeedtestCliVersion}\"");
+        sb.AppendLine($"SPEEDTEST_BUILD_ID=\"{ManagedSpeedtestBuildId}\"");
+        sb.AppendLine();
+        sb.AppendLine("log_speedtest_install_error() {");
+        sb.AppendLine("    echo \"[$(date)] ERROR: $*\" >> \"$LOG_FILE\"");
+        sb.AppendLine("    echo \"ERROR: $*\" >&2");
+        sb.AppendLine("}");
         sb.AppendLine();
         // Rotate log on boot/deploy: keep last 2000 lines (~1.5 days at 1 min ping interval)
         sb.AppendLine("# Rotate log to prevent unbounded growth");
@@ -90,19 +110,94 @@ public class ScriptGenerator
         sb.AppendLine("# Section 1: Install Dependencies");
         sb.AppendLine("# ============================================");
         sb.AppendLine();
-        sb.AppendLine("# Install official Ookla speedtest if not present");
-        sb.AppendLine("if ! which speedtest > /dev/null 2>&1; then");
-        sb.AppendLine("    echo \"Installing Ookla speedtest...\" >> $LOG_FILE");
-        sb.AppendLine("    # Remove UniFi's speedtest if present");
-        sb.AppendLine("    apt-get remove -y speedtest 2>/dev/null || true");
-        sb.AppendLine("    # Install official Speedtest by Ookla");
-        sb.AppendLine("    curl -s https://packagecloud.io/install/repositories/ookla/speedtest-cli/script.deb.sh | bash");
-        sb.AppendLine("    apt-get install -y speedtest");
+        sb.AppendLine("case \"$(uname -m)\" in");
+        sb.AppendLine("    aarch64|arm64)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"aarch64\"");
+        sb.AppendLine($"        SPEEDTEST_ARCHIVE_SHA256=\"{ManagedSpeedtestAarch64ArchiveSha256}\"");
+        sb.AppendLine($"        SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestAarch64BinarySha256}\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    armv7l|armv7)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"armhf\"");
+        sb.AppendLine($"        SPEEDTEST_ARCHIVE_SHA256=\"{ManagedSpeedtestArmhfArchiveSha256}\"");
+        sb.AppendLine($"        SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestArmhfBinarySha256}\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    x86_64|amd64)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"x86_64\"");
+        sb.AppendLine($"        SPEEDTEST_ARCHIVE_SHA256=\"{ManagedSpeedtestX86_64ArchiveSha256}\"");
+        sb.AppendLine($"        SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestX86_64BinarySha256}\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("    *)");
+        sb.AppendLine("        SPEEDTEST_ARCH=\"unsupported\"");
+        sb.AppendLine("        SPEEDTEST_ARCHIVE_SHA256=\"unsupported\"");
+        sb.AppendLine("        SPEEDTEST_BINARY_SHA256=\"unsupported\"");
+        sb.AppendLine("        ;;");
+        sb.AppendLine("esac");
+        sb.AppendLine("SPEEDTEST_URL=\"https://install.speedtest.net/app/cli/ookla-speedtest-${SPEEDTEST_RELEASE}-linux-${SPEEDTEST_ARCH}.tgz\"");
+        sb.AppendLine();
+        sb.AppendLine("speedtest_is_valid() {");
+        sb.AppendLine("    [ \"$SPEEDTEST_BINARY_SHA256\" != \"unsupported\" ] && command -v sha256sum >/dev/null 2>&1 \\");
+        sb.AppendLine("        && [ -f \"$SPEEDTEST_BIN\" ] && [ ! -L \"$SPEEDTEST_BIN\" ] && [ -x \"$SPEEDTEST_BIN\" ] \\");
+        sb.AppendLine("        && printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_BIN\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        && \"$SPEEDTEST_BIN\" --version 2>/dev/null | head -n 1 | grep -Fq \"Speedtest by Ookla ${SPEEDTEST_CLI_VERSION} (${SPEEDTEST_BUILD_ID})\"");
+        sb.AppendLine("}");
+        sb.AppendLine();
+        sb.AppendLine("install_managed_speedtest() (");
+        sb.AppendLine("    for required_command in curl tar sha256sum; do");
+        sb.AppendLine("        if ! command -v \"$required_command\" >/dev/null 2>&1; then");
+        sb.AppendLine("            log_speedtest_install_error \"required command not found: $required_command\"");
+        sb.AppendLine("            return 1");
+        sb.AppendLine("        fi");
+        sb.AppendLine("    done");
+        sb.AppendLine("    if [ \"$SPEEDTEST_ARCH\" = \"unsupported\" ]; then");
+        sb.AppendLine("        log_speedtest_install_error \"unsupported gateway architecture: $(uname -m)\"");
+        sb.AppendLine("        return 1");
+        sb.AppendLine("    fi");
+        sb.AppendLine("    SPEEDTEST_DIR=$(dirname \"$SPEEDTEST_BIN\")");
+        sb.AppendLine("    if ! mkdir -p \"$SPEEDTEST_DIR\"; then");
+        sb.AppendLine("        log_speedtest_install_error \"could not create speedtest directory\"");
+        sb.AppendLine("        return 1");
+        sb.AppendLine("    fi");
+        sb.AppendLine("    SPEEDTEST_STAGE=$(mktemp -d \"${SPEEDTEST_DIR}/.speedtest-install.XXXXXX\") || {");
+        sb.AppendLine("        log_speedtest_install_error \"could not create speedtest staging directory\"");
+        sb.AppendLine("        return 1");
+        sb.AppendLine("    }");
+        sb.AppendLine("    cleanup_speedtest_stage() {");
+        sb.AppendLine("        rm -rf \"$SPEEDTEST_STAGE\"");
+        sb.AppendLine("        rm -f \"${SPEEDTEST_BIN}.new\"");
+        sb.AppendLine("    }");
+        sb.AppendLine("    trap cleanup_speedtest_stage EXIT");
+        sb.AppendLine("    trap 'exit 1' HUP INT TERM");
+        sb.AppendLine("    curl --fail --silent --show-error --location --proto '=https' --max-time 120 --max-filesize 4194304 \"$SPEEDTEST_URL\" -o \"$SPEEDTEST_STAGE/speedtest.tgz\" \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"failed to download Ookla speedtest\"; return 1; }");
+        sb.AppendLine("    printf '%s  %s\\n' \"$SPEEDTEST_ARCHIVE_SHA256\" \"$SPEEDTEST_STAGE/speedtest.tgz\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"Ookla speedtest archive checksum mismatch\"; return 1; }");
+        sb.AppendLine("    tar -xzf \"$SPEEDTEST_STAGE/speedtest.tgz\" -C \"$SPEEDTEST_STAGE\" speedtest \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"failed to extract Ookla speedtest\"; return 1; }");
+        sb.AppendLine("    [ -f \"$SPEEDTEST_STAGE/speedtest\" ] && [ ! -L \"$SPEEDTEST_STAGE/speedtest\" ] \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"Ookla speedtest archive did not contain a regular binary\"; return 1; }");
+        sb.AppendLine("    chmod 0755 \"$SPEEDTEST_STAGE/speedtest\" \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"could not make Ookla speedtest executable\"; return 1; }");
+        sb.AppendLine("    printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_STAGE/speedtest\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"Ookla speedtest binary checksum mismatch\"; return 1; }");
+        sb.AppendLine("    mv -f \"$SPEEDTEST_STAGE/speedtest\" \"${SPEEDTEST_BIN}.new\" \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"could not stage Ookla speedtest\"; return 1; }");
+        sb.AppendLine("    mv -f \"${SPEEDTEST_BIN}.new\" \"$SPEEDTEST_BIN\" \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"could not activate Ookla speedtest\"; return 1; }");
+        sb.AppendLine("    speedtest_is_valid \\");
+        sb.AppendLine("        || { log_speedtest_install_error \"installed Ookla speedtest failed validation\"; return 1; }");
+        sb.AppendLine(")");
+        sb.AppendLine();
+        sb.AppendLine("# A missing calibration CLI should not prevent the SQM scripts and cron entries from deploying.");
+        sb.AppendLine("if ! speedtest_is_valid; then");
+        sb.AppendLine("    echo \"[$(date)] Installing Ookla speedtest ${SPEEDTEST_CLI_VERSION}...\" >> \"$LOG_FILE\"");
+        sb.AppendLine("    if ! install_managed_speedtest; then");
+        sb.AppendLine("        echo \"[$(date)] WARNING: Ookla speedtest installation failed; continuing without adaptive calibration\" >> \"$LOG_FILE\"");
+        sb.AppendLine("        echo \"WARNING: Ookla speedtest installation failed; continuing without adaptive calibration\" >&2");
+        sb.AppendLine("    fi");
         sb.AppendLine("fi");
         sb.AppendLine();
         // Refresh the package index once if either base dependency is missing, so a
-        // console with stale/empty apt lists can still resolve bc/jq. The Ookla block
-        // above gets its index refresh from the packagecloud script; these don't.
+        // console with stale/empty apt lists can still resolve bc/jq.
         sb.AppendLine("# Refresh package lists once if a base dependency is missing");
         sb.AppendLine("if ! which bc > /dev/null 2>&1 || ! which jq > /dev/null 2>&1; then");
         sb.AppendLine("    apt-get update");
@@ -253,6 +348,15 @@ public class ScriptGenerator
         sb.AppendLine($"LINK_SPEED_HEADROOM=\"0.98\"");
         sb.AppendLine($"RESULT_FILE=\"/data/sqm/{_name}-result.txt\"");
         sb.AppendLine($"LOG_FILE=\"/var/log/sqm-{_name}.log\"");
+        sb.AppendLine($"SPEEDTEST_BIN=\"{ManagedSpeedtestPath}\"");
+        sb.AppendLine($"SPEEDTEST_CLI_VERSION=\"{ManagedSpeedtestCliVersion}\"");
+        sb.AppendLine($"SPEEDTEST_BUILD_ID=\"{ManagedSpeedtestBuildId}\"");
+        sb.AppendLine("case \"$(uname -m)\" in");
+        sb.AppendLine($"    aarch64|arm64) SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestAarch64BinarySha256}\" ;;");
+        sb.AppendLine($"    armv7l|armv7) SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestArmhfBinarySha256}\" ;;");
+        sb.AppendLine($"    x86_64|amd64) SPEEDTEST_BINARY_SHA256=\"{ManagedSpeedtestX86_64BinarySha256}\" ;;");
+        sb.AppendLine("    *) SPEEDTEST_BINARY_SHA256=\"unsupported\" ;;");
+        sb.AppendLine("esac");
         sb.AppendLine();
 
         // Baseline data
@@ -265,9 +369,12 @@ public class ScriptGenerator
         sb.AppendLine();
 
         // Check for speedtest
-        sb.AppendLine("# Check if speedtest is installed");
-        sb.AppendLine("if ! which speedtest > /dev/null 2>&1; then");
-        sb.AppendLine("    echo \"[$(date)] ERROR: speedtest not found\" >> $LOG_FILE");
+        sb.AppendLine("# Validate the exact managed speedtest build before changing TC rates");
+        sb.AppendLine("if [ \"$SPEEDTEST_BINARY_SHA256\" = \"unsupported\" ] \\");
+        sb.AppendLine("    || [ ! -f \"$SPEEDTEST_BIN\" ] || [ -L \"$SPEEDTEST_BIN\" ] || [ ! -x \"$SPEEDTEST_BIN\" ] \\");
+        sb.AppendLine("    || ! printf '%s  %s\\n' \"$SPEEDTEST_BINARY_SHA256\" \"$SPEEDTEST_BIN\" | sha256sum -c - >/dev/null 2>&1 \\");
+        sb.AppendLine("    || ! \"$SPEEDTEST_BIN\" --version 2>/dev/null | head -n 1 | grep -Fq \"Speedtest by Ookla ${SPEEDTEST_CLI_VERSION} (${SPEEDTEST_BUILD_ID})\"; then");
+        sb.AppendLine("    echo \"[$(date)] ERROR: managed speedtest binary is missing or failed validation\" >> $LOG_FILE");
         sb.AppendLine("    exit 1");
         sb.AppendLine("fi");
         sb.AppendLine();
@@ -306,7 +413,7 @@ public class ScriptGenerator
             ? ""
             : $" --server-id={_config.PreferredSpeedtestServerId}";
         sb.AppendLine("# Run speedtest");
-        sb.AppendLine($"speedtest_output=$(speedtest --accept-license --accept-gdpr --format=json --interface=$INTERFACE{serverIdArg})");
+        sb.AppendLine($"speedtest_output=$(\"$SPEEDTEST_BIN\" --accept-license --accept-gdpr --format=json --interface=$INTERFACE{serverIdArg})");
         sb.AppendLine();
         sb.AppendLine("# Parse download speed (bytes/sec to Mbps)");
         sb.AppendLine("download_speed_bytes=$(echo \"$speedtest_output\" | jq .download.bandwidth)");

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2661,6 +2661,8 @@
     private HistoricStatSnapshot? _historicSnapshot;
     // Seeks overlap during a drag, and a slow older query must not land over a newer answer.
     private int _historicSnapshotSeq;
+    // The instant the landed snapshot's WAN rate describes; Bandwidth Hogs asks once it matches the playhead.
+    private DateTime? _hogsWanRateAt;
 
     // Setup is the default so a site that cannot finish initializing - unreachable InfluxDB,
     // failing SNMP - still lands where it can be fixed. It just must not RENDER before the
@@ -4437,6 +4439,7 @@
             ClearLinkedInstant();
             _mapHistoricAt = null;
             _historicSnapshot = null;
+            _hogsWanRateAt = null;
             Interlocked.Increment(ref _historicSnapshotSeq);
             await InvokeAsync(StateHasChanged);
             return;
@@ -4733,6 +4736,7 @@
 
         // A newer seek (or a return to live) has superseded this instant.
         if (seq != _historicSnapshotSeq) return;
+        _hogsWanRateAt = at;
         _historicSnapshot = new HistoricStatSnapshot
         {
             PerWan = perWan,
@@ -5003,7 +5007,7 @@
     private RenderFragment BandwidthHogs => __builder =>
     {
         var wanRates = GetWanRates();
-        <BandwidthHogsCard HistoricAt="_mapHistoricAt" Paused="_mapPaused"
+        <BandwidthHogsCard HistoricAt="_mapHistoricAt" Paused="_mapPaused" WanRateAt="_hogsWanRateAt"
                            WanDownBps="wanRates.download" WanUpBps="wanRates.upload"
                            WanKeys="LiveWan.SelectedKeys" WanHistoryKeys="GetWanHistoryKeys()"
                            MultiWan="_multiWanUiVisible" />
@@ -5707,6 +5711,7 @@
             _mapMounted = false;
             _mapHistoricAt = null;
             _historicSnapshot = null;
+            _hogsWanRateAt = null;
             Interlocked.Increment(ref _historicSnapshotSeq);
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2659,6 +2659,8 @@
     private DotNetObjectReference<Monitoring>? _mapDotNetRef;
     private DateTime? _mapHistoricAt;
     private HistoricStatSnapshot? _historicSnapshot;
+    // Seeks overlap during a drag, and a slow older query must not land over a newer answer.
+    private int _historicSnapshotSeq;
 
     // Setup is the default so a site that cannot finish initializing - unreachable InfluxDB,
     // failing SNMP - still lands where it can be fixed. It just must not RENDER before the
@@ -4435,6 +4437,7 @@
             ClearLinkedInstant();
             _mapHistoricAt = null;
             _historicSnapshot = null;
+            Interlocked.Increment(ref _historicSnapshotSeq);
             await InvokeAsync(StateHasChanged);
             return;
         }
@@ -4516,6 +4519,7 @@
 
     private async Task FetchHistoricSnapshotAsync(DateTime at)
     {
+        var seq = Interlocked.Increment(ref _historicSnapshotSeq);
         var from = at.AddSeconds(-90);
         var to = at.AddSeconds(30);
 
@@ -4727,6 +4731,8 @@
             ? await BuildPerWanLatencyAsync(from, to, at)
             : new Dictionary<string, WanLatencySnapshot>();
 
+        // A newer seek (or a return to live) has superseded this instant.
+        if (seq != _historicSnapshotSeq) return;
         _historicSnapshot = new HistoricStatSnapshot
         {
             PerWan = perWan,
@@ -5701,6 +5707,7 @@
             _mapMounted = false;
             _mapHistoricAt = null;
             _historicSnapshot = null;
+            Interlocked.Increment(ref _historicSnapshotSeq);
             try { await JS.InvokeVoidAsync("eval", "window.__lanFlowMap?.unmount();"); }
             catch { }
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/BandwidthHogsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/BandwidthHogsCard.razor
@@ -332,7 +332,10 @@
     private int _loading;
     private bool _ready;
     private DateTime? _loadedAt;
-    private string _loadedWanKeys = "";
+    private string _loadedSeekKey = "";
+    // Cancels the answer in flight when the playhead moves: whatever it was answering for is
+    // behind the user now, and rendering it anyway is what made a scrub land twice.
+    private CancellationTokenSource? _refreshCts;
     private System.Threading.Timer? _timer;
     private System.Threading.Timer? _seekTimer;
     // Timers are armed after awaits. If the circuit is torn down during one, Dispose has already
@@ -415,9 +418,9 @@
     protected override void OnParametersSet()
     {
         if (!_ready) return;
-        var wanKeys = string.Join(",", WanKeys);
-        if (HistoricAt != _loadedAt || (HistoricAt != null && wanKeys != _loadedWanKeys))
+        if (HistoricAt != _loadedAt || SeekKey() != _loadedSeekKey)
         {
+            _refreshCts?.Cancel();
             ScheduleSeekRefresh();
             return;
         }
@@ -428,6 +431,15 @@
             && DateTime.UtcNow - _lastLiveRefresh >= LiveRefreshFloor)
             _ = RefreshAsync();
     }
+
+    /// <summary>
+    /// What a playhead answer depends on beyond the instant: the selected WANs and their rate,
+    /// which the split is allocated against. The page's snapshot for an instant can land after
+    /// the instant itself, so a changed rate at the same playhead is a new question. Empty live;
+    /// Data usage at the playhead depends on neither.
+    /// </summary>
+    private string SeekKey() => HistoricAt == null || _mode != Mode.Throughput ? ""
+        : $"{string.Join(",", WanKeys)}|{WanDownBps?.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}|{WanUpBps?.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}";
 
     /// <summary>
     /// A drag or playback moves the playhead many times a second; one refresh after it settles,
@@ -542,24 +554,41 @@
     private async Task RefreshAsync()
     {
         if (Interlocked.CompareExchange(ref _loading, 1, 0) != 0) return;
+        var cts = new CancellationTokenSource();
+        _refreshCts = cts;
+        // Recorded up front: what this answer is FOR, so a failure does not ask again forever.
+        // A cancelled answer is not a failure - the record goes back to what is on screen.
+        var (shownAt, shownKey) = (_loadedAt, _loadedSeekKey);
+        var at = HistoricAt;
+        _loadedAt = at;
+        _loadedSeekKey = SeekKey();
+        var discarded = false;
         try
         {
-            // Recorded up front: what this answer is FOR, so a failure does not ask again forever.
-            var at = HistoricAt;
             var wanKeys = WanKeys.ToList();
-            _loadedAt = at;
-            _loadedWanKeys = string.Join(",", wanKeys);
             if (at == null) _lastLiveRefresh = DateTime.UtcNow;
             // At the playhead the window snaps to five minutes, so a drag inside them reuses the
             // same cached answer rather than asking for each position.
             var end = at is { } a ? new DateTime(a.Ticks - a.Ticks % TimeSpan.FromMinutes(5).Ticks, DateTimeKind.Utc) : DateTime.UtcNow;
             var result = _mode == Mode.Throughput
-                ? await Hogs.GetThroughputAsync(at, WanDownBps, WanUpBps, wanKeys, WanHistoryKeys)
-                : await Hogs.GetDataUsageAsync(end - TimeSpan.FromHours(_hours), end, includeLan: _view == View.LanPlusWan);
-            _result = result;
-            await RefreshAgentStatusAsync();
-            _error = false;
-            StampQualified(at);
+                ? await Hogs.GetThroughputAsync(at, WanDownBps, WanUpBps, wanKeys, WanHistoryKeys, cts.Token)
+                : await Hogs.GetDataUsageAsync(end - TimeSpan.FromHours(_hours), end, includeLan: _view == View.LanPlusWan, ct: cts.Token);
+            // Answered for an instant the playhead has since left: nobody's answer now.
+            if (cts.IsCancellationRequested)
+            {
+                discarded = true;
+            }
+            else
+            {
+                _result = result;
+                await RefreshAgentStatusAsync();
+                _error = false;
+                StampQualified(at);
+            }
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            discarded = true;
         }
         catch (Exception ex)
         {
@@ -568,11 +597,15 @@
         }
         finally
         {
+            if (discarded) (_loadedAt, _loadedSeekKey) = (shownAt, shownKey);
+            if (ReferenceEquals(_refreshCts, cts)) _refreshCts = null;
+            cts.Dispose();
             Interlocked.Exchange(ref _loading, 0);
         }
-        await InvokeAsync(StateHasChanged);
-        // The playhead moved while this was answering: answer for where it is now.
-        if (HistoricAt != _loadedAt) ScheduleSeekRefresh();
+        if (!discarded) await InvokeAsync(StateHasChanged);
+        // The playhead moved while this was answering: answer for where it is now. The seek that
+        // moved it armed the debounce, but it may have fired into the loading guard and been dropped.
+        if (HistoricAt != _loadedAt || SeekKey() != _loadedSeekKey) ScheduleSeekRefresh();
     }
 
     private double RowValue(HogRow row) => RowValue(row, _view);
@@ -651,13 +684,12 @@
     private double ShareDenominator(View view) => VisibleRows(view).Sum(r => RowValue(r, view));
 
     /// <summary>
-    /// The WAN rate as the tiles beside the card carry it right now, so the WAN line moves with
-    /// them rather than with the card's own refresh. At the playhead, the answer's own.
+    /// The WAN rate as the tiles beside the card carry it, live or at the playhead, so the WAN
+    /// line moves with them rather than with the card's own refresh. Never the answer's echo of
+    /// it: that is the rate the tiles held when the question was asked, and at the playhead the
+    /// snapshot can land after the question does.
     /// </summary>
-    private (double? Down, double? Up) CurrentWanRate() =>
-        HistoricAt == null && _result?.At == null
-            ? (WanDownBps, WanUpBps)
-            : (_result?.WanDownBps, _result?.WanUpBps);
+    private (double? Down, double? Up) CurrentWanRate() => (WanDownBps, WanUpBps);
 
     private string FormatDown(HogRow row) => (_mode, _view) switch
     {
@@ -695,5 +727,6 @@
         _disposed = true;
         _timer?.Dispose();
         _seekTimer?.Dispose();
+        try { _refreshCts?.Cancel(); } catch (ObjectDisposedException) { }
     }
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/BandwidthHogsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/BandwidthHogsCard.razor
@@ -261,6 +261,10 @@
     [Parameter] public double? WanDownBps { get; set; }
     [Parameter] public double? WanUpBps { get; set; }
 
+    /// <summary>The instant the WAN rate above describes, once the page's snapshot for it has
+    /// landed; null while live. At the playhead the card waits for it to match HistoricAt.</summary>
+    [Parameter] public DateTime? WanRateAt { get; set; }
+
     /// <summary>The selected WAN keys, for their expected speeds.</summary>
     [Parameter] public IReadOnlyCollection<string> WanKeys { get; set; } = Array.Empty<string>();
 
@@ -344,7 +348,9 @@
     private bool _disposed;
     private DateTime _lastLiveRefresh = DateTime.MinValue;
     private static readonly TimeSpan LiveRefreshFloor = TimeSpan.FromSeconds(1);
-    private static readonly TimeSpan SeekDebounce = TimeSpan.FromMilliseconds(400);
+    // Short: the map already spaces seeks half a second apart and the rate gate above admits
+    // one render per seek, so this only folds the odd back-to-back render.
+    private static readonly TimeSpan SeekDebounce = TimeSpan.FromMilliseconds(150);
 
     // Same key shape chart-window.js writes for the Network Performance and Stats tabs, so this is
     // one more remembered window per site, per tab, in this browser.
@@ -421,6 +427,9 @@
         if (HistoricAt != _loadedAt || SeekKey() != _loadedSeekKey)
         {
             _refreshCts?.Cancel();
+            // The page renders on its own tick before the snapshot for a seek lands, carrying
+            // the previous instant's rate. Asking then is a question the snapshot cancels.
+            if (AwaitingPlayheadRate) { _seekTimer?.Dispose(); return; }
             ScheduleSeekRefresh();
             return;
         }
@@ -440,6 +449,9 @@
     /// </summary>
     private string SeekKey() => HistoricAt == null || _mode != Mode.Throughput ? ""
         : $"{string.Join(",", WanKeys)}|{WanDownBps?.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}|{WanUpBps?.ToString("R", System.Globalization.CultureInfo.InvariantCulture)}";
+
+    /// <summary>The playhead has moved but the WAN rate on the tiles still describes the previous instant.</summary>
+    private bool AwaitingPlayheadRate => HistoricAt != null && _mode == Mode.Throughput && WanRateAt != HistoricAt;
 
     /// <summary>
     /// A drag or playback moves the playhead many times a second; one refresh after it settles,
@@ -605,7 +617,7 @@
         if (!discarded) await InvokeAsync(StateHasChanged);
         // The playhead moved while this was answering: answer for where it is now. The seek that
         // moved it armed the debounce, but it may have fired into the loading guard and been dropped.
-        if (HistoricAt != _loadedAt || SeekKey() != _loadedSeekKey) ScheduleSeekRefresh();
+        if ((HistoricAt != _loadedAt || SeekKey() != _loadedSeekKey) && !AwaitingPlayheadRate) ScheduleSeekRefresh();
     }
 
     private double RowValue(HogRow row) => RowValue(row, _view);

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
@@ -252,7 +252,7 @@ public class RolloutAutopilot : IRolloutAutopilot
             _logger.LogDebug(
                 "Autopilot is holding off on site {Site}: the last unattended rollout was stopped and nothing new has been released since",
                 _siteSlug);
-            HoldReason = "The last Autopilot plan was stopped, so it's waiting for new firmware before proposing again. Save Autopilot Configuration to plan now.";
+            HoldReason = "The last Autopilot plan was stopped, so it's waiting for new firmware before proposing again.";
             return null;
         }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -2905,9 +2905,12 @@ public class LanFlowMapService
 
         var healthByDevice = new Dictionary<string, IReadOnlyList<MonitoringInfluxClient.DeviceHealthPoint>>(
             StringComparer.OrdinalIgnoreCase);
+        // Infrastructure only: clients write no device_health, and these run one at a time, so
+        // a site's hundred client nodes were a hundred empty round trips per seek.
         foreach (var node in snapshot.Nodes)
         {
             if (string.IsNullOrEmpty(node.Mac)) continue;
+            if (node.Kind is LanNodeKind.WifiClient or LanNodeKind.WiredClient or LanNodeKind.VirtualHub) continue;
             try
             {
                 healthByDevice[node.Mac] = await _influx.QueryDeviceHealthRawAsync(node.Mac, from, to, ct);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/BandwidthHogs/BandwidthHogsService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/BandwidthHogs/BandwidthHogsService.cs
@@ -154,6 +154,7 @@ public class BandwidthHogsService
         DateTime? at, double? wanDownBps, double? wanUpBps, IReadOnlyCollection<string> wanKeys,
         IReadOnlyCollection<string>? wanHistoryKeys = null, CancellationToken ct = default)
     {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         var snapshot = await _map.BuildSnapshotAsync(ct);
         List<LanNode> nodes;
         List<LanLink> links;
@@ -172,6 +173,7 @@ public class BandwidthHogsService
             links = snapshot.Links.Concat(historic.AddedClientLinks).ToList();
             rates = historic.LinkRates;
         }
+        var mapMs = sw.ElapsedMilliseconds;
 
         var nodeById = new Dictionary<string, LanNode>(StringComparer.OrdinalIgnoreCase);
         foreach (var n in nodes) nodeById.TryAdd(n.Id, n);
@@ -208,22 +210,6 @@ public class BandwidthHogsService
             measured.Add((node, Math.Max(0, rate.DownstreamBps), Math.Max(0, rate.UpstreamBps), capDown, capUp, historyKey));
         }
 
-        // Live weights by the last quarter hour. At the playhead the window snaps to quarter-hour
-        // boundaries, so every position inside one shares a single cached DPI report.
-        var end = at is { } a ? new DateTime(a.Ticks - a.Ticks % DpiRecentWindow.Ticks, DateTimeKind.Utc) : DateTime.UtcNow;
-        var dpi = await DpiTotalsAsync(end - DpiRecentWindow, end, ct);
-        var history = await DpiTotalsAsync(end - ExclusionLookback, end, ct);
-        var firstSeen = await FirstSeenAsync(ct);
-
-        bool NotAWanUser(string mac) => IsNotAWanUser(
-            firstSeen.TryGetValue(mac, out var seen) ? seen : null,
-            history.TryGetValue(mac, out var h) ? h.Down + h.Up : 0,
-            dpi.TryGetValue(mac, out var r) ? r.Down + r.Up : 0,
-            end, ExclusionLookback, ExclusionFloorBytes);
-
-        var included = new List<int>(measured.Count);
-        var loadsDown = new List<WanShareReconciler.Load>(measured.Count);
-        var loadsUp = new List<WanShareReconciler.Load>(measured.Count);
         // Live only; at the playhead the split runs on DPI weights alone. Per-row source
         // hierarchy, best evidence first:
         //   1. The gateway agent's conntrack-measured WAN: exact from its first report. A
@@ -250,13 +236,35 @@ public class BandwidthHogsService
                     playbackRates = measuredAt.ToDictionary(
                         r => r.ClientMac, r => (r.DownBps, r.UpBps), StringComparer.OrdinalIgnoreCase);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogDebug(ex, "Bandwidth Hogs: measured WAN unavailable at the playhead; splitting from DPI");
             }
         }
         var conntrackCovered = playbackRates != null
             || (liveStats != null && liveStats.HasConntrackCoverage());
+        var measuredMs = sw.ElapsedMilliseconds - mapMs;
+
+        // Live weights by the last quarter hour. At the playhead the window snaps to quarter-hour
+        // boundaries, so every position inside one shares a single cached DPI report. Only the
+        // estimated split reads these: a covered site skips them, and at the playhead each new
+        // quarter hour is otherwise two console reports behind the console's own call spacing.
+        var end = at is { } a ? new DateTime(a.Ticks - a.Ticks % DpiRecentWindow.Ticks, DateTimeKind.Utc) : DateTime.UtcNow;
+        var none = new Dictionary<string, (double Down, double Up)>(StringComparer.OrdinalIgnoreCase);
+        var dpi = conntrackCovered ? none : await DpiTotalsAsync(end - DpiRecentWindow, end, ct);
+        var history = conntrackCovered ? none : await DpiTotalsAsync(end - ExclusionLookback, end, ct);
+        var firstSeen = conntrackCovered ? new Dictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase) : await FirstSeenAsync(ct);
+        var dpiMs = sw.ElapsedMilliseconds - mapMs - measuredMs;
+
+        bool NotAWanUser(string mac) => IsNotAWanUser(
+            firstSeen.TryGetValue(mac, out var seen) ? seen : null,
+            history.TryGetValue(mac, out var h) ? h.Down + h.Up : 0,
+            dpi.TryGetValue(mac, out var r) ? r.Down + r.Up : 0,
+            end, ExclusionLookback, ExclusionFloorBytes);
+
+        var included = new List<int>(measured.Count);
+        var loadsDown = new List<WanShareReconciler.Load>(measured.Count);
+        var loadsUp = new List<WanShareReconciler.Load>(measured.Count);
         var wanDown = new double[measured.Count];
         var wanUp = new double[measured.Count];
         var wanHistory = liveStats != null && wanHistoryKeys is { Count: > 0 }
@@ -434,6 +442,9 @@ public class BandwidthHogsService
         }
 
         var (capDownTotal, capUpTotal) = await CapacityAsync(wanKeys, ct);
+        if (at != null)
+            _logger.LogDebug("Bandwidth Hogs: playhead answer in {Ms} ms (map {MapMs}, measured {MeasuredMs}, dpi {DpiMs}; covered={Covered})",
+                sw.ElapsedMilliseconds, mapMs, measuredMs, dpiMs, conntrackCovered);
         return new HogsResult
         {
             Rows = rows,
@@ -469,7 +480,7 @@ public class BandwidthHogsService
             return hit.Result;
         LanFlowMapSnapshot? snapshot = null;
         try { snapshot = await _map.BuildSnapshotAsync(ct); }
-        catch (Exception ex) { _logger.LogDebug(ex, "Bandwidth Hogs: no topology snapshot; naming clients from telemetry"); }
+        catch (Exception ex) when (ex is not OperationCanceledException) { _logger.LogDebug(ex, "Bandwidth Hogs: no topology snapshot; naming clients from telemetry"); }
         var nodeByMac = new Dictionary<string, LanNode>(StringComparer.OrdinalIgnoreCase);
         var nodeById = new Dictionary<string, LanNode>(StringComparer.OrdinalIgnoreCase);
         if (snapshot != null)
@@ -511,7 +522,7 @@ public class BandwidthHogsService
                     };
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogDebug(ex, "Bandwidth Hogs: WAN usage unavailable");
             }
@@ -535,7 +546,7 @@ public class BandwidthHogsService
                     };
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger.LogDebug(ex, "Bandwidth Hogs: measured WAN usage unavailable");
             }
@@ -562,7 +573,7 @@ public class BandwidthHogsService
                 rows[t.ClientMac] = row with { DownBytes = t.ToClientBytes, UpBytes = t.FromClientBytes, IsWired = false };
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: wireless usage unavailable");
         }
@@ -667,7 +678,7 @@ public class BandwidthHogsService
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: wired usage unavailable");
         }
@@ -688,7 +699,7 @@ public class BandwidthHogsService
             var coverage = await _influx.QueryClientWanCoverageHoursAsync(from, to, ct);
             return coverage.Count == 0 ? to : CoverageBoundary(coverage, from, to);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: conntrack coverage unavailable; WAN usage stays DPI");
             return to;
@@ -912,7 +923,7 @@ public class BandwidthHogsService
                 totals[mac] = (down, up);
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: DPI report unavailable; WAN split weighted by rate");
         }
@@ -1088,7 +1099,7 @@ public class BandwidthHogsService
                 }
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: client list unavailable; nothing excluded from WAN");
         }
@@ -1127,7 +1138,7 @@ public class BandwidthHogsService
             }
             return (down, up);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Bandwidth Hogs: WAN capacity unavailable");
             return (null, null);

--- a/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/PerfTweaksDeploymentService.cs
@@ -20,13 +20,14 @@ public class PerfTweaksDeploymentService : IPerfTweaksDeploymentService
     private const string OnBootDir = "/data/on_boot.d";
     private const string PerfTweaksDir = "/data/perf-tweaks";
     private const string SfpModuleDir = "/data/sfp-sgmiiplus";
-    // Highest UniFi OS version the perf tweaks + SGMII+ module are verified against.
-    // 5.1.31 static/bench-verified: kernel unchanged, qca-ssdk.ko byte-identical to
-    // 5.1.26/5.1.28/5.1.29/5.1.30, all boot-tweak userland deps present. A full
-    // 5.1.30->5.1.31 image diff showed all 361 kernel modules byte-identical (5.1.31
-    // is a pure userland patch) (unifi-perf-tweaks docs/compat-5.1.31.md).
-    private static readonly Version MaxSupportedFirmware = new(5, 1, 31);
-    // The UXG line moved to UniFi OS 6 while the UCGs did not, so one ceiling cannot gate both.
+    // Highest UniFi OS version the perf tweaks + SGMII+ module are verified against, one
+    // ceiling per gateway line because the UXG and UCG lines receive UniFi OS 6 releases on
+    // different schedules (6.0.5 shipped for the UXG-Fiber only; 6.0.7 for the UCG-Fiber).
+    // 6.0.7 static/bench-verified on the UCG-Fiber, the first 6.0.x image for that line:
+    // qca-ssdk.ko .text byte-identical to the live-verified 6.0.5 SSDK, every other common
+    // kernel module .text-identical, vermagic unchanged, all boot-tweak userland deps present
+    // including MongoDB (unifi-perf-tweaks docs/compat-6.0.7.md).
+    private static readonly Version MaxSupportedFirmware = new(6, 0, 7);
     // 6.0.5 live-verified on UXG-Fiber: the trixie toolchain recompiled qca-ssdk.ko, ending the
     // byte-identical streak, but vermagic, all 10 SGMII+ symbols and the 0x690/0x6d0 speed and
     // duplex offsets are unchanged (unifi-perf-tweaks docs/compat-6.0.5.md).

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -114,6 +114,21 @@ public class SqmDeploymentService : ISqmDeploymentService
     private static string GetSection(Dictionary<string, string> sections, string key)
         => sections.TryGetValue(key, out var value) ? value : "";
 
+    internal static string BuildDeploymentStatusCommand()
+    {
+        return
+            "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
+            "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
+            $"echo '---SQM_BOOT_SCRIPTS---'; ls {OnBootDir}/20-sqm-*.sh 2>/dev/null | grep -v 'sqm-monitor' | wc -l; " +
+            $"echo '---SQM_SPEEDTEST_SCRIPTS---'; ls {SqmDir}/*-speedtest.sh 2>/dev/null | wc -l; " +
+            $"echo '---SQM_MONITOR_CHECK---'; test -f {OnBootDir}/20-sqm-monitor.sh && echo 'exists' || echo 'missing'; " +
+            "echo '---WATCHDOG_RUNNING---'; crontab -l 2>/dev/null | grep -q sqm-watchdog && echo 'active' || echo 'inactive'; " +
+            "echo '---CRON_CHECK---'; crontab -l 2>/dev/null | grep -c sqm || echo '0'; " +
+            $"echo '---SPEEDTEST_CLI---'; SPEEDTEST_SHA256=$(case \"$(uname -m)\" in aarch64|arm64) echo 'd99fa13293f658b53eaa79fe81f4b210db39fdfc1e9698f33da3f234a6008df7' ;; armv7l|armv7) echo '66ad57568664e6f8580e14ad67316a57038fd22b30548bef98531df4ebcc8956' ;; x86_64|amd64) echo '31f1124c5ab8acdae6b9fe1741e704df420f9f2e7d429679fabe62075453c051' ;; *) echo 'unsupported' ;; esac); test \"$SPEEDTEST_SHA256\" != 'unsupported' && command -v sha256sum >/dev/null 2>&1 && test -f '{ScriptGenerator.ManagedSpeedtestPath}' && test ! -L '{ScriptGenerator.ManagedSpeedtestPath}' && test -x '{ScriptGenerator.ManagedSpeedtestPath}' && printf '%s  %s\\n' \"$SPEEDTEST_SHA256\" '{ScriptGenerator.ManagedSpeedtestPath}' | sha256sum -c - >/dev/null 2>&1 && '{ScriptGenerator.ManagedSpeedtestPath}' --version 2>/dev/null | head -n 1 | grep -Fq 'Speedtest by Ookla {ScriptGenerator.ManagedSpeedtestCliVersion} ({ScriptGenerator.ManagedSpeedtestBuildId})' && echo 'installed' || echo 'missing'; " +
+            "echo '---BC_CHECK---'; command -v bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
+            "echo '---JQ_CHECK---'; command -v jq >/dev/null 2>&1 && echo 'installed' || echo 'missing'";
+    }
+
     /// <summary>
     /// Check if SQM scripts are already deployed
     /// </summary>
@@ -127,16 +142,7 @@ public class SqmDeploymentService : ISqmDeploymentService
             // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
             // this inline test (shared gateway boot infrastructure -
             // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
-            var combinedCommand =
-                "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
-                "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
-                $"echo '---SQM_BOOT_SCRIPTS---'; ls {OnBootDir}/20-sqm-*.sh 2>/dev/null | grep -v 'sqm-monitor' | wc -l; " +
-                $"echo '---SQM_SPEEDTEST_SCRIPTS---'; ls {SqmDir}/*-speedtest.sh 2>/dev/null | wc -l; " +
-                $"echo '---SQM_MONITOR_CHECK---'; test -f {OnBootDir}/20-sqm-monitor.sh && echo 'exists' || echo 'missing'; " +
-                "echo '---WATCHDOG_RUNNING---'; crontab -l 2>/dev/null | grep -q sqm-watchdog && echo 'active' || echo 'inactive'; " +
-                "echo '---CRON_CHECK---'; crontab -l 2>/dev/null | grep -c sqm || echo '0'; " +
-                "echo '---SPEEDTEST_CLI---'; which speedtest >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
-                "echo '---BC_CHECK---'; which bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'";
+            var combinedCommand = BuildDeploymentStatusCommand();
 
             var result = await RunCommandAsync(combinedCommand);
             var sections = ParseDelimitedOutput(result.output);
@@ -171,6 +177,7 @@ public class SqmDeploymentService : ISqmDeploymentService
             status.SpeedtestCliInstalled = result.success && GetSection(sections, "SPEEDTEST_CLI").Contains("installed");
 
             status.BcInstalled = result.success && GetSection(sections, "BC_CHECK").Contains("installed");
+            status.JqInstalled = result.success && GetSection(sections, "JQ_CHECK").Contains("installed");
 
             status.IsDeployed = status.SpeedtestScriptDeployed && status.PingScriptDeployed;
         }
@@ -1369,6 +1376,7 @@ public class SqmDeploymentStatus
     public int CronJobsConfigured { get; set; }
     public bool SpeedtestCliInstalled { get; set; }
     public bool BcInstalled { get; set; }
+    public bool JqInstalled { get; set; }
     public string? Error { get; set; }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -123,6 +123,21 @@ public class SqmDeploymentService : ISqmDeploymentService
     private static string GetSection(Dictionary<string, string> sections, string key)
         => sections.TryGetValue(key, out var value) ? value : "";
 
+    internal static string BuildDeploymentStatusCommand()
+    {
+        return
+            "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
+            "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
+            $"echo '---SQM_BOOT_SCRIPTS---'; ls {OnBootDir}/20-sqm-*.sh 2>/dev/null | grep -v 'sqm-monitor' | wc -l; " +
+            $"echo '---SQM_SPEEDTEST_SCRIPTS---'; ls {SqmDir}/*-speedtest.sh 2>/dev/null | wc -l; " +
+            $"echo '---SQM_MONITOR_CHECK---'; test -f {OnBootDir}/20-sqm-monitor.sh && echo 'exists' || echo 'missing'; " +
+            "echo '---WATCHDOG_RUNNING---'; crontab -l 2>/dev/null | grep -q sqm-watchdog && echo 'active' || echo 'inactive'; " +
+            "echo '---CRON_CHECK---'; crontab -l 2>/dev/null | grep -c sqm || echo '0'; " +
+            $"echo '---SPEEDTEST_CLI---'; SPEEDTEST_SHA256=$(case \"$(uname -m)\" in aarch64|arm64) echo '{ScriptGenerator.ManagedSpeedtestAarch64BinarySha256}' ;; armv7l|armv7) echo '{ScriptGenerator.ManagedSpeedtestArmhfBinarySha256}' ;; x86_64|amd64) echo '{ScriptGenerator.ManagedSpeedtestX86_64BinarySha256}' ;; *) echo 'unsupported' ;; esac); test \"$SPEEDTEST_SHA256\" != 'unsupported' && command -v sha256sum >/dev/null 2>&1 && test -f '{ScriptGenerator.ManagedSpeedtestPath}' && test ! -L '{ScriptGenerator.ManagedSpeedtestPath}' && test -x '{ScriptGenerator.ManagedSpeedtestPath}' && printf '%s  %s\\n' \"$SPEEDTEST_SHA256\" '{ScriptGenerator.ManagedSpeedtestPath}' | sha256sum -c - >/dev/null 2>&1 && '{ScriptGenerator.ManagedSpeedtestPath}' --version 2>/dev/null | head -n 1 | grep -Fq 'Speedtest by Ookla {ScriptGenerator.ManagedSpeedtestCliVersion} ({ScriptGenerator.ManagedSpeedtestBuildId})' && echo 'installed' || echo 'missing'; " +
+            "echo '---BC_CHECK---'; command -v bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
+            "echo '---JQ_CHECK---'; command -v jq >/dev/null 2>&1 && echo 'installed' || echo 'missing'";
+    }
+
     /// <summary>
     /// Check if SQM scripts are already deployed
     /// </summary>
@@ -136,16 +151,7 @@ public class SqmDeploymentService : ISqmDeploymentService
             // TODO: use IUdmBootService.IsInstalledAsync() for the udm-boot check instead of
             // this inline test (shared gateway boot infrastructure -
             // NetworkOptimizer.Web.Services.Ssh.UdmBootService).
-            var combinedCommand =
-                "echo '---UDM_BOOT_CHECK---'; test -f /etc/systemd/system/udm-boot.service && echo 'installed' || echo 'missing'; " +
-                "echo '---UDM_BOOT_ENABLED---'; systemctl is-enabled udm-boot 2>/dev/null || echo 'disabled'; " +
-                $"echo '---SQM_BOOT_SCRIPTS---'; ls {OnBootDir}/20-sqm-*.sh 2>/dev/null | grep -v 'sqm-monitor' | wc -l; " +
-                $"echo '---SQM_SPEEDTEST_SCRIPTS---'; ls {SqmDir}/*-speedtest.sh 2>/dev/null | wc -l; " +
-                $"echo '---SQM_MONITOR_CHECK---'; test -f {OnBootDir}/20-sqm-monitor.sh && echo 'exists' || echo 'missing'; " +
-                "echo '---WATCHDOG_RUNNING---'; crontab -l 2>/dev/null | grep -q sqm-watchdog && echo 'active' || echo 'inactive'; " +
-                "echo '---CRON_CHECK---'; crontab -l 2>/dev/null | grep -c sqm || echo '0'; " +
-                "echo '---SPEEDTEST_CLI---'; which speedtest >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
-                "echo '---BC_CHECK---'; which bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'";
+            var combinedCommand = BuildDeploymentStatusCommand();
 
             var result = await RunCommandAsync(combinedCommand);
             var sections = ParseDelimitedOutput(result.output);
@@ -180,6 +186,7 @@ public class SqmDeploymentService : ISqmDeploymentService
             status.SpeedtestCliInstalled = result.success && GetSection(sections, "SPEEDTEST_CLI").Contains("installed");
 
             status.BcInstalled = result.success && GetSection(sections, "BC_CHECK").Contains("installed");
+            status.JqInstalled = result.success && GetSection(sections, "JQ_CHECK").Contains("installed");
 
             status.IsDeployed = status.SpeedtestScriptDeployed && status.PingScriptDeployed;
         }
@@ -1382,6 +1389,7 @@ public class SqmDeploymentStatus
     public int CronJobsConfigured { get; set; }
     public bool SpeedtestCliInstalled { get; set; }
     public bool BcInstalled { get; set; }
+    public bool JqInstalled { get; set; }
     public string? Error { get; set; }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using NetworkOptimizer.Sqm.Models;
 using Xunit;
@@ -484,6 +485,110 @@ public class ScriptGeneratorTests
         // on Windows, which made these assertions pass on CI and fail locally).
         return generator.GenerateAllScripts(new Dictionary<string, string> { ["0_12"] = "880" })
             .ToDictionary(kv => kv.Key, kv => kv.Value.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void GenerateBootScript_InstallsPinnedOoklaArchiveAtomically()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+
+        Assert.Contains("SPEEDTEST_RELEASE=\"1.2.0\"", script);
+        Assert.Contains("SPEEDTEST_CLI_VERSION=\"1.2.0.84\"", script);
+        Assert.Contains("https://install.speedtest.net/app/cli/ookla-speedtest-${SPEEDTEST_RELEASE}-linux-${SPEEDTEST_ARCH}.tgz", script);
+        Assert.Contains("SPEEDTEST_ARCHIVE_SHA256", script);
+        Assert.Contains("SPEEDTEST_BINARY_SHA256", script);
+        Assert.Contains("--max-filesize 4194304", script);
+        Assert.Contains("mktemp -d \"${SPEEDTEST_DIR}/.speedtest-install.XXXXXX\"", script);
+        Assert.Contains("mv -f \"${SPEEDTEST_BIN}.new\" \"$SPEEDTEST_BIN\"", script);
+    }
+
+    [Fact]
+    public void GenerateBootScript_DoesNotMutateUniFiSpeedtestPackage()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+
+        Assert.DoesNotContain("packagecloud.io", script);
+        Assert.DoesNotContain("apt-get remove -y speedtest", script);
+        Assert.DoesNotContain("apt-get install -y speedtest", script);
+    }
+
+    [Fact]
+    public void GenerateBootScript_CalibrationUsesOnlyManagedSpeedtest()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+        var speedtest = ExtractHeredocSection(script, "SPEEDTEST_EOF");
+
+        Assert.Contains($"SPEEDTEST_BIN=\"{ScriptGenerator.ManagedSpeedtestPath}\"", speedtest);
+        Assert.Contains("speedtest_output=$(\"$SPEEDTEST_BIN\" --accept-license", speedtest);
+        Assert.DoesNotContain("speedtest_output=$(speedtest ", speedtest);
+    }
+
+    [Fact]
+    public void GenerateBootScript_HasValidBashSyntax()
+    {
+        if (OperatingSystem.IsWindows() || !File.Exists("/bin/bash"))
+            return;
+
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+        var path = Path.Combine(Path.GetTempPath(), $"networkoptimizer-sqm-{Guid.NewGuid():N}.sh");
+
+        try
+        {
+            File.WriteAllText(path, generator.GenerateBootScript(new Dictionary<string, string>()));
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                ArgumentList = { "-n", path }
+            });
+
+            Assert.NotNull(process);
+            process!.WaitForExit();
+            Assert.True(process.ExitCode == 0, process.StandardError.ReadToEnd());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/ScriptGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using NetworkOptimizer.Sqm.Models;
 using Xunit;
@@ -484,6 +485,141 @@ public class ScriptGeneratorTests
         // on Windows, which made these assertions pass on CI and fail locally).
         return generator.GenerateAllScripts(new Dictionary<string, string> { ["0_12"] = "880" })
             .ToDictionary(kv => kv.Key, kv => kv.Value.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void GenerateBootScript_InstallsPinnedOoklaArchiveAtomically()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+
+        Assert.Contains("SPEEDTEST_RELEASE=\"1.2.0\"", script);
+        Assert.Contains("SPEEDTEST_CLI_VERSION=\"1.2.0.84\"", script);
+        Assert.Contains("https://install.speedtest.net/app/cli/ookla-speedtest-${SPEEDTEST_RELEASE}-linux-${SPEEDTEST_ARCH}.tgz", script);
+        Assert.Contains("SPEEDTEST_ARCHIVE_SHA256", script);
+        Assert.Contains("SPEEDTEST_BINARY_SHA256", script);
+        Assert.Contains("--max-filesize 4194304", script);
+        Assert.Contains("mktemp -d \"${SPEEDTEST_DIR}/.speedtest-install.XXXXXX\"", script);
+        Assert.Contains("mv -f \"${SPEEDTEST_BIN}.new\" \"$SPEEDTEST_BIN\"", script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestAarch64ArchiveSha256, script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestAarch64BinarySha256, script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestArmhfArchiveSha256, script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestArmhfBinarySha256, script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestX86_64ArchiveSha256, script);
+        Assert.Contains(ScriptGenerator.ManagedSpeedtestX86_64BinarySha256, script);
+    }
+
+    [Fact]
+    public void GenerateBootScript_OoklaInstallFailureDoesNotAbortDeployment()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+
+        Assert.Contains("install_managed_speedtest() (", script);
+        Assert.Contains("if ! install_managed_speedtest; then", script);
+        Assert.Contains("continuing without adaptive calibration", script);
+        Assert.DoesNotContain("fail_boot", script);
+
+        var warningIndex = script.IndexOf("continuing without adaptive calibration", StringComparison.Ordinal);
+        var scriptCreationIndex = script.IndexOf("# Section 2: Create Directories", StringComparison.Ordinal);
+        Assert.True(warningIndex >= 0 && warningIndex < scriptCreationIndex);
+    }
+
+    [Fact]
+    public void GenerateBootScript_DoesNotMutateUniFiSpeedtestPackage()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+
+        Assert.DoesNotContain("packagecloud.io", script);
+        Assert.DoesNotContain("apt-get remove -y speedtest", script);
+        Assert.DoesNotContain("apt-get install -y speedtest", script);
+    }
+
+    [Fact]
+    public void GenerateBootScript_CalibrationUsesOnlyManagedSpeedtest()
+    {
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+
+        var script = generator.GenerateBootScript(new Dictionary<string, string>());
+        var speedtest = ExtractHeredocSection(script, "SPEEDTEST_EOF");
+
+        Assert.Contains($"SPEEDTEST_BIN=\"{ScriptGenerator.ManagedSpeedtestPath}\"", speedtest);
+        Assert.Contains("speedtest_output=$(\"$SPEEDTEST_BIN\" --accept-license", speedtest);
+        Assert.DoesNotContain("speedtest_output=$(speedtest ", speedtest);
+    }
+
+    [Fact]
+    public void GenerateBootScript_HasValidBashSyntax()
+    {
+        if (OperatingSystem.IsWindows() || !File.Exists("/bin/bash"))
+            return;
+
+        var generator = new ScriptGenerator(new SqmConfiguration
+        {
+            ConnectionName = "WAN",
+            Interface = "eth8.201",
+            MaxDownloadSpeed = 1000,
+            MinDownloadSpeed = 100,
+            AbsoluteMaxDownloadSpeed = 1100,
+            PingHost = "1.1.1.1"
+        });
+        var path = Path.Combine(Path.GetTempPath(), $"networkoptimizer-sqm-{Guid.NewGuid():N}.sh");
+
+        try
+        {
+            File.WriteAllText(path, generator.GenerateBootScript(new Dictionary<string, string>()));
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                UseShellExecute = false,
+                RedirectStandardError = true,
+                ArgumentList = { "-n", path }
+            });
+
+            Assert.NotNull(process);
+            process!.WaitForExit();
+            Assert.True(process.ExitCode == 0, process.StandardError.ReadToEnd());
+        }
+        finally
+        {
+            File.Delete(path);
+        }
     }
 
     /// <summary>

--- a/tests/NetworkOptimizer.Web.Tests/SqmDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmDeploymentServiceTests.cs
@@ -1,0 +1,22 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class SqmDeploymentServiceTests
+{
+    [Fact]
+    public void DeploymentStatus_ValidatesTheManagedOoklaBuildAndBothParserDependencies()
+    {
+        var command = SqmDeploymentService.BuildDeploymentStatusCommand();
+
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestPath);
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestCliVersion);
+        command.Should().Contain("sha256sum -c -");
+        command.Should().Contain("---BC_CHECK---");
+        command.Should().Contain("---JQ_CHECK---");
+        command.Should().NotContain("which speedtest");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/SqmDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmDeploymentServiceTests.cs
@@ -1,0 +1,25 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class SqmDeploymentServiceTests
+{
+    [Fact]
+    public void DeploymentStatus_ValidatesTheManagedOoklaBuildAndBothParserDependencies()
+    {
+        var command = SqmDeploymentService.BuildDeploymentStatusCommand();
+
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestPath);
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestCliVersion);
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestAarch64BinarySha256);
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestArmhfBinarySha256);
+        command.Should().Contain(ScriptGenerator.ManagedSpeedtestX86_64BinarySha256);
+        command.Should().Contain("sha256sum -c -");
+        command.Should().Contain("---BC_CHECK---");
+        command.Should().Contain("---JQ_CHECK---");
+        command.Should().NotContain("which speedtest");
+    }
+}


### PR DESCRIPTION
## Problem

Adaptive SQM currently pipes the packagecloud repository bootstrap into a shell, removes any existing `speedtest` package, and installs an unpinned candidate with `apt`. That can fail when UniFi OS changes its Debian base, mutates a vendor-managed package surface, and makes the calibration binary drift independently of Network Optimizer.

## Fix

- install the official Ookla archive directly into `/data/network-optimizer/bin`
- pin the same `1.2.0.84 (ea6b6773cf)` build selected by the existing packagecloud install path
- centralize the reviewed archive and executable SHA-256 values so installation, calibration, and status checks share one source of truth
- select reviewed aarch64, armhf, or x86_64 artifacts and verify both archive and executable SHA-256 values
- bound the HTTPS download, extract in a private staging directory, and atomically activate the validated executable
- log a failed Ookla installation and continue deploying the SQM scripts and cron entries; calibration remains fail-closed until the managed binary validates
- invoke and report health for that exact path/build without removing a UniFi package
- report `jq` separately alongside the existing `bc` dependency status

## Validation

- full Release solution build against current `dev`: succeeded
- SQM test project: 272 passed, including best-effort installation, checksum-source, managed invocation, and generated Bash syntax coverage
- focused Web deployment-status test: passed
- `git diff --check`: passed

GitHub did not schedule a new Actions run for this head because the upstream workflow currently filters pull-request events to `main`, while this pull request targets `dev`. The unfiltered Web suite is not claimed as locally green on macOS: two existing Vodafone AES-CCM tests are unsupported on this host, and the remaining run exceeded the bounded local test window.

No gateway package, SQM script, cron entry, service, or live installation was changed while validating this fix.
