### PR TITLE
Gate reading the audit log at the service, not only at the page in front of it

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Auditing/AuditQueryService.cs
@@ -1,6 +1,7 @@
-using System.Text;
+﻿using System.Text;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Web.Services.Gates;
 using NetworkOptimizer.Storage.Models.Identity;
 
 namespace NetworkOptimizer.Web.Services.Auditing;
@@ -18,12 +19,36 @@ public sealed record AuditFilter
     public int Take { get; init; } = 100;
 }
 
-/// <summary>Read-only, filtered access to the audit log plus CSV/JSON export of the current filter.</summary>
+/// <summary>
+/// Read-only, filtered access to the audit log plus CSV/JSON export of the current filter.
+///
+/// Gated even though every member is a read. The audit log is the record of who did what across the
+/// whole install - actors, source addresses, target names, and now the site each action touched - so
+/// it is closer to a credential store than to a status page, and reads of it are worth the same
+/// service-tier check as writes elsewhere.
+///
+/// Until this attribute, nothing here was checked at all. The export endpoints carry
+/// RequireAuthorization(RequireAdmin) and the page sits behind an AuthorizeView, so the surface was
+/// covered in practice - but by the endpoint and the page rather than by the service, which is the
+/// arrangement the gate engine exists to replace. Any new caller reaching this interface (a component
+/// on another page, a background job, a future endpoint) would have inherited nothing.
+///
+/// No [AuditAction]: recording every read would write an entry for each page and each page-turn of
+/// the log itself, which buries the actions the log is kept for.
+/// </summary>
+[MutatingService]
 public interface IAuditQueryService
 {
+    [RequireRole(Roles.Admin)]
     Task<IReadOnlyList<AuditEvent>> QueryAsync(AuditFilter filter);
+
+    [RequireRole(Roles.Admin)]
     Task<int> CountAsync(AuditFilter filter);
+
+    [RequireRole(Roles.Admin)]
     Task<string> ExportJsonAsync(AuditFilter filter);
+
+    [RequireRole(Roles.Admin)]
     Task<string> ExportCsvAsync(AuditFilter filter);
 }
 

--- a/src/NetworkOptimizer.Web/Services/Identity/IdentityRegistration.cs
+++ b/src/NetworkOptimizer.Web/Services/Identity/IdentityRegistration.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Authentication.Cookies;
+﻿using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
@@ -126,7 +126,9 @@ public static class IdentityRegistration
         services.AddSingleton<AuditWriterService>();
         services.AddSingleton<IAuditLogger>(sp => sp.GetRequiredService<AuditWriterService>());
         services.AddHostedService(sp => sp.GetRequiredService<AuditWriterService>());
-        services.AddScoped<IAuditQueryService, AuditQueryService>();
+        // Gated, so it goes through the proxy rather than being resolved raw - registering the
+        // implementation as its own service type would leave an ungated instance in the container.
+        services.AddMutatingService<IAuditQueryService, AuditQueryService>();
 
         return services;
     }

--- a/tests/NetworkOptimizer.Web.Tests/Identity/AuditQueryGateTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Identity/AuditQueryGateTests.cs
@@ -1,0 +1,110 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Auditing;
+using NetworkOptimizer.Web.Services.Gates;
+using NetworkOptimizer.Web.Services.Identity;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Identity;
+
+/// <summary>
+/// The audit log is the record of who did what across the whole install - actors, source addresses,
+/// target names, and the site each action touched. Reading it is closer to reading a credential store
+/// than a status page, so it earns a service-tier check rather than relying on the page and the export
+/// endpoint that happen to sit in front of it today.
+/// </summary>
+public sealed class AuditQueryGateTests
+{
+    private static ServiceProvider Build()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContextFactory<AuthDbContext>(o =>
+            o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddScoped<ICallerContext, CallerContext>();
+        services.AddSingleton<IAuditLogger>(new NoOpAudit());
+        // Non-site-scoped gate, so the interceptor ranks the global role and never asks this - it is
+        // here because SiteRoleHandler takes it as a dependency.
+        services.AddScoped<NetworkOptimizer.Web.Services.Authorization.IEffectiveSiteRoleResolver, UnusedResolver>();
+        services.AddGatePlumbing();
+        services.AddMutatingService<IAuditQueryService, AuditQueryService>();
+        return services.BuildServiceProvider();
+    }
+
+    private sealed class NoOpAudit : IAuditLogger
+    {
+        public void Log(AuditEvent auditEvent) { }
+    }
+
+    private sealed class UnusedResolver : NetworkOptimizer.Web.Services.Authorization.IEffectiveSiteRoleResolver
+    {
+        public void Invalidate(string userId) { }
+        public void InvalidateAll() { }
+        public Task<string?> FirstAdministeredSlugAsync(System.Security.Claims.ClaimsPrincipal user)
+            => Task.FromResult<string?>(null);
+        public Task<SiteRole?> GetEffectiveRoleAsync(System.Security.Claims.ClaimsPrincipal user, string slug)
+            => Task.FromResult<SiteRole?>(null);
+        public Task<IReadOnlySet<string>> GetAuthorizedSlugsAsync(System.Security.Claims.ClaimsPrincipal user)
+            => Task.FromResult<IReadOnlySet<string>>(new HashSet<string>());
+    }
+
+    [Fact]
+    public async Task An_admin_may_read_the_audit_log()
+    {
+        await using var provider = Build();
+        using var scope = provider.ScopeAs("admin-1", Roles.Admin);
+
+        var act = async () => await scope.ServiceProvider
+            .GetRequiredService<IAuditQueryService>().QueryAsync(new AuditFilter());
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Theory]
+    [InlineData(Roles.Viewer)]
+    [InlineData(Roles.Operator)]
+    public async Task Anyone_below_Admin_is_refused(string role)
+    {
+        await using var provider = Build();
+        using var scope = provider.ScopeAs("someone", role);
+
+        var act = async () => await scope.ServiceProvider
+            .GetRequiredService<IAuditQueryService>().QueryAsync(new AuditFilter());
+
+        await act.Should().ThrowAsync<AuthorizationDeniedException>();
+    }
+
+    [Fact]
+    public async Task Export_is_gated_the_same_way_as_the_page_read()
+    {
+        // The two exports leave the app as files and were reachable through their own endpoint, so a
+        // gate that covered only the interactive read would have missed the larger disclosure.
+        await using var provider = Build();
+        using var scope = provider.ScopeAs("viewer-1", Roles.Viewer);
+        var query = scope.ServiceProvider.GetRequiredService<IAuditQueryService>();
+
+        var json = async () => await query.ExportJsonAsync(new AuditFilter());
+        var csv = async () => await query.ExportCsvAsync(new AuditFilter());
+
+        await json.Should().ThrowAsync<AuthorizationDeniedException>();
+        await csv.Should().ThrowAsync<AuthorizationDeniedException>();
+    }
+
+    /// <summary>
+    /// The gate has to stay declared on the interface. Losing the attribute puts the reads back
+    /// behind nothing but the page and the endpoint, which is where they started.
+    /// </summary>
+    [Fact]
+    public void Every_member_carries_a_role_gate()
+    {
+        typeof(IAuditQueryService).Should().BeDecoratedWith<MutatingServiceAttribute>();
+
+        foreach (var method in typeof(IAuditQueryService).GetMethods())
+        {
+            method.Should().BeDecoratedWith<RequireRoleAttribute>(
+                $"{method.Name} reads the audit log and must be gated");
+        }
+    }
+}


### PR DESCRIPTION
## Settings - Audit Log

- **Reading the audit log is gated at the service** - `IAuditQueryService` carried no gate at all. The surface was covered in practice, since the export endpoints have `RequireAuthorization(RequireAdmin)` and the tab sits behind an `AuthorizeView` on the main site, but by the endpoint and the page rather than by the service. Every member now takes `[RequireRole(Roles.Admin)]`, and the registration moves to `AddMutatingService` so the implementation is not resolvable ungated.

## Why this one rather than leaving it to the page

The log is the record of who did what across the whole install: actors, source addresses, target names, and since the site-stamping work, the site each action touched. Reading it is closer to reading a credential store than a status page.

The practical gap is a future caller. A component on another page, a background job, or a new endpoint reaching this interface would have inherited no check, because there was none to inherit - only the two call sites that happen to exist today are covered, and each covers itself.

No `[AuditAction]`. Recording every read would write an entry for each page and each page-turn of the log itself, burying the actions the log is kept for.

## Both callers keep working

`CallerContextMiddleware` populates the caller for the export endpoints and `CallerContextCircuitHandler` does it for the interactive page, so the proxy has a principal on either path. Verified by running the suite rather than by reading the pipeline.

## Verification

- 0 build warnings, 13/13 test projects green
- New `AuditQueryGateTests`: Admin allowed; Viewer and Operator refused; both exports refused separately from the page read, since they leave as files through their own endpoint and a gate covering only the interactive read would have missed the larger disclosure; plus a reflection check that the attributes stay on the interface

## Note

Found while reviewing a large dev batch from a multi-tenant angle, where an ungated instance-wide read is the shape that matters most. It is worth having on its own regardless - this is plain hardening for any install with more than one account.
