### PR TITLE
Config Optimizer: catch Smart Queues that UniFi Network never actually turned on

### DIFF
--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -647,7 +647,7 @@ public class PerformanceAnalyzer
             {
                 Title = "Streaming Video Not Rate-Limited",
                 Description = streamingGap,
-                Recommendation = "Create a QoS Rule under Policy Engine > Policy Table > QoS Rules to limit " +
+                Recommendation = "Create a QoS Rule under Settings > Policy Engine > Policy Table > QoS Rules to limit " +
                     "streaming video apps when on cellular. " +
                     "<br><a href=\"https://ozarkconnect.net/blog/unifi-5g-backup-qos\" target=\"_blank\">How-To Guide</a>",
                 Severity = severity,
@@ -664,7 +664,7 @@ public class PerformanceAnalyzer
             {
                 Title = "Cloud Sync Not Rate-Limited",
                 Description = cloudGap,
-                Recommendation = "Create a QoS Rule under Policy Engine > Policy Table > QoS Rules to limit cloud storage sync speed when on cellular. " +
+                Recommendation = "Create a QoS Rule under Settings > Policy Engine > Policy Table > QoS Rules to limit cloud storage sync speed when on cellular. " +
                     "This prevents large uploads/downloads from burning through your data plan. " +
                     "<br><a href=\"https://ozarkconnect.net/blog/unifi-5g-backup-qos\" target=\"_blank\">How-To Guide</a>",
                 Severity = severity,
@@ -681,7 +681,7 @@ public class PerformanceAnalyzer
             {
                 Title = "Game/App Downloads Not Rate-Limited",
                 Description = downloadGap,
-                Recommendation = "Create a QoS Rule under Policy Engine > Policy Table > QoS Rules to limit or block game/app downloads when on cellular. " +
+                Recommendation = "Create a QoS Rule under Settings > Policy Engine > Policy Table > QoS Rules to limit or block game/app downloads when on cellular. " +
                     "Game updates alone can exceed monthly data caps in a single download. " +
                     "<br><a href=\"https://ozarkconnect.net/blog/unifi-5g-backup-qos\" target=\"_blank\">How-To Guide</a>",
                 Severity = severity,

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PerformanceAnalyzer.cs
@@ -44,7 +44,8 @@ public class PerformanceAnalyzer
         JsonDocument? wanEnrichedData = null,
         bool runPerformanceChecks = true,
         bool runCellularChecks = true,
-        List<UniFiPortProfile>? portProfiles = null)
+        List<UniFiPortProfile>? portProfiles = null,
+        List<WanShaperState>? wanShaperStates = null)
     {
         var issues = new List<PerformanceIssue>();
 
@@ -54,6 +55,7 @@ public class PerformanceAnalyzer
             issues.AddRange(CheckJumboFrames(devices, settingsData));
             issues.AddRange(CheckFlowControl(devices, networks, clients, settingsData, portProfiles));
             issues.AddRange(CheckSqmFirmwareRegression(devices, networks));
+            issues.AddRange(CheckSqmNotShaping(devices, wanShaperStates));
         }
 
         if (runCellularChecks)
@@ -486,6 +488,93 @@ public class PerformanceAnalyzer
             Category = PerformanceCategory.Performance,
             DeviceName = gateway.Name
         });
+
+        return issues;
+    }
+
+    /// <summary>
+    /// Check whether the WANs that have Smart Queues enabled are actually being shaped.
+    ///
+    /// UniFi Network regularly accepts the Smart Queues toggle without provisioning the queues:
+    /// the setting reads as on, no shaper is ever created, and the connection runs unshaped with
+    /// nothing on screen to say so. The gateway's own traffic control is the only place the truth
+    /// shows, so the states come from an SSH read (GatewayShaperProbeService) and are empty
+    /// whenever the gateway cannot be reached - a site we cannot see raises nothing.
+    ///
+    /// Egress rides the WAN's data-path interface (upload), ingress rides its "ifb" companion
+    /// (download), and a direction UniFi was explicitly told to shape at 0 is not expected to
+    /// have a shaper at all.
+    /// </summary>
+    [VendorSpecific("UniFi", "UniFi Network's Smart Queues provisioning and its ifb ingress device naming")]
+    internal List<PerformanceIssue> CheckSqmNotShaping(
+        List<UniFiDeviceResponse> devices,
+        List<WanShaperState>? wanShaperStates)
+    {
+        var issues = new List<PerformanceIssue>();
+
+        if (wanShaperStates == null || wanShaperStates.Count == 0)
+            return issues;
+
+        var gatewayName = devices.FirstOrDefault(d => d.DeviceType == DeviceType.Gateway)?.Name;
+
+        foreach (var state in wanShaperStates)
+        {
+            // The WAN's own interface missing means we asked about a device this box does not
+            // have, so the readout says nothing about UniFi's provisioning.
+            if (!state.Egress.DeviceFound)
+            {
+                _logger?.LogDebug(
+                    "Skipping Smart Queues shaper check for {Wan}: {Interface} not found on the gateway",
+                    state.WanName, state.Interface);
+                continue;
+            }
+
+            var uploadExpected = state.UpRateMbps != 0;
+            var downloadExpected = state.DownRateMbps != 0;
+
+            var uploadShaped = state.Egress.HasRootHtb;
+            var downloadShaped = state.Ingress.DeviceFound && state.Ingress.HasRootHtb;
+
+            var uploadMissing = uploadExpected && !uploadShaped;
+            var downloadMissing = downloadExpected && !downloadShaped;
+
+            if (!uploadMissing && !downloadMissing)
+                continue;
+
+            var preamble = $"Smart Queues is enabled for {state.WanName} in UniFi Network, but the gateway ";
+            string description;
+
+            if (uploadMissing && downloadMissing)
+            {
+                description = preamble +
+                    $"has no shaper on {state.Interface} or {state.IfbInterface}. UniFi Network took the setting " +
+                    "without provisioning the queues, so this connection is running unshaped.";
+            }
+            else if (uploadMissing)
+            {
+                description = downloadShaped
+                    ? preamble + $"is only shaping download. {state.Interface} has no shaper, so upload traffic is running unshaped."
+                    : preamble + $"has no shaper on {state.Interface}, so upload traffic is running unshaped.";
+            }
+            else
+            {
+                description = uploadShaped
+                    ? preamble + $"is only shaping upload. {state.IfbInterface} has no shaper, so download traffic is running unshaped."
+                    : preamble + $"has no shaper on {state.IfbInterface}, so download traffic is running unshaped.";
+            }
+
+            issues.Add(new PerformanceIssue
+            {
+                Title = $"Smart Queues Not Shaping on {state.WanName}",
+                Description = description,
+                Recommendation = "Add any QoS rule in UniFi Network under Settings > Policy Engine > Policy Table > QoS Rules. " +
+                    "It does not matter what the rule targets - creating one makes UniFi Network provision the queues. " +
+                    "Give it about 45 seconds, then run Analyze again.",
+                Severity = PerformanceSeverity.Recommendation,
+                Category = PerformanceCategory.Performance,
+                DeviceName = gatewayName
+            });
+        }
 
         return issues;
     }

--- a/src/NetworkOptimizer.Diagnostics/DiagnosticsEngine.cs
+++ b/src/NetworkOptimizer.Diagnostics/DiagnosticsEngine.cs
@@ -84,6 +84,10 @@ public class DiagnosticsEngine
     /// <param name="clientHistory">Optional historical clients for offline device detection</param>
     /// <param name="settingsData">Raw settings JSON for global switch settings</param>
     /// <param name="qosRulesData">Raw QoS rules JSON for cellular bandwidth checks</param>
+    /// <param name="wanShaperStates">
+    /// Gateway traffic control state for WANs with Smart Queues enabled, read over SSH. Null or
+    /// empty whenever the gateway could not be read, which simply skips that check.
+    /// </param>
     /// <returns>Complete diagnostics result</returns>
     public DiagnosticsResult RunDiagnostics(
         IEnumerable<UniFiClientResponse> clients,
@@ -94,7 +98,8 @@ public class DiagnosticsEngine
         IEnumerable<UniFiClientDetailResponse>? clientHistory = null,
         JsonDocument? settingsData = null,
         JsonDocument? qosRulesData = null,
-        JsonDocument? wanEnrichedData = null)
+        JsonDocument? wanEnrichedData = null,
+        List<WanShaperState>? wanShaperStates = null)
     {
         options ??= new DiagnosticsOptions();
         var stopwatch = Stopwatch.StartNew();
@@ -190,7 +195,8 @@ public class DiagnosticsEngine
                     deviceList, networkList, clientList, settingsData, qosRulesData, wanEnrichedData,
                     runPerformanceChecks: options.RunPerformanceAnalyzer,
                     runCellularChecks: options.RunCellularDataSavings,
-                    portProfiles: profileList);
+                    portProfiles: profileList,
+                    wanShaperStates: wanShaperStates);
                 result.CellularWanDetected = _performanceAnalyzer.CellularWanDetected;
                 _logger?.LogDebug("Performance Analyzer found {Count} issues", result.PerformanceIssues.Count);
             }

--- a/src/NetworkOptimizer.Diagnostics/Models/WanShaperState.cs
+++ b/src/NetworkOptimizer.Diagnostics/Models/WanShaperState.cs
@@ -1,0 +1,59 @@
+namespace NetworkOptimizer.Diagnostics.Models;
+
+/// <summary>
+/// What the gateway's traffic control actually looks like on one WAN that has UniFi Smart Queues
+/// turned on. Read over SSH and handed to the analyzer as plain data, so the check itself stays
+/// free of any SSH or controller dependency.
+///
+/// Both directions are described because UniFi shapes them on different devices: egress rides the
+/// WAN's own data-path interface, ingress rides the mirred "ifb" companion. A WAN can end up with
+/// one and not the other.
+/// </summary>
+public class WanShaperState
+{
+    /// <summary>The WAN's display name in UniFi Network, used in the finding.</summary>
+    public string WanName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The data-path interface: "eth6" plain, "eth6.100" VLAN-tagged, "ppp0" for PPPoE. This is
+    /// the egress (upload) shaper's device.
+    /// </summary>
+    public string Interface { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The ingress (download) shaper's device - "ifb" plus <see cref="Interface"/>. UniFi creates
+    /// it when it provisions Smart Queues, so its absence is itself the symptom.
+    /// </summary>
+    public string IfbInterface { get; init; } = string.Empty;
+
+    /// <summary>Configured Smart Queue download rate in Mbps, null or 0 when UniFi has none.</summary>
+    public int? DownRateMbps { get; init; }
+
+    /// <summary>Configured Smart Queue upload rate in Mbps, null or 0 when UniFi has none.</summary>
+    public int? UpRateMbps { get; init; }
+
+    /// <summary>What tc reported for <see cref="Interface"/>.</summary>
+    public TcDeviceState Egress { get; init; } = new();
+
+    /// <summary>What tc reported for <see cref="IfbInterface"/>.</summary>
+    public TcDeviceState Ingress { get; init; } = new();
+}
+
+/// <summary>
+/// One interface's traffic control state, as read from "tc class show dev &lt;name&gt;".
+/// </summary>
+public class TcDeviceState
+{
+    /// <summary>
+    /// False when tc could not find the device at all. On the ifb companion that means UniFi never
+    /// created it; on the WAN's own interface it means we resolved a name this box does not have,
+    /// which is our problem rather than a finding.
+    /// </summary>
+    public bool DeviceFound { get; init; }
+
+    /// <summary>
+    /// True when tc reported an htb root class - the shaper actually running. A device with only
+    /// the kernel's default "mq" classes is not being shaped.
+    /// </summary>
+    public bool HasRootHtb { get; init; }
+}

--- a/src/NetworkOptimizer.Web/Components/Pages/Optimize.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Optimize.razor
@@ -72,7 +72,7 @@
                         <input type="checkbox" @bind="_runPortProfileSuggestions" />
                         <span>Ethernet Port Profile Suggestions</span>
                     </label>
-                    <label class="checkbox-label">
+                    <label class="checkbox-label" data-tour="performance-suggestions">
                         <input type="checkbox" @bind="_runPerformanceSuggestions" />
                         <span>Performance Suggestions</span>
                     </label>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -664,6 +664,8 @@ builder.Services.AddScoped<AuditService>(); // Scoped - uses IMemoryCache for cr
 // Running a scan and curating findings are gated separately from the audit read surface.
 builder.Services.AddMutatingService<IAuditScanService>(sp => sp.GetRequiredService<AuditService>());
 builder.Services.AddScoped<DiagnosticsService>(); // Scoped - network diagnostics (trunk consistency, AP lock, etc.)
+// Scoped - reads the gateway's traffic control over SSH for the Smart Queues shaper check
+builder.Services.AddScoped<NetworkOptimizer.Web.Services.Ssh.GatewayShaperProbeService>();
 // Mutating product services go through the declarative gate (design doc 06, gate 9): the
 // interface is proxied by MethodSecurityInterceptor, which authorizes the ambient caller against
 // the method's [RequireRole] and writes its [AuditAction] envelope.

--- a/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
+++ b/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
@@ -24,6 +24,7 @@ public class DiagnosticsService
     private readonly ILoggerFactory _loggerFactory;
     private readonly SiteContextService _siteContext;
     private readonly Licensing.LicenseStateService _licenseState;
+    private readonly Ssh.GatewayShaperProbeService _shaperProbe;
 
     public DiagnosticsService(
         ILogger<DiagnosticsService> logger,
@@ -33,7 +34,8 @@ public class DiagnosticsService
         IMemoryCache cache,
         ILoggerFactory loggerFactory,
         SiteContextService siteContext,
-        Licensing.LicenseStateService licenseState)
+        Licensing.LicenseStateService licenseState,
+        Ssh.GatewayShaperProbeService shaperProbe)
     {
         _siteContext = siteContext;
         _licenseState = licenseState;
@@ -43,6 +45,7 @@ public class DiagnosticsService
         _ieeeOuiDb = ieeeOuiDb;
         _cache = cache;
         _loggerFactory = loggerFactory;
+        _shaperProbe = shaperProbe;
     }
 
     /// <summary>
@@ -108,8 +111,15 @@ public class DiagnosticsService
             var qosRulesTask = _connectionService.Client.GetQosRulesRawAsync();
             var wanEnrichedTask = _connectionService.Client.GetWanEnrichedConfigRawAsync();
 
+            // The gateway's traffic control, for WANs with Smart Queues enabled. Rides along with
+            // the controller fetches rather than after them, and returns nothing at all when the
+            // gateway can't be read over SSH.
+            var shaperTask = (options?.RunPerformanceAnalyzer ?? true)
+                ? _shaperProbe.RunAsync()
+                : Task.FromResult(new List<Diagnostics.Models.WanShaperState>());
+
             await Task.WhenAll(devicesTask, clientsTask, networksTask, portProfilesTask, clientHistoryTask,
-                settingsTask, qosRulesTask, wanEnrichedTask);
+                settingsTask, qosRulesTask, wanEnrichedTask, shaperTask);
 
             var devices = await devicesTask;
             var clients = await clientsTask;
@@ -119,6 +129,7 @@ public class DiagnosticsService
             using var settingsDoc = await settingsTask;
             using var qosRulesDoc = await qosRulesTask;
             using var wanEnrichedDoc = await wanEnrichedTask;
+            var wanShaperStates = await shaperTask;
 
             _logger.LogInformation(
                 "Fetched data for diagnostics: {DeviceCount} devices, {ClientCount} clients, " +
@@ -145,7 +156,7 @@ public class DiagnosticsService
                 performanceLogger: _loggerFactory.CreateLogger<Diagnostics.Analyzers.PerformanceAnalyzer>());
 
             var result = engine.RunDiagnostics(clients, devices, portProfiles, networks, options, clientHistory,
-                settingsDoc, qosRulesDoc, wanEnrichedDoc);
+                settingsDoc, qosRulesDoc, wanEnrichedDoc, wanShaperStates);
 
             // Cache the result
             _cache.Set(CacheKeyLastResult, result);

--- a/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
+++ b/src/NetworkOptimizer.Web/Services/DiagnosticsService.cs
@@ -111,12 +111,10 @@ public class DiagnosticsService
             var qosRulesTask = _connectionService.Client.GetQosRulesRawAsync();
             var wanEnrichedTask = _connectionService.Client.GetWanEnrichedConfigRawAsync();
 
-            // The gateway's traffic control, for WANs with Smart Queues enabled. Rides along with
-            // the controller fetches rather than after them, and returns nothing at all when the
-            // gateway can't be read over SSH.
-            var shaperTask = (options?.RunPerformanceAnalyzer ?? true)
-                ? _shaperProbe.RunAsync()
-                : Task.FromResult(new List<Diagnostics.Models.WanShaperState>());
+            // The gateway's traffic control, for WANs with Smart Queues enabled. Runs alongside
+            // the rest of the fetches and returns nothing at all when the gateway can't be read
+            // over SSH.
+            var shaperTask = ProbeWanShapersAsync(networksTask, options);
 
             await Task.WhenAll(devicesTask, clientsTask, networksTask, portProfilesTask, clientHistoryTask,
                 settingsTask, qosRulesTask, wanEnrichedTask, shaperTask);
@@ -177,6 +175,36 @@ public class DiagnosticsService
         {
             _cache.Set(CacheKeyIsRunning, false);
         }
+    }
+
+    /// <summary>
+    /// The gateway's shaper state for WANs with Smart Queues enabled, or nothing when there is
+    /// no such WAN.
+    ///
+    /// Gated on the network configs this run already fetches: reading the shapers means asking the
+    /// controller for the WAN interface names, which costs a second device-list fetch, and an
+    /// install with Smart Queues off everywhere can never produce the finding that would pay for
+    /// it. Waiting on that one small call is what buys the skip - everything else stays parallel.
+    /// </summary>
+    private async Task<List<Diagnostics.Models.WanShaperState>> ProbeWanShapersAsync(
+        Task<List<UniFi.Models.UniFiNetworkConfig>> networksTask, DiagnosticsOptions? options)
+    {
+        var none = new List<Diagnostics.Models.WanShaperState>();
+
+        if (!(options?.RunPerformanceAnalyzer ?? true))
+            return none;
+
+        var networks = await networksTask;
+        var smartQueuesAnywhere = networks.Any(n =>
+            string.Equals(n.Purpose, "wan", StringComparison.OrdinalIgnoreCase) && n.WanSmartqEnabled);
+
+        if (!smartQueuesAnywhere)
+        {
+            _logger.LogDebug("No WAN has Smart Queues enabled - skipping the gateway shaper read");
+            return none;
+        }
+
+        return await _shaperProbe.RunAsync();
     }
 
     private static DiagnosticsResult CreateErrorResult(string title, string message)

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -372,7 +372,7 @@ public class SqmDeploymentService : ISqmDeploymentService
                 result.Success = false;
                 result.Error = $"IFB device {ifbDevice} does not exist. " +
                     "Smart Queues is enabled but UniFi didn't actually create the traffic control classes - this is a known UniFi bug. " +
-                    "To fix it, add any QoS rule in UniFi Network (Settings > Policy Table > QoS Rules). " +
+                    "To fix it, add any QoS rule in UniFi Network (Settings > Policy Engine > Policy Table > QoS Rules). " +
                     "It doesn't matter what the rule targets. Wait 45 seconds, then deploy again.";
                 result.Steps = steps;
                 _logger.LogWarning("SQM deployment blocked: IFB device {Device} not found on gateway", ifbDevice);

--- a/src/NetworkOptimizer.Web/Services/SqmService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmService.cs
@@ -266,6 +266,11 @@ public class SqmService : ISqmService
                 .Where(w => !string.IsNullOrEmpty(w.WanNetworkgroup) && w.WanSmartqDownRate.HasValue)
                 .ToDictionary(w => w.WanNetworkgroup!, w => w.WanSmartqDownRate!.Value / 1000, StringComparer.OrdinalIgnoreCase);
 
+            // Build lookup by wan_networkgroup for SmartQ upload rate (kbps -> Mbps)
+            var networkGroupToSmartqUpRate = wanConfigs
+                .Where(w => !string.IsNullOrEmpty(w.WanNetworkgroup) && w.WanSmartqUpRate.HasValue)
+                .ToDictionary(w => w.WanNetworkgroup!, w => w.WanSmartqUpRate!.Value / 1000, StringComparer.OrdinalIgnoreCase);
+
             // Build lookup by wan_networkgroup for friendly name
             var networkGroupToName = wanConfigs
                 .Where(w => !string.IsNullOrEmpty(w.WanNetworkgroup))
@@ -286,7 +291,7 @@ public class SqmService : ISqmService
             _logger.LogDebug("Enabled WAN network groups (used to filter device WANs): [{Groups}]",
                 enabledNetworkGroups.Count > 0 ? string.Join(", ", enabledNetworkGroups) : "none");
 
-            result = ExtractWanInterfacesFromDeviceData(deviceJson, ipToName, networkGroupToSmartq, networkGroupToSmartqDownRate, networkGroupToName, networkGroupToWanType, enabledNetworkGroups);
+            result = ExtractWanInterfacesFromDeviceData(deviceJson, ipToName, networkGroupToSmartq, networkGroupToSmartqDownRate, networkGroupToSmartqUpRate, networkGroupToName, networkGroupToWanType, enabledNetworkGroups);
 
             _logger.LogInformation("WAN interface detection complete: {Count} interface(s) available for Adaptive SQM", result.Count);
         }
@@ -309,6 +314,7 @@ public class SqmService : ISqmService
         Dictionary<string, string> ipToName,
         Dictionary<string, bool> networkGroupToSmartq,
         Dictionary<string, int> networkGroupToSmartqDownRate,
+        Dictionary<string, int> networkGroupToSmartqUpRate,
         Dictionary<string, string> networkGroupToName,
         Dictionary<string, string> networkGroupToWanType,
         HashSet<string> enabledNetworkGroups)
@@ -521,6 +527,14 @@ public class SqmService : ISqmService
                             smartqDownRateMbps = downRate;
                         }
 
+                        // Get Smart Queue upload rate (Mbps) if configured
+                        int? smartqUpRateMbps = null;
+                        if (!string.IsNullOrEmpty(networkGroup) &&
+                            networkGroupToSmartqUpRate.TryGetValue(networkGroup, out var upRate))
+                        {
+                            smartqUpRateMbps = upRate;
+                        }
+
                         // Get the actual WAN type from network config (dhcp, static, pppoe)
                         var wanType = "dhcp"; // default
                         if (!string.IsNullOrEmpty(networkGroup) &&
@@ -557,6 +571,7 @@ public class SqmService : ISqmService
                             SuggestedPingIp = suggestedPingIp,
                             SmartqEnabled = smartqEnabled,
                             SmartqDownRateMbps = smartqDownRateMbps,
+                            SmartqUpRateMbps = smartqUpRateMbps,
                             LinkSpeedMbps = linkSpeedMbps,
                             WanIndex = i,
                             PhysicalIfName = physicalIfname,
@@ -768,6 +783,9 @@ public class WanInterfaceInfo
 
     /// <summary>Smart Queue download rate in Mbps (from UniFi config, converted from kbps)</summary>
     public int? SmartqDownRateMbps { get; set; }
+
+    /// <summary>Smart Queue upload rate in Mbps (from UniFi config, converted from kbps)</summary>
+    public int? SmartqUpRateMbps { get; set; }
 
     /// <summary>Physical WAN port link speed in Mbps (e.g., 1000 for 1GbE, 2500 for 2.5GbE). Null if unknown (GRE tunnels, etc.)</summary>
     public int? LinkSpeedMbps { get; set; }

--- a/src/NetworkOptimizer.Web/Services/Ssh/GatewayShaperProbe.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/GatewayShaperProbe.cs
@@ -1,0 +1,153 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using NetworkOptimizer.Diagnostics.Models;
+
+namespace NetworkOptimizer.Web.Services.Ssh;
+
+/// <summary>
+/// One WAN to read traffic control for: the names of its two shaper devices plus the rates UniFi
+/// says it should be shaping at, which is what tells a missing shaper apart from a direction
+/// UniFi was never asked to shape.
+/// </summary>
+/// <param name="WanName">The WAN's display name in UniFi Network.</param>
+/// <param name="Interface">Data-path interface - "eth6", "eth6.100", "ppp0".</param>
+/// <param name="IfbInterface">The ingress companion - "ifb" plus the data-path name.</param>
+/// <param name="DownRateMbps">Configured Smart Queue download rate, if any.</param>
+/// <param name="UpRateMbps">Configured Smart Queue upload rate, if any.</param>
+public record ShaperProbeTarget(
+    string WanName,
+    string Interface,
+    string IfbInterface,
+    int? DownRateMbps,
+    int? UpRateMbps);
+
+/// <summary>
+/// Builds and reads the gateway's traffic control readout for WANs with Smart Queues enabled.
+/// Pure string work with no I/O, so the parsing is unit-testable against real gateway output.
+///
+/// Every interface is asked in a single marker-separated command, the same shape
+/// <see cref="Monitoring.GatewayDiagnosticsService"/> uses: SSH session setup dominates the cost,
+/// so one round trip covers every WAN whatever the count.
+/// </summary>
+public static partial class GatewayShaperProbe
+{
+    /// <summary>Prefix of the line that introduces one interface's section.</summary>
+    public const string Marker = "###TC";
+
+    /// <summary>
+    /// The command reading every interface in one trip. Each section is introduced by
+    /// "###TC &lt;interface&gt;", stderr is folded into stdout so "Cannot find device" arrives as
+    /// section text rather than vanishing, and the chain ends on `true` so a non-zero exit from
+    /// the last tc call isn't reported as a failed SSH run.
+    /// </summary>
+    public static string BuildCommand(IEnumerable<string> interfaces)
+    {
+        var command = new StringBuilder();
+        foreach (var name in interfaces)
+        {
+            command.Append($"echo '{Marker} {name}'; tc class show dev {name} 2>&1; ");
+        }
+        command.Append("true");
+        return command.ToString();
+    }
+
+    /// <summary>
+    /// Reads the command output into one state per target. A target whose sections did not both
+    /// come back is dropped rather than guessed at - a truncated readout must not read as a
+    /// missing shaper.
+    /// </summary>
+    public static List<WanShaperState> Parse(string output, IEnumerable<ShaperProbeTarget> targets)
+    {
+        var sections = SplitSections(output);
+        var states = new List<WanShaperState>();
+
+        foreach (var target in targets)
+        {
+            if (!sections.TryGetValue(target.Interface, out var egress) ||
+                !sections.TryGetValue(target.IfbInterface, out var ingress))
+            {
+                continue;
+            }
+
+            states.Add(new WanShaperState
+            {
+                WanName = target.WanName,
+                Interface = target.Interface,
+                IfbInterface = target.IfbInterface,
+                DownRateMbps = target.DownRateMbps,
+                UpRateMbps = target.UpRateMbps,
+                Egress = ReadDevice(egress),
+                Ingress = ReadDevice(ingress)
+            });
+        }
+
+        return states;
+    }
+
+    /// <summary>
+    /// Guards an interface name before it reaches the command line. Interface names are the only
+    /// caller-supplied part of the command and they come from the controller, so they are checked
+    /// rather than escaped.
+    /// </summary>
+    public static bool IsValidInterfaceName(string? name) =>
+        !string.IsNullOrWhiteSpace(name) && InterfaceNamePattern().IsMatch(name);
+
+    /// <summary>
+    /// What one section says about its device. An empty section is a real answer: an interface
+    /// with no shaper and no classful qdisc lists nothing at all.
+    /// </summary>
+    private static TcDeviceState ReadDevice(string section)
+    {
+        if (DeviceMissingPattern().IsMatch(section))
+            return new TcDeviceState { DeviceFound = false, HasRootHtb = false };
+
+        return new TcDeviceState
+        {
+            DeviceFound = true,
+            HasRootHtb = RootHtbPattern().IsMatch(section)
+        };
+    }
+
+    private static Dictionary<string, string> SplitSections(string output)
+    {
+        var sections = new Dictionary<string, string>(StringComparer.Ordinal);
+        string? current = null;
+        var buffer = new List<string>();
+
+        void Flush()
+        {
+            if (current != null)
+                sections[current] = string.Join("\n", buffer);
+            buffer.Clear();
+        }
+
+        foreach (var raw in (output ?? string.Empty).Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith(Marker + " ", StringComparison.Ordinal))
+            {
+                Flush();
+                current = trimmed[(Marker.Length + 1)..].Trim();
+                continue;
+            }
+            if (current != null) buffer.Add(line);
+        }
+        Flush();
+        return sections;
+    }
+
+    /// <summary>
+    /// The shaper actually running: "class htb 1:1 root rate 550Mbit ...". An interface left to
+    /// the kernel's own multiqueue shows "class mq :1 root" and matches nothing here.
+    /// </summary>
+    [GeneratedRegex(@"^\s*class\s+htb\s+\S+\s+root\b", RegexOptions.Multiline)]
+    private static partial Regex RootHtbPattern();
+
+    /// <summary>iproute2's wording when the device does not exist on the box.</summary>
+    [GeneratedRegex(@"Cannot find device|does not exist", RegexOptions.IgnoreCase)]
+    private static partial Regex DeviceMissingPattern();
+
+    [GeneratedRegex(@"^[A-Za-z0-9][A-Za-z0-9._-]{0,30}$")]
+    private static partial Regex InterfaceNamePattern();
+}

--- a/src/NetworkOptimizer.Web/Services/Ssh/GatewayShaperProbeService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/GatewayShaperProbeService.cs
@@ -1,0 +1,117 @@
+using NetworkOptimizer.Diagnostics.Models;
+
+namespace NetworkOptimizer.Web.Services.Ssh;
+
+/// <summary>
+/// Reads, over SSH, whether the gateway is actually shaping the WANs that have UniFi Smart Queues
+/// turned on. UniFi Network regularly accepts the Smart Queues toggle without provisioning the
+/// queues, and the only place that shows is the gateway's own traffic control - the controller
+/// keeps reporting the feature as enabled.
+///
+/// Every command is a read, and everything is asked in one round trip. Anything that makes the
+/// answer unavailable - SSH off, no credentials, an offline agent tunnel, a failed command -
+/// returns no states at all rather than a guess, so a site we cannot see is never accused of a
+/// misconfiguration.
+/// </summary>
+public class GatewayShaperProbeService
+{
+    private readonly ISqmService _sqmService;
+    private readonly IGatewaySshService _gatewaySsh;
+    private readonly ILogger<GatewayShaperProbeService> _logger;
+
+    public GatewayShaperProbeService(
+        ISqmService sqmService,
+        IGatewaySshService gatewaySsh,
+        ILogger<GatewayShaperProbeService> logger)
+    {
+        _sqmService = sqmService;
+        _gatewaySsh = gatewaySsh;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// The shaper state of every WAN with Smart Queues enabled. Empty when there are none, or
+    /// when the gateway cannot be read.
+    /// </summary>
+    public async Task<List<WanShaperState>> RunAsync(CancellationToken ct = default)
+    {
+        var empty = new List<WanShaperState>();
+
+        try
+        {
+            var targets = await BuildTargetsAsync();
+            if (targets.Count == 0)
+                return empty;
+
+            var settings = await _gatewaySsh.GetSettingsAsync();
+            if (!settings.Enabled || string.IsNullOrEmpty(settings.Host) || !settings.HasCredentials)
+            {
+                _logger.LogDebug("Skipping Smart Queues shaper probe: gateway SSH not available");
+                return empty;
+            }
+
+            if (await _gatewaySsh.IsAwaitingAgentTunnelAsync())
+            {
+                _logger.LogDebug("Skipping Smart Queues shaper probe: waiting for the site's agent");
+                return empty;
+            }
+
+            var interfaces = targets
+                .SelectMany(t => new[] { t.Interface, t.IfbInterface })
+                .ToList();
+
+            var (success, output) = await _gatewaySsh.RunCommandAsync(
+                GatewayShaperProbe.BuildCommand(interfaces), TimeSpan.FromSeconds(20), ct);
+
+            if (!success)
+            {
+                _logger.LogDebug("Smart Queues shaper probe command failed: {Output}", output);
+                return empty;
+            }
+
+            var states = GatewayShaperProbe.Parse(output, targets);
+            _logger.LogDebug(
+                "Smart Queues shaper probe read {Count} of {Target} WAN(s) with Smart Queues enabled",
+                states.Count, targets.Count);
+            return states;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Smart Queues shaper probe failed");
+            return empty;
+        }
+    }
+
+    /// <summary>
+    /// The WANs worth reading: Smart Queues on, and interface names the controller gave us that
+    /// are safe to put on a command line. Interface resolution is the controller's - "eth6" plain,
+    /// "eth6.100" VLAN-tagged, "ppp0" for PPPoE - so this check looks at exactly the devices
+    /// Adaptive SQM and Monitoring do.
+    /// </summary>
+    private async Task<List<ShaperProbeTarget>> BuildTargetsAsync()
+    {
+        var wans = await _sqmService.GetWanInterfacesFromControllerAsync();
+        var targets = new List<ShaperProbeTarget>();
+
+        foreach (var wan in wans.Where(w => w.SmartqEnabled))
+        {
+            if (!GatewayShaperProbe.IsValidInterfaceName(wan.Interface) ||
+                !GatewayShaperProbe.IsValidInterfaceName(wan.TcInterface))
+            {
+                _logger.LogDebug(
+                    "Skipping WAN {Name} in shaper probe: unusable interface name '{Interface}'",
+                    wan.Name, wan.Interface);
+                continue;
+            }
+
+            targets.Add(new ShaperProbeTarget(
+                wan.Name,
+                wan.Interface,
+                wan.TcInterface,
+                wan.SmartqDownRateMbps,
+                wan.SmartqUpRateMbps));
+        }
+
+        return targets;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Tours/TourPredicateResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Tours/TourPredicateResolver.cs
@@ -33,8 +33,17 @@ public class TourPredicateResolver
     /// </summary>
     public const string SqmEnabled = "sqm-enabled";
 
+    /// <summary>
+    /// UniFi's own Smart Queues is on for at least one of the site's WANs. Not the same thing as
+    /// <see cref="SqmEnabled"/>, which is our Adaptive SQM: a WAN can have UniFi's Smart Queues on
+    /// without Adaptive SQM ever being deployed, and that is exactly the case the Smart Queues
+    /// shaper check exists for.
+    /// </summary>
+    public const string SmartQueues = "smart-queues";
+
     private readonly SiteManagementService _siteManagement;
     private readonly GatewaySshRegistry _gatewaySshRegistry;
+    private readonly SiteConnectionRegistry _siteConnections;
     private readonly AgentEnrollmentService _agentEnrollment;
     private readonly SiteDbContextFactory _siteDbFactory;
     private readonly ILogger<TourPredicateResolver> _logger;
@@ -42,12 +51,14 @@ public class TourPredicateResolver
     public TourPredicateResolver(
         SiteManagementService siteManagement,
         GatewaySshRegistry gatewaySshRegistry,
+        SiteConnectionRegistry siteConnections,
         AgentEnrollmentService agentEnrollment,
         SiteDbContextFactory siteDbFactory,
         ILogger<TourPredicateResolver> logger)
     {
         _siteManagement = siteManagement;
         _gatewaySshRegistry = gatewaySshRegistry;
+        _siteConnections = siteConnections;
         _agentEnrollment = agentEnrollment;
         _siteDbFactory = siteDbFactory;
         _logger = logger;
@@ -119,6 +130,7 @@ public class TourPredicateResolver
         var gatewaySshSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var ispHealthSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var sqmSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var smartQueuesSites = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var site in sites)
         {
             try
@@ -150,6 +162,16 @@ public class TourPredicateResolver
             {
                 _logger.LogDebug(ex, "Tour predicate {Predicate} evaluation failed for site {Slug}", SqmEnabled, site.Slug);
             }
+
+            try
+            {
+                if (await HasSmartQueuesAsync(site.Slug))
+                    smartQueuesSites.Add(site.Slug);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Tour predicate {Predicate} evaluation failed for site {Slug}", SmartQueues, site.Slug);
+            }
         }
         if (gatewaySshSites.Count > 0)
             qualifying[GatewaySsh] = gatewaySshSites;
@@ -157,6 +179,8 @@ public class TourPredicateResolver
             qualifying[IspHealth] = ispHealthSites;
         if (sqmSites.Count > 0)
             qualifying[SqmEnabled] = sqmSites;
+        if (smartQueuesSites.Count > 0)
+            qualifying[SmartQueues] = smartQueuesSites;
 
         return new PredicateContext
         {
@@ -194,5 +218,21 @@ public class TourPredicateResolver
     {
         using var db = _siteDbFactory.CreateForSite(slug, isDefault);
         return await db.SqmWanConfigurations.AsNoTracking().AnyAsync(c => c.Enabled);
+    }
+
+    /// <summary>
+    /// Whether the site has UniFi's Smart Queues turned on for at least one enabled WAN. This one
+    /// has to ask the console - nothing stores UniFi's own toggle locally - which is affordable
+    /// only because predicates resolve just for a tour that is actually due, never on the ordinary
+    /// Dashboard visit. A site that isn't connected simply does not qualify.
+    /// </summary>
+    private async Task<bool> HasSmartQueuesAsync(string slug)
+    {
+        var connection = _siteConnections.GetFor(slug);
+        if (!connection.IsConnected || connection.Client == null)
+            return false;
+
+        var wans = await connection.Client.GetWanConfigsAsync();
+        return wans.Any(w => w.Enabled && w.WanSmartqEnabled);
     }
 }

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.6.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.6.0.json
@@ -1,0 +1,20 @@
+{
+  "id": "2.6.0",
+  "kind": "whats-new",
+  "title": "What's new in v2.6.0",
+  "summary": "Config Optimizer now catches Smart Queues that UniFi Network never actually turned on.",
+  "steps": [
+    {
+      "id": "smart-queues-not-shaping",
+      "level": "minor",
+      "url": "/config-optimizer",
+      "selector": "[data-tour=\"performance-suggestions\"]",
+      "title": "Smart Queues check",
+      "listLabel": "Smart Queues that UniFi Network never actually turned on",
+      "badge": "improved",
+      "body": "UniFi Network can leave Smart Queues switched on with no shaper actually running. **Analyze** now catches that and tells you how to fix it.",
+      "placement": "top",
+      "requires": ["smart-queues"]
+    }
+  ]
+}

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PerformanceAnalyzerTests.cs
@@ -1980,4 +1980,132 @@ public class PerformanceAnalyzerTests
     }
 
     #endregion
+
+    #region SQM Not Shaping
+
+    [Fact]
+    public void CheckSqmNotShaping_NoStates_ReturnsEmpty()
+    {
+        _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, null)
+            .Should().BeEmpty();
+
+        _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, new List<WanShaperState>())
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_BothDirectionsShaped_ReturnsEmpty()
+    {
+        var states = new List<WanShaperState> { CreateShaperState(egressHtb: true, ingressHtb: true) };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_NeitherDirectionShaped_ReportsBothInterfaces()
+    {
+        var states = new List<WanShaperState> { CreateShaperState(egressHtb: false, ingressHtb: false) };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        var issue = result.Should().ContainSingle().Subject;
+        issue.Title.Should().Be("Smart Queues Not Shaping on Fiber");
+        issue.Severity.Should().Be(PerformanceSeverity.Recommendation);
+        issue.Category.Should().Be(PerformanceCategory.Performance);
+        issue.DeviceName.Should().Be("Test Gateway");
+        issue.Description.Should().Contain("no shaper on ppp0 or ifbppp0");
+        issue.Description.Should().Contain("running unshaped");
+        issue.Recommendation.Should().Contain("QoS rule");
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_IfbDeviceMissing_ReportsDownloadUnshaped()
+    {
+        var states = new List<WanShaperState> { CreateShaperState(egressHtb: true, ingressFound: false) };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        var issue = result.Should().ContainSingle().Subject;
+        issue.Description.Should().Contain("only shaping upload");
+        issue.Description.Should().Contain("ifbppp0 has no shaper");
+        issue.Description.Should().Contain("download traffic is running unshaped");
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_EgressUnshaped_ReportsUploadUnshaped()
+    {
+        var states = new List<WanShaperState> { CreateShaperState(egressHtb: false, ingressHtb: true) };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        var issue = result.Should().ContainSingle().Subject;
+        issue.Description.Should().Contain("only shaping download");
+        issue.Description.Should().Contain("ppp0 has no shaper");
+        issue.Description.Should().Contain("upload traffic is running unshaped");
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_DirectionRatedZero_IsNotExpectedToShape()
+    {
+        var states = new List<WanShaperState>
+        {
+            CreateShaperState(egressHtb: false, ingressHtb: true, upRateMbps: 0)
+        };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_WanInterfaceNotOnGateway_ReturnsEmpty()
+    {
+        // We resolved a device name the box doesn't have - that says nothing about UniFi's
+        // provisioning, so it must not surface as a finding.
+        var states = new List<WanShaperState> { CreateShaperState(egressFound: false, ingressFound: false) };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CheckSqmNotShaping_MultipleWans_ReportsOnlyTheUnshapedOne()
+    {
+        var states = new List<WanShaperState>
+        {
+            CreateShaperState(egressHtb: true, ingressHtb: true),
+            CreateShaperState(egressHtb: false, ingressHtb: false, wanName: "Cable", ifName: "eth7")
+        };
+
+        var result = _analyzer.CheckSqmNotShaping(new List<UniFiDeviceResponse> { CreateGateway() }, states);
+
+        result.Should().ContainSingle().Which.Title.Should().Be("Smart Queues Not Shaping on Cable");
+    }
+
+    private static WanShaperState CreateShaperState(
+        bool egressHtb = false,
+        bool ingressHtb = false,
+        bool egressFound = true,
+        bool ingressFound = true,
+        int? downRateMbps = 900,
+        int? upRateMbps = 500,
+        string wanName = "Fiber",
+        string ifName = "ppp0")
+    {
+        return new WanShaperState
+        {
+            WanName = wanName,
+            Interface = ifName,
+            IfbInterface = $"ifb{ifName}",
+            DownRateMbps = downRateMbps,
+            UpRateMbps = upRateMbps,
+            Egress = new TcDeviceState { DeviceFound = egressFound, HasRootHtb = egressHtb },
+            Ingress = new TcDeviceState { DeviceFound = ingressFound, HasRootHtb = ingressHtb }
+        };
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Web.Tests/Ssh/GatewayShaperProbeServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Ssh/GatewayShaperProbeServiceTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using NetworkOptimizer.Web.Services.Ssh;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Ssh;
+
+/// <summary>
+/// The preconditions around the Smart Queues shaper read. Everything here is about NOT asking:
+/// a site with nothing to check, or a gateway we cannot see, must cost no SSH and produce no
+/// state - a finding raised from a failed read would accuse a healthy install.
+/// </summary>
+public class GatewayShaperProbeServiceTests
+{
+    private readonly Mock<ISqmService> _sqm = new();
+    private readonly Mock<IGatewaySshService> _ssh = new();
+
+    private GatewayShaperProbeService CreateService() =>
+        new(_sqm.Object, _ssh.Object, NullLogger<GatewayShaperProbeService>.Instance);
+
+    [Fact]
+    public async Task RunAsync_NoWanWithSmartQueues_NeverTouchesSsh()
+    {
+        SetWans(CreateWan("Fiber", "eth6", smartqEnabled: false));
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+        _ssh.Verify(s => s.GetSettingsAsync(It.IsAny<bool>()), Times.Never);
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_GatewaySshDisabled_ReturnsNothing()
+    {
+        SetWans(CreateWan("Fiber", "eth6"));
+        SetSshSettings(enabled: false);
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_NoCredentials_ReturnsNothing()
+    {
+        SetWans(CreateWan("Fiber", "eth6"));
+        SetSshSettings(password: null);
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_AgentTunnelNotUp_ReturnsNothing()
+    {
+        SetWans(CreateWan("Fiber", "eth6"));
+        SetSshSettings();
+        _ssh.Setup(s => s.IsAwaitingAgentTunnelAsync()).ReturnsAsync(true);
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task RunAsync_CommandFails_ReturnsNothing()
+    {
+        SetWans(CreateWan("Fiber", "eth6"));
+        SetSshSettings();
+        SetCommandResult(success: false, output: "Connection refused");
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RunAsync_ReadsEveryEnabledWanInOneCommand()
+    {
+        SetWans(
+            CreateWan("Fiber", "ppp0"),
+            CreateWan("Cable", "eth7"),
+            CreateWan("Backup", "eth8", smartqEnabled: false));
+        SetSshSettings();
+
+        string? issued = null;
+        _ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, TimeSpan?, CancellationToken>((cmd, _, _) => issued = cmd)
+            .ReturnsAsync(() => (true, """
+                ###TC ppp0
+                class htb 1:1 root rate 550Mbit ceil 550Mbit
+                ###TC ifbppp0
+                class htb 1:1 root rate 894Mbit ceil 894Mbit
+                ###TC eth7
+                class mq :1 root
+                ###TC ifbeth7
+                Cannot find device "ifbeth7"
+                """));
+
+        var states = await CreateService().RunAsync();
+
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Once);
+        issued.Should().Contain("ppp0").And.Contain("ifbppp0").And.Contain("eth7").And.Contain("ifbeth7");
+        issued.Should().NotContain("eth8");
+
+        states.Should().HaveCount(2);
+        states[0].WanName.Should().Be("Fiber");
+        states[0].Egress.HasRootHtb.Should().BeTrue();
+        states[1].WanName.Should().Be("Cable");
+        states[1].Ingress.DeviceFound.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunAsync_UnusableInterfaceName_SkipsThatWan()
+    {
+        SetWans(CreateWan("Odd", "eth6; reboot"));
+        SetSshSettings();
+
+        var states = await CreateService().RunAsync();
+
+        states.Should().BeEmpty();
+        _ssh.Verify(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private void SetWans(params WanInterfaceInfo[] wans) =>
+        _sqm.Setup(s => s.GetWanInterfacesFromControllerAsync()).ReturnsAsync(wans.ToList());
+
+    private void SetSshSettings(bool enabled = true, string? host = "192.0.2.1", string? password = "secret") =>
+        _ssh.Setup(s => s.GetSettingsAsync(It.IsAny<bool>())).ReturnsAsync(new GatewaySshSettings
+        {
+            Enabled = enabled,
+            Host = host,
+            Username = "root",
+            Password = password
+        });
+
+    private void SetCommandResult(bool success, string output) =>
+        _ssh.Setup(s => s.RunCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((success, output));
+
+    private static WanInterfaceInfo CreateWan(string name, string ifName, bool smartqEnabled = true) =>
+        new()
+        {
+            Name = name,
+            Interface = ifName,
+            TcInterface = $"ifb{ifName}",
+            SmartqEnabled = smartqEnabled,
+            SmartqDownRateMbps = 900,
+            SmartqUpRateMbps = 500
+        };
+}

--- a/tests/NetworkOptimizer.Web.Tests/Ssh/GatewayShaperProbeTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Ssh/GatewayShaperProbeTests.cs
@@ -1,0 +1,157 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Ssh;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Ssh;
+
+/// <summary>
+/// Parser coverage for the Smart Queues shaper probe. The samples are what a UniFi gateway
+/// actually emits: an htb root class when the shaper is running, the kernel's own multiqueue
+/// classes when it is not (the exact output from the report in #1083), and iproute2's message
+/// when UniFi never created the ingress device at all.
+/// </summary>
+public class GatewayShaperProbeTests
+{
+    private static readonly ShaperProbeTarget PppoeWan =
+        new("Fiber", "ppp0", "ifbppp0", DownRateMbps: 894, UpRateMbps: 550);
+
+    [Fact]
+    public void BuildCommand_AsksEveryInterfaceInOneTrip()
+    {
+        var command = GatewayShaperProbe.BuildCommand(new[] { "ppp0", "ifbppp0", "eth7" });
+
+        command.Should().Contain("###TC ppp0");
+        command.Should().Contain("tc class show dev ppp0 2>&1");
+        command.Should().Contain("###TC ifbppp0");
+        command.Should().Contain("tc class show dev eth7 2>&1");
+        command.Should().EndWith("true");
+    }
+
+    [Fact]
+    public void Parse_ShapedWan_ReadsBothDirections()
+    {
+        const string output = """
+            ###TC ppp0
+            class htb 1:1 root rate 550Mbit ceil 550Mbit burst 2750b cburst 2750b
+            ###TC ifbppp0
+            class htb 1:1 root rate 894Mbit ceil 894Mbit burst 111750b cburst 111750b
+            """;
+
+        var state = GatewayShaperProbe.Parse(output, new[] { PppoeWan }).Should().ContainSingle().Subject;
+
+        state.WanName.Should().Be("Fiber");
+        state.Egress.DeviceFound.Should().BeTrue();
+        state.Egress.HasRootHtb.Should().BeTrue();
+        state.Ingress.DeviceFound.Should().BeTrue();
+        state.Ingress.HasRootHtb.Should().BeTrue();
+        state.DownRateMbps.Should().Be(894);
+        state.UpRateMbps.Should().Be(550);
+    }
+
+    [Fact]
+    public void Parse_MultiqueueOnly_IsNotShaped()
+    {
+        // A physical WAN port left unshaped: the kernel's own mq classes and nothing else.
+        const string output = """
+            ###TC eth6
+            class mq :1 root
+            class mq :2 root
+            class mq :3 root
+            class mq :4 root
+            ###TC ifbeth6
+            class mq :1 root
+            """;
+
+        var target = new ShaperProbeTarget("Fiber", "eth6", "ifbeth6", 900, 500);
+
+        var state = GatewayShaperProbe.Parse(output, new[] { target }).Should().ContainSingle().Subject;
+
+        state.Egress.DeviceFound.Should().BeTrue();
+        state.Egress.HasRootHtb.Should().BeFalse();
+        state.Ingress.HasRootHtb.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_EmptySection_IsAFoundButUnshapedDevice()
+    {
+        // An interface with no classful qdisc lists nothing at all - that is an answer, not a gap.
+        const string output = """
+            ###TC ppp0
+            ###TC ifbppp0
+            """;
+
+        var state = GatewayShaperProbe.Parse(output, new[] { PppoeWan }).Should().ContainSingle().Subject;
+
+        state.Egress.DeviceFound.Should().BeTrue();
+        state.Egress.HasRootHtb.Should().BeFalse();
+        state.Ingress.DeviceFound.Should().BeTrue();
+        state.Ingress.HasRootHtb.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_MissingIfbDevice_IsReportedAsNotFound()
+    {
+        const string output = """
+            ###TC ppp0
+            class htb 1:1 root rate 550Mbit ceil 550Mbit
+            ###TC ifbppp0
+            Cannot find device "ifbppp0"
+            """;
+
+        var state = GatewayShaperProbe.Parse(output, new[] { PppoeWan }).Should().ContainSingle().Subject;
+
+        state.Egress.HasRootHtb.Should().BeTrue();
+        state.Ingress.DeviceFound.Should().BeFalse();
+        state.Ingress.HasRootHtb.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_SeveralWansInOneOutput_KeepsThemApart()
+    {
+        const string output = """
+            ###TC ppp0
+            class htb 1:1 root rate 550Mbit ceil 550Mbit
+            ###TC ifbppp0
+            class htb 1:1 root rate 894Mbit ceil 894Mbit
+            ###TC eth7
+            class mq :1 root
+            ###TC ifbeth7
+            Cannot find device "ifbeth7"
+            """;
+
+        var second = new ShaperProbeTarget("Cable", "eth7", "ifbeth7", 500, 20);
+
+        var states = GatewayShaperProbe.Parse(output, new[] { PppoeWan, second });
+
+        states.Should().HaveCount(2);
+        states[0].Egress.HasRootHtb.Should().BeTrue();
+        states[1].Egress.HasRootHtb.Should().BeFalse();
+        states[1].Ingress.DeviceFound.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_TruncatedOutput_DropsTheWanRatherThanGuessing()
+    {
+        // Only the egress section came back. Treating the absent ifb section as "no shaper"
+        // would turn a truncated read into a finding.
+        const string output = """
+            ###TC ppp0
+            class htb 1:1 root rate 550Mbit ceil 550Mbit
+            """;
+
+        GatewayShaperProbe.Parse(output, new[] { PppoeWan }).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("eth6", true)]
+    [InlineData("eth6.100", true)]
+    [InlineData("ifbppp0", true)]
+    [InlineData("", false)]
+    [InlineData("eth6; rm -rf /", false)]
+    [InlineData("$(reboot)", false)]
+    [InlineData("eth6 && reboot", false)]
+    public void IsValidInterfaceName_RejectsAnythingWithShellMeaning(string name, bool expected)
+    {
+        GatewayShaperProbe.IsValidInterfaceName(name).Should().Be(expected);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Tours/TourDefinitionFileTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Tours/TourDefinitionFileTests.cs
@@ -1,0 +1,58 @@
+using System.Reflection;
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Tours;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Tours;
+
+/// <summary>
+/// Guards the shipped tour JSON against the mistake it cannot report: a step whose "requires"
+/// names a predicate that does not exist resolves to "no site qualifies", so the step is silently
+/// dropped from every install forever, with nothing in the logs to say a tour lost a step.
+/// </summary>
+public class TourDefinitionFileTests
+{
+    private static readonly HashSet<string> KnownPredicates = typeof(TourPredicateResolver)
+        .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+        .Where(f => f.IsLiteral && f.FieldType == typeof(string))
+        .Select(f => (string)f.GetRawConstantValue()!)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    public static TheoryData<string> TourFiles()
+    {
+        var data = new TheoryData<string>();
+        foreach (var file in Directory.GetFiles(ToursDirectory(), "*.json"))
+            data.Add(Path.GetFileName(file));
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(TourFiles))]
+    public void EveryStepRequiresAKnownPredicate(string fileName)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(Path.Combine(ToursDirectory(), fileName)));
+
+        foreach (var step in doc.RootElement.GetProperty("steps").EnumerateArray())
+        {
+            if (!step.TryGetProperty("requires", out var requires))
+                continue;
+
+            foreach (var predicate in requires.EnumerateArray())
+            {
+                KnownPredicates.Should().Contain(predicate.GetString()!,
+                    $"step '{step.GetProperty("id").GetString()}' in {fileName} would never be shown otherwise");
+            }
+        }
+    }
+
+    private static string ToursDirectory()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "NetworkOptimizer.sln")))
+            directory = directory.Parent;
+
+        directory.Should().NotBeNull("the test must run from inside a NetworkOptimizer checkout");
+        return Path.Combine(directory!.FullName, "src", "NetworkOptimizer.Web", "wwwroot", "data", "tours");
+    }
+}


### PR DESCRIPTION
Closes #1083

UniFi Network regularly accepts the Smart Queues toggle on a WAN without provisioning the shaper. The setting reads as on, the gateway has no htb root class, and the connection runs unshaped with nothing on screen to say so - the user just sees a lopsided upload. Until now the only place that got said was an Adaptive SQM deploy failing on the missing IFB device, so nobody who wasn't deploying Adaptive SQM ever heard it.

## Config Optimizer - Performance Suggestions

- **Smart Queues Not Shaping on \<WAN\>** - For each WAN with Smart Queues enabled, Network Optimizer now reads the gateway's traffic control over SSH and raises a recommendation when the shaper isn't actually there, with the fix: add any QoS rule in UniFi Network, which makes it provision the queues. A WAN shaped in only one direction is reported naming the direction that isn't.

Interface resolution is the one Adaptive SQM and Monitoring already use - the WAN's `uplink_ifname` (`eth6` plain, `eth6.100` VLAN-tagged, `ppp0` for PPPoE) plus its `ifb` companion. Egress rides the WAN interface (upload), ingress rides the `ifb` (download).

The check runs with the existing **Performance Suggestions** option, needs no new setting, and goes out in a single SSH round trip however many WANs there are. It stays silent whenever it can't see the answer: no WAN with Smart Queues on (no console read and no SSH at all then), gateway SSH off or without credentials, a site whose agent tunnel isn't up, a failed command, a truncated readout, or a WAN interface the gateway doesn't have. A direction UniFi Network was told to shape at 0 isn't expected to have a shaper either.

Ships with a v2.6.0 tour step, shown only where UniFi Smart Queues is actually on - a new `smart-queues` predicate, distinct from the existing `sqm-enabled`, which is our Adaptive SQM.

## Fixes

- **QoS rule menu path** - The app gave the path to UniFi Network's QoS Rules three different ways. The Cellular Data Savings recommendations and the Adaptive SQM deploy message now read the same as the new finding.
