### PR TITLE
Per-WAN outage alerting, and the Alerts & Schedule page it lands on

### DIFF
--- a/src/NetworkOptimizer.Alerts/AlertCorrelationService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertCorrelationService.cs
@@ -41,6 +41,40 @@ public class AlertCorrelationService
     /// in that incident, and persists it when it changed. No-op for an uncorrelated alert. Shared
     /// by the UI's acknowledge/resolve actions and by the pipeline's automatic resolution.
     /// </summary>
+    /// <summary>
+    /// Re-derives many incidents at once: one read for the incidents, one for every alert on them,
+    /// and one save. Doing it per incident costs two round trips and a commit each, which is what
+    /// the bulk buttons still paid after the alerts themselves were batched - a few hundred alerts
+    /// usually means nearly as many incidents, since most incidents hold one alert.
+    /// </summary>
+    public static async Task RecalculateIncidentStatusesAsync(
+        IReadOnlyCollection<int> incidentIds,
+        IAlertRepository repository,
+        CancellationToken cancellationToken = default)
+    {
+        if (incidentIds.Count == 0) return;
+
+        var incidents = await repository.GetIncidentsByIdsAsync(incidentIds, cancellationToken);
+        if (incidents.Count == 0) return;
+
+        var alertsByIncident = (await repository.GetAlertsByIncidentIdsAsync(incidentIds, cancellationToken))
+            .GroupBy(a => a.IncidentId!.Value)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var changed = new List<AlertIncident>();
+        foreach (var incident in incidents)
+        {
+            if (!alertsByIncident.TryGetValue(incident.Id, out var alerts)) continue;
+            var (status, resolvedAt) = DeriveIncidentStatus(alerts);
+            if (status == incident.Status) continue;
+            incident.Status = status;
+            incident.ResolvedAt = resolvedAt;
+            changed.Add(incident);
+        }
+
+        await repository.UpdateIncidentsAsync(changed, cancellationToken);
+    }
+
     public static async Task RecalculateIncidentStatusAsync(
         AlertHistoryEntry alert,
         IAlertRepository repository,

--- a/src/NetworkOptimizer.Alerts/AlertCorrelationService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertCorrelationService.cs
@@ -37,6 +37,31 @@ public class AlertCorrelationService
     }
 
     /// <summary>
+    /// Re-derives the status of the incident an alert belongs to from the statuses of every alert
+    /// in that incident, and persists it when it changed. No-op for an uncorrelated alert. Shared
+    /// by the UI's acknowledge/resolve actions and by the pipeline's automatic resolution.
+    /// </summary>
+    public static async Task RecalculateIncidentStatusAsync(
+        AlertHistoryEntry alert,
+        IAlertRepository repository,
+        CancellationToken cancellationToken = default)
+    {
+        if (!alert.IncidentId.HasValue) return;
+
+        var incident = await repository.GetIncidentAsync(alert.IncidentId.Value, cancellationToken);
+        if (incident == null) return;
+
+        var incidentAlerts = await repository.GetAlertsByIncidentIdAsync(incident.Id, cancellationToken);
+        var (newStatus, resolvedAt) = DeriveIncidentStatus(incidentAlerts);
+
+        if (newStatus == incident.Status) return;
+
+        incident.Status = newStatus;
+        incident.ResolvedAt = resolvedAt;
+        await repository.UpdateIncidentAsync(incident, cancellationToken);
+    }
+
+    /// <summary>
     /// Derive a correlation key from an alert event.
     /// Events with the same key within the correlation window will be grouped.
     /// </summary>

--- a/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
@@ -127,6 +127,10 @@ public class AlertProcessingService : BackgroundService
         scope.ServiceProvider.GetRequiredService<IAlertSiteScope>().UseSite(alertEvent.SiteSlug);
         var repository = scope.ServiceProvider.GetRequiredService<IAlertRepository>();
 
+        // Close whatever this event supersedes before any rule is consulted, so an install with
+        // no rule for the recovery event still gets its outage alerts closed.
+        await ResolveSupersededWanAlertsAsync(alertEvent, repository, cancellationToken);
+
         var siteKey = alertEvent.SiteSlug ?? "";
         var rules = await GetRulesAsync(repository, siteKey, cancellationToken);
 
@@ -157,6 +161,89 @@ public class AlertProcessingService : BackgroundService
             {
                 _logger.LogError(ex, "Failed to process rule {RuleId} for event {EventType}", rule.Id, alertEvent.EventType);
             }
+        }
+    }
+
+    // --- WAN outage alerts: an open/close family, unlike the rest of the alert catalog ---
+    //
+    // The three monitoring.wan_* event types maintain at most one open alert per (WAN, kind).
+    // A WAN raises a partial outage while part of the path out is unreachable but traffic still
+    // flows, and a total outage once the whole WAN is confirmed down; "all-wans" is the site-level
+    // rollup raised when every WAN is out at once. Both kinds close themselves: monitoring.wan_recovered
+    // closes the WAN's open outage alerts (and invalidates any rollup, since a rollup asserts that
+    // every WAN was out), and a confirmed total outage supersedes the partial it grew out of rather
+    // than stacking a second open alert on the same WAN.
+    //
+    // Per-target monitoring alerts (monitoring.target_offline and friends) have no such pairing and
+    // stay open until a user resolves them, so this closing step applies to the WAN family only.
+
+    internal const string WanOutageEventType = "monitoring.wan_outage";
+    internal const string WanOutagePartialEventType = "monitoring.wan_outage_partial";
+    internal const string WanRecoveredEventType = "monitoring.wan_recovered";
+
+    /// <summary>DeviceId carried by the site-level rollup alert, instead of a single WAN's key.</summary>
+    internal const string AllWansDeviceId = "all-wans";
+
+    /// <summary>
+    /// Decides which open alerts an incoming event closes: each entry is the set of event types to
+    /// resolve for one DeviceId. Empty for every event outside the WAN outage family.
+    /// </summary>
+    internal static List<(string[] EventTypes, string DeviceId)> GetWanAlertsToResolve(string eventType, string? deviceId)
+    {
+        var targets = new List<(string[] EventTypes, string DeviceId)>();
+        var wanKey = deviceId?.Trim();
+
+        if (eventType == WanRecoveredEventType)
+        {
+            // A recovery closes this WAN's own outage alerts, whichever kind is open...
+            if (!string.IsNullOrEmpty(wanKey))
+                targets.Add(([WanOutageEventType, WanOutagePartialEventType], wanKey));
+
+            // ...and invalidates the site rollup, which claimed every WAN was out.
+            targets.Add(([WanOutageEventType], AllWansDeviceId));
+        }
+        else if (eventType == WanOutageEventType && !string.IsNullOrEmpty(wanKey) && wanKey != AllWansDeviceId)
+        {
+            // The total outage supersedes the partial that preceded it on the same WAN.
+            targets.Add(([WanOutagePartialEventType], wanKey));
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Closes the open WAN outage alerts this event supersedes and re-derives the status of any
+    /// incident they belonged to. Failures are logged and swallowed: resolution is housekeeping and
+    /// must never stop the event from being processed into an alert.
+    /// </summary>
+    internal async Task ResolveSupersededWanAlertsAsync(
+        AlertEvent alertEvent,
+        IAlertRepository repository,
+        CancellationToken cancellationToken)
+    {
+        var targets = GetWanAlertsToResolve(alertEvent.EventType, alertEvent.DeviceId);
+        if (targets.Count == 0)
+            return;
+
+        try
+        {
+            foreach (var (eventTypes, deviceId) in targets)
+            {
+                var resolved = await repository.ResolveActiveAlertsAsync(eventTypes, deviceId, cancellationToken);
+                if (resolved.Count == 0)
+                    continue;
+
+                _logger.LogDebug("Closed {Count} open WAN alert(s) for {DeviceId} on {EventType}",
+                    resolved.Count, deviceId, alertEvent.EventType);
+
+                foreach (var alert in resolved)
+                    await AlertCorrelationService.RecalculateIncidentStatusAsync(alert, repository, cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to close open WAN alerts for event {EventType} ({DeviceId})",
+                alertEvent.EventType, alertEvent.DeviceId);
         }
     }
 

--- a/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
@@ -186,12 +186,21 @@ public class AlertProcessingService : BackgroundService
 
     /// <summary>
     /// Decides which open alerts an incoming event closes: each entry is the set of event types to
-    /// resolve for one DeviceId. Empty for every event outside the WAN outage family.
+    /// resolve for one DeviceId, or for EVERY device when the DeviceId is null. Empty for every
+    /// event outside the WAN outage family.
     /// </summary>
-    internal static List<(string[] EventTypes, string DeviceId)> GetWanAlertsToResolve(string eventType, string? deviceId)
+    internal static List<(string[] EventTypes, string? DeviceId)> GetWanAlertsToResolve(string eventType, string? deviceId)
     {
-        var targets = new List<(string[] EventTypes, string DeviceId)>();
+        var targets = new List<(string[] EventTypes, string? DeviceId)>();
         var wanKey = deviceId?.Trim();
+
+        // The site rollup supersedes every per-WAN alert: it says the whole site is down, which
+        // is the same outage those alerts were each describing a piece of.
+        if (eventType == WanOutageEventType && wanKey == AllWansDeviceId)
+        {
+            targets.Add(([WanOutageEventType, WanOutagePartialEventType], null));
+            return targets;
+        }
 
         if (eventType == WanRecoveredEventType)
         {
@@ -229,7 +238,9 @@ public class AlertProcessingService : BackgroundService
         {
             foreach (var (eventTypes, deviceId) in targets)
             {
-                var resolved = await repository.ResolveActiveAlertsAsync(eventTypes, deviceId, cancellationToken);
+                var resolved = deviceId == null
+                    ? await repository.ResolveActiveAlertsAnyDeviceAsync(eventTypes, cancellationToken)
+                    : await repository.ResolveActiveAlertsAsync(eventTypes, deviceId, cancellationToken);
                 if (resolved.Count == 0)
                     continue;
 

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -251,6 +251,35 @@ public static class DefaultAlertRules
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 1800 // 30 minutes
         },
+        new AlertRule
+        {
+            Name = "Monitoring: WAN Outage",
+            IsEnabled = true,
+            EventTypePattern = "monitoring.wan_outage",
+            Source = "monitoring",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 600 // 10 minutes - the WAN outage evaluator opens one alert per outage
+        },
+        new AlertRule
+        {
+            // Info on purpose: a partial outage on a non-primary WAN publishes at Info, and this
+            // rule has to match it.
+            Name = "Monitoring: WAN Partial Outage",
+            IsEnabled = true,
+            EventTypePattern = "monitoring.wan_outage_partial",
+            Source = "monitoring",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 600 // 10 minutes - the WAN outage evaluator opens one alert per outage
+        },
+        new AlertRule
+        {
+            Name = "Monitoring: WAN Recovered",
+            IsEnabled = true,
+            EventTypePattern = "monitoring.wan_recovered",
+            Source = "monitoring",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 60 // 1 minute - recoveries are paired with outage events
+        },
 
         // --- SFP / PON threshold alerts (enabled - auto-managed for detected modules) ---
         new AlertRule

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -34,6 +34,13 @@ public interface IAlertRepository
     Task<List<AlertHistoryEntry>> GetUnresolvedAlertsAsync(CancellationToken cancellationToken = default);
     Task<List<AlertHistoryEntry>> GetAlertsByIncidentIdAsync(int incidentId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Marks every active alert of the given event types on the given device as resolved and
+    /// returns the entries that were closed. Used by the alert pipeline to close open WAN outage
+    /// alerts when their recovery - or a superseding total outage - event arrives.
+    /// </summary>
+    Task<List<AlertHistoryEntry>> ResolveActiveAlertsAsync(IReadOnlyCollection<string> eventTypes, string deviceId, CancellationToken cancellationToken = default);
+
     // --- Alert Incidents ---
     Task<int> SaveIncidentAsync(AlertIncident incident, CancellationToken cancellationToken = default);
     Task UpdateIncidentAsync(AlertIncident incident, CancellationToken cancellationToken = default);

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -35,6 +35,14 @@ public interface IAlertRepository
     Task<List<AlertHistoryEntry>> GetAlertsByIncidentIdAsync(int incidentId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Sets the status of many alerts in ONE round trip, stamping the timestamp that goes with it.
+    /// The bulk buttons used to call <see cref="UpdateAlertAsync"/> per alert, and each of those is
+    /// a SaveChanges - a SQLite commit - against a change tracker that grew by an entity every
+    /// iteration. Returns the number of rows changed.
+    /// </summary>
+    Task<int> SetAlertStatusAsync(IReadOnlyCollection<int> alertIds, AlertStatus status, DateTime timestamp, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Marks every active alert of the given event types on the given device as resolved and
     /// returns the entries that were closed. Used by the alert pipeline to close open WAN outage
     /// alerts when their recovery - or a superseding total outage - event arrives.

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -42,6 +42,19 @@ public interface IAlertRepository
     /// </summary>
     Task<int> SetAlertStatusAsync(IReadOnlyCollection<int> alertIds, AlertStatus status, DateTime timestamp, CancellationToken cancellationToken = default);
 
+    /// <summary>Incidents by id, in one query - the batch counterpart of GetIncidentAsync.</summary>
+    Task<List<AlertIncident>> GetIncidentsByIdsAsync(IReadOnlyCollection<int> incidentIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Every alert belonging to any of these incidents, in one query. Re-deriving a few hundred
+    /// incidents one at a time is two round trips each, which is the bulk buttons' remaining cost
+    /// once the alerts themselves are written together.
+    /// </summary>
+    Task<List<AlertHistoryEntry>> GetAlertsByIncidentIdsAsync(IReadOnlyCollection<int> incidentIds, CancellationToken cancellationToken = default);
+
+    /// <summary>Saves several incidents in one round trip.</summary>
+    Task UpdateIncidentsAsync(IReadOnlyCollection<AlertIncident> incidents, CancellationToken cancellationToken = default);
+
     /// <summary>
     /// Marks every active alert of the given event types on the given device as resolved and
     /// returns the entries that were closed. Used by the alert pipeline to close open WAN outage

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -29,6 +29,14 @@ public interface IAlertRepository
     Task UpdateAlertAsync(AlertHistoryEntry alert, CancellationToken cancellationToken = default);
     Task<List<AlertHistoryEntry>> GetActiveAlertsAsync(CancellationToken cancellationToken = default);
     Task<List<AlertHistoryEntry>> GetAlertHistoryAsync(int limit = 100, string? source = null, AlertSeverity? minSeverity = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// One page of alert history, newest first, with the total the filters match so the caller can
+    /// say how many pages there are. Paged in SQL: the history of a site that has been running a
+    /// while is far more than a page, and the flat take showed only its newest slice with nothing
+    /// to say the rest existed.
+    /// </summary>
+    Task<(List<AlertHistoryEntry> Items, int Total)> GetAlertHistoryPageAsync(int skip, int take, string? source = null, AlertSeverity? minSeverity = null, CancellationToken cancellationToken = default);
     Task<AlertHistoryEntry?> GetAlertAsync(int id, CancellationToken cancellationToken = default);
     Task<List<AlertHistoryEntry>> GetAlertsForDigestAsync(DateTime since, CancellationToken cancellationToken = default);
     Task<List<AlertHistoryEntry>> GetUnresolvedAlertsAsync(CancellationToken cancellationToken = default);

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -41,6 +41,13 @@ public interface IAlertRepository
     /// </summary>
     Task<List<AlertHistoryEntry>> ResolveActiveAlertsAsync(IReadOnlyCollection<string> eventTypes, string deviceId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Marks every active alert of the given event types as resolved, whatever device it names,
+    /// and returns the entries that were closed. Used when a site-wide alert supersedes the
+    /// per-device alerts describing pieces of the same event.
+    /// </summary>
+    Task<List<AlertHistoryEntry>> ResolveActiveAlertsAnyDeviceAsync(IReadOnlyCollection<string> eventTypes, CancellationToken cancellationToken = default);
+
     // --- Alert Incidents ---
     Task<int> SaveIncidentAsync(AlertIncident incident, CancellationToken cancellationToken = default);
     Task UpdateIncidentAsync(AlertIncident incident, CancellationToken cancellationToken = default);

--- a/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
+++ b/src/NetworkOptimizer.Alerts/Interfaces/IAlertRepository.cs
@@ -54,6 +54,13 @@ public interface IAlertRepository
     Task<List<AlertIncident>> GetIncidentsByIdsAsync(IReadOnlyCollection<int> incidentIds, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// The incidents that are not resolved, newest first. Filtered in SQL rather than by the
+    /// caller: taking the newest N and filtering afterwards hides an unresolved incident the
+    /// moment N newer ones have been resolved, which on a busy site is permanent.
+    /// </summary>
+    Task<List<AlertIncident>> GetUnresolvedIncidentsAsync(int limit = 50, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Every alert belonging to any of these incidents, in one query. Re-deriving a few hundred
     /// incidents one at a time is two round trips each, which is the bulk buttons' remaining cost
     /// once the alerts themselves are written together.

--- a/src/NetworkOptimizer.Alerts/Models/SeededAlertRule.cs
+++ b/src/NetworkOptimizer.Alerts/Models/SeededAlertRule.cs
@@ -1,0 +1,23 @@
+namespace NetworkOptimizer.Alerts.Models;
+
+/// <summary>
+/// Records that a default alert rule pattern has been seeded into this database once, so
+/// deleting the rule is honored across restarts. Startup only inserts a default whose pattern
+/// is missing from both AlertRules and this table; without the record, every restart brought
+/// back rules the user had deliberately deleted.
+/// </summary>
+public class SeededAlertRule
+{
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Event type pattern of the default rule that was seeded.
+    /// </summary>
+    public string EventTypePattern { get; set; } = string.Empty;
+
+    /// <summary>
+    /// When the pattern was seeded, or when it was backfilled for an install whose rules
+    /// predate this record.
+    /// </summary>
+    public DateTime SeededAt { get; set; } = DateTime.UtcNow;
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260805120000_AddSeededAlertRules.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260805120000_AddSeededAlertRules.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260805120000_AddSeededAlertRules")]
+    partial class AddSeededAlertRules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260805120000_AddSeededAlertRules.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260805120000_AddSeededAlertRules.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <summary>
+    /// Records which default alert rule patterns have already been seeded into this database, so
+    /// startup seeds each pattern at most once. Seeding previously inserted any default whose
+    /// pattern was missing from AlertRules, which brought deleted rules back on every restart.
+    /// </summary>
+    public partial class AddSeededAlertRules : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SeededAlertRules",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    EventTypePattern = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    SeededAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeededAlertRules", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeededAlertRules_EventTypePattern",
+                table: "SeededAlertRules",
+                column: "EventTypePattern",
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SeededAlertRules");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -37,6 +37,7 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<FloorPlanImage> FloorPlanImages { get; set; }
     public DbSet<ClientSignalLog> ClientSignalLogs { get; set; }
     public DbSet<AlertRule> AlertRules { get; set; }
+    public DbSet<SeededAlertRule> SeededAlertRules { get; set; }
     public DbSet<DeliveryChannel> DeliveryChannels { get; set; }
     public DbSet<AlertHistoryEntry> AlertHistory { get; set; }
     public DbSet<AlertIncident> AlertIncidents { get; set; }
@@ -425,6 +426,14 @@ public class NetworkOptimizerDbContext : DbContext
             entity.ToTable("AlertRules");
             entity.Property(e => e.MinSeverity).HasConversion<int>();
             entity.Property(e => e.EscalationSeverity).HasConversion<int>();
+        });
+
+        // SeededAlertRule configuration
+        modelBuilder.Entity<SeededAlertRule>(entity =>
+        {
+            entity.ToTable("SeededAlertRules");
+            entity.Property(e => e.EventTypePattern).HasMaxLength(200);
+            entity.HasIndex(e => e.EventTypePattern).IsUnique();
         });
 
         // DeliveryChannel configuration

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -399,12 +399,24 @@ public class AlertRepository : IAlertRepository
         }
     }
 
-    public async Task<List<AlertHistoryEntry>> ResolveActiveAlertsAsync(
+    public Task<List<AlertHistoryEntry>> ResolveActiveAlertsAnyDeviceAsync(
+        IReadOnlyCollection<string> eventTypes,
+        CancellationToken cancellationToken = default) =>
+        ResolveActiveAlertsCoreAsync(eventTypes, "", anyDevice: true, cancellationToken);
+
+    public Task<List<AlertHistoryEntry>> ResolveActiveAlertsAsync(
         IReadOnlyCollection<string> eventTypes,
         string deviceId,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default) =>
+        ResolveActiveAlertsCoreAsync(eventTypes, deviceId, anyDevice: false, cancellationToken);
+
+    private async Task<List<AlertHistoryEntry>> ResolveActiveAlertsCoreAsync(
+        IReadOnlyCollection<string> eventTypes,
+        string deviceId,
+        bool anyDevice,
+        CancellationToken cancellationToken)
     {
-        if (eventTypes.Count == 0 || string.IsNullOrEmpty(deviceId))
+        if (eventTypes.Count == 0 || (!anyDevice && string.IsNullOrEmpty(deviceId)))
             return [];
 
         try
@@ -413,7 +425,7 @@ public class AlertRepository : IAlertRepository
             var types = eventTypes.ToList();
             var open = await _context.AlertHistory
                 .Where(a => a.Status == AlertStatus.Active
-                    && a.DeviceId == deviceId
+                    && (anyDevice || a.DeviceId == deviceId)
                     && types.Contains(a.EventType))
                 .ToListAsync(cancellationToken);
 

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -399,6 +399,44 @@ public class AlertRepository : IAlertRepository
         }
     }
 
+    public async Task<List<AlertIncident>> GetIncidentsByIdsAsync(
+        IReadOnlyCollection<int> incidentIds, CancellationToken cancellationToken = default)
+    {
+        if (incidentIds.Count == 0) return [];
+        var ids = incidentIds.ToList();
+        return await _context.AlertIncidents
+            .Where(i => ids.Contains(i.Id))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<List<AlertHistoryEntry>> GetAlertsByIncidentIdsAsync(
+        IReadOnlyCollection<int> incidentIds, CancellationToken cancellationToken = default)
+    {
+        if (incidentIds.Count == 0) return [];
+        var ids = incidentIds.ToList();
+        return await _context.AlertHistory
+            .AsNoTracking()
+            .Where(a => a.IncidentId != null && ids.Contains(a.IncidentId.Value))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task UpdateIncidentsAsync(
+        IReadOnlyCollection<AlertIncident> incidents, CancellationToken cancellationToken = default)
+    {
+        if (incidents.Count == 0) return;
+        try
+        {
+            // The rows come back tracked from GetIncidentsByIdsAsync, so this is one commit for
+            // the lot rather than one per incident.
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update {Count} incident(s)", incidents.Count);
+            throw;
+        }
+    }
+
     public async Task<int> SetAlertStatusAsync(
         IReadOnlyCollection<int> alertIds,
         AlertStatus status,

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -399,6 +399,45 @@ public class AlertRepository : IAlertRepository
         }
     }
 
+    public async Task<List<AlertHistoryEntry>> ResolveActiveAlertsAsync(
+        IReadOnlyCollection<string> eventTypes,
+        string deviceId,
+        CancellationToken cancellationToken = default)
+    {
+        if (eventTypes.Count == 0 || string.IsNullOrEmpty(deviceId))
+            return [];
+
+        try
+        {
+            // Tracked on purpose: these rows are read to be written back in the same call.
+            var types = eventTypes.ToList();
+            var open = await _context.AlertHistory
+                .Where(a => a.Status == AlertStatus.Active
+                    && a.DeviceId == deviceId
+                    && types.Contains(a.EventType))
+                .ToListAsync(cancellationToken);
+
+            if (open.Count == 0)
+                return [];
+
+            var resolvedAt = DateTime.UtcNow;
+            foreach (var alert in open)
+            {
+                alert.Status = AlertStatus.Resolved;
+                alert.ResolvedAt = resolvedAt;
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Resolved {Count} active alert(s) for {DeviceId}", open.Count, deviceId);
+            return open;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to resolve active alerts for {DeviceId}", deviceId);
+            throw;
+        }
+    }
+
     #endregion
 
     #region Alert Incidents

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -399,6 +399,42 @@ public class AlertRepository : IAlertRepository
         }
     }
 
+    public async Task<int> SetAlertStatusAsync(
+        IReadOnlyCollection<int> alertIds,
+        AlertStatus status,
+        DateTime timestamp,
+        CancellationToken cancellationToken = default)
+    {
+        if (alertIds.Count == 0) return 0;
+
+        try
+        {
+            var ids = alertIds.ToList();
+            var rows = await _context.AlertHistory
+                .Where(a => ids.Contains(a.Id))
+                .ToListAsync(cancellationToken);
+
+            foreach (var row in rows)
+            {
+                row.Status = status;
+                if (status == AlertStatus.Acknowledged) row.AcknowledgedAt = timestamp;
+                else if (status == AlertStatus.Resolved) row.ResolvedAt = timestamp;
+            }
+
+            // One commit for the lot. Per-alert saves meant a SQLite transaction each, and the
+            // tracked graph grew every iteration, so a few hundred alerts turned a button press
+            // into hundreds of fsyncs and a quadratic walk of the change tracker.
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Set {Count} alert(s) to {Status}", rows.Count, status);
+            return rows.Count;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to set {Count} alert(s) to {Status}", alertIds.Count, status);
+            throw;
+        }
+    }
+
     public Task<List<AlertHistoryEntry>> ResolveActiveAlertsAnyDeviceAsync(
         IReadOnlyCollection<string> eventTypes,
         CancellationToken cancellationToken = default) =>

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -643,6 +643,25 @@ public class AlertRepository : IAlertRepository
         }
     }
 
+    public async Task<List<AlertIncident>> GetUnresolvedIncidentsAsync(
+        int limit = 50, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            return await _context.AlertIncidents
+                .AsNoTracking()
+                .Where(i => i.Status != AlertStatus.Resolved)
+                .OrderByDescending(i => i.LastTriggeredAt)
+                .Take(limit)
+                .ToListAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get unresolved alert incidents");
+            throw;
+        }
+    }
+
     public async Task<AlertIncident?> GetIncidentAsync(int id, CancellationToken cancellationToken = default)
     {
         try

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -426,8 +426,25 @@ public class AlertRepository : IAlertRepository
         if (incidents.Count == 0) return;
         try
         {
-            // The rows come back tracked from GetIncidentsByIdsAsync, so this is one commit for
-            // the lot rather than one per incident.
+            // Callers pass either the tracked rows from GetIncidentsByIdsAsync or detached copies
+            // the page is holding, so each is attached unless this very instance is already
+            // tracked. The tracked set is read once: scanning it per incident is the quadratic
+            // walk these batch methods exist to avoid.
+            var tracked = _context.ChangeTracker.Entries<AlertIncident>()
+                .GroupBy(e => e.Entity.Id)
+                .ToDictionary(g => g.Key, g => g.First());
+
+            foreach (var incident in incidents)
+            {
+                if (tracked.TryGetValue(incident.Id, out var entry))
+                {
+                    if (ReferenceEquals(entry.Entity, incident)) continue;
+                    entry.State = EntityState.Detached;
+                }
+                _context.AlertIncidents.Update(incident);
+            }
+
+            // One commit for the lot rather than one per incident.
             await _context.SaveChangesAsync(cancellationToken);
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/AlertRepository.cs
@@ -334,6 +334,41 @@ public class AlertRepository : IAlertRepository
         }
     }
 
+    public async Task<(List<AlertHistoryEntry> Items, int Total)> GetAlertHistoryPageAsync(
+        int skip,
+        int take,
+        string? source = null,
+        AlertSeverity? minSeverity = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var query = _context.AlertHistory.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrEmpty(source))
+                query = query.Where(a => a.Source == source);
+
+            if (minSeverity.HasValue)
+                query = query.Where(a => a.Severity >= minSeverity.Value);
+
+            // Counted against the same filters, before paging: the page controls need to know how
+            // much there is, not how much this page holds.
+            var total = await query.CountAsync(cancellationToken);
+            var items = await query
+                .OrderByDescending(a => a.TriggeredAt)
+                .Skip(Math.Max(0, skip))
+                .Take(Math.Max(1, take))
+                .ToListAsync(cancellationToken);
+
+            return (items, total);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get a page of alert history");
+            throw;
+        }
+    }
+
     public async Task<AlertHistoryEntry?> GetAlertAsync(int id, CancellationToken cancellationToken = default)
     {
         try

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -775,7 +775,7 @@
                                     }
                                     @if (_canOperate)
                                     {
-                                    <button class="btn btn-sm btn-secondary" @onclick="() => AcknowledgeAlert(alert)">
+                                    <button class="btn btn-sm btn-tertiary" @onclick="() => AcknowledgeAlert(alert)">
                                         Acknowledge
                                     </button>
                                     }

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -723,6 +723,12 @@
             }
             else
             {
+                @if (PendingAlertCount > 0)
+                {
+                    <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingAlerts">
+                        @PendingAlertCount new @(PendingAlertCount == 1 ? "alert" : "alerts") - show
+                    </button>
+                }
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Active))
                 {
                     <div class="alert-group-header">
@@ -747,7 +753,7 @@
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active))
                         {
-                            <div class="alert-item @GetSeverityClass(alert.Severity)">
+                            <div class="alert-item @GetSeverityClass(alert.Severity)" @key="alert.Id">
                                 <div class="alert-icon">@((MarkupString)GetSeverityIcon(alert.Severity))</div>
                                 <div class="alert-content">
                                     <div class="alert-header">
@@ -814,7 +820,7 @@
                     <div class="alert-list">
                         @foreach (var alert in _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged))
                         {
-                            <div class="alert-item @GetSeverityClass(alert.Severity)">
+                            <div class="alert-item @GetSeverityClass(alert.Severity)" @key="alert.Id">
                                 <div class="alert-icon">@((MarkupString)GetSeverityIcon(alert.Severity))</div>
                                 <div class="alert-content">
                                     <div class="alert-header">
@@ -1157,9 +1163,15 @@
                         }
                     </div>
                 </div>
+                @if (PendingIncidentCount > 0)
+                {
+                    <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingIncidents">
+                        @PendingIncidentCount new @(PendingIncidentCount == 1 ? "incident" : "incidents") - show
+                    </button>
+                }
                 @foreach (var incident in _incidents.Where(i => i.Status != AlertStatus.Resolved))
                 {
-                    <div class="card" style="margin-bottom: 1rem;">
+                    <div class="card" style="margin-bottom: 1rem;" @key="incident.Id">
                         <div class="card-header" style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.5rem;">
                             <div style="display: flex; align-items: center; gap: 0.75rem;">
                                 <span class="severity-badge @GetSeverityBadgeClass(incident.Severity)">
@@ -1856,6 +1868,32 @@
     /// being written.
     /// </summary>
     private bool _bulkBusy;
+
+    /// <summary>
+    /// Alerts and incidents the poll has found but has NOT put on screen. The list only changes
+    /// when the user says so: entries arrive newest-first, so folding them in unprompted pushes
+    /// everything down - past the row someone was reading, or under the button they were about to
+    /// press. Held here instead, counted in a pill they can take when they are ready.
+    /// </summary>
+    private List<AlertHistoryEntry>? _pendingAlerts;
+    private List<AlertIncident>? _pendingIncidents;
+
+    /// <summary>How many held entries are new to the list on screen, which is what the pill offers.</summary>
+    private int PendingAlertCount => _pendingAlerts is null
+        ? 0
+        : _pendingAlerts.Count(p => !_unresolvedAlerts.Any(a => a.Id == p.Id));
+
+    private int PendingIncidentCount => _pendingIncidents is null
+        ? 0
+        : _pendingIncidents.Count(p => !_incidents.Any(i => i.Id == p.Id));
+
+    /// <summary>
+    /// Whether a refresh may redraw the list without interrupting anything: no bulk action in
+    /// flight, and no modal or inline edit open on top of it.
+    /// </summary>
+    private bool SafeToRedraw =>
+        !_bulkBusy && !_showEventTypeKey
+        && !_editingWanScheduleId.HasValue && !_editingLanScheduleId.HasValue;
     private int? _editingWanScheduleId;
     private int? _editingLanScheduleId;
     private string? _scheduleMessage;
@@ -2160,8 +2198,13 @@
             {
                 await InvokeAsync(async () =>
                 {
+                    // The alert and incident lists are read into a holding buffer and only take
+                    // the screen when the user asks (see PendingAlertCount). Everything else here
+                    // is a whole-panel redraw with nothing to lose its place.
                     if (_activeTab == "active")
-                        await LoadActiveAlerts();
+                        await PollUnresolvedAlertsAsync();
+                    else if (_activeTab == "incidents")
+                        await PollIncidentsAsync();
                     else if (_activeTab == "schedule")
                         await LoadSchedules();
                     else if (_activeTab == "data-usage")
@@ -2397,6 +2440,8 @@
         try
         {
             _unresolvedAlerts = await AlertRepository.GetUnresolvedAlertsAsync();
+            // This read IS the list now, so nothing the poll was holding is still pending.
+            _pendingAlerts = null;
         }
         catch (Exception ex)
         {
@@ -2436,11 +2481,66 @@
         }
     }
 
+    /// <summary>
+    /// Reads the unresolved alerts on the poll without disturbing the list on screen. A first
+    /// load, or one where nothing new turned up, is applied straight away - there is nothing to
+    /// push down. Anything genuinely new waits behind the pill.
+    /// </summary>
+    private async Task PollUnresolvedAlertsAsync()
+    {
+        if (!SafeToRedraw) return;
+        try
+        {
+            var latest = await AlertRepository.GetUnresolvedAlertsAsync();
+            var isNew = latest.Any(p => !_unresolvedAlerts.Any(a => a.Id == p.Id));
+            _pendingAlerts = latest;
+            // Nothing new to push the list down: take the read as-is so acknowledged states and
+            // removals still keep up on their own.
+            if (!isNew) ApplyPendingAlerts();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Polling unresolved alerts failed; the list on screen stands");
+        }
+    }
+
+    private async Task PollIncidentsAsync()
+    {
+        if (!SafeToRedraw) return;
+        try
+        {
+            var latest = await AlertRepository.GetIncidentsAsync();
+            var isNew = latest.Any(p => !_incidents.Any(i => i.Id == p.Id));
+            _pendingIncidents = latest;
+            if (!isNew) ApplyPendingIncidents();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Polling incidents failed; the list on screen stands");
+        }
+    }
+
+    /// <summary>Puts the held read on screen - what the pill does.</summary>
+    private void ApplyPendingAlerts()
+    {
+        if (_pendingAlerts is null) return;
+        _unresolvedAlerts = _pendingAlerts;
+        _pendingAlerts = null;
+    }
+
+    private void ApplyPendingIncidents()
+    {
+        if (_pendingIncidents is null) return;
+        _incidents = _pendingIncidents;
+        _pendingIncidents = null;
+    }
+
     private async Task LoadIncidents()
     {
         try
         {
             _incidents = await AlertRepository.GetIncidentsAsync();
+            _pendingIncidents = null;
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1893,14 +1893,30 @@
     private List<AlertHistoryEntry>? _pendingAlerts;
     private List<AlertIncident>? _pendingIncidents;
 
-    /// <summary>How many held entries are new to the list on screen, which is what the pill offers.</summary>
-    private int PendingAlertCount => _pendingAlerts is null
-        ? 0
-        : _pendingAlerts.Count(p => !_unresolvedAlerts.Any(a => a.Id == p.Id));
+    /// <summary>
+    /// How many held entries are new to the list on screen, which is what the pill offers. Counted
+    /// against a set rather than by scanning the visible list per held entry: this is read on every
+    /// render, and the pairwise form is quadratic in the size of a list that reaches the hundreds.
+    /// </summary>
+    private int PendingAlertCount
+    {
+        get
+        {
+            if (_pendingAlerts is null) return 0;
+            var shown = _unresolvedAlerts.Select(a => a.Id).ToHashSet();
+            return _pendingAlerts.Count(p => !shown.Contains(p.Id));
+        }
+    }
 
-    private int PendingIncidentCount => _pendingIncidents is null
-        ? 0
-        : _pendingIncidents.Count(p => !_incidents.Any(i => i.Id == p.Id));
+    private int PendingIncidentCount
+    {
+        get
+        {
+            if (_pendingIncidents is null) return 0;
+            var shown = _incidents.Select(i => i.Id).ToHashSet();
+            return _pendingIncidents.Count(p => !shown.Contains(p.Id));
+        }
+    }
 
     /// <summary>
     /// Whether a refresh may redraw the list without interrupting anything: no bulk action in
@@ -2548,7 +2564,8 @@
         try
         {
             var latest = await AlertRepository.GetUnresolvedAlertsAsync();
-            var isNew = latest.Any(p => !_unresolvedAlerts.Any(a => a.Id == p.Id));
+            var shown = _unresolvedAlerts.Select(a => a.Id).ToHashSet();
+            var isNew = latest.Any(p => !shown.Contains(p.Id));
             _pendingAlerts = latest;
             // Held back only when there is a list to disturb. Nothing new pushes nothing down, and
             // an EMPTY list has nothing to push either - withholding there just left the tab
@@ -2567,7 +2584,8 @@
         try
         {
             var latest = await AlertRepository.GetUnresolvedIncidentsAsync();
-            var isNew = latest.Any(p => !_incidents.Any(i => i.Id == p.Id));
+            var shown = _incidents.Select(i => i.Id).ToHashSet();
+            var isNew = latest.Any(p => !shown.Contains(p.Id));
             _pendingIncidents = latest;
             if (!isNew || _incidents.Count == 0) ApplyPendingIncidents();
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -956,7 +956,7 @@
                     </div>
                     @if (_historyTotal > HistoryPageSize)
                     {
-                        <div class="pagination">
+                        <div class="pagination history-pagination">
                             <button class="btn btn-sm btn-secondary" disabled="@(_historyPage == 0)"
                                     @onclick="() => GoToHistoryPage(_historyPage - 1)">Prev</button>
                             <span class="pagination-info">

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -730,11 +730,17 @@
                         <div class="alert-group-actions">
                             @if (_canOperate)
                             {
-                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllActive">Acknowledge All</button>
+                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllActive" disabled="@_bulkBusy">
+                                @if (_bulkBusy) { <span class="spinner spinner-sm"></span> }
+                                <text>Acknowledge All</text>
+                            </button>
                             }
                             @if (_canOperate)
                             {
-                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllActive">Resolve All</button>
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllActive" disabled="@_bulkBusy">
+                                @if (_bulkBusy) { <span class="spinner spinner-sm"></span> }
+                                <text>Resolve All</text>
+                            </button>
                             }
                         </div>
                     </div>
@@ -798,7 +804,10 @@
                         <div class="alert-group-actions">
                             @if (_canOperate)
                             {
-                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged">Resolve Acknowledged</button>
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged" disabled="@_bulkBusy">
+                                @if (_bulkBusy) { <span class="spinner spinner-sm"></span> }
+                                <text>Resolve Acknowledged</text>
+                            </button>
                             }
                         </div>
                     </div>
@@ -1133,12 +1142,18 @@
                         {
                             @if (_canOperate)
                             {
-                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllIncidents">Acknowledge All</button>
+                            <button class="btn btn-sm btn-secondary" @onclick="AcknowledgeAllIncidents" disabled="@_bulkBusy">
+                                @if (_bulkBusy) { <span class="spinner spinner-sm"></span> }
+                                <text>Acknowledge All</text>
+                            </button>
                             }
                         }
                         @if (_canOperate)
                         {
-                        <button class="btn btn-sm btn-primary" @onclick="ResolveAllIncidents">Resolve All</button>
+                        <button class="btn btn-sm btn-primary" @onclick="ResolveAllIncidents" disabled="@_bulkBusy">
+                            @if (_bulkBusy) { <span class="spinner spinner-sm"></span> }
+                            <text>Resolve All</text>
+                        </button>
                         }
                     </div>
                 </div>
@@ -1834,6 +1849,13 @@
     private int _newWanFrequency = 1440;
     private int _newLanFrequency = 1440;
     private bool _creatingSchedule;
+
+    /// <summary>
+    /// A bulk acknowledge or resolve is running. All five bulk buttons share it: they act on the
+    /// same lists, so a second press while one is in flight would work from a set that is already
+    /// being written.
+    /// </summary>
+    private bool _bulkBusy;
     private int? _editingWanScheduleId;
     private int? _editingLanScheduleId;
     private string? _scheduleMessage;
@@ -2463,6 +2485,8 @@
 
     private async Task AcknowledgeAllActive()
     {
+        if (_bulkBusy) return;
+        _bulkBusy = true;
         try
         {
             var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
@@ -2480,10 +2504,16 @@
         {
             Logger.LogError(ex, "Error acknowledging all active alerts");
         }
+        finally
+        {
+            _bulkBusy = false;
+        }
     }
 
     private async Task ResolveAllActive()
     {
+        if (_bulkBusy) return;
+        _bulkBusy = true;
         try
         {
             // Everything unresolved, not just what is still Active. Acknowledge All moves the whole
@@ -2506,10 +2536,16 @@
         {
             Logger.LogError(ex, "Error resolving all active alerts");
         }
+        finally
+        {
+            _bulkBusy = false;
+        }
     }
 
     private async Task ResolveAllAcknowledged()
     {
+        if (_bulkBusy) return;
+        _bulkBusy = true;
         try
         {
             // This section's button, and this section's alerts. Resolve All in the Active section
@@ -2531,6 +2567,10 @@
         {
             Logger.LogError(ex, "Error resolving all acknowledged alerts");
         }
+        finally
+        {
+            _bulkBusy = false;
+        }
     }
 
     /// <summary>
@@ -2541,8 +2581,11 @@
     /// </summary>
     private async Task RecalculateIncidentsOnceAsync(IReadOnlyList<AlertHistoryEntry> resolved)
     {
-        foreach (var group in resolved.Where(a => a.IncidentId.HasValue).GroupBy(a => a.IncidentId!.Value))
-            await RecalculateIncidentStatusAsync(group.First());
+        var incidentIds = resolved.Where(a => a.IncidentId.HasValue)
+            .Select(a => a.IncidentId!.Value)
+            .Distinct()
+            .ToList();
+        await AlertCorrelationService.RecalculateIncidentStatusesAsync(incidentIds, AlertRepository);
     }
 
     private async Task RecalculateIncidentStatusAsync(AlertHistoryEntry alert)
@@ -2611,6 +2654,8 @@
 
     private async Task AcknowledgeAllIncidents()
     {
+        if (_bulkBusy) return;
+        _bulkBusy = true;
         try
         {
             var now = DateTime.UtcNow;
@@ -2637,10 +2682,16 @@
         {
             Logger.LogError(ex, "Error acknowledging all incidents");
         }
+        finally
+        {
+            _bulkBusy = false;
+        }
     }
 
     private async Task ResolveAllIncidents()
     {
+        if (_bulkBusy) return;
+        _bulkBusy = true;
         try
         {
             var now = DateTime.UtcNow;
@@ -2665,6 +2716,10 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error resolving all incidents");
+        }
+        finally
+        {
+            _bulkBusy = false;
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1711,6 +1711,9 @@
                         <div @onclick='() => SelectEventType("monitoring.target_offline")'><code>monitoring.target_offline</code> <span>Probe target went offline</span></div>
                         <div @onclick='() => SelectEventType("monitoring.target_recovered")'><code>monitoring.target_recovered</code> <span>Probe target came back online</span></div>
                         <div @onclick='() => SelectEventType("monitoring.target_sustained_loss")'><code>monitoring.target_sustained_loss</code> <span>Sustained packet loss detected</span></div>
+                        <div @onclick='() => SelectEventType("monitoring.wan_outage")'><code>monitoring.wan_outage</code> <span>Internet down on a WAN - one alert per outage instead of one per target</span></div>
+                        <div @onclick='() => SelectEventType("monitoring.wan_outage_partial")'><code>monitoring.wan_outage_partial</code> <span>Partial internet outage on a WAN - some destinations unreachable while the connection still passes traffic</span></div>
+                        <div @onclick='() => SelectEventType("monitoring.wan_recovered")'><code>monitoring.wan_recovered</code> <span>A WAN's internet connection is back</span></div>
                         <div @onclick='() => SelectEventType("monitoring.sfp_rx_power")'><code>monitoring.sfp_rx_power</code> <span>SFP/PON RX power below threshold</span></div>
                         <div @onclick='() => SelectEventType("monitoring.sfp_tx_power")'><code>monitoring.sfp_tx_power</code> <span>SFP/PON TX power above threshold</span></div>
                         <div @onclick='() => SelectEventType("monitoring.sfp_temperature")'><code>monitoring.sfp_temperature</code> <span>SFP temperature above threshold</span></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -713,6 +713,14 @@
         @* ========== Active Alerts Tab ========== *@
         @if (_activeTab == "active")
         {
+            @* Outside the empty/non-empty split below: held alerts must always be reachable, and
+               inside the else they were unreachable exactly when the list was empty. *@
+            @if (PendingAlertCount > 0)
+            {
+                <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingAlerts">
+                    @PendingAlertCount new @(PendingAlertCount == 1 ? "alert" : "alerts") - show
+                </button>
+            }
             @if (_unresolvedAlerts.Count == 0)
             {
                 <div class="empty-state">
@@ -723,12 +731,6 @@
             }
             else
             {
-                @if (PendingAlertCount > 0)
-                {
-                    <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingAlerts">
-                        @PendingAlertCount new @(PendingAlertCount == 1 ? "alert" : "alerts") - show
-                    </button>
-                }
                 @if (_unresolvedAlerts.Any(a => a.Status == AlertStatus.Active))
                 {
                     <div class="alert-group-header">
@@ -1144,6 +1146,13 @@
         @* ========== Incidents Tab ========== *@
         @if (_activeTab == "incidents")
         {
+            @* Outside the empty/non-empty split, for the same reason as the alerts pill. *@
+            @if (PendingIncidentCount > 0)
+            {
+                <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingIncidents">
+                    @PendingIncidentCount new @(PendingIncidentCount == 1 ? "incident" : "incidents") - show
+                </button>
+            }
             @if (!_incidents.Any(i => i.Status != AlertStatus.Resolved))
             {
                 <div class="empty-state">
@@ -1175,12 +1184,6 @@
                         }
                     </div>
                 </div>
-                @if (PendingIncidentCount > 0)
-                {
-                    <button class="btn btn-sm btn-secondary alert-pending-pill" @onclick="ApplyPendingIncidents">
-                        @PendingIncidentCount new @(PendingIncidentCount == 1 ? "incident" : "incidents") - show
-                    </button>
-                }
                 @foreach (var incident in _incidents.Where(i => i.Status != AlertStatus.Resolved))
                 {
                     <div class="card" style="margin-bottom: 1rem;" @key="incident.Id">
@@ -2547,9 +2550,10 @@
             var latest = await AlertRepository.GetUnresolvedAlertsAsync();
             var isNew = latest.Any(p => !_unresolvedAlerts.Any(a => a.Id == p.Id));
             _pendingAlerts = latest;
-            // Nothing new to push the list down: take the read as-is so acknowledged states and
-            // removals still keep up on their own.
-            if (!isNew) ApplyPendingAlerts();
+            // Held back only when there is a list to disturb. Nothing new pushes nothing down, and
+            // an EMPTY list has nothing to push either - withholding there just left the tab
+            // reading All Clear with the alerts parked out of sight.
+            if (!isNew || _unresolvedAlerts.Count == 0) ApplyPendingAlerts();
         }
         catch (Exception ex)
         {
@@ -2565,7 +2569,7 @@
             var latest = await AlertRepository.GetIncidentsAsync();
             var isNew = latest.Any(p => !_incidents.Any(i => i.Id == p.Id));
             _pendingIncidents = latest;
-            if (!isNew) ApplyPendingIncidents();
+            if (!isNew || _incidents.Count == 0) ApplyPendingIncidents();
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2498,8 +2498,8 @@
                 alert.Status = AlertStatus.Resolved;
                 alert.ResolvedAt = now;
                 await AlertConfig.UpdateAlertAsync(alert);
-                await RecalculateIncidentStatusAsync(alert);
             }
+            await RecalculateIncidentsOnceAsync(active);
             await LoadActiveAlerts();
         }
         catch (Exception ex)
@@ -2520,14 +2520,26 @@
                 alert.Status = AlertStatus.Resolved;
                 alert.ResolvedAt = now;
                 await AlertConfig.UpdateAlertAsync(alert);
-                await RecalculateIncidentStatusAsync(alert);
             }
+            await RecalculateIncidentsOnceAsync(acknowledged);
             await LoadActiveAlerts();
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error resolving all acknowledged alerts");
         }
+    }
+
+    /// <summary>
+    /// Re-derives each affected incident's status ONCE, after the alerts have been written.
+    /// Recalculating per alert re-read the incident and every alert on it for each of its members,
+    /// so a list where twenty alerts shared one incident did that work twenty times - and every
+    /// read and write is its own SQLite transaction, which is what made Resolve All crawl.
+    /// </summary>
+    private async Task RecalculateIncidentsOnceAsync(IReadOnlyList<AlertHistoryEntry> resolved)
+    {
+        foreach (var group in resolved.Where(a => a.IncidentId.HasValue).GroupBy(a => a.IncidentId!.Value))
+            await RecalculateIncidentStatusAsync(group.First());
     }
 
     private async Task RecalculateIncidentStatusAsync(AlertHistoryEntry alert)

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -798,7 +798,7 @@
                         <div class="alert-group-actions">
                             @if (_canOperate)
                             {
-                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged">Resolve All</button>
+                            <button class="btn btn-sm btn-primary" @onclick="ResolveAllAcknowledged">Resolve Acknowledged</button>
                             }
                         </div>
                     </div>
@@ -2512,8 +2512,11 @@
     {
         try
         {
-            // Same reasoning: whichever section's Resolve All you press, it clears the unresolved list.
-            var acknowledged = _unresolvedAlerts.Where(a => a.Status != AlertStatus.Resolved).ToList();
+            // This section's button, and this section's alerts. Resolve All in the Active section
+            // above still takes the whole unresolved list, so acknowledging everything and then
+            // resolving in one go is still one press - which is what the wider scope here was for
+            // before the button said which alerts it meant.
+            var acknowledged = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged).ToList();
             var now = DateTime.UtcNow;
             foreach (var alert in acknowledged)
             {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2467,13 +2467,13 @@
         {
             var active = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Active).ToList();
             var now = DateTime.UtcNow;
+            await AlertConfig.SetAlertStatusAsync(active.Select(a => a.Id).ToList(), AlertStatus.Acknowledged, now);
             foreach (var alert in active)
             {
                 alert.Status = AlertStatus.Acknowledged;
                 alert.AcknowledgedAt = now;
-                await AlertConfig.UpdateAlertAsync(alert);
-                await RecalculateIncidentStatusAsync(alert);
             }
+            await RecalculateIncidentsOnceAsync(active);
             await LoadActiveAlerts();
         }
         catch (Exception ex)
@@ -2493,11 +2493,11 @@
             // read this way.
             var active = _unresolvedAlerts.Where(a => a.Status != AlertStatus.Resolved).ToList();
             var now = DateTime.UtcNow;
+            await AlertConfig.SetAlertStatusAsync(active.Select(a => a.Id).ToList(), AlertStatus.Resolved, now);
             foreach (var alert in active)
             {
                 alert.Status = AlertStatus.Resolved;
                 alert.ResolvedAt = now;
-                await AlertConfig.UpdateAlertAsync(alert);
             }
             await RecalculateIncidentsOnceAsync(active);
             await LoadActiveAlerts();
@@ -2518,11 +2518,11 @@
             // before the button said which alerts it meant.
             var acknowledged = _unresolvedAlerts.Where(a => a.Status == AlertStatus.Acknowledged).ToList();
             var now = DateTime.UtcNow;
+            await AlertConfig.SetAlertStatusAsync(acknowledged.Select(a => a.Id).ToList(), AlertStatus.Resolved, now);
             foreach (var alert in acknowledged)
             {
                 alert.Status = AlertStatus.Resolved;
                 alert.ResolvedAt = now;
-                await AlertConfig.UpdateAlertAsync(alert);
             }
             await RecalculateIncidentsOnceAsync(acknowledged);
             await LoadActiveAlerts();
@@ -2614,16 +2614,19 @@
         try
         {
             var now = DateTime.UtcNow;
-            foreach (var incident in _incidents.Where(i => i.Status == AlertStatus.Active).ToList())
+            // Every incident's alerts are gathered first and written in one go: a save per alert
+            // is a database commit per alert, which is what made these buttons crawl on a site
+            // with a few hundred of them.
+            var incidents = _incidents.Where(i => i.Status == AlertStatus.Active).ToList();
+            var alertIds = new List<int>();
+            foreach (var incident in incidents)
             {
                 var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
-                foreach (var alert in alerts.Where(a => a.Status == AlertStatus.Active))
-                {
-                    alert.Status = AlertStatus.Acknowledged;
-                    alert.AcknowledgedAt = now;
-                    await AlertConfig.UpdateAlertAsync(alert);
-                }
-
+                alertIds.AddRange(alerts.Where(a => a.Status == AlertStatus.Active).Select(a => a.Id));
+            }
+            await AlertConfig.SetAlertStatusAsync(alertIds, AlertStatus.Acknowledged, now);
+            foreach (var incident in incidents)
+            {
                 incident.Status = AlertStatus.Acknowledged;
                 await AlertConfig.UpdateIncidentAsync(incident);
             }
@@ -2641,16 +2644,17 @@
         try
         {
             var now = DateTime.UtcNow;
-            foreach (var incident in _incidents.Where(i => i.Status != AlertStatus.Resolved).ToList())
+            // Same as Acknowledge All Incidents: gather every incident's alerts, write them once.
+            var incidents = _incidents.Where(i => i.Status != AlertStatus.Resolved).ToList();
+            var alertIds = new List<int>();
+            foreach (var incident in incidents)
             {
                 var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
-                foreach (var alert in alerts.Where(a => a.Status != AlertStatus.Resolved))
-                {
-                    alert.Status = AlertStatus.Resolved;
-                    alert.ResolvedAt = now;
-                    await AlertConfig.UpdateAlertAsync(alert);
-                }
-
+                alertIds.AddRange(alerts.Where(a => a.Status != AlertStatus.Resolved).Select(a => a.Id));
+            }
+            await AlertConfig.SetAlertStatusAsync(alertIds, AlertStatus.Resolved, now);
+            foreach (var incident in incidents)
+            {
                 incident.Status = AlertStatus.Resolved;
                 incident.ResolvedAt = now;
                 await AlertConfig.UpdateIncidentAsync(incident);

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -875,7 +875,7 @@
                     <div class="history-filters">
                         <div class="filter-group">
                             <label class="filter-label">Source:</label>
-                            <select class="filter-select" @bind="_historySourceFilter" @bind:after="LoadHistory">
+                            <select class="filter-select" @bind="_historySourceFilter" @bind:after="ReloadHistoryFromFirstPage">
                                 <option value="">All Sources</option>
                                 <option value="audit">Audit</option>
                                 <option value="device">Device</option>
@@ -887,7 +887,7 @@
                         </div>
                         <div class="filter-group">
                             <label class="filter-label">Min Severity:</label>
-                            <select class="filter-select" @bind="_historySeverityFilter" @bind:after="LoadHistory">
+                            <select class="filter-select" @bind="_historySeverityFilter" @bind:after="ReloadHistoryFromFirstPage">
                                 <option value="">All</option>
                                 <option value="Info">Info</option>
                                 <option value="Warning">Warning</option>
@@ -952,6 +952,18 @@
                             </tbody>
                         </table>
                     </div>
+                    @if (_historyTotal > HistoryPageSize)
+                    {
+                        <div class="pagination">
+                            <button class="btn btn-sm btn-secondary" disabled="@(_historyPage == 0)"
+                                    @onclick="() => GoToHistoryPage(_historyPage - 1)">Prev</button>
+                            <span class="pagination-info">
+                                Page @(_historyPage + 1) of @HistoryPageCount (@_historyTotal alerts)
+                            </span>
+                            <button class="btn btn-sm btn-secondary" disabled="@(_historyPage >= HistoryPageCount - 1)"
+                                    @onclick="() => GoToHistoryPage(_historyPage + 1)">Next</button>
+                        </div>
+                    }
                 </div>
             }
         }
@@ -2459,13 +2471,54 @@
                 severity = s;
 
             var source = string.IsNullOrEmpty(_historySourceFilter) ? null : _historySourceFilter;
-            _historyAlerts = await AlertRepository.GetAlertHistoryAsync(200, source, severity);
+            // A filter change re-reads from the first page: page 4 of the old filter is a
+            // different set of alerts, and usually past the end of the new one.
+            if (_historyPage < 0) _historyPage = 0;
+            var (items, total) = await AlertRepository.GetAlertHistoryPageAsync(
+                _historyPage * HistoryPageSize, HistoryPageSize, source, severity);
+            // A page that has fallen off the end (the filter narrowed, or alerts aged out) steps
+            // back to the last one that exists rather than showing nothing.
+            if (items.Count == 0 && total > 0 && _historyPage > 0)
+            {
+                _historyPage = Math.Max(0, (total - 1) / HistoryPageSize);
+                (items, total) = await AlertRepository.GetAlertHistoryPageAsync(
+                    _historyPage * HistoryPageSize, HistoryPageSize, source, severity);
+            }
+            _historyAlerts = items;
+            _historyTotal = total;
         }
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error loading alert history");
             _historyAlerts = [];
+            _historyTotal = 0;
         }
+    }
+
+    private const int HistoryPageSize = 50;
+
+    /// <summary>Zero-based page the History tab is showing.</summary>
+    private int _historyPage;
+
+    /// <summary>How many alerts the current filters match, across every page.</summary>
+    private int _historyTotal;
+
+    private int HistoryPageCount => _historyTotal == 0 ? 1 : (_historyTotal + HistoryPageSize - 1) / HistoryPageSize;
+
+    private async Task GoToHistoryPage(int page)
+    {
+        var last = HistoryPageCount - 1;
+        var target = Math.Clamp(page, 0, last);
+        if (target == _historyPage) return;
+        _historyPage = target;
+        await LoadHistory();
+    }
+
+    /// <summary>Filter changes start again from the first page.</summary>
+    private async Task ReloadHistoryFromFirstPage()
+    {
+        _historyPage = 0;
+        await LoadHistory();
     }
 
     private async Task LoadRules()

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2663,18 +2663,15 @@
             // is a database commit per alert, which is what made these buttons crawl on a site
             // with a few hundred of them.
             var incidents = _incidents.Where(i => i.Status == AlertStatus.Active).ToList();
-            var alertIds = new List<int>();
-            foreach (var incident in incidents)
-            {
-                var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
-                alertIds.AddRange(alerts.Where(a => a.Status == AlertStatus.Active).Select(a => a.Id));
-            }
+            var incidentIds = incidents.Select(i => i.Id).ToList();
+            var alertIds = (await AlertRepository.GetAlertsByIncidentIdsAsync(incidentIds))
+                .Where(a => a.Status == AlertStatus.Active)
+                .Select(a => a.Id)
+                .ToList();
             await AlertConfig.SetAlertStatusAsync(alertIds, AlertStatus.Acknowledged, now);
             foreach (var incident in incidents)
-            {
                 incident.Status = AlertStatus.Acknowledged;
-                await AlertConfig.UpdateIncidentAsync(incident);
-            }
+            await AlertConfig.UpdateIncidentsAsync(incidents);
             await LoadIncidents();
             await LoadActiveAlerts();
         }
@@ -2697,19 +2694,18 @@
             var now = DateTime.UtcNow;
             // Same as Acknowledge All Incidents: gather every incident's alerts, write them once.
             var incidents = _incidents.Where(i => i.Status != AlertStatus.Resolved).ToList();
-            var alertIds = new List<int>();
-            foreach (var incident in incidents)
-            {
-                var alerts = await AlertRepository.GetAlertsByIncidentIdAsync(incident.Id);
-                alertIds.AddRange(alerts.Where(a => a.Status != AlertStatus.Resolved).Select(a => a.Id));
-            }
+            var incidentIds = incidents.Select(i => i.Id).ToList();
+            var alertIds = (await AlertRepository.GetAlertsByIncidentIdsAsync(incidentIds))
+                .Where(a => a.Status != AlertStatus.Resolved)
+                .Select(a => a.Id)
+                .ToList();
             await AlertConfig.SetAlertStatusAsync(alertIds, AlertStatus.Resolved, now);
             foreach (var incident in incidents)
             {
                 incident.Status = AlertStatus.Resolved;
                 incident.ResolvedAt = now;
-                await AlertConfig.UpdateIncidentAsync(incident);
             }
+            await AlertConfig.UpdateIncidentsAsync(incidents);
             await LoadIncidents();
             await LoadActiveAlerts();
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2566,7 +2566,7 @@
         if (!SafeToRedraw) return;
         try
         {
-            var latest = await AlertRepository.GetIncidentsAsync();
+            var latest = await AlertRepository.GetUnresolvedIncidentsAsync();
             var isNew = latest.Any(p => !_incidents.Any(i => i.Id == p.Id));
             _pendingIncidents = latest;
             if (!isNew || _incidents.Count == 0) ApplyPendingIncidents();
@@ -2596,7 +2596,7 @@
     {
         try
         {
-            _incidents = await AlertRepository.GetIncidentsAsync();
+            _incidents = await AlertRepository.GetUnresolvedIncidentsAsync();
             _pendingIncidents = null;
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -4635,16 +4635,24 @@
         // Pick the target with the lowest RTT (nearest ISP infrastructure).
         double? bestRtt = null;
         double bestLoss = 0;
+        var freshLosses = new List<double>();
+        var freshAfter = DateTime.UtcNow - Services.MonitoringLiveStats.LiveReadingMaxAge;
         foreach (var t in targets)
         {
             var s = LiveStats.GetTargetStats(t.TargetId);
-            if (s?.RttAvgMs != null && (bestRtt == null || s.RttAvgMs.Value < bestRtt.Value))
+            // Current readings only - a target that stopped reporting must not keep presenting
+            // the reading it carried before it went quiet.
+            if (s == null || s.LastUpdate < freshAfter) continue;
+            freshLosses.Add(s.LossPercent);
+            if (s.RttAvgMs != null && (bestRtt == null || s.RttAvgMs.Value < bestRtt.Value))
             {
                 bestRtt = s.RttAvgMs;
                 bestLoss = s.LossPercent;
             }
         }
-        return (bestRtt, bestLoss);
+        // Nothing answered, so there is no nearest hop to read loss off; the mean of what did
+        // report is the honest figure, and 0% would read as a healthy connection mid-outage.
+        return (bestRtt, bestRtt == null ? (freshLosses.Count > 0 ? freshLosses.Average() : 0) : bestLoss);
     }
 
 
@@ -4731,10 +4739,13 @@
                 var losses = new List<double>();
                 double? best = null;
                 double bestLoss = 0;
+                var freshAfter = DateTime.UtcNow - Services.MonitoringLiveStats.LiveReadingMaxAge;
                 foreach (var t in targets)
                 {
                     var st = LiveStats.GetTargetStats(t.TargetId);
-                    if (st == null) continue;
+                    // A reading only counts while it is current: a target that stops reporting
+                    // otherwise keeps presenting the reading it carried before it went quiet.
+                    if (st == null || st.LastUpdate < freshAfter) continue;
                     losses.Add(st.LossPercent);
                     if (st.RttAvgMs == null) continue;
                     rtts.Add(st.RttAvgMs.Value);
@@ -4747,7 +4758,12 @@
                 // Transit reads as the mean of its hops; the access ISP reads as its nearest clean
                 // hop. Same choice the single-WAN tiles have always made, kept per WAN.
                 rtt = meanAcrossTargets ? (rtts.Count > 0 ? rtts.Average() : null) : best;
-                loss = meanAcrossTargets ? (losses.Count > 0 ? losses.Average() : 0) : bestLoss;
+                // With no hop answering there is no nearest hop to read loss off, and taking it
+                // from one anyway left the tile reporting that hop's last loss - 0% - through an
+                // outage where every hop was dark. Fall back to the mean of what did report.
+                loss = meanAcrossTargets || best == null
+                    ? (losses.Count > 0 ? losses.Average() : 0)
+                    : bestLoss;
             }
             rows.Add((WanRowLabel(wan), rtt, loss));
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1897,6 +1897,12 @@
     private string _primaryWanKey = NetworkOptimizer.UniFi.GatewayWanHelper.DefaultWanKey;
     private bool _wanSelectionRestored;
 
+    /// <summary>
+    /// A link named a WAN before the WAN options had loaded, so it could not be resolved yet and
+    /// is applied as soon as they arrive. Without it the link was simply lost on those loads.
+    /// </summary>
+    private bool _linkWanAwaitingOptions;
+
     // The modifier that adds a WAN to the comparison set, named the way the reader's own keyboard
     // names it - telling a Mac user to Ctrl-click is telling them to open a context menu. Ctrl
     // until the browser says otherwise, so the hint is never blank on the first paint.
@@ -2179,6 +2185,10 @@
         _selectedWanKeys.RemoveWhere(k => !_wanOptions.Any(o => o.Key.Equals(k, StringComparison.OrdinalIgnoreCase)));
         if (_selectedWanKeys.Count == 0)
             _selectedWanKeys.Add(_primaryWanKey);
+        // A link that arrived before this point resolved nothing and was waiting on it. Applying
+        // it here rather than leaving it to the next mount is what makes a deep link land on its
+        // WAN every time instead of most of the time.
+        await ApplyPendingLinkWanAsync();
     }
 
     /// <summary>Restores the persisted WAN selection once localStorage is reachable.</summary>
@@ -2270,10 +2280,33 @@
     /// </summary>
     private async Task ApplyLinkWanSelectionAsync()
     {
-        if (!_wanOptionsLoaded) return;
-        if (!_multiWanUiVisible || _wanOptions.Count <= 1) return;
-        if (string.IsNullOrWhiteSpace(WanParam) || !LinkNarrowsWanFilter) return;
-        if (_appliedLinkWanKey == LinkWanKey) return;
+        // The options answer the question this needs answered, and the mount that calls this runs
+        // once - so returning here without remembering the link dropped it for the rest of the
+        // visit, and the stored filter that was read a line earlier stood instead. Whether that
+        // happened came down to which finished first, so the same link kept or lost its WAN from
+        // one load to the next. The flag lets the load itself finish the job.
+        if (string.IsNullOrWhiteSpace(WanParam) || !LinkNarrowsWanFilter)
+        {
+            _linkWanAwaitingOptions = false;
+            return;
+        }
+        if (_appliedLinkWanKey == LinkWanKey)
+        {
+            _linkWanAwaitingOptions = false;
+            return;
+        }
+        // Nothing to resolve against yet. The mount that calls this runs once, so returning
+        // without remembering the link dropped it for the rest of the visit and left the stored
+        // filter - read a line earlier - standing in its place. Whether that happened came down
+        // to which finished first, so the same link kept or lost its WAN from one load to the
+        // next. The flag holds it until the answers arrive.
+        if (!_wanOptionsLoaded || !_multiWanUiVisible)
+        {
+            _linkWanAwaitingOptions = true;
+            return;
+        }
+        _linkWanAwaitingOptions = false;
+        if (_wanOptions.Count <= 1) return;
 
         var keys = ResolveLinkWanKeys(WanParam);
         // Stamped before the resolve is judged: the link has been CONSIDERED either way, and the
@@ -3393,12 +3426,26 @@
         if (_wanContexts.Count > 0)
         {
             _multiWanUiVisible = true;
+            await ApplyPendingLinkWanAsync();
             return;
         }
         if (_wanCountChecked) return;
         _wanCountChecked = true;
         try { _multiWanUiVisible = (await PathView.GetWansAsync()).Count > 1; }
         catch { _multiWanUiVisible = false; }
+        await ApplyPendingLinkWanAsync();
+    }
+
+    /// <summary>
+    /// Applies a link's WAN that arrived before the page could resolve it - the WAN options or the
+    /// multi-WAN answer landing after the mount that first tried. Cheap and idempotent: it does
+    /// nothing unless a link is actually waiting.
+    /// </summary>
+    private async Task ApplyPendingLinkWanAsync()
+    {
+        if (!_linkWanAwaitingOptions) return;
+        await ApplyLinkWanSelectionAsync();
+        await InvokeAsync(StateHasChanged);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3427,15 +3427,6 @@
     private const string LiveAtToken = "live";
 
     /// <summary>
-    /// The live WAN selection as a ?wan= value - the whole set rather than just the focus, so a
-    /// comparison of two WANs arrives at the other tab as that same comparison.
-    /// </summary>
-    private string LiveWanQueryValue() =>
-        LiveWan.AllSelected
-            ? Services.Monitoring.LiveWanScope.AllWansToken
-            : string.Join(",", LiveWan.SelectedKeys);
-
-    /// <summary>
     /// Opens Latency and Packet Loss on what the Live tab is showing: the same instant, the
     /// category for the thing being watched, and the WAN selection carried across. The analysis
     /// view's own saved filter survives untouched - navigateToTime stashes what it replaces and
@@ -3449,10 +3440,8 @@
             : LiveAtToken;
         // LAN targets are not reached over any one WAN, so that jump asks for all of them rather
         // than narrowing the analysis to whichever WAN the tiles happened to be showing.
-        var wan = category == FabricCategory
-            ? Services.Monitoring.LiveWanScope.AllWansToken
-            : LiveWanQueryValue();
-        var wanQuery = LiveWan.HasChoice && wan.Length > 0 ? $"&wan={Uri.EscapeDataString(wan)}" : "";
+        var wanQuery = LiveWan.QueryFragment(
+            category == FabricCategory ? Services.Monitoring.LiveWanScope.AllWansToken : null);
         NavigationManager.NavigateTo($"/monitoring?tab=performance&category={category}&at={at}{wanQuery}");
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -98,7 +98,7 @@ else
                 }
             </div>
             @{ var ispTarget = ScopedTargetStats(MonitoringTargetType.AccessIsp, meanAcrossTargets: false); }
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis("AccessIsp"))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -114,7 +114,7 @@ else
                 }
                 <div class="stat-label">ISP RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=AccessIsp"))">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis("AccessIsp"))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -131,7 +131,7 @@ else
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = ScopedTargetStats(MonitoringTargetType.Transit, meanAcrossTargets: true); }
-            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis("Transit"))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -147,7 +147,7 @@ else
                 }
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&category=Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis("Transit"))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -684,6 +684,23 @@ else
         if (targetId == null) return (null, 0);
         var s = LiveStats.GetTargetStats(targetId);
         return (s?.RttAvgMs, s?.LossPercent ?? 0);
+    }
+
+    /// <summary>
+    /// Opens Latency and Packet Loss on what these tiles are showing, carrying the WAN selection
+    /// across. On the Monitoring page the tiles jump within the page, which keeps the filter by
+    /// staying put; from the Dashboard the same tiles navigate, and without the WAN on the link
+    /// the destination opened unfiltered - showing every WAN's targets after a click on one WAN's
+    /// tile. Mirrors Monitoring's own JumpToAnalysis: the whole selection, so a comparison of two
+    /// WANs arrives as that same comparison.
+    /// </summary>
+    private void JumpToAnalysis(string category)
+    {
+        var wan = LiveWan.AllSelected
+            ? Services.Monitoring.LiveWanScope.AllWansToken
+            : string.Join(",", LiveWan.SelectedKeys);
+        var wanQuery = LiveWan.HasChoice && wan.Length > 0 ? $"&wan={Uri.EscapeDataString(wan)}" : "";
+        NavigationManager.NavigateTo($"/monitoring?tab=performance&category={category}{wanQuery}");
     }
 
     private (double? rtt, double loss) GetBestTargetStats(MonitoringTargetType type)

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -692,16 +692,24 @@ else
         if (targets.Count == 0) return (null, 0);
         double? bestRtt = null;
         double bestLoss = 0;
+        var losses = new List<double>();
+        var freshAfter = DateTime.UtcNow - Services.MonitoringLiveStats.LiveReadingMaxAge;
         foreach (var t in targets)
         {
             var st = LiveStats.GetTargetStats(t.TargetId);
-            if (st?.RttAvgMs != null && (bestRtt == null || st.RttAvgMs.Value < bestRtt.Value))
+            // Current readings only - a target that stopped reporting must not keep presenting
+            // the reading it carried before it went quiet.
+            if (st == null || st.LastUpdate < freshAfter) continue;
+            losses.Add(st.LossPercent);
+            if (st.RttAvgMs != null && (bestRtt == null || st.RttAvgMs.Value < bestRtt.Value))
             {
                 bestRtt = st.RttAvgMs;
                 bestLoss = st.LossPercent;
             }
         }
-        return (bestRtt, bestLoss);
+        // Nothing answered, so there is no nearest hop to read loss off; the mean of what did
+        // report is the honest figure, and 0% would read as a healthy connection mid-outage.
+        return (bestRtt, bestRtt == null ? (losses.Count > 0 ? losses.Average() : 0) : bestLoss);
     }
 
 
@@ -764,7 +772,9 @@ else
                 foreach (var t in targets)
                 {
                     var st = LiveStats.GetTargetStats(t.TargetId);
-                    if (st == null) continue;
+                    // A reading only counts while it is current: a target that stops reporting
+                    // otherwise keeps presenting the reading it carried before it went quiet.
+                    if (st == null || st.LastUpdate < DateTime.UtcNow - Services.MonitoringLiveStats.LiveReadingMaxAge) continue;
                     losses.Add(st.LossPercent);
                     if (st.RttAvgMs == null) continue;
                     rtts.Add(st.RttAvgMs.Value);
@@ -777,7 +787,12 @@ else
                 // Transit reads as the mean of its hops; the access ISP reads as its nearest clean
                 // hop. Same choice the single-WAN tiles have always made, kept per WAN.
                 rtt = meanAcrossTargets ? (rtts.Count > 0 ? rtts.Average() : null) : best;
-                loss = meanAcrossTargets ? (losses.Count > 0 ? losses.Average() : 0) : bestLoss;
+                // With no hop answering there is no nearest hop to read loss off, and taking it
+                // from one anyway left the tile reporting that hop's last loss - 0% - through an
+                // outage where every hop was dark. Fall back to the mean of what did report.
+                loss = meanAcrossTargets || best == null
+                    ? (losses.Count > 0 ? losses.Average() : 0)
+                    : bestLoss;
             }
             var label = NetworkOptimizer.UniFi.GatewayWanHelper.SplitWanLabel(
                 wan.Label, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(wan.Key)).WanToken ?? wan.Label;

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -696,11 +696,8 @@ else
     /// </summary>
     private void JumpToAnalysis(string category)
     {
-        var wan = LiveWan.AllSelected
-            ? Services.Monitoring.LiveWanScope.AllWansToken
-            : string.Join(",", LiveWan.SelectedKeys);
-        var wanQuery = LiveWan.HasChoice && wan.Length > 0 ? $"&wan={Uri.EscapeDataString(wan)}" : "";
-        NavigationManager.NavigateTo($"/monitoring?tab=performance&category={category}{wanQuery}");
+        NavigationManager.NavigateTo(
+            $"/monitoring?tab=performance&category={category}{LiveWan.QueryFragment()}");
     }
 
     private (double? rtt, double loss) GetBestTargetStats(MonitoringTargetType type)

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -187,12 +187,12 @@ else if (_report == null)
                 <span class="banner-icon banner-icon-info">i</span>
                 <div class="banner-text" style="flex: 1;">
                     Collecting monitoring data. ISP Health needs a few hours of latency history before it can grade your connection; check back soon.
-                    @if (!_wanHasSpeedTestSchedule)
+                    @if (ShowScheduleNudge)
                     {
                         <text> No speed tests are scheduled for this WAN yet - schedule recurring tests and run one now, so throughput history builds alongside.</text>
                     }
                 </div>
-                @if (!_wanHasSpeedTestSchedule)
+                @if (ShowScheduleNudge)
                 {
                     <div class="banner-actions">
                         <a href="/alerts" class="btn btn-sm btn-primary">Set up schedule</a>
@@ -1073,6 +1073,16 @@ else
     /// on an unknown answer.
     /// </summary>
     private bool _wanHasSpeedTestSchedule = true;
+
+    /// <summary>
+    /// Whether this user could act on the schedule nudge. Creating a scheduled speed test is a
+    /// site administrator's to do, so anyone else is left with the plain collecting-data line
+    /// rather than being sent to a page that will not let them do it.
+    /// </summary>
+    private bool _canConfigureSchedules;
+
+    /// <summary>Whether to offer the schedule nudge: this WAN has none, and the user could add one.</summary>
+    private bool ShowScheduleNudge => !_wanHasSpeedTestSchedule && _canConfigureSchedules;
     private string SharedWanScopeKey => SiteContext.ScopeStorageKey("monitoringWanScope");
 
     /// <summary>
@@ -1367,6 +1377,10 @@ else
     {
         _canOperate = AuthState is null
             || (await Authz.AuthorizeAsync((await AuthState).User, SiteContext.Slug, Policies.SiteOperator)).Succeeded;
+        // Scheduled speed tests are a site administrator's to create (Alerts & Schedule gates the
+        // whole section on it), so only an administrator is pointed at them.
+        _canConfigureSchedules = AuthState is null
+            || (await Authz.AuthorizeAsync((await AuthState).User, SiteContext.Slug, Policies.SiteAdmin)).Succeeded;
 
         // Pull-to-refresh on this tab recomputes the scorecard (the Refresh button's action)
         // instead of the layout's full-page-reload fallback.

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -187,7 +187,17 @@ else if (_report == null)
                 <span class="banner-icon banner-icon-info">i</span>
                 <div class="banner-text" style="flex: 1;">
                     Collecting monitoring data. ISP Health needs a few hours of latency history before it can grade your connection; check back soon.
+                    @if (!_wanHasSpeedTestSchedule)
+                    {
+                        <text> No speed tests are scheduled for this WAN yet - schedule recurring tests and run one now, so throughput history builds alongside.</text>
+                    }
                 </div>
+                @if (!_wanHasSpeedTestSchedule)
+                {
+                    <div class="banner-actions">
+                        <a href="/alerts" class="btn btn-sm btn-primary">Set up schedule</a>
+                    </div>
+                }
             </div>
         </div>
     }
@@ -1055,6 +1065,14 @@ else
     // not probed at all, and discovery cannot change that.
     private HashSet<string> _wansWithContext = new(StringComparer.OrdinalIgnoreCase);
     private string _selectedWanKey = "";
+
+    /// <summary>
+    /// Whether the selected WAN has an enabled scheduled WAN speed test. Read alongside the
+    /// report so the collecting-data banner can point a freshly monitored WAN at Alerts &amp;
+    /// Schedule while its latency history builds. Defaults to true so the nudge never shows
+    /// on an unknown answer.
+    /// </summary>
+    private bool _wanHasSpeedTestSchedule = true;
     private string SharedWanScopeKey => SiteContext.ScopeStorageKey("monitoringWanScope");
 
     /// <summary>
@@ -1137,6 +1155,53 @@ else
             // and let the status funnels render the fallback message.
             _report = null;
         }
+        await RefreshWanScheduleHintAsync();
+    }
+
+    /// <summary>
+    /// Rereads whether the selected WAN is covered by an enabled scheduled WAN speed test. A
+    /// gateway schedule carries its network group(s) in TargetConfig ("WAN", "WAN+WAN2"); a
+    /// server-vantage schedule carries none and rides the default route, so it counts for the
+    /// primary. Any failure reads as covered - the banner nudge must never appear on a guess.
+    /// </summary>
+    private async Task RefreshWanScheduleHintAsync()
+    {
+        try
+        {
+            var choice = _wanOptions.FirstOrDefault(w => string.Equals(w.Key, _selectedWanKey, StringComparison.OrdinalIgnoreCase));
+            var wanKey = string.IsNullOrEmpty(_selectedWanKey) ? NetworkOptimizer.UniFi.GatewayWanHelper.DefaultWanKey : _selectedWanKey;
+            var wanGroup = NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(wanKey);
+            var isPrimary = choice?.IsPrimary ?? true;
+
+            await using var db = SiteDb.CreateForSite(SiteContext.Slug, SiteContext.IsDefault);
+            var configs = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(
+                System.Linq.Queryable.Select(
+                    System.Linq.Queryable.Where(db.ScheduledTasks,
+                        t => t.Enabled && t.TaskType == "wan_speedtest"),
+                    t => t.TargetConfig));
+            _wanHasSpeedTestSchedule = configs.Any(c => ScheduleCoversWan(c, wanGroup, isPrimary));
+        }
+        catch
+        {
+            _wanHasSpeedTestSchedule = true;
+        }
+    }
+
+    private static bool ScheduleCoversWan(string? targetConfig, string wanGroup, bool wanIsPrimary)
+    {
+        if (string.IsNullOrEmpty(targetConfig)) return wanIsPrimary;
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(targetConfig);
+            if (!doc.RootElement.TryGetProperty("wanGroup", out var g) || g.ValueKind != System.Text.Json.JsonValueKind.String)
+                return wanIsPrimary;
+            return (g.GetString() ?? "").Split('+')
+                .Any(part => string.Equals(part.Trim(), wanGroup, StringComparison.OrdinalIgnoreCase));
+        }
+        catch
+        {
+            return wanIsPrimary;
+        }
     }
 
     private async Task SelectWanAsync(string key, bool persist = true)
@@ -1175,6 +1240,7 @@ else
                 : await Svc.GetReportAsync();
         }
         catch { _report = null; }
+        await RefreshWanScheduleHintAsync();
         // The chart fetches its own series and scopes them by WAN, so it has to be told. The
         // chart itself is dropped right now (the content render below re-mounts it), but the WAN
         // key is module-level JS state that survives the remount - pushing it here means the

--- a/src/NetworkOptimizer.Web/Endpoints/AlertEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/AlertEndpoints.cs
@@ -95,6 +95,11 @@ public static class AlertEndpoints
         });
 
         // --- Incidents ---
+        // TODO: takes the newest `limit` incidents whatever their status, so a caller wanting the
+        // unresolved ones cannot get at them once that many newer ones have been resolved - the
+        // trap the Incidents tab was in until it moved to GetUnresolvedIncidentsAsync. Give this a
+        // status filter applied in SQL. Left as-is for now because changing what the resource
+        // returns by default would change it for anyone already reading it.
         read.MapGet("/api/alerts/incidents", async (IAlertRepository repo, int limit = 50) =>
             Results.Ok(await repo.GetIncidentsAsync(limit)));
 

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -277,19 +277,61 @@ public static class MonitoringChartEndpoints
             // 5s window - and SNMP polls get delayed exactly under load, so loss
             // spikes vanished from the chart precisely when they mattered.
             var rttSorted = rttData.OrderBy(p => p.Time).ToList();
+            var wanSorted = wanData.OrderBy(w => w.Time).ToList();
+
+            // Rows come from the throughput series, so a span with no throughput point had no row
+            // at all - and took its latency and loss down with it. The gateway's SNMP counters are
+            // collected by whoever collects for the site, and on a site that leaves collection to
+            // the server there is nothing to buffer them: a server restart leaves a real hole in
+            // throughput while the agent's probe results replay into it perfectly. The chart drew
+            // the hole across every series, so backfilled latency and loss were invisible.
+            //
+            // Latency points landing in such a hole get a row of their own, with no throughput on
+            // it. Only in a hole: a point with throughput either side of it within a couple of
+            // sample intervals still rides that throughput point, so ordinary operation keeps
+            // exactly the rows it had and the throughput line does not turn dotted. Both series
+            // are already in hand - this adds no query.
+            var holeTolerance = TimeSpan.FromSeconds(Math.Max(sampleIntervalSeconds * 2, 10));
+            var orphanTimes = new List<DateTime>();
+            if (wanSorted.Count == 0)
+            {
+                orphanTimes.AddRange(rttSorted.Select(p => p.Time));
+            }
+            else
+            {
+                var wi = 0;
+                foreach (var p in rttSorted)
+                {
+                    while (wi + 1 < wanSorted.Count && wanSorted[wi + 1].Time <= p.Time) wi++;
+                    var nearest = (p.Time - wanSorted[wi].Time).Duration();
+                    if (wi + 1 < wanSorted.Count)
+                    {
+                        var next = (wanSorted[wi + 1].Time - p.Time).Duration();
+                        if (next < nearest) nearest = next;
+                    }
+                    if (nearest > holeTolerance) orphanTimes.Add(p.Time);
+                }
+            }
+
+            var rows = wanSorted
+                .Select(w => (Time: w.Time, Down: (double?)w.DownloadBps, Up: (double?)w.UploadBps))
+                .Concat(orphanTimes.Select(t => (Time: t, Down: (double?)null, Up: (double?)null)))
+                .OrderBy(r => r.Time)
+                .ToList();
+
             var ri = 0;
             MonitoringInfluxClient.LatencyPoint? lastRtt = null;
 
-            var points = wanData.OrderBy(w => w.Time).Select(w =>
+            var points = rows.Select(r =>
             {
-                while (ri < rttSorted.Count && rttSorted[ri].Time <= w.Time)
+                while (ri < rttSorted.Count && rttSorted[ri].Time <= r.Time)
                     lastRtt = rttSorted[ri++];
 
                 return new
                 {
-                    time = w.Time.ToString("o"),
-                    downloadBps = w.DownloadBps,
-                    uploadBps = w.UploadBps,
+                    time = r.Time.ToString("o"),
+                    downloadBps = r.Down,
+                    uploadBps = r.Up,
                     rttMs = lastRtt?.RttAvgMs,
                     lossPercent = lastRtt?.LossPercent,
                 };

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -613,6 +613,9 @@ builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.AsnResolu
 builder.Services.AddSiteScopedRegistry<MonitoringAlertRegistry>();
 // (The cable modem, ONT, and cellular alert evaluators are per site via
 // MonitoringAlertRegistry.)
+// Loads the per-site WAN context (roles, labels, trace map) the WAN outage evaluator
+// classifies against; the evaluator instances themselves live in MonitoringAlertRegistry.
+builder.Services.AddSingleton<NetworkOptimizer.Web.Services.Monitoring.WanOutageContextSource>();
 // Upstream tracer is per site (isolated discovery state in each site's DB, traceroute
 // from the site's own vantage). Scoped resolution forwards to the current site's tracer;
 // the background re-discovery iterates sites via the registry.
@@ -1024,20 +1027,16 @@ using (var scope = app.Services.CreateScope())
             // Seed the Alerts & Schedule defaults into each site's DB too, so secondary
             // sites match the main site instead of showing blank lists. The main-DB seed
             // below only covers the default site.
-            var siteMissingRules = NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults()
-                .Where(r => !siteDb.AlertRules.Select(x => x.EventTypePattern).Contains(r.EventTypePattern))
-                .ToList();
-            if (siteMissingRules.Count > 0)
+            var siteSeededPatterns = StartupHelpers.SeedAlertRules(
+                siteDb, NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults());
+            if (siteSeededPatterns.Count > 0)
             {
-                siteDb.AlertRules.AddRange(siteMissingRules);
-                siteDb.SaveChanges();
-                app.Logger.LogInformation("Seeded {Count} alert rule(s) for site {Slug}", siteMissingRules.Count, site.Slug);
+                app.Logger.LogInformation("Seeded {Count} alert rule(s) for site {Slug}", siteSeededPatterns.Count, site.Slug);
 
                 // Enable any freshly seeded modem/ONT rules for a secondary site that already
                 // has the matching monitoring configured (mirrors the main-site seed below,
                 // which secondary sites otherwise never got - a new ONT rule landed disabled).
-                var siteSeededPatterns = siteMissingRules.Select(m => m.EventTypePattern).ToHashSet();
-
+                //
                 // Same one-time Device Offline enable as the main site, so managed sites match.
                 AlertRuleAutoEnable.EnableNowThatItHasAPublisher(
                     siteDb, "device.offline", "device.recovered", siteSeededPatterns, app.Logger);
@@ -1088,7 +1087,7 @@ using (var scope = app.Services.CreateScope())
         app.Logger.LogInformation("Database journal mode: WAL (filesystem: {FilesystemType})", detectedFsType);
     }
 
-    // Seed default alert rules - insert any missing rules by EventTypePattern
+    // Seed default alert rules - insert any rule this database has never been seeded before
     {
         var defaults = NetworkOptimizer.Alerts.DefaultAlertRules.GetDefaults();
 
@@ -1103,22 +1102,15 @@ using (var scope = app.Services.CreateScope())
         if (defaultSiteId == null || !db.SiteAgents.Any(a => a.SiteId == defaultSiteId))
             defaults = defaults.Where(d => d.Source != "agent").ToList();
 
-        var existingPatterns = db.AlertRules.Select(r => r.EventTypePattern).ToHashSet();
-        var missing = defaults.Where(d => !existingPatterns.Contains(d.EventTypePattern)).ToList();
-        if (missing.Count > 0)
-        {
-            db.AlertRules.AddRange(missing);
-            db.SaveChanges();
-            app.Logger.LogInformation("Seeded {Count} new alert rules", missing.Count);
-        }
+        var seededPatterns = StartupHelpers.SeedAlertRules(db, defaults);
+        if (seededPatterns.Count > 0)
+            app.Logger.LogInformation("Seeded {Count} new alert rules", seededPatterns.Count);
 
         // Auto-enable freshly seeded modem/ONT rules for users who already have
         // configs. Only touches rules we just inserted - never re-enables rules
         // the user has manually disabled.
-        if (missing.Count > 0)
+        if (seededPatterns.Count > 0)
         {
-            var seededPatterns = missing.Select(m => m.EventTypePattern).ToHashSet();
-
             // Device Offline shipped disabled because nothing published device.offline until this
             // release. Enable that ONE rule as its publisher lands - keyed off the paired
             // device.recovered rule arriving, so it happens once and overrides no later choice.
@@ -1606,6 +1598,55 @@ static partial class StartupHelpers
         return System.Security.Cryptography.X509Certificates.X509CertificateLoader.LoadPkcs12(
             certificate.Export(System.Security.Cryptography.X509Certificates.X509ContentType.Pfx),
             password: null);
+    }
+
+    /// <summary>
+    /// Inserts the default alert rules a database has never been given, and records every default
+    /// pattern it holds in SeededAlertRules so each one is seeded at most once per database. The
+    /// record is what makes a deletion stick: seeding used to key off AlertRules alone, so a rule
+    /// the user deleted (or a whole source they cleared out) came straight back on the next start.
+    ///
+    /// Patterns already present in AlertRules but not yet recorded are backfilled, including when
+    /// nothing was inserted, so existing installs stop resurrecting rules from here on.
+    /// <paramref name="defaults"/> is the caller's already-filtered list and is the only source of
+    /// recorded patterns - a default held back because the site lacks its capability (agent rules)
+    /// stays unrecorded and can still seed once that capability arrives.
+    /// </summary>
+    /// <param name="db">Database to seed (main or a site's).</param>
+    /// <param name="defaults">Default rules this database should have.</param>
+    /// <returns>The patterns inserted by this pass, for the auto-enable helpers to act on.</returns>
+    internal static HashSet<string> SeedAlertRules(
+        NetworkOptimizerDbContext db, List<NetworkOptimizer.Alerts.Models.AlertRule> defaults)
+    {
+        var existingPatterns = db.AlertRules.Select(r => r.EventTypePattern).ToHashSet();
+        var recordedPatterns = db.SeededAlertRules.Select(s => s.EventTypePattern).ToHashSet();
+
+        var missing = defaults
+            .Where(d => !existingPatterns.Contains(d.EventTypePattern) && !recordedPatterns.Contains(d.EventTypePattern))
+            .ToList();
+        if (missing.Count > 0)
+        {
+            db.AlertRules.AddRange(missing);
+            db.SaveChanges();
+        }
+
+        var seededPatterns = missing.Select(m => m.EventTypePattern).ToHashSet();
+
+        var toRecord = defaults
+            .Select(d => d.EventTypePattern)
+            .Distinct()
+            .Where(p => !recordedPatterns.Contains(p) && (existingPatterns.Contains(p) || seededPatterns.Contains(p)))
+            .ToList();
+        if (toRecord.Count > 0)
+        {
+            db.SeededAlertRules.AddRange(toRecord.Select(p => new NetworkOptimizer.Alerts.Models.SeededAlertRule
+            {
+                EventTypePattern = p
+            }));
+            db.SaveChanges();
+        }
+
+        return seededPatterns;
     }
 
     internal static (bool isFuse, string filesystemType) DetectFilesystem(string filePath)

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -671,7 +671,14 @@ public class AgentProbeResultSink
     /// "is there anything worth reading this agent's results for" - the per-result check below then
     /// decides which of them to keep.
     /// </summary>
-    private async Task<bool> AgentOwnsAnyContextAsync(AgentTunnelConnection connection, CancellationToken ct)
+    /// <returns>
+    /// True or false when the site's contexts could be read, and NULL when they could not - which
+    /// is not the same answer and must not be treated as one. Reading them fails while the site's
+    /// database is still coming up, and the first batch after a restart is the agent's buffered
+    /// backlog: answering false there threw the whole backlog away silently, every time the server
+    /// was restarted, on the one site that consults this at all.
+    /// </returns>
+    private async Task<bool?> AgentOwnsAnyContextAsync(AgentTunnelConnection connection, CancellationToken ct)
     {
         try
         {
@@ -683,7 +690,7 @@ public class AgentProbeResultSink
         {
             _logger.LogDebug(ex, "Could not read WAN contexts for agent {Id} (site {Slug})",
                 connection.AgentId, connection.SiteSlug);
-            return false;
+            return null;
         }
     }
 
@@ -1635,7 +1642,21 @@ public class AgentProbeResultSink
         // yet its context's results are still the only measurement that WAN has. Asking the steering
         // question here threw away every result from a gateway vantage the moment it was given an
         // interface to bind.
-        if (!agentCoversPrimary && !await AgentOwnsAnyContextAsync(connection, ct)) return;
+        // Only a definite "owns nothing" drops the batch. An unreadable answer lets it through to
+        // the per-result judgement below, which asks the same question per target and keeps
+        // whatever it can stand behind - the batch is evidence that was expensive to collect and
+        // cannot be asked for again.
+        if (!agentCoversPrimary)
+        {
+            var ownsContext = await AgentOwnsAnyContextAsync(connection, ct);
+            if (ownsContext == false)
+            {
+                _logger.LogDebug(
+                    "Dropped a batch of {Count} result(s) from agent {Id}: the main site collects for itself and this agent owns no WAN context",
+                    batch.Results.Count, connection.AgentId);
+                return;
+            }
+        }
 
         await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault);
         var ids = batch.Results.Select(r => r.TargetId).Distinct().ToList();
@@ -1652,6 +1673,15 @@ public class AgentProbeResultSink
         // configures itself from that site's MonitoringSettings on first use.
         var influx = _influxRegistry.GetFor(connection.SiteSlug);
         if (!influx.IsConfigured) await influx.ReconfigureAsync(ct);
+        // The latency writes below no-op silently on an unconfigured client, so a batch arriving
+        // while the site's Influx settings are unreadable - the buffered backlog being the first
+        // thing an agent sends after a restart - is swallowed with nothing to show for it. Say so;
+        // the batch still runs, because the live caches and alerting do not depend on Influx and
+        // are worth having either way.
+        if (!influx.IsConfigured)
+            _logger.LogWarning(
+                "{Count} result(s) from agent {Id} (site {Slug}) will not be stored: the site's InfluxDB client is not configured",
+                batch.Results.Count, connection.AgentId, connection.SiteSlug);
         var liveStats = _liveStatsRegistry.GetFor(connection.SiteSlug);
         var discarded = 0;
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -671,14 +671,7 @@ public class AgentProbeResultSink
     /// "is there anything worth reading this agent's results for" - the per-result check below then
     /// decides which of them to keep.
     /// </summary>
-    /// <returns>
-    /// True or false when the site's contexts could be read, and NULL when they could not - which
-    /// is not the same answer and must not be treated as one. Reading them fails while the site's
-    /// database is still coming up, and the first batch after a restart is the agent's buffered
-    /// backlog: answering false there threw the whole backlog away silently, every time the server
-    /// was restarted, on the one site that consults this at all.
-    /// </returns>
-    private async Task<bool?> AgentOwnsAnyContextAsync(AgentTunnelConnection connection, CancellationToken ct)
+    private async Task<bool> AgentOwnsAnyContextAsync(AgentTunnelConnection connection, CancellationToken ct)
     {
         try
         {
@@ -690,7 +683,7 @@ public class AgentProbeResultSink
         {
             _logger.LogDebug(ex, "Could not read WAN contexts for agent {Id} (site {Slug})",
                 connection.AgentId, connection.SiteSlug);
-            return null;
+            return false;
         }
     }
 
@@ -1642,20 +1635,12 @@ public class AgentProbeResultSink
         // yet its context's results are still the only measurement that WAN has. Asking the steering
         // question here threw away every result from a gateway vantage the moment it was given an
         // interface to bind.
-        // Only a definite "owns nothing" drops the batch. An unreadable answer lets it through to
-        // the per-result judgement below, which asks the same question per target and keeps
-        // whatever it can stand behind - the batch is evidence that was expensive to collect and
-        // cannot be asked for again.
-        if (!agentCoversPrimary)
+        if (!agentCoversPrimary && !await AgentOwnsAnyContextAsync(connection, ct))
         {
-            var ownsContext = await AgentOwnsAnyContextAsync(connection, ct);
-            if (ownsContext == false)
-            {
-                _logger.LogDebug(
-                    "Dropped a batch of {Count} result(s) from agent {Id}: the main site collects for itself and this agent owns no WAN context",
-                    batch.Results.Count, connection.AgentId);
-                return;
-            }
+            _logger.LogDebug(
+                "Dropped a batch of {Count} result(s) from agent {Id}: the main site collects for itself and this agent owns no WAN context",
+                batch.Results.Count, connection.AgentId);
+            return;
         }
 
         await using var db = _siteDbFactory.CreateForSite(connection.SiteSlug, isDefault);

--- a/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
@@ -65,6 +65,14 @@ public interface IAlertConfigService
     [AuditAction(AuditActions.AlertRuleChanged, TargetType = "alert")]
     Task UpdateAlertAsync(AlertHistoryEntry alert);
 
+    /// <summary>
+    /// Sets many alerts to one status in a single round trip. What the bulk buttons use: updating
+    /// them one at a time is a database commit each, and slows to a crawl on a few hundred alerts.
+    /// </summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.AlertRuleChanged, TargetType = "alert")]
+    Task<int> SetAlertStatusAsync(IReadOnlyCollection<int> alertIds, AlertStatus status, DateTime timestamp);
+
     /// <summary>Saves an incident's state, which the alert list edits alongside its alerts.</summary>
     [RequireRole(Roles.Operator)]
     [AuditAction(AuditActions.AlertRuleChanged, TargetType = "incident")]
@@ -118,6 +126,17 @@ public sealed class AlertConfigService : IAlertConfigService
         await _alerts.UpdateAlertAsync(alert);
         _auditContext.SetTarget(alert.Id.ToString(), alert.EventType);
         _auditContext.SetDetails(new { alert.AcknowledgedAt, alert.ResolvedAt });
+    }
+
+    /// <inheritdoc />
+    public async Task<int> SetAlertStatusAsync(IReadOnlyCollection<int> alertIds, AlertStatus status, DateTime timestamp)
+    {
+        var changed = await _alerts.SetAlertStatusAsync(alertIds, status, timestamp);
+        // One audit entry for the action, not one per alert: the bulk buttons are a single
+        // deliberate act and the count is what makes it readable afterwards.
+        _auditContext.SetTarget($"{changed} alert(s)", status.ToString());
+        _auditContext.SetDetails(new { Status = status.ToString(), Count = changed, Timestamp = timestamp });
+        return changed;
     }
 
     /// <inheritdoc />

--- a/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
@@ -292,20 +292,6 @@ public sealed class AlertConfigService : IAlertConfigService
         return alert;
     }
 
-    private async Task RecalculateIncidentStatusAsync(AlertHistoryEntry alert)
-    {
-        if (!alert.IncidentId.HasValue) return;
-
-        var incident = await _alerts.GetIncidentAsync(alert.IncidentId.Value);
-        if (incident == null) return;
-
-        var incidentAlerts = await _alerts.GetAlertsByIncidentIdAsync(incident.Id);
-        var (newStatus, resolvedAt) = AlertCorrelationService.DeriveIncidentStatus(incidentAlerts);
-
-        if (newStatus == incident.Status) return;
-
-        incident.Status = newStatus;
-        incident.ResolvedAt = resolvedAt;
-        await _alerts.UpdateIncidentAsync(incident);
-    }
+    private Task RecalculateIncidentStatusAsync(AlertHistoryEntry alert)
+        => AlertCorrelationService.RecalculateIncidentStatusAsync(alert, _alerts);
 }

--- a/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
+++ b/src/NetworkOptimizer.Web/Services/AlertConfigService.cs
@@ -78,6 +78,14 @@ public interface IAlertConfigService
     [AuditAction(AuditActions.AlertRuleChanged, TargetType = "incident")]
     Task UpdateIncidentAsync(AlertIncident incident);
 
+    /// <summary>
+    /// Saves several incidents in one round trip. What the bulk incident buttons use: saving them
+    /// one at a time is a database commit each.
+    /// </summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.AlertRuleChanged, TargetType = "incident")]
+    Task UpdateIncidentsAsync(IReadOnlyCollection<AlertIncident> incidents);
+
     /// <summary>Runs a scheduled task immediately. Returns false when it could not be started.</summary>
     [RequireRole(Roles.Operator)]
     [AuditAction(AuditActions.ScheduleChanged, TargetType = "schedule")]
@@ -144,6 +152,13 @@ public sealed class AlertConfigService : IAlertConfigService
     {
         await _alerts.UpdateIncidentAsync(incident);
         _auditContext.SetTarget(incident.Id.ToString(), incident.Title);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateIncidentsAsync(IReadOnlyCollection<AlertIncident> incidents)
+    {
+        await _alerts.UpdateIncidentsAsync(incidents);
+        _auditContext.SetTarget($"{incidents.Count} incident(s)", "bulk");
     }
 
     /// <inheritdoc />

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -28,7 +28,9 @@ public class IspHealthOptions
     public TimeSpan ComputeBudget { get; set; } = TimeSpan.FromSeconds(25);
 
     /// <summary>Minimum hours of latency data required before a score is shown (new installs).</summary>
-    public int MinDataHours { get; set; } = 4;
+    // TEMPORARY (2026-08-05): raised from 4 to exercise the collecting-data banner on a WAN that
+    // has just crossed the real threshold. REVERT TO 4 once that has been checked.
+    public int MinDataHours { get; set; } = 5;
 
     /// <summary>Weight of the access-layer dimension in the overall score.</summary>
     public double AccessWeight { get; set; } = 1.0 / 3.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -28,9 +28,7 @@ public class IspHealthOptions
     public TimeSpan ComputeBudget { get; set; } = TimeSpan.FromSeconds(25);
 
     /// <summary>Minimum hours of latency data required before a score is shown (new installs).</summary>
-    // TEMPORARY (2026-08-05): raised from 4 to exercise the collecting-data banner on a WAN that
-    // has since built up more history. REVERT TO 4 once that has been checked.
-    public int MinDataHours { get; set; } = 9;
+    public int MinDataHours { get; set; } = 4;
 
     /// <summary>Weight of the access-layer dimension in the overall score.</summary>
     public double AccessWeight { get; set; } = 1.0 / 3.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -29,8 +29,8 @@ public class IspHealthOptions
 
     /// <summary>Minimum hours of latency data required before a score is shown (new installs).</summary>
     // TEMPORARY (2026-08-05): raised from 4 to exercise the collecting-data banner on a WAN that
-    // has just crossed the real threshold. REVERT TO 4 once that has been checked.
-    public int MinDataHours { get; set; } = 5;
+    // has since built up more history. REVERT TO 4 once that has been checked.
+    public int MinDataHours { get; set; } = 9;
 
     /// <summary>Weight of the access-layer dimension in the overall score.</summary>
     public double AccessWeight { get; set; } = 1.0 / 3.0;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/OutageDetector.cs
@@ -196,7 +196,7 @@ public static class OutageDetector
     /// regional endpoints of one provider, all reached over that provider's network, count once.
     /// An unattributed destination falls back to its name - its own network, the safe reading.
     /// </summary>
-    private static string NetworkKey(Hop h) =>
+    internal static string NetworkKey(Hop h) =>
         h.AsnLabel ?? (h.AsnNumber > 0 ? $"AS{h.AsnNumber}" : h.Name);
 
     private static OutageEvent BuildPartialEvent(
@@ -315,7 +315,7 @@ public static class OutageDetector
     /// real access-ISP outage), partials require a hop untouched in the window (intermittent
     /// 60%-loss buckets are not "reachable").
     /// </summary>
-    private static (string? LastReachableHop, string? BrokenNetwork) AttributeBreak(
+    internal static (string? LastReachableHop, string? BrokenNetwork) AttributeBreak(
         IEnumerable<Hop> wanHops, Func<Hop, bool> judged, Func<Hop, bool> isClean, Func<Hop, bool> isBroken)
     {
         var rows = wanHops.Where(judged).ToList();

--- a/src/NetworkOptimizer.Web/Services/Monitoring/LiveWanScope.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/LiveWanScope.cs
@@ -266,17 +266,20 @@ public sealed class LiveWanScope
     /// </para>
     /// </summary>
     /// <summary>
-    /// Lets go of a link's selection once the URL stops naming a WAN, so the stored one is read
-    /// again. The pin exists to stop storage landing on top of a link that is still in force - it
-    /// was never meant to outlive the link, and leaving it set meant a WAN chosen by one jump held
-    /// for the rest of the page's life, which is indistinguishable from having overwritten the
-    /// saved filter.
+    /// Lets go of a link's claim once the URL stops naming a WAN, so a later visit reads the
+    /// stored selection instead of the jump's choice holding forever.
+    /// <para>
+    /// What it deliberately does NOT do is re-read storage over the current selection. The URL
+    /// drops its <c>?wan=</c> on ordinary interactions - changing the time filter, resuming Live -
+    /// and re-reading there yanked the view off the WAN being watched and back to the saved set,
+    /// mid-look. Releasing the pin is enough: the selection on screen stays until someone changes
+    /// it, and the stored one is read again on the next load.
+    /// </para>
     /// </summary>
     public void ReleaseLink()
     {
         if (!_pinned) return;
         _pinned = false;
-        _restored = false;
     }
 
     public async Task<bool> SelectFromLinkAsync(string? wanParam)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/LiveWanScope.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/LiveWanScope.cs
@@ -202,6 +202,24 @@ public sealed class LiveWanScope
     /// <summary>Whether every WAN is on screen, which is what the All pill means.</summary>
     public bool AllSelected => Options.Count > 1 && Options.All(o => _selected.Contains(o.Key));
 
+    /// <summary>
+    /// The current selection as a <c>?wan=</c> value - the whole set rather than just the focus,
+    /// so a comparison of two WANs arrives wherever the link goes as that same comparison.
+    /// </summary>
+    public string QueryValue() => AllSelected ? AllWansToken : string.Join(",", _selected);
+
+    /// <summary>
+    /// The <c>&amp;wan=...</c> fragment to append to a link, or an empty string when there is no
+    /// choice worth carrying (a single-WAN site, where every view is that WAN's already).
+    /// <paramref name="value"/> overrides the current selection for a link that means something
+    /// else by it - a LAN view asking for every WAN rather than the tiles' focus.
+    /// </summary>
+    public string QueryFragment(string? value = null)
+    {
+        var wan = value ?? QueryValue();
+        return HasChoice && wan.Length > 0 ? $"&wan={Uri.EscapeDataString(wan)}" : "";
+    }
+
     /// <summary>Puts every WAN on screen at once - the All pill.</summary>
     public async Task SelectAllAsync(bool persist = true)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -155,7 +155,7 @@ public class MonitoringAlertEvaluator
         DeviceId = target.DeviceMac,
         DeviceName = target.Name,
         DeviceIp = target.Address,
-        SourceUrl = "/monitoring?tab=performance",
+        SourceUrl = TargetSourceUrl(target, DateTime.UtcNow),
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -176,7 +176,7 @@ public class MonitoringAlertEvaluator
         DeviceName = target.Name,
         DeviceIp = target.Address,
         MetricValue = result.RttAvgMs,
-        SourceUrl = "/monitoring?tab=performance",
+        SourceUrl = TargetSourceUrl(target, DateTime.UtcNow),
         Tags = ["monitoring", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -197,7 +197,7 @@ public class MonitoringAlertEvaluator
         DeviceIp = target.Address,
         MetricValue = avgLossPercent,
         ThresholdValue = SustainedLossThresholdPercent,
-        SourceUrl = "/monitoring?tab=performance",
+        SourceUrl = TargetSourceUrl(target, DateTime.UtcNow),
         Tags = ["monitoring", "packet-loss", target.TargetType.ToString().ToLowerInvariant()],
         Context = new Dictionary<string, string>
         {
@@ -205,6 +205,28 @@ public class MonitoringAlertEvaluator
             ["target_type"] = target.TargetType.ToString()
         }
     };
+
+    /// <summary>
+    /// Where the alert takes you: the Network Performance chart, on this target's own category
+    /// and parked at the moment the alert fired, rather than the tab's default view of now. The
+    /// analysis page reads all three from the link. WAN-scoped targets carry their WAN too, so a
+    /// secondary WAN's alert does not open on the primary's chart.
+    /// </summary>
+    private static string TargetSourceUrl(MonitoringTarget target, DateTime firedAt)
+    {
+        var category = target.TargetType switch
+        {
+            MonitoringTargetType.Fabric => "Fabric",
+            MonitoringTargetType.AccessIsp => "AccessIsp",
+            MonitoringTargetType.Transit => "Transit",
+            _ => "Custom"
+        };
+        var at = new DateTimeOffset(DateTime.SpecifyKind(firedAt, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+        var url = $"/monitoring?tab=performance&category={category}&at={at}";
+        return string.IsNullOrEmpty(target.WanInterface)
+            ? url
+            : $"{url}&wan={Uri.EscapeDataString(target.WanInterface)}";
+    }
 
     /// <summary>
     /// WAN/access-ISP/transit failures are user-impacting and rate as Critical. Fabric

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -20,6 +20,12 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// looks for ≥30% loss across the trailing window. No flapping suppression
 /// beyond the consecutive-failure threshold; AlertCooldownTracker upstream
 /// already handles repeat-event suppression.
+///
+/// Per-target events are published for Fabric and Custom targets only. The WAN-facing
+/// categories (access ISP, transit, internet, legacy WAN) fail together when the connection
+/// does, so their per-target state feeds <see cref="WanOutageEvaluator"/> - which publishes
+/// one per-WAN outage alert instead of one alert per target - while the state machine here
+/// keeps running unchanged underneath for all types.
 /// </summary>
 public class MonitoringAlertEvaluator
 {
@@ -31,6 +37,7 @@ public class MonitoringAlertEvaluator
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<MonitoringAlertEvaluator> _logger;
     private readonly DeviceTransitionTracker _transitions;
+    private readonly WanOutageEvaluator _wanOutages;
     private readonly ConcurrentDictionary<string, TargetAlertState> _states = new();
     private readonly string _siteSuffix;
     private readonly string _siteSlug;
@@ -42,12 +49,13 @@ public class MonitoringAlertEvaluator
     /// alert titles; the default site reads exactly as before.
     /// </param>
     public MonitoringAlertEvaluator(IAlertEventBus eventBus, ILogger<MonitoringAlertEvaluator> logger,
-        DeviceTransitionTracker transitions,
+        DeviceTransitionTracker transitions, WanOutageEvaluator wanOutages,
         string siteSlug = SiteManagementService.DefaultSiteSlug)
     {
         _eventBus = eventBus;
         _logger = logger;
         _transitions = transitions;
+        _wanOutages = wanOutages;
         _siteSlug = siteSlug ?? SiteManagementService.DefaultSiteSlug;
         _siteSuffix = string.IsNullOrEmpty(siteSlug) || siteSlug == SiteManagementService.DefaultSiteSlug
             ? "" : $" (site {siteSlug})";
@@ -56,7 +64,20 @@ public class MonitoringAlertEvaluator
     public async ValueTask EvaluateAsync(MonitoringTarget target, PingProbeResult result, CancellationToken ct = default)
     {
         var state = _states.GetOrAdd(target.TargetId, _ => new TargetAlertState());
+        var publishPerTarget = !WanOutageEvaluator.CoversTargetType(target.TargetType);
 
+        await EvaluatePerTargetAsync(target, result, state, publishPerTarget, ct);
+
+        if (!publishPerTarget)
+        {
+            _wanOutages.RecordTargetState(target, state.IsOffline, state.IsLossy);
+            await _wanOutages.EvaluateAsync(ct);
+        }
+    }
+
+    private async ValueTask EvaluatePerTargetAsync(MonitoringTarget target, PingProbeResult result,
+        TargetAlertState state, bool publishPerTarget, CancellationToken ct)
+    {
         if (result.Success)
         {
             state.ConsecutiveFailures = 0;
@@ -68,7 +89,8 @@ public class MonitoringAlertEvaluator
             if (state.IsOffline && state.ConsecutiveSuccesses >= SuccessesToDeclareRecovered)
             {
                 state.IsOffline = false;
-                await _eventBus.PublishAsync(BuildRecoveredEvent(target, result), ct);
+                if (publishPerTarget)
+                    await _eventBus.PublishAsync(BuildRecoveredEvent(target, result), ct);
             }
 
             // Sustained-loss detection only matters while the target is nominally up.
@@ -78,7 +100,8 @@ public class MonitoringAlertEvaluator
                 if (!state.IsLossy && avgLoss >= SustainedLossThresholdPercent)
                 {
                     state.IsLossy = true;
-                    await _eventBus.PublishAsync(BuildSustainedLossEvent(target, avgLoss), ct);
+                    if (publishPerTarget)
+                        await _eventBus.PublishAsync(BuildSustainedLossEvent(target, avgLoss), ct);
                 }
                 else if (state.IsLossy && avgLoss < SustainedLossThresholdPercent / 2)
                 {
@@ -116,7 +139,8 @@ public class MonitoringAlertEvaluator
                 state.IsLossy = false; // offline supersedes lossy
                 state.LossWindow.Clear();
                 state.TransitionSuppressionLogged = false;
-                await _eventBus.PublishAsync(BuildOfflineEvent(target), ct);
+                if (publishPerTarget)
+                    await _eventBus.PublishAsync(BuildOfflineEvent(target), ct);
             }
         }
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -70,7 +70,7 @@ public class MonitoringAlertEvaluator
 
         if (!publishPerTarget)
         {
-            _wanOutages.RecordTargetState(target, state.IsOffline, state.IsLossy);
+            _wanOutages.RecordTargetState(target, state.IsOffline, state.IsLossy, state.ConsecutiveFailures);
             await _wanOutages.EvaluateAsync(ct);
         }
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -223,6 +223,11 @@ public class MonitoringAlertEvaluator
         };
         var at = new DateTimeOffset(DateTime.SpecifyKind(firedAt, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
         var url = $"/monitoring?tab=performance&category={category}&at={at}";
+        // A LAN target is not reached over any one WAN, so it asks for all of them rather than
+        // arriving narrowed to whichever WAN the analysis filter happened to be left on - the same
+        // choice the page's own LAN jump makes. A stamped target names its WAN.
+        if (target.TargetType == MonitoringTargetType.Fabric)
+            return $"{url}&wan={LiveWanScope.AllWansToken}";
         return string.IsNullOrEmpty(target.WanInterface)
             ? url
             : $"{url}&wan={Uri.EscapeDataString(target.WanInterface)}";

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageClassifier.cs
@@ -1,0 +1,204 @@
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring.IspHealth;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// What one WAN's monitored targets currently say about that WAN, classified for alerting.
+/// </summary>
+internal enum WanVerdictKind
+{
+    /// <summary>Nothing alert-worthy: everything reachable, or too little evidence to say.</summary>
+    None,
+
+    /// <summary>Part of the path beyond the access layer is out while the WAN still passes traffic.</summary>
+    Partial,
+
+    /// <summary>The WAN's internet is down: every destination failing, with or without the first hop.</summary>
+    Total
+}
+
+/// <summary>
+/// One WAN-scoped monitoring target's current state, as the WAN outage classifier sees it.
+/// <paramref name="Failing"/> is the per-target offline state machine's verdict (consecutive
+/// failed probes); <paramref name="Degraded"/> additionally includes sustained-loss targets,
+/// and is what the partial pass keys on - a branch can be "out or degraded" without every
+/// probe failing outright. <paramref name="Depth"/> is the trace-map hop number
+/// (<see cref="int.MaxValue"/> when the trace map does not place the row, which also clears
+/// <paramref name="KnownPosition"/>). <paramref name="AncestorIps"/> are the proven-upstream
+/// monitored hop addresses from <see cref="UpstreamDiscovery.AncestorHopIps"/>.
+/// </summary>
+internal sealed record WanTargetSnapshot(
+    string TargetId,
+    MonitoringTargetType Type,
+    string Name,
+    string Address,
+    bool Failing,
+    bool Degraded,
+    int Depth,
+    bool KnownPosition,
+    bool IsInternet,
+    string? AsnLabel,
+    int AsnNumber,
+    IReadOnlySet<string> AncestorIps);
+
+/// <summary>
+/// The classifier's answer for one WAN on one evaluation pass. <paramref name="AccessDown"/>
+/// distinguishes "access layer and out" from "upstream of the access layer" for a
+/// <see cref="WanVerdictKind.Total"/> verdict. <paramref name="LastReachableHop"/> /
+/// <paramref name="BrokenNetwork"/> carry <see cref="OutageDetector.AttributeBreak"/>'s
+/// attribution for the upstream case; <paramref name="BranchLabel"/> names the shared
+/// ancestor (or shared network) for a branch-shaped partial, null for an independent one.
+/// </summary>
+internal sealed record WanVerdict(
+    WanVerdictKind Kind,
+    bool AccessDown,
+    string? LastReachableHop,
+    string? BrokenNetwork,
+    string? BranchLabel,
+    int FailingCount,
+    int TotalCount)
+{
+    public static readonly WanVerdict None = new(WanVerdictKind.None, false, null, null, null, 0, 0);
+}
+
+/// <summary>
+/// Classifies one WAN's current target states into an outage verdict. Pure and stateless: the
+/// evaluator owns freshness, confirmation counting and publishing; this owns only "what shape
+/// is the failure". The attribution rules are inherited from <see cref="OutageDetector"/>
+/// rather than restated: break naming goes through <see cref="OutageDetector.AttributeBreak"/>
+/// (which refuses to anchor on off-map or internet-endpoint rows), and network independence
+/// uses <see cref="OutageDetector.NetworkKey"/> so several regional endpoints of one provider
+/// never read as several independent networks.
+/// </summary>
+internal static class WanOutageClassifier
+{
+    public static WanVerdict Classify(IReadOnlyList<WanTargetSnapshot> targets)
+    {
+        if (targets.Count == 0) return WanVerdict.None;
+
+        var failing = targets.Where(t => t.Failing).ToList();
+        var degraded = targets.Where(t => t.Degraded).ToList();
+        var accessRows = targets.Where(t => t.Type == MonitoringTargetType.AccessIsp).ToList();
+
+        // Access layer and out: every target on the WAN is failing, first hop included.
+        if (failing.Count == targets.Count)
+            return new WanVerdict(WanVerdictKind.Total, AccessDown: accessRows.Count > 0,
+                null, null, null, failing.Count, targets.Count);
+
+        // Upstream of the access layer: the first hop answers, everything beyond it is failing.
+        if (accessRows.Count > 0
+            && accessRows.All(a => !a.Failing)
+            && targets.Where(t => t.Type != MonitoringTargetType.AccessIsp).All(t => t.Failing)
+            && failing.Count > 0)
+        {
+            var (lastReachable, brokenNetwork) = AttributeUpstreamBreak(targets);
+            return new WanVerdict(WanVerdictKind.Total, AccessDown: false,
+                lastReachable, brokenNetwork, null, failing.Count, targets.Count);
+        }
+
+        // Partial pass, over the degraded set (offline or sustained loss). A partial only opens
+        // when at least one internet destination is affected: transit hops routinely stop
+        // answering probes with nothing wrong, so a transit-only picture with every destination
+        // reachable is a rate-limited router, not an outage. Corroboration for a transit failure
+        // is exactly a destination behind it also failing, which the branch pass below finds.
+        if (degraded.Count == 0 || !degraded.Any(t => t.IsInternet))
+            return WanVerdict.None;
+
+        // Single destination: one internet endpoint dark while everything else is fine is nearly
+        // always the endpoint's problem, and the flappy CDN endpoints would rebuild the noise
+        // this alert class exists to remove. Visible on the charts, never notified.
+        if (degraded.Count == 1)
+            return WanVerdict.None;
+
+        var branch = FindBranchLabel(targets, degraded);
+        if (branch != null)
+            return new WanVerdict(WanVerdictKind.Partial, false, null, null, branch,
+                degraded.Count, targets.Count);
+
+        // Independence gate, by network (ASN label / real ASN), inherited from the partial
+        // detector: several endpoints of one provider are one network, not several.
+        var networks = degraded.Select(NetworkKeyOf).Distinct().Count();
+        if (networks >= 2)
+            return new WanVerdict(WanVerdictKind.Partial, false, null, null, null,
+                degraded.Count, targets.Count);
+
+        // One network, no monitored shared ancestor: the network itself is the branch.
+        return new WanVerdict(WanVerdictKind.Partial, false, null, null,
+            NetworkKeyOf(degraded[0]), degraded.Count, targets.Count);
+    }
+
+    /// <summary>
+    /// Break attribution for a total-with-first-hop-answering verdict, through
+    /// <see cref="OutageDetector.AttributeBreak"/> with the current failing states as the
+    /// cleanliness tests, so the alert path inherits its rules: only trace-map-anchored path
+    /// hops may name where the break sat, and a clean row deeper than a failing one (a sibling
+    /// branch) never anchors.
+    /// </summary>
+    private static (string? LastReachableHop, string? BrokenNetwork) AttributeUpstreamBreak(
+        IReadOnlyList<WanTargetSnapshot> targets)
+    {
+        var failingByHop = new Dictionary<OutageDetector.Hop, bool>();
+        foreach (var t in targets)
+        {
+            var hop = new OutageDetector.Hop(t.Name, t.Depth, Array.Empty<LatencySample>(),
+                Groupable: false, AsnLabel: t.AsnLabel, IsGateway: false,
+                KnownPosition: t.KnownPosition, IsInternet: t.IsInternet, AsnNumber: t.AsnNumber);
+            failingByHop[hop] = t.Failing;
+        }
+        return OutageDetector.AttributeBreak(failingByHop.Keys,
+            judged: _ => true,
+            isClean: h => !failingByHop[h],
+            isBroken: h => failingByHop[h]);
+    }
+
+    /// <summary>
+    /// The shared-ancestor label for a branch-shaped partial, or null when the degraded set has
+    /// no usable common ancestor. Two shapes count: a degraded path hop that every other
+    /// degraded target sits behind (the branch head itself went dark), and a still-reachable
+    /// hop that every degraded target - and no healthy one - sits behind (the break is just
+    /// past it). Candidates must be trace-map-anchored path rows, never internet endpoints,
+    /// mirroring the attribution rules.
+    /// </summary>
+    private static string? FindBranchLabel(
+        IReadOnlyList<WanTargetSnapshot> targets, List<WanTargetSnapshot> degraded)
+    {
+        // A degraded path hop all other degraded targets are behind: the branch head. A healthy
+        // target behind the same hop disqualifies it - the targets behind it must AGREE it is
+        // gone, or the hop is just deprioritizing probes while forwarding fine.
+        var head = degraded
+            .Where(c => c.KnownPosition && !c.IsInternet
+                && degraded.All(t => ReferenceEquals(t, c)
+                    || t.AncestorIps.Contains(c.Address))
+                && !targets.Any(t => !t.Degraded && t.AncestorIps.Contains(c.Address)))
+            .OrderByDescending(c => c.Depth)
+            .FirstOrDefault();
+        if (head != null) return head.AsnLabel ?? head.Name;
+
+        // A common ancestor of every degraded target that no healthy target is behind - an
+        // ancestor healthy traffic also crosses (the access hop, usually) cannot be where the
+        // break sits. Ancestors are raw hop IPs; only ones that map onto a trace-map-anchored
+        // monitored path row can be named.
+        var common = degraded
+            .Select(t => (IEnumerable<string>)t.AncestorIps)
+            .Aggregate((a, b) => a.Intersect(b, StringComparer.OrdinalIgnoreCase));
+        var healthyAncestors = targets.Where(t => !t.Degraded)
+            .SelectMany(t => t.AncestorIps)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var byAddress = targets
+            .Where(t => t.KnownPosition && !t.IsInternet)
+            .GroupBy(t => t.Address, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+        var sharedAncestor = common
+            .Where(ip => !healthyAncestors.Contains(ip) && byAddress.ContainsKey(ip))
+            .Select(ip => byAddress[ip])
+            .OrderByDescending(t => t.Depth)
+            .FirstOrDefault();
+        return sharedAncestor == null ? null : sharedAncestor.AsnLabel ?? sharedAncestor.Name;
+    }
+
+    /// <summary>Independence key, deferring to <see cref="OutageDetector.NetworkKey"/>.</summary>
+    private static string NetworkKeyOf(WanTargetSnapshot t) =>
+        OutageDetector.NetworkKey(new OutageDetector.Hop(t.Name, t.Depth,
+            Array.Empty<LatencySample>(), AsnLabel: t.AsnLabel, AsnNumber: t.AsnNumber));
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageClassifier.cs
@@ -87,10 +87,13 @@ internal static class WanOutageClassifier
                 null, null, null, failing.Count, targets.Count);
 
         // Upstream of the access layer: the first hop answers, everything beyond it is failing.
+        // At least one failing internet destination is required - a set that is all transit
+        // beyond the access hop can go probe-dark from rate limiting alone, and with no
+        // destination monitored there is no evidence anything the user reaches is down.
         if (accessRows.Count > 0
             && accessRows.All(a => !a.Failing)
             && targets.Where(t => t.Type != MonitoringTargetType.AccessIsp).All(t => t.Failing)
-            && failing.Count > 0)
+            && targets.Any(t => t.IsInternet && t.Failing))
         {
             var (lastReachable, brokenNetwork) = AttributeUpstreamBreak(targets);
             return new WanVerdict(WanVerdictKind.Total, AccessDown: false,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageContextSource.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageContextSource.cs
@@ -1,0 +1,152 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.UniFi;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>One WAN as the outage evaluator needs it: identity, label, role, and link state.</summary>
+/// <param name="WanKey">Normalized interface key ("wan", "wan2").</param>
+/// <param name="Label">Display label from <see cref="GatewayWanHelper.FormatWanLabel"/> ("Acme Fiber WAN2").</param>
+/// <param name="TreatAsPrimary">
+/// Whether outage severity should treat this WAN as the primary. True when the console said so
+/// AND when nothing has ever said (unknown role must over-alert about the connection the site
+/// actually uses, not stay quiet); false only when the console recorded another WAN as primary.
+/// </param>
+/// <param name="ConsoleUp">The console's link state for the WAN, when a console was reachable; null when unknown.</param>
+internal sealed record WanOutageWanInfo(string WanKey, string Label, bool TreatAsPrimary, bool? ConsoleUp);
+
+/// <summary>A target's place in the persisted trace map.</summary>
+internal sealed record WanOutageHopInfo(int Depth, IReadOnlySet<string> AncestorIps);
+
+/// <summary>
+/// Everything the WAN outage evaluator needs from the site's database, loaded as one snapshot
+/// and cached by the evaluator. <see cref="HopsByTargetId"/> is keyed by
+/// <c>MonitoringTarget.TargetId</c>; targets absent from it have no trace-map position.
+/// </summary>
+internal sealed record WanOutageContext(
+    string PrimaryWanKey,
+    IReadOnlyDictionary<string, WanOutageWanInfo> Wans,
+    IReadOnlyDictionary<string, WanOutageHopInfo> HopsByTargetId,
+    IReadOnlyDictionary<string, string> AccessNeighborIpByWan)
+{
+    public static readonly WanOutageContext Empty = new(
+        GatewayWanHelper.DefaultWanKey,
+        new Dictionary<string, WanOutageWanInfo>(),
+        new Dictionary<string, WanOutageHopInfo>(),
+        new Dictionary<string, string>());
+}
+
+/// <summary>
+/// Loads the per-site WAN context the outage evaluator classifies against: WAN roles and labels
+/// from <see cref="Storage.Models.WanProfile"/>, trace-map positions from
+/// <see cref="Storage.Models.UpstreamDiscovery"/>, and each WAN's first-hop neighbor from
+/// <see cref="Storage.Models.WanDiscoveryContext"/>. Reads the owning site's database directly
+/// (the evaluator lives outside the ambient site scope), and consults the console's WAN link
+/// state only for the default site, where the console connection is local; a missing console
+/// just leaves the link state unknown, it never blocks evaluation.
+/// </summary>
+public class WanOutageContextSource
+{
+    private readonly SiteDbContextFactory _dbFactory;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<WanOutageContextSource> _logger;
+
+    public WanOutageContextSource(SiteDbContextFactory dbFactory, IServiceScopeFactory scopeFactory,
+        ILogger<WanOutageContextSource> logger)
+    {
+        _dbFactory = dbFactory;
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    internal virtual async Task<WanOutageContext> LoadAsync(string siteSlug, IReadOnlyCollection<string> wanKeysInUse,
+        CancellationToken ct = default)
+    {
+        var isDefault = siteSlug == SiteManagementService.DefaultSiteSlug;
+        await using var db = _dbFactory.CreateForSite(siteSlug, isDefault);
+
+        var profiles = await db.WanProfiles.AsNoTracking().ToListAsync(ct);
+        var discoveryContexts = await db.WanDiscoveryContexts.AsNoTracking().ToListAsync(ct);
+        var hopRows = await db.UpstreamDiscoveries.AsNoTracking()
+            .Where(u => u.IsActive && u.MonitoringTargetId != null)
+            .Select(u => new { u.MonitoringTargetId, u.HopNumber, u.AncestorHopIps })
+            .ToListAsync(ct);
+        var targetIdByDbId = await db.MonitoringTargets.AsNoTracking()
+            .Select(t => new { t.Id, t.TargetId })
+            .ToDictionaryAsync(t => t.Id, t => t.TargetId, ct);
+
+        // The primary WAN owns every unstamped (legacy/hand-added) target. When no console has
+        // ever recorded the role, the conventional first group is the documented guess.
+        var primaryKey = profiles.FirstOrDefault(p => p.IsPrimary == true) is { } primary
+            ? KeyFromGroup(primary.WanNetworkgroup)
+            : GatewayWanHelper.DefaultWanKey;
+
+        var consoleUp = isDefault ? await TryGetConsoleLinkStatesAsync(ct) : null;
+
+        // Every WAN we know about, from any source: profiles, discovery contexts, and the WAN
+        // keys the live targets are stamped with (a WAN can have targets before its profile row).
+        var wans = new Dictionary<string, WanOutageWanInfo>(StringComparer.OrdinalIgnoreCase);
+        var allKeys = profiles.Select(p => KeyFromGroup(p.WanNetworkgroup))
+            .Concat(discoveryContexts.Select(d => GatewayWanHelper.WanInterfaceKeyFromKey(d.WanInterface)))
+            .Concat(wanKeysInUse.Select(GatewayWanHelper.WanInterfaceKeyFromKey))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        foreach (var key in allKeys)
+        {
+            var profile = profiles.FirstOrDefault(p =>
+                string.Equals(KeyFromGroup(p.WanNetworkgroup), key, StringComparison.OrdinalIgnoreCase));
+            var index = GatewayWanHelper.WanIndexFromKey(key);
+            wans[key] = new WanOutageWanInfo(
+                key,
+                GatewayWanHelper.FormatWanLabel(profile?.Name, index, null, null),
+                // Only an explicit "another WAN is primary" makes a WAN non-primary; an unknown
+                // role must over-alert about the connection the site may actually be using.
+                profile?.IsPrimary != false,
+                consoleUp != null && consoleUp.TryGetValue(key, out var up) ? up : null);
+        }
+
+        var hops = new Dictionary<string, WanOutageHopInfo>();
+        foreach (var group in hopRows.GroupBy(r => r.MonitoringTargetId!.Value))
+        {
+            if (!targetIdByDbId.TryGetValue(group.Key, out var targetId)) continue;
+            var depths = group.Where(r => r.HopNumber > 0).Select(r => r.HopNumber).ToList();
+            var ancestors = group
+                .SelectMany(r => (r.AncestorHopIps ?? "").Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            hops[targetId] = new WanOutageHopInfo(depths.Count > 0 ? depths.Min() : int.MaxValue, ancestors);
+        }
+
+        var accessNeighbors = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var dc in discoveryContexts.Where(d => !string.IsNullOrEmpty(d.L2NeighborIp)))
+            accessNeighbors[GatewayWanHelper.WanInterfaceKeyFromKey(dc.WanInterface)] = dc.L2NeighborIp!;
+
+        return new WanOutageContext(primaryKey, wans, hops, accessNeighbors);
+    }
+
+    /// <summary>
+    /// The console's per-WAN link state for the default site, via the cached
+    /// <see cref="MonitoringPathView"/> WAN summary. Null (unknown) whenever the console is not
+    /// connected or the read fails - the outage verdict never depends on it, it only lets the
+    /// notification say "the console reports the link down" instead of describing an outage.
+    /// </summary>
+    private async Task<Dictionary<string, bool>?> TryGetConsoleLinkStatesAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var pathView = scope.ServiceProvider.GetRequiredService<MonitoringPathView>();
+            var wans = await pathView.GetWansAsync(ct);
+            return wans.ToDictionary(
+                w => GatewayWanHelper.WanInterfaceKeyFromKey(w.WanInterface),
+                w => w.Up,
+                StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "WAN link state unavailable for outage context; continuing without it");
+            return null;
+        }
+    }
+
+    private static string KeyFromGroup(string wanNetworkgroup) =>
+        GatewayWanHelper.WanInterfaceKeyFromKey(wanNetworkgroup.ToLowerInvariant());
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageContextSource.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageContextSource.cs
@@ -12,8 +12,14 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// AND when nothing has ever said (unknown role must over-alert about the connection the site
 /// actually uses, not stay quiet); false only when the console recorded another WAN as primary.
 /// </param>
+/// <param name="CarriesTraffic">
+/// Whether this WAN is carrying user traffic right now, which is what outage severity turns on.
+/// True for the primary, and true for every WAN on a load-balancing site: under load balancing
+/// each WAN carries live sessions, so losing a non-primary one drops real traffic rather than
+/// only redundancy. False only for an idle failover backup.
+/// </param>
 /// <param name="ConsoleUp">The console's link state for the WAN, when a console was reachable; null when unknown.</param>
-internal sealed record WanOutageWanInfo(string WanKey, string Label, bool TreatAsPrimary, bool? ConsoleUp);
+internal sealed record WanOutageWanInfo(string WanKey, string Label, bool TreatAsPrimary, bool CarriesTraffic, bool? ConsoleUp);
 
 /// <summary>A target's place in the persisted trace map.</summary>
 internal sealed record WanOutageHopInfo(int Depth, IReadOnlySet<string> AncestorIps);
@@ -81,6 +87,9 @@ public class WanOutageContextSource
             ? KeyFromGroup(primary.WanNetworkgroup)
             : GatewayWanHelper.DefaultWanKey;
 
+        // Recorded per WAN but a site-wide fact, so any row that has an answer speaks for the site.
+        var loadBalances = profiles.Any(p => p.SiteLoadBalances == true);
+
         var consoleUp = isDefault ? await TryGetConsoleLinkStatesAsync(ct) : null;
 
         // Every WAN we know about, from any source: profiles, discovery contexts, and the WAN
@@ -95,12 +104,17 @@ public class WanOutageContextSource
             var profile = profiles.FirstOrDefault(p =>
                 string.Equals(KeyFromGroup(p.WanNetworkgroup), key, StringComparison.OrdinalIgnoreCase));
             var index = GatewayWanHelper.WanIndexFromKey(key);
+            // Only an explicit "another WAN is primary" makes a WAN non-primary; an unknown
+            // role must over-alert about the connection the site may actually be using.
+            var treatAsPrimary = profile?.IsPrimary != false;
             wans[key] = new WanOutageWanInfo(
                 key,
                 GatewayWanHelper.FormatWanLabel(profile?.Name, index, null, null),
-                // Only an explicit "another WAN is primary" makes a WAN non-primary; an unknown
-                // role must over-alert about the connection the site may actually be using.
-                profile?.IsPrimary != false,
+                treatAsPrimary,
+                // Load balancing puts traffic on every WAN, so a backup's outage is a real
+                // service loss there, not just lost redundancy. Unknown reads as failover:
+                // that is the conventional setup, and the primary is covered either way.
+                treatAsPrimary || loadBalances,
                 consoleUp != null && consoleUp.TryGetValue(key, out var up) ? up : null);
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -219,7 +219,17 @@ public class WanOutageEvaluator
             {
                 if (!other.CoveredByRollup) continue;
                 other.CoveredByRollup = false;
-                other.OpenKind = WanVerdictKind.Total;
+                var otherKind = other.LastVerdict?.Kind ?? WanVerdictKind.None;
+                if (otherKind == WanVerdictKind.None)
+                {
+                    // Recovering alongside this WAN (possibly in the very same pass): the
+                    // rollup's close already says the site is back, so nothing reopens and
+                    // its own None-confirmation has nothing left to announce.
+                    other.OpenKind = WanVerdictKind.None;
+                    other.EpisodeStart = null;
+                    continue;
+                }
+                other.OpenKind = otherKind;
                 await _eventBus.PublishAsync(BuildOutageEvent(WanInfo(otherKey), other, now), ct);
             }
             _rollupSince = null;
@@ -316,9 +326,9 @@ public class WanOutageEvaluator
                 message += $" The break looks like it sits in {verdict.BrokenNetwork}.";
         }
         else if (verdict.BranchLabel != null)
-            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}, all behind {verdict.BranchLabel}. Other destinations are reachable, so the connection itself looks fine.";
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, all behind {verdict.BranchLabel}. Other destinations are reachable, so the connection itself looks fine.";
         else
-            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}, across unrelated networks. The connection itself is still passing traffic.";
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, across unrelated networks. The connection itself is still passing traffic.";
 
         return new AlertEvent
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -31,9 +31,17 @@ public class WanOutageEvaluator
     /// <summary>AlertEvent.DeviceId of the site-level all-WANs rollup alert.</summary>
     internal const string RollupDeviceId = "all-wans";
 
-    private const int EvaluationIntervalSeconds = 30;
-    private const int ConfirmsToOpen = 3;
+    // Tuned to beat the console's own WAN-down push (~60-120 s): a target counts as failing
+    // for WAN verdicts after two failed probes (each probe is multi-ping, and no WAN verdict
+    // ever rests on one target - a total needs the whole cohort failing at once, which is the
+    // real flap suppression), passes run at probe cadence, and two held passes open. Closing
+    // stays at three so a flapping WAN still produces one alert and one recovery rather than
+    // a stream. Net budget: ~25-40 s from first lost packet to alert. The per-target machine's
+    // own 3-strikes threshold (Fabric/Custom alerts) is deliberately untouched.
+    private const int EvaluationIntervalSeconds = 10;
+    private const int ConfirmsToOpen = 2;
     private const int ConfirmsToClose = 3;
+    private const int FailedProbesToCountFailing = 2;
     private const int TargetStalenessSeconds = 180;
     private const int ContextTtlSeconds = 300;
 
@@ -82,12 +90,12 @@ public class WanOutageEvaluator
     /// <see cref="MonitoringAlertEvaluator"/> on every probe result for a covered target,
     /// from both the local collection loop and the agent result sink.
     /// </summary>
-    internal void RecordTargetState(MonitoringTarget target, bool isOffline, bool isLossy)
+    internal void RecordTargetState(MonitoringTarget target, bool isOffline, bool isLossy, int consecutiveFailures)
     {
         if (!CoversTargetType(target.TargetType)) return;
         var state = _targets.GetOrAdd(target.TargetId, _ => new TargetLiveState());
         state.Target = target;
-        state.Offline = isOffline;
+        state.Offline = isOffline || consecutiveFailures >= FailedProbesToCountFailing;
         state.Lossy = isLossy;
         state.LastResultUtc = _time.GetUtcNow().UtcDateTime;
     }
@@ -299,7 +307,7 @@ public class WanOutageEvaluator
             ? info
             : new WanOutageWanInfo(wanKey,
                 GatewayWanHelper.FormatWanLabel(null, GatewayWanHelper.WanIndexFromKey(wanKey), null, null),
-                TreatAsPrimary: true, ConsoleUp: null);
+                TreatAsPrimary: true, CarriesTraffic: true, ConsoleUp: null);
 
     private AlertEvent BuildOutageEvent(WanOutageWanInfo info, WanState state, DateTime now)
     {
@@ -334,9 +342,12 @@ public class WanOutageEvaluator
         {
             EventType = total ? "monitoring.wan_outage" : "monitoring.wan_outage_partial",
             Source = "monitoring",
+            // Severity tracks user impact, not which link failed: a WAN that is carrying traffic
+            // (the primary, or any WAN on a load-balancing site) taking a total outage is a real
+            // service loss, while an idle failover backup dropping costs redundancy only.
             Severity = total
-                ? info.TreatAsPrimary ? AlertSeverity.Critical : AlertSeverity.Warning
-                : info.TreatAsPrimary ? AlertSeverity.Warning : AlertSeverity.Info,
+                ? info.CarriesTraffic ? AlertSeverity.Critical : AlertSeverity.Warning
+                : info.CarriesTraffic ? AlertSeverity.Warning : AlertSeverity.Info,
             Title = total
                 ? $"Internet down on {info.Label}{_siteSuffix}"
                 : $"Partial internet outage on {info.Label}{_siteSuffix}",

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -380,7 +380,11 @@ public class WanOutageEvaluator
             Message = message,
             DeviceId = info.WanKey,
             DeviceName = info.Label,
-            SourceUrl = "/monitoring?tab=performance",
+            // Opens on this WAN's own chart at the moment the outage started, rather than the
+            // tab's default view of now: by the time anyone follows the link the window that
+            // shows what happened has usually scrolled off the live view.
+            SourceUrl = WanSourceUrl(info.WanKey, total ? "AccessIsp" : "InternetService",
+                state.EpisodeStart ?? now),
             Tags = ["monitoring", "wan-outage"],
             Context = BuildContext(info, verdict, state.EpisodeStart, breakAt)
         };
@@ -398,7 +402,9 @@ public class WanOutageEvaluator
             Message = $"Targets on {info.Label} are answering again. The outage lasted {duration}.",
             DeviceId = info.WanKey,
             DeviceName = info.Label,
-            SourceUrl = "/monitoring?tab=performance",
+            // Parked at the START of the outage, not the recovery: what someone following a
+            // recovery wants to see is the episode that just ended.
+            SourceUrl = WanSourceUrl(info.WanKey, "AccessIsp", state.EpisodeStart ?? now),
             Tags = ["monitoring", "wan-outage"],
             Context = new Dictionary<string, string>
             {
@@ -425,7 +431,8 @@ public class WanOutageEvaluator
             Message = $"Every WAN ({string.Join(", ", labels)}) has been failing all of its monitored targets for {duration}. The site looks offline.",
             DeviceId = RollupDeviceId,
             DeviceName = "All WANs",
-            SourceUrl = "/monitoring?tab=performance",
+            // Every WAN is out, so this one spans them all rather than naming one.
+            SourceUrl = $"/monitoring?tab=performance&category=AccessIsp&at={new DateTimeOffset(DateTime.SpecifyKind(_rollupSince ?? now, DateTimeKind.Utc)).ToUnixTimeMilliseconds()}&wan={Services.Monitoring.LiveWanScope.AllWansToken}",
             Tags = ["monitoring", "wan-outage"],
             Context = new Dictionary<string, string>
             {
@@ -453,6 +460,17 @@ public class WanOutageEvaluator
         if (breakAt != null) context["break_at"] = breakAt;
         if (since != null) context["since"] = since.Value.ToString("o", CultureInfo.InvariantCulture);
         return context;
+    }
+
+    /// <summary>
+    /// The Network Performance chart, scoped to one WAN and parked at an instant. The analysis
+    /// page reads the category, the WAN and the timestamp from the link, so following an alert
+    /// lands on the evidence rather than on whatever the tab happens to show now.
+    /// </summary>
+    private static string WanSourceUrl(string wanKey, string category, DateTime at)
+    {
+        var ms = new DateTimeOffset(DateTime.SpecifyKind(at, DateTimeKind.Utc)).ToUnixTimeMilliseconds();
+        return $"/monitoring?tab=performance&category={category}&at={ms}&wan={Uri.EscapeDataString(wanKey)}";
     }
 
     private static string Humanize(TimeSpan duration)

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -43,6 +43,9 @@ public class WanOutageEvaluator
     private const int ConfirmsToClose = 3;
     private const int FailedProbesToCountFailing = 2;
     private const int TargetStalenessSeconds = 180;
+
+    /// <summary>How far apart the WANs' total-outage confirmations may sit and still read as one site outage.</summary>
+    private const int RollupWindowSeconds = 90;
     private const int ContextTtlSeconds = 300;
 
     private readonly IAlertEventBus _eventBus;
@@ -164,19 +167,39 @@ public class WanOutageEvaluator
 
             var needed = verdict.Kind == WanVerdictKind.None ? ConfirmsToClose : ConfirmsToOpen;
             if (state.PendingCount >= needed) confirmedThisPass[wanKey] = verdict.Kind;
+
+            // When this WAN's total outage was first confirmed, for the rollup's window. Cleared
+            // the moment it is no longer verdicted total, so a recovered WAN cannot hold a stale
+            // confirmation and let a later rollup claim the site was wholly down.
+            if (verdict.Kind == WanVerdictKind.Total && state.PendingCount >= ConfirmsToOpen)
+                state.TotalConfirmedAt ??= now;
+            else if (verdict.Kind != WanVerdictKind.Total)
+                state.TotalConfirmedAt = null;
         }
 
-        // Site rollup: every WAN of a multi-WAN site confirmed down in the same evaluation, with
-        // nothing already open, collapses into ONE site-level Critical - N notifications for one
-        // event is the spam this alert class exists to remove.
+        // Site rollup: every WAN of a multi-WAN site down together collapses into ONE site-level
+        // Critical - N notifications for one event is the spam this alert class exists to remove.
+        // "Together" is a window rather than a single evaluation: WANs are polled at their own
+        // intervals (10 s on one, 60 s on another is ordinary), so a site that loses everything
+        // at once still confirms its WANs a minute apart, and a same-pass test would almost never
+        // fire. A WAN that already opened its own alert is folded in - the rollup event resolves
+        // the per-WAN alerts it supersedes - so the worst case is one alert then the rollup,
+        // rather than one per WAN.
+        var totalEverywhere = byWan.Keys.All(k => GetWanState(k).TotalConfirmedAt != null);
         if (!_rollupOpen
             && byWan.Count >= 2
-            && byWan.Keys.All(k => confirmedThisPass.TryGetValue(k, out var kind) && kind == WanVerdictKind.Total)
-            && byWan.Keys.All(k => GetWanState(k).OpenKind == WanVerdictKind.None && !GetWanState(k).CoveredByRollup))
+            && totalEverywhere
+            && now - byWan.Keys.Min(k => GetWanState(k).TotalConfirmedAt!.Value)
+                <= TimeSpan.FromSeconds(RollupWindowSeconds))
         {
             _rollupOpen = true;
             _rollupSince = byWan.Keys.Select(k => GetWanState(k).EpisodeStart).Min() ?? now;
-            foreach (var k in byWan.Keys) GetWanState(k).CoveredByRollup = true;
+            foreach (var k in byWan.Keys)
+            {
+                var s = GetWanState(k);
+                s.CoveredByRollup = true;
+                s.OpenKind = WanVerdictKind.None;
+            }
             await _eventBus.PublishAsync(BuildRollupEvent(byWan.Keys.ToList(), now), ct);
             return;
         }
@@ -470,6 +493,9 @@ public class WanOutageEvaluator
 
         /// <summary>Whether this WAN's outage is represented by the site-level rollup alert.</summary>
         public bool CoveredByRollup;
+
+        /// <summary>When this WAN's total outage was confirmed, for the site rollup's window.</summary>
+        public DateTime? TotalConfirmedAt;
 
         /// <summary>The most recent classification, carried into the event bodies.</summary>
         public WanVerdict? LastVerdict;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -1,0 +1,453 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Turns per-target failure states into per-WAN outage alerts. The WAN-facing target categories
+/// (access ISP, transit, internet, legacy WAN) are not independent - one access-layer outage
+/// takes them all out at once - so instead of a pile of per-target notifications this publishes
+/// one alert per WAN, classified by shape: <c>monitoring.wan_outage</c> (the connection is down),
+/// <c>monitoring.wan_outage_partial</c> (part of the path beyond the access layer, while the WAN
+/// still passes traffic), and <c>monitoring.wan_recovered</c> (closes either). One open alert per
+/// (WAN, kind); a partial that becomes total is superseded, never stacked; when every WAN of a
+/// multi-WAN site is out in the same evaluation, one site-level rollup replaces the per-WAN pile.
+///
+/// Fed by <see cref="MonitoringAlertEvaluator"/>, whose per-target offline state machine keeps
+/// running underneath for every category (it just stops publishing per-target events for the WAN
+/// categories). Evaluation is a throttled whole-site pass over the current target states, and a
+/// verdict must hold across consecutive passes to open - the per-target
+/// FailuresToDeclareOffline idea applied to the WAN - and to close, so a flapping WAN produces
+/// one alert and one recovery. State is in memory only, rebuilt from live probe results after a
+/// restart; an outage spanning a restart re-opens its alert once, which is the accepted cost of
+/// never persisting outage state that could go stale against a network that has recovered.
+/// </summary>
+public class WanOutageEvaluator
+{
+    /// <summary>AlertEvent.DeviceId of the site-level all-WANs rollup alert.</summary>
+    internal const string RollupDeviceId = "all-wans";
+
+    private const int EvaluationIntervalSeconds = 30;
+    private const int ConfirmsToOpen = 3;
+    private const int ConfirmsToClose = 3;
+    private const int TargetStalenessSeconds = 180;
+    private const int ContextTtlSeconds = 300;
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<WanOutageEvaluator> _logger;
+    private readonly WanOutageContextSource _contextSource;
+    private readonly TimeProvider _time;
+    private readonly string _siteSlug;
+    private readonly string _siteSuffix;
+
+    private readonly ConcurrentDictionary<string, TargetLiveState> _targets = new();
+    private readonly SemaphoreSlim _passGate = new(1, 1);
+    private readonly Dictionary<string, WanState> _wanStates = new(StringComparer.OrdinalIgnoreCase);
+    private WanOutageContext _context = WanOutageContext.Empty;
+    private DateTime _contextLoadedUtc = DateTime.MinValue;
+    private DateTime _lastPassUtc = DateTime.MinValue;
+    private bool _rollupOpen;
+    private DateTime? _rollupSince;
+
+    /// <param name="siteSlug">
+    /// Site this instance evaluates for (one instance per site, owned by
+    /// <see cref="MonitoringAlertRegistry"/>, same pattern as <see cref="MonitoringAlertEvaluator"/>).
+    /// </param>
+    public WanOutageEvaluator(IAlertEventBus eventBus, ILogger<WanOutageEvaluator> logger,
+        WanOutageContextSource contextSource,
+        string siteSlug = SiteManagementService.DefaultSiteSlug,
+        TimeProvider? timeProvider = null)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+        _contextSource = contextSource;
+        _time = timeProvider ?? TimeProvider.System;
+        _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
+        _siteSuffix = _siteSlug == SiteManagementService.DefaultSiteSlug ? "" : $" (site {_siteSlug})";
+    }
+
+    /// <summary>Whether a target type is alerted per WAN here rather than per target.</summary>
+    public static bool CoversTargetType(MonitoringTargetType type) => type is
+        MonitoringTargetType.Wan or
+        MonitoringTargetType.AccessIsp or
+        MonitoringTargetType.Transit or
+        MonitoringTargetType.InternetService;
+
+    /// <summary>
+    /// Records a WAN-scoped target's current per-target state machine verdict. Called by
+    /// <see cref="MonitoringAlertEvaluator"/> on every probe result for a covered target,
+    /// from both the local collection loop and the agent result sink.
+    /// </summary>
+    internal void RecordTargetState(MonitoringTarget target, bool isOffline, bool isLossy)
+    {
+        if (!CoversTargetType(target.TargetType)) return;
+        var state = _targets.GetOrAdd(target.TargetId, _ => new TargetLiveState());
+        state.Target = target;
+        state.Offline = isOffline;
+        state.Lossy = isLossy;
+        state.LastResultUtc = _time.GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>
+    /// Runs one whole-site evaluation pass when due. Throttled to one pass per
+    /// <see cref="EvaluationIntervalSeconds"/> and single-flight, so the per-probe call sites
+    /// can invoke it unconditionally.
+    /// </summary>
+    internal async ValueTask EvaluateAsync(CancellationToken ct = default)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        if (now - _lastPassUtc < TimeSpan.FromSeconds(EvaluationIntervalSeconds)) return;
+        if (!await _passGate.WaitAsync(0, ct)) return;
+        try
+        {
+            if (now - _lastPassUtc < TimeSpan.FromSeconds(EvaluationIntervalSeconds)) return;
+            _lastPassUtc = now;
+            await RunPassAsync(now, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "WAN outage evaluation pass failed for site {Site}", _siteSlug);
+        }
+        finally
+        {
+            _passGate.Release();
+        }
+    }
+
+    private async Task RunPassAsync(DateTime now, CancellationToken ct)
+    {
+        // Group fresh target states by WAN. A target with no recent result says nothing about
+        // the WAN: when probing stops entirely (agent disconnected, monitoring off), every
+        // target goes stale and no verdict is reached - a monitoring gap is not an outage,
+        // and not a recovery either.
+        var staleness = TimeSpan.FromSeconds(TargetStalenessSeconds);
+        var fresh = _targets.Values
+            .Where(t => now - t.LastResultUtc <= staleness)
+            .ToList();
+
+        await RefreshContextAsync(now, fresh, ct);
+
+        var byWan = fresh
+            .GroupBy(t => string.IsNullOrEmpty(t.Target.WanInterface)
+                ? _context.PrimaryWanKey
+                : GatewayWanHelper.WanInterfaceKeyFromKey(t.Target.WanInterface!),
+                StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        // Verdict and confirmation counting per WAN.
+        var confirmedThisPass = new Dictionary<string, WanVerdictKind>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (wanKey, targets) in byWan)
+        {
+            var verdict = WanOutageClassifier.Classify(targets.Select(ToSnapshot).ToList());
+            var state = GetWanState(wanKey);
+            if (verdict.Kind == state.PendingKind) state.PendingCount++;
+            else
+            {
+                state.PendingKind = verdict.Kind;
+                state.PendingCount = 1;
+            }
+            if (verdict.Kind != WanVerdictKind.None && state.EpisodeStart == null)
+                state.EpisodeStart = now;
+            state.LastVerdict = verdict;
+
+            var needed = verdict.Kind == WanVerdictKind.None ? ConfirmsToClose : ConfirmsToOpen;
+            if (state.PendingCount >= needed) confirmedThisPass[wanKey] = verdict.Kind;
+        }
+
+        // Site rollup: every WAN of a multi-WAN site confirmed down in the same evaluation, with
+        // nothing already open, collapses into ONE site-level Critical - N notifications for one
+        // event is the spam this alert class exists to remove.
+        if (!_rollupOpen
+            && byWan.Count >= 2
+            && byWan.Keys.All(k => confirmedThisPass.TryGetValue(k, out var kind) && kind == WanVerdictKind.Total)
+            && byWan.Keys.All(k => GetWanState(k).OpenKind == WanVerdictKind.None && !GetWanState(k).CoveredByRollup))
+        {
+            _rollupOpen = true;
+            _rollupSince = byWan.Keys.Select(k => GetWanState(k).EpisodeStart).Min() ?? now;
+            foreach (var k in byWan.Keys) GetWanState(k).CoveredByRollup = true;
+            await _eventBus.PublishAsync(BuildRollupEvent(byWan.Keys.ToList(), now), ct);
+            return;
+        }
+
+        foreach (var (wanKey, kind) in confirmedThisPass)
+        {
+            var state = GetWanState(wanKey);
+            var info = WanInfo(wanKey);
+            switch (kind)
+            {
+                case WanVerdictKind.Total when !state.CoveredByRollup && state.OpenKind != WanVerdictKind.Total:
+                    // Opens fresh, or supersedes an open partial: publishing the total closes
+                    // the partial downstream (AlertProcessingService resolves it), so the two
+                    // never stack.
+                    state.OpenKind = WanVerdictKind.Total;
+                    await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
+                    break;
+
+                case WanVerdictKind.Partial when !state.CoveredByRollup && state.OpenKind == WanVerdictKind.None:
+                    // A partial never downgrades an open total; the total stays open until
+                    // recovery closes it.
+                    state.OpenKind = WanVerdictKind.Partial;
+                    await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
+                    break;
+
+                case WanVerdictKind.None:
+                    await HandleRecoveryAsync(wanKey, state, info, now, ct);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recovery confirmed for one WAN. Under an open rollup the first recovery closes the rollup
+    /// (its "every WAN is out" premise is gone) and any still-out WAN opens its own alert, so
+    /// the picture goes back to per-WAN as soon as the WANs differ again.
+    /// </summary>
+    private async Task HandleRecoveryAsync(string wanKey, WanState state, WanOutageWanInfo info,
+        DateTime now, CancellationToken ct)
+    {
+        if (state.CoveredByRollup && _rollupOpen)
+        {
+            _rollupOpen = false;
+            state.CoveredByRollup = false;
+            await _eventBus.PublishAsync(BuildRecoveredEvent(info, state, now), ct);
+            state.EpisodeStart = null;
+            foreach (var (otherKey, other) in _wanStates)
+            {
+                if (!other.CoveredByRollup) continue;
+                other.CoveredByRollup = false;
+                other.OpenKind = WanVerdictKind.Total;
+                await _eventBus.PublishAsync(BuildOutageEvent(WanInfo(otherKey), other, now), ct);
+            }
+            _rollupSince = null;
+            return;
+        }
+
+        if (state.OpenKind != WanVerdictKind.None)
+        {
+            state.OpenKind = WanVerdictKind.None;
+            await _eventBus.PublishAsync(BuildRecoveredEvent(info, state, now), ct);
+        }
+        state.EpisodeStart = null;
+    }
+
+    private async Task RefreshContextAsync(DateTime now, List<TargetLiveState> fresh, CancellationToken ct)
+    {
+        if (now - _contextLoadedUtc < TimeSpan.FromSeconds(ContextTtlSeconds)) return;
+        try
+        {
+            var wanKeys = fresh
+                .Select(t => t.Target.WanInterface)
+                .Where(w => !string.IsNullOrEmpty(w))
+                .Select(w => w!)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            _context = await _contextSource.LoadAsync(_siteSlug, wanKeys, ct);
+            _contextLoadedUtc = now;
+        }
+        catch (Exception ex)
+        {
+            // Keep the previous snapshot: classification still works from the targets alone,
+            // it just loses trace-map attribution until the next successful load.
+            _contextLoadedUtc = now;
+            _logger.LogDebug(ex, "WAN outage context load failed for site {Site}; keeping previous snapshot", _siteSlug);
+        }
+    }
+
+    private WanTargetSnapshot ToSnapshot(TargetLiveState t)
+    {
+        var hop = _context.HopsByTargetId.TryGetValue(t.Target.TargetId, out var h)
+            ? h
+            : new WanOutageHopInfo(int.MaxValue, new HashSet<string>());
+        return new WanTargetSnapshot(
+            t.Target.TargetId,
+            t.Target.TargetType,
+            t.Target.Name,
+            t.Target.Address,
+            Failing: t.Offline,
+            Degraded: t.Offline || t.Lossy,
+            Depth: hop.Depth,
+            KnownPosition: hop.Depth != int.MaxValue,
+            IsInternet: t.Target.TargetType is MonitoringTargetType.InternetService or MonitoringTargetType.Wan,
+            AsnLabel: string.IsNullOrEmpty(t.Target.AsnName) ? null : t.Target.AsnName,
+            AsnNumber: t.Target.AsnNumber ?? 0,
+            AncestorIps: hop.AncestorIps);
+    }
+
+    private WanState GetWanState(string wanKey)
+    {
+        if (!_wanStates.TryGetValue(wanKey, out var state))
+            _wanStates[wanKey] = state = new WanState();
+        return state;
+    }
+
+    private WanOutageWanInfo WanInfo(string wanKey) =>
+        _context.Wans.TryGetValue(wanKey, out var info)
+            ? info
+            : new WanOutageWanInfo(wanKey,
+                GatewayWanHelper.FormatWanLabel(null, GatewayWanHelper.WanIndexFromKey(wanKey), null, null),
+                TreatAsPrimary: true, ConsoleUp: null);
+
+    private AlertEvent BuildOutageEvent(WanOutageWanInfo info, WanState state, DateTime now)
+    {
+        var verdict = state.LastVerdict!;
+        var total = verdict.Kind == WanVerdictKind.Total;
+        var duration = Humanize(now - (state.EpisodeStart ?? now));
+        var breakAt = total
+            ? verdict.LastReachableHop ?? verdict.BrokenNetwork
+            : verdict.BranchLabel;
+
+        string message;
+        if (total && verdict.AccessDown && info.ConsoleUp == false)
+            message = $"The console reports the {info.Label} link down. All {verdict.TotalCount} monitored targets on it have been failing for {duration}.";
+        else if (total && verdict.AccessDown)
+            message = $"All {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}, including your ISP's first hop. This looks like the connection itself.";
+        else if (total && verdict.LastReachableHop == null && verdict.BrokenNetwork == null)
+            message = $"All {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}. This looks like the connection itself.";
+        else if (total)
+        {
+            message = $"Your ISP's first hop on {info.Label} still answers, but the {verdict.FailingCount} targets beyond it have been failing for {duration}.";
+            if (verdict.LastReachableHop != null)
+                message += $" The path is fine up to {verdict.LastReachableHop}; past that, nothing responds.";
+            else if (verdict.BrokenNetwork != null)
+                message += $" The break looks like it sits in {verdict.BrokenNetwork}.";
+        }
+        else if (verdict.BranchLabel != null)
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}, all behind {verdict.BranchLabel}. Other destinations are reachable, so the connection itself looks fine.";
+        else
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing for {duration}, across unrelated networks. The connection itself is still passing traffic.";
+
+        return new AlertEvent
+        {
+            EventType = total ? "monitoring.wan_outage" : "monitoring.wan_outage_partial",
+            Source = "monitoring",
+            Severity = total
+                ? info.TreatAsPrimary ? AlertSeverity.Critical : AlertSeverity.Warning
+                : info.TreatAsPrimary ? AlertSeverity.Warning : AlertSeverity.Info,
+            Title = total
+                ? $"Internet down on {info.Label}{_siteSuffix}"
+                : $"Partial internet outage on {info.Label}{_siteSuffix}",
+            Message = message,
+            DeviceId = info.WanKey,
+            DeviceName = info.Label,
+            SourceUrl = "/monitoring?tab=performance",
+            Tags = ["monitoring", "wan-outage"],
+            Context = BuildContext(info, verdict, state.EpisodeStart, breakAt)
+        };
+    }
+
+    private AlertEvent BuildRecoveredEvent(WanOutageWanInfo info, WanState state, DateTime now)
+    {
+        var duration = Humanize(now - (state.EpisodeStart ?? now));
+        return new AlertEvent
+        {
+            EventType = "monitoring.wan_recovered",
+            Source = "monitoring",
+            Severity = AlertSeverity.Info,
+            Title = $"{info.Label} is back{_siteSuffix}",
+            Message = $"Targets on {info.Label} are answering again. The outage lasted {duration}.",
+            DeviceId = info.WanKey,
+            DeviceName = info.Label,
+            SourceUrl = "/monitoring?tab=performance",
+            Tags = ["monitoring", "wan-outage"],
+            Context = new Dictionary<string, string>
+            {
+                ["wan"] = info.WanKey,
+                ["wan_label"] = info.Label,
+                ["verdict"] = "recovered",
+                ["since"] = (state.EpisodeStart ?? now).ToString("o", CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    private AlertEvent BuildRollupEvent(IReadOnlyList<string> wanKeys, DateTime now)
+    {
+        var labels = wanKeys.Select(k => WanInfo(k).Label).ToList();
+        var failing = wanKeys.Sum(k => GetWanState(k).LastVerdict?.FailingCount ?? 0);
+        var totalTargets = wanKeys.Sum(k => GetWanState(k).LastVerdict?.TotalCount ?? 0);
+        var duration = Humanize(now - (_rollupSince ?? now));
+        return new AlertEvent
+        {
+            EventType = "monitoring.wan_outage",
+            Source = "monitoring",
+            Severity = AlertSeverity.Critical,
+            Title = $"Internet down on all WANs{_siteSuffix}",
+            Message = $"Every WAN ({string.Join(", ", labels)}) has been failing all of its monitored targets for {duration}. The site looks offline.",
+            DeviceId = RollupDeviceId,
+            DeviceName = "All WANs",
+            SourceUrl = "/monitoring?tab=performance",
+            Tags = ["monitoring", "wan-outage"],
+            Context = new Dictionary<string, string>
+            {
+                ["verdict"] = "all_wans_down",
+                ["targets_failing"] = failing.ToString(CultureInfo.InvariantCulture),
+                ["targets_total"] = totalTargets.ToString(CultureInfo.InvariantCulture),
+                ["since"] = (_rollupSince ?? now).ToString("o", CultureInfo.InvariantCulture)
+            }
+        };
+    }
+
+    private Dictionary<string, string> BuildContext(WanOutageWanInfo info, WanVerdict verdict,
+        DateTime? since, string? breakAt)
+    {
+        var context = new Dictionary<string, string>
+        {
+            ["wan"] = info.WanKey,
+            ["wan_label"] = info.Label,
+            ["verdict"] = verdict.Kind == WanVerdictKind.Total
+                ? verdict.AccessDown ? "access_down" : "upstream"
+                : verdict.BranchLabel != null ? "partial_branch" : "partial_independent",
+            ["targets_failing"] = verdict.FailingCount.ToString(CultureInfo.InvariantCulture),
+            ["targets_total"] = verdict.TotalCount.ToString(CultureInfo.InvariantCulture)
+        };
+        if (breakAt != null) context["break_at"] = breakAt;
+        if (since != null) context["since"] = since.Value.ToString("o", CultureInfo.InvariantCulture);
+        return context;
+    }
+
+    private static string Humanize(TimeSpan duration)
+    {
+        if (duration.TotalMinutes < 1) return "under a minute";
+        if (duration.TotalHours < 1)
+        {
+            var minutes = (int)duration.TotalMinutes;
+            return minutes == 1 ? "1 minute" : $"{minutes} minutes";
+        }
+        var hours = (int)duration.TotalHours;
+        var rest = (int)duration.Subtract(TimeSpan.FromHours(hours)).TotalMinutes;
+        var hourPart = hours == 1 ? "1 hour" : $"{hours} hours";
+        return rest == 0 ? hourPart : $"{hourPart} {rest} minutes";
+    }
+
+    private sealed class TargetLiveState
+    {
+        public MonitoringTarget Target = null!;
+        public bool Offline;
+        public bool Lossy;
+        public DateTime LastResultUtc;
+    }
+
+    private sealed class WanState
+    {
+        /// <summary>Verdict kind observed on recent passes, awaiting confirmation.</summary>
+        public WanVerdictKind PendingKind;
+
+        /// <summary>Consecutive passes the pending kind has held.</summary>
+        public int PendingCount;
+
+        /// <summary>When the current outage episode was first observed (pre-confirmation), for the notification body.</summary>
+        public DateTime? EpisodeStart;
+
+        /// <summary>Which alert is currently open for this WAN, so a partial is superseded rather than stacked.</summary>
+        public WanVerdictKind OpenKind;
+
+        /// <summary>Whether this WAN's outage is represented by the site-level rollup alert.</summary>
+        public bool CoveredByRollup;
+
+        /// <summary>The most recent classification, carried into the event bodies.</summary>
+        public WanVerdict? LastVerdict;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -333,10 +333,13 @@ public class WanOutageEvaluator
             else if (verdict.BrokenNetwork != null)
                 message += $" The break looks like it sits in {verdict.BrokenNetwork}.";
         }
+        // No reassurance about the connection itself: a partial is often a total still arriving,
+        // with the rest of the targets a probe cycle behind. State the evidence, not a verdict
+        // on the WAN that the next evaluation may overturn.
         else if (verdict.BranchLabel != null)
-            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, all behind {verdict.BranchLabel}. Other destinations are reachable, so the connection itself looks fine.";
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, all behind {verdict.BranchLabel}. Other destinations are still reachable.";
         else
-            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, across unrelated networks. The connection itself is still passing traffic.";
+            message = $"{verdict.FailingCount} of {verdict.TotalCount} monitored targets on {info.Label} have been failing or degraded for {duration}, across unrelated networks.";
 
         return new AlertEvent
         {

--- a/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
@@ -44,8 +44,12 @@ public class MonitoringAlertRegistry : ISiteScopedRegistry
             // Wrap the shared bus so every event these per-site evaluators publish is
             // stamped with this site's slug, routing it to the site's rules and channels.
             var bus = new SiteAlertEventBus(_serviceProvider.GetRequiredService<IAlertEventBus>(), s);
+            // The WAN outage evaluator is fed by the target evaluator (which suppresses
+            // per-target events for the WAN categories in its favor), so it is created first
+            // and handed in rather than exposed on the bundle.
+            var wanOutages = ActivatorUtilities.CreateInstance<WanOutageEvaluator>(_serviceProvider, s, bus);
             return new SiteAlertEvaluators(
-                ActivatorUtilities.CreateInstance<MonitoringAlertEvaluator>(_serviceProvider, s, bus),
+                ActivatorUtilities.CreateInstance<MonitoringAlertEvaluator>(_serviceProvider, s, bus, wanOutages),
                 ActivatorUtilities.CreateInstance<DeviceHealthAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<SfpAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<CableModemAlertEvaluator>(_serviceProvider, s, bus),

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -24,6 +24,13 @@ public class MonitoringLiveStats
     private List<(string TargetId, MonitoringTargetType TargetType, string? WanInterface)>? _ispTransitTargets;
     private DateTime _ispTransitTargetsCacheTime;
     private static readonly TimeSpan TargetCacheTtl = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How old a target's last probe reading may be and still be plotted as live. Half again the
+    /// slowest poll interval a target can be given (60 s), so one missed cycle rides through and
+    /// the next expires the reading rather than letting it stand in for a current one.
+    /// </summary>
+    public static readonly TimeSpan LiveReadingMaxAge = TimeSpan.FromSeconds(90);
     private readonly Lock _targetCacheLock = new();
 
     private readonly SiteDbContextFactory? _siteDbFactory;
@@ -376,7 +383,7 @@ public class MonitoringLiveStats
     /// its own returns nothing rather than borrowing the primary's numbers and presenting them as
     /// its own.
     /// </param>
-    public async Task<(double? MeanRttMs, double MeanLossPercent)> GetMeanIspTransitLiveAsync(
+    public async Task<(double? MeanRttMs, double? MeanLossPercent)> GetMeanIspTransitLiveAsync(
         CancellationToken ct = default,
         string? wanInterface = null,
         bool isPrimary = false)
@@ -402,10 +409,18 @@ public class MonitoringLiveStats
         var transitRtts = new List<double>();
         var transitLosses = new List<double>();
 
+        // A reading is only evidence while it is current. A target that stops reporting - which is
+        // exactly what some failures look like, rather than a reported 100% loss - otherwise keeps
+        // presenting its last good reading forever, and the card reads healthy through an outage.
+        // Observed on a WAN whose ISP targets went quiet under a blackhole while its transit
+        // targets kept reporting: transit showed the true 100% loss, the ISP rows showed the RTT
+        // and 0% loss they had carried before it started.
+        var stale = DateTime.UtcNow - LiveReadingMaxAge;
+
         foreach (var t in targets)
         {
             var st = GetTargetStats(t.TargetId);
-            if (st == null) continue;
+            if (st == null || st.LastUpdate < stale) continue;
 
             if (t.TargetType == MonitoringTargetType.AccessIsp)
             {
@@ -420,20 +435,21 @@ public class MonitoringLiveStats
         }
 
         var ispRtt = ispRtts.Count > 0 ? ispRtts.Average() : (double?)null;
-        var ispLoss = ispLosses.Count > 0 ? ispLosses.Average() : 0.0;
+        var ispLoss = ispLosses.Count > 0 ? ispLosses.Average() : (double?)null;
         var transitRtt = transitRtts.Count > 0 ? transitRtts.Average() : (double?)null;
-        var transitLoss = transitLosses.Count > 0 ? transitLosses.Average() : 0.0;
+        var transitLoss = transitLosses.Count > 0 ? transitLosses.Average() : (double?)null;
 
         double? meanRtt;
         if (ispRtt != null && transitRtt != null)
             meanRtt = (ispRtt.Value + transitRtt.Value) / 2;
         else meanRtt = ispRtt ?? transitRtt;
 
-        double meanLoss = 0;
-        if (ispLosses.Count > 0 && transitLosses.Count > 0)
-            meanLoss = (ispLoss + transitLoss) / 2;
-        else if (ispLosses.Count > 0) meanLoss = ispLoss;
-        else if (transitLosses.Count > 0) meanLoss = transitLoss;
+        // Null, never zero, when nothing fresh reported: no reading is not the same claim as no
+        // loss, and the zero read as a healthy connection during an outage.
+        double? meanLoss;
+        if (ispLoss != null && transitLoss != null)
+            meanLoss = (ispLoss.Value + transitLoss.Value) / 2;
+        else meanLoss = ispLoss ?? transitLoss;
 
         return (meanRtt, meanLoss);
     }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2116,6 +2116,12 @@ a.stat-card-link:active {
     }
 }
 
+/* Offers a poll's findings without moving the list underneath the reader. */
+.alert-pending-pill {
+    display: block;
+    margin: 0 auto 1rem;
+}
+
 .no-alerts {
     text-align: center;
     padding: 2rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2110,6 +2110,12 @@ a.stat-card-link:active {
     align-items: flex-end;
 }
 
+@media (min-width: 769px) {
+    .alert-actions .btn {
+        min-width: 6.75rem;
+    }
+}
+
 .no-alerts {
     text-align: center;
     padding: 2rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6593,6 +6593,11 @@ a.path-hop.hop-clickable:hover {
     font-size: 0.875rem;
 }
 
+/* Sits inside the history card rather than between sections, so it needs the room underneath. */
+.history-pagination {
+    margin-bottom: 1rem;
+}
+
 .pag-arrow {
     position: relative;
     top: -1px;

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -577,7 +577,7 @@ async function loadHistory() {
             download: p.downloadBps,
             upload: p.uploadBps,
             rtt: p.rttMs,
-            loss: p.lossPercent ?? 0,
+            loss: p.lossPercent,
         }));
         // Advance the live-sample watermark past the reloaded history so the
         // next pollLive can't append a sample older than the last history
@@ -693,7 +693,9 @@ async function pollLive() {
             time: sampleTime,
             download: d.downloadBps,
             upload: d.uploadBps,
-            loss: d.lossPercent ?? 0,
+            // Null, not zero: no fresh reading is a gap in the series, and plotting it as 0%
+            // drew a healthy connection through an outage that had stopped reporting.
+            loss: d.lossPercent,
             rtt: d.rttMs,
         });
         buffer = buffer.filter(p => p.time >= cutoff);
@@ -774,7 +776,7 @@ async function backfillHistory() {
             download: p.downloadBps,
             upload: p.uploadBps,
             rtt: p.rttMs,
-            loss: p.lossPercent ?? 0,
+            loss: p.lossPercent,
         }));
     } catch { return 0; }
     // Bail if the mount changed or we left live mode while fetching.

--- a/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
@@ -1,0 +1,248 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Alerts.Interfaces;
+using NetworkOptimizer.Alerts.Models;
+using NetworkOptimizer.Core.Enums;
+using Xunit;
+
+namespace NetworkOptimizer.Alerts.Tests;
+
+/// <summary>
+/// The open/close half of the WAN outage alert family: which open alerts an incoming
+/// monitoring.wan_* event closes, and what that does to the incident they belonged to.
+/// </summary>
+public class WanOutageAlertResolutionTests
+{
+    private readonly AlertProcessingService _service;
+    private readonly Mock<IAlertRepository> _repository = new();
+    private readonly List<(string[] EventTypes, string DeviceId)> _resolveCalls = [];
+
+    public WanOutageAlertResolutionTests()
+    {
+        _repository
+            .Setup(r => r.ResolveActiveAlertsAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>, string, CancellationToken>(
+                (types, deviceId, _) => _resolveCalls.Add((types.ToArray(), deviceId)))
+            .ReturnsAsync(new List<AlertHistoryEntry>());
+
+        var configuration = new Mock<IConfiguration>();
+        configuration.Setup(c => c["HOST_NAME"]).Returns("host.example");
+
+        var cooldownTracker = new AlertCooldownTracker();
+        _service = new AlertProcessingService(
+            NullLogger<AlertProcessingService>.Instance,
+            Mock.Of<IAlertEventBus>(),
+            Mock.Of<IServiceScopeFactory>(),
+            new AlertRuleEvaluator(cooldownTracker, NullLogger<AlertRuleEvaluator>.Instance),
+            new AlertCorrelationService(NullLogger<AlertCorrelationService>.Instance),
+            [],
+            cooldownTracker,
+            Mock.Of<IAlertSiteNameResolver>(),
+            configuration.Object);
+    }
+
+    private static AlertEvent CreateEvent(string eventType, string? deviceId) => new()
+    {
+        EventType = eventType,
+        Severity = AlertSeverity.Critical,
+        Source = "monitoring",
+        Title = "Test alert",
+        DeviceId = deviceId
+    };
+
+    private void SetupResolved(string eventType, string deviceId, params AlertHistoryEntry[] resolved)
+    {
+        _repository
+            .Setup(r => r.ResolveActiveAlertsAsync(
+                It.Is<IReadOnlyCollection<string>>(t => t.Contains(eventType)),
+                deviceId,
+                It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>, string, CancellationToken>(
+                (types, device, _) => _resolveCalls.Add((types.ToArray(), device)))
+            .ReturnsAsync(resolved.ToList());
+    }
+
+    #region GetWanAlertsToResolve
+
+    [Fact]
+    public void GetWanAlertsToResolve_TotalOutage_SupersedesThePartialOnTheSameWan()
+    {
+        var targets = AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_outage", "wan2");
+
+        targets.Should().ContainSingle();
+        targets[0].DeviceId.Should().Be("wan2");
+        targets[0].EventTypes.Should().Equal("monitoring.wan_outage_partial");
+    }
+
+    [Fact]
+    public void GetWanAlertsToResolve_SiteRollupOutage_ClosesNothing()
+    {
+        var targets = AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_outage", "all-wans");
+
+        targets.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetWanAlertsToResolve_OutageWithoutDeviceId_ClosesNothing()
+    {
+        AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_outage", null).Should().BeEmpty();
+        AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_outage", "").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetWanAlertsToResolve_Recovery_ClosesBothKindsOnTheWanAndTheRollup()
+    {
+        var targets = AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_recovered", "wan");
+
+        targets.Should().HaveCount(2);
+        targets[0].DeviceId.Should().Be("wan");
+        targets[0].EventTypes.Should().BeEquivalentTo(new[] { "monitoring.wan_outage", "monitoring.wan_outage_partial" });
+        targets[1].DeviceId.Should().Be("all-wans");
+        targets[1].EventTypes.Should().Equal("monitoring.wan_outage");
+    }
+
+    [Fact]
+    public void GetWanAlertsToResolve_RecoveryWithoutDeviceId_StillClosesTheRollup()
+    {
+        var targets = AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_recovered", null);
+
+        targets.Should().ContainSingle();
+        targets[0].DeviceId.Should().Be("all-wans");
+        targets[0].EventTypes.Should().Equal("monitoring.wan_outage");
+    }
+
+    [Theory]
+    [InlineData("monitoring.target_offline")]
+    [InlineData("monitoring.target_recovered")]
+    [InlineData("device.offline")]
+    public void GetWanAlertsToResolve_EventOutsideTheWanFamily_ClosesNothing(string eventType)
+    {
+        AlertProcessingService.GetWanAlertsToResolve(eventType, "wan").Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region ResolveSupersededWanAlertsAsync
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_TotalOutage_ResolvesOnlyThatWansPartial()
+    {
+        var evt = CreateEvent("monitoring.wan_outage", "wan2");
+
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        _resolveCalls.Should().ContainSingle();
+        _resolveCalls[0].DeviceId.Should().Be("wan2");
+        _resolveCalls[0].EventTypes.Should().Equal("monitoring.wan_outage_partial");
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_Recovery_ResolvesOutagePartialAndRollup()
+    {
+        var evt = CreateEvent("monitoring.wan_recovered", "wan2");
+
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        _resolveCalls.Should().HaveCount(2);
+        _resolveCalls.Select(c => c.DeviceId).Should().Equal("wan2", "all-wans");
+        _resolveCalls[0].EventTypes.Should().BeEquivalentTo(new[] { "monitoring.wan_outage", "monitoring.wan_outage_partial" });
+        _resolveCalls[1].EventTypes.Should().Equal("monitoring.wan_outage");
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_NeverTouchesAnotherWansAlerts()
+    {
+        var evt = CreateEvent("monitoring.wan_recovered", "wan2");
+
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        // Only this WAN and the site rollup - "wan" and "wan3" keep their open alerts, and the
+        // repository handed in is already pinned to the event's site, so other sites are untouched.
+        _resolveCalls.Select(c => c.DeviceId).Should().NotContain("wan").And.NotContain("wan3");
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_EventOutsideTheWanFamily_ResolvesNothing()
+    {
+        var evt = CreateEvent("monitoring.target_offline", "wan2");
+
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        _resolveCalls.Should().BeEmpty();
+        _repository.Verify(r => r.ResolveActiveAlertsAsync(
+            It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_ResolvedAlertInIncident_RecalculatesIncidentStatus()
+    {
+        var resolved = new AlertHistoryEntry
+        {
+            Id = 5,
+            EventType = "monitoring.wan_outage_partial",
+            DeviceId = "wan2",
+            IncidentId = 7,
+            Status = AlertStatus.Resolved
+        };
+        SetupResolved("monitoring.wan_outage_partial", "wan2", resolved);
+
+        var incident = new AlertIncident { Id = 7, Status = AlertStatus.Active };
+        _repository.Setup(r => r.GetIncidentAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(incident);
+        _repository.Setup(r => r.GetAlertsByIncidentIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AlertHistoryEntry> { resolved });
+
+        var evt = CreateEvent("monitoring.wan_outage", "wan2");
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        incident.Status.Should().Be(AlertStatus.Resolved);
+        incident.ResolvedAt.Should().NotBeNull();
+        _repository.Verify(r => r.UpdateIncidentAsync(incident, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_IncidentStillHasActiveAlerts_LeavesIncidentOpen()
+    {
+        var resolved = new AlertHistoryEntry
+        {
+            Id = 5,
+            EventType = "monitoring.wan_outage_partial",
+            DeviceId = "wan2",
+            IncidentId = 7,
+            Status = AlertStatus.Resolved
+        };
+        SetupResolved("monitoring.wan_outage_partial", "wan2", resolved);
+
+        var incident = new AlertIncident { Id = 7, Status = AlertStatus.Active };
+        _repository.Setup(r => r.GetIncidentAsync(7, It.IsAny<CancellationToken>())).ReturnsAsync(incident);
+        _repository.Setup(r => r.GetAlertsByIncidentIdAsync(7, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<AlertHistoryEntry> { resolved, new() { Id = 6, Status = AlertStatus.Active } });
+
+        var evt = CreateEvent("monitoring.wan_outage", "wan2");
+        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        incident.Status.Should().Be(AlertStatus.Active);
+        _repository.Verify(r => r.UpdateIncidentAsync(It.IsAny<AlertIncident>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ResolveSupersededWanAlertsAsync_RepositoryThrows_DoesNotPropagate()
+    {
+        _repository
+            .Setup(r => r.ResolveActiveAlertsAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+
+        var evt = CreateEvent("monitoring.wan_recovered", "wan2");
+
+        var act = async () => await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    #endregion
+}

--- a/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
@@ -79,12 +79,18 @@ public class WanOutageAlertResolutionTests
         targets[0].EventTypes.Should().Equal("monitoring.wan_outage_partial");
     }
 
+    /// <summary>
+    /// The rollup says the whole site is down, which is the same outage every per-WAN alert was
+    /// describing a piece of - so it closes them all, whatever WAN they name.
+    /// </summary>
     [Fact]
-    public void GetWanAlertsToResolve_SiteRollupOutage_ClosesNothing()
+    public void GetWanAlertsToResolve_SiteRollupOutage_ClosesEveryPerWanAlert()
     {
         var targets = AlertProcessingService.GetWanAlertsToResolve("monitoring.wan_outage", "all-wans");
 
-        targets.Should().BeEmpty();
+        targets.Should().ContainSingle();
+        targets[0].DeviceId.Should().BeNull("a null device id means every device");
+        targets[0].EventTypes.Should().Equal("monitoring.wan_outage", "monitoring.wan_outage_partial");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/AlertRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/AlertRepositoryTests.cs
@@ -1,0 +1,147 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetworkOptimizer.Alerts.Models;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Repositories;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+public class AlertRepositoryTests : IDisposable
+{
+    private readonly string _databaseName = Guid.NewGuid().ToString();
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly AlertRepository _repository;
+
+    public AlertRepositoryTests()
+    {
+        _context = CreateContext();
+        _repository = new AlertRepository(_context, new Mock<ILogger<AlertRepository>>().Object);
+    }
+
+    private NetworkOptimizerDbContext CreateContext()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: _databaseName)
+            .Options;
+        return new NetworkOptimizerDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+    }
+
+    private async Task<AlertHistoryEntry> SeedAlertAsync(
+        string eventType,
+        string? deviceId,
+        AlertStatus status = AlertStatus.Active)
+    {
+        var alert = new AlertHistoryEntry
+        {
+            EventType = eventType,
+            Severity = AlertSeverity.Critical,
+            Status = status,
+            Source = "monitoring",
+            Title = "Test alert",
+            DeviceId = deviceId,
+            TriggeredAt = DateTime.UtcNow
+        };
+
+        _context.AlertHistory.Add(alert);
+        await _context.SaveChangesAsync();
+        return alert;
+    }
+
+    #region ResolveActiveAlertsAsync
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_ResolvesOnlyMatchingEventTypeAndDevice()
+    {
+        var partialOnWan2 = await SeedAlertAsync("monitoring.wan_outage_partial", "wan2");
+        var partialOnWan = await SeedAlertAsync("monitoring.wan_outage_partial", "wan");
+        var outageOnWan2 = await SeedAlertAsync("monitoring.wan_outage", "wan2");
+        var rollup = await SeedAlertAsync("monitoring.wan_outage", "all-wans");
+
+        var resolved = await _repository.ResolveActiveAlertsAsync(["monitoring.wan_outage_partial"], "wan2");
+
+        resolved.Should().ContainSingle();
+        resolved[0].Id.Should().Be(partialOnWan2.Id);
+
+        using var verify = CreateContext();
+        var stored = await verify.AlertHistory.AsNoTracking().ToDictionaryAsync(a => a.Id, a => a.Status);
+        stored[partialOnWan2.Id].Should().Be(AlertStatus.Resolved);
+        stored[partialOnWan.Id].Should().Be(AlertStatus.Active);
+        stored[outageOnWan2.Id].Should().Be(AlertStatus.Active);
+        stored[rollup.Id].Should().Be(AlertStatus.Active);
+    }
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_ResolvesEveryListedEventTypeOnTheDevice()
+    {
+        var outage = await SeedAlertAsync("monitoring.wan_outage", "wan2");
+        var partial = await SeedAlertAsync("monitoring.wan_outage_partial", "wan2");
+
+        var resolved = await _repository.ResolveActiveAlertsAsync(
+            ["monitoring.wan_outage", "monitoring.wan_outage_partial"], "wan2");
+
+        resolved.Select(a => a.Id).Should().BeEquivalentTo(new[] { outage.Id, partial.Id });
+        resolved.Should().OnlyContain(a => a.Status == AlertStatus.Resolved);
+    }
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_LeavesAcknowledgedAndAlreadyResolvedEntriesAlone()
+    {
+        var acknowledged = await SeedAlertAsync("monitoring.wan_outage", "wan2", AlertStatus.Acknowledged);
+        var alreadyResolved = await SeedAlertAsync("monitoring.wan_outage", "wan2", AlertStatus.Resolved);
+
+        var resolved = await _repository.ResolveActiveAlertsAsync(["monitoring.wan_outage"], "wan2");
+
+        resolved.Should().BeEmpty();
+
+        using var verify = CreateContext();
+        var stored = await verify.AlertHistory.AsNoTracking().ToDictionaryAsync(a => a.Id, a => a.Status);
+        stored[acknowledged.Id].Should().Be(AlertStatus.Acknowledged);
+        stored[alreadyResolved.Id].Should().Be(AlertStatus.Resolved);
+    }
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_StampsResolvedAt()
+    {
+        var before = DateTime.UtcNow;
+        await SeedAlertAsync("monitoring.wan_outage", "wan2");
+
+        var resolved = await _repository.ResolveActiveAlertsAsync(["monitoring.wan_outage"], "wan2");
+
+        resolved.Should().ContainSingle();
+        resolved[0].ResolvedAt.Should().NotBeNull();
+        resolved[0].ResolvedAt!.Value.Should().BeOnOrAfter(before).And.BeOnOrBefore(DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_NoMatches_ReturnsEmpty()
+    {
+        await SeedAlertAsync("monitoring.wan_outage", "wan");
+
+        var resolved = await _repository.ResolveActiveAlertsAsync(["monitoring.wan_outage"], "wan2");
+
+        resolved.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveActiveAlertsAsync_NoEventTypesOrNoDevice_ReturnsEmpty()
+    {
+        var alert = await SeedAlertAsync("monitoring.wan_outage", "wan2");
+
+        (await _repository.ResolveActiveAlertsAsync([], "wan2")).Should().BeEmpty();
+        (await _repository.ResolveActiveAlertsAsync(["monitoring.wan_outage"], "")).Should().BeEmpty();
+
+        using var verify = CreateContext();
+        var stored = await verify.AlertHistory.AsNoTracking().FirstAsync(a => a.Id == alert.Id);
+        stored.Status.Should().Be(AlertStatus.Active);
+    }
+
+    #endregion
+}

--- a/tests/NetworkOptimizer.Storage.Tests/AlertRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/AlertRepositoryTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using NetworkOptimizer.Alerts.Models;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Repositories;
 using Xunit;
 

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageClassifierTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageClassifierTests.cs
@@ -1,0 +1,291 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// The shape half of the WAN outage alert family: given one WAN's current target states, which
+/// outage the picture is. Pure and stateless, so these cover every branch directly - the two
+/// total shapes (access layer down, and the first hop answering while everything beyond it is
+/// dark), the branch-shaped and independent partials, and the deliberate silences that keep the
+/// alert class quiet: one dark destination, a transit hop nobody sits behind, and too little
+/// evidence to say anything at all.
+/// </summary>
+public class WanOutageClassifierTests
+{
+    private const string AccessIp = "192.0.2.1";
+    private const string TransitIp = "198.51.100.1";
+    private const string SecondTransitIp = "198.51.100.2";
+
+    private static WanTargetSnapshot Access(bool failing = false, bool degraded = false) =>
+        new("wan-access", MonitoringTargetType.AccessIsp, "Acme Fiber first hop", AccessIp,
+            Failing: failing, Degraded: failing || degraded, Depth: 1, KnownPosition: true,
+            IsInternet: false, AsnLabel: "Acme Fiber", AsnNumber: 64500,
+            AncestorIps: Ancestors(null));
+
+    private static WanTargetSnapshot Transit(string id, string address, int depth,
+        bool failing = false, bool degraded = false, string? asnLabel = "TransitNet",
+        int asnNumber = 64501, string[]? ancestors = null) =>
+        new(id, MonitoringTargetType.Transit, id, address,
+            Failing: failing, Degraded: failing || degraded, Depth: depth, KnownPosition: true,
+            IsInternet: false, AsnLabel: asnLabel, AsnNumber: asnNumber,
+            AncestorIps: Ancestors(ancestors));
+
+    private static WanTargetSnapshot Internet(string id, string address,
+        bool failing = false, bool degraded = false, string? asnLabel = "Alpha Cloud",
+        int asnNumber = 64510, string[]? ancestors = null) =>
+        new(id, MonitoringTargetType.InternetService, id, address,
+            Failing: failing, Degraded: failing || degraded, Depth: 6, KnownPosition: true,
+            IsInternet: true, AsnLabel: asnLabel, AsnNumber: asnNumber,
+            AncestorIps: Ancestors(ancestors));
+
+    private static IReadOnlySet<string> Ancestors(string[]? ips) =>
+        new HashSet<string>(ips ?? [], StringComparer.OrdinalIgnoreCase);
+
+    [Fact]
+    public void Classify_NoTargets_ReturnsNone()
+    {
+        var verdict = WanOutageClassifier.Classify([]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.None);
+        verdict.Should().BeSameAs(WanVerdict.None);
+    }
+
+    [Fact]
+    public void Classify_EveryTargetFailingWithAnAccessHop_IsTotalWithTheAccessLayerDown()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(failing: true),
+            Transit("transit-a", TransitIp, 3, failing: true, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Total);
+        verdict.AccessDown.Should().BeTrue();
+        verdict.FailingCount.Should().Be(3);
+        verdict.TotalCount.Should().Be(3);
+    }
+
+    /// <summary>
+    /// Same picture without a monitored first hop: still the connection, but nothing to say the
+    /// access layer itself is the part that went - so no attribution is claimed.
+    /// </summary>
+    [Fact]
+    public void Classify_EveryTargetFailingWithNoAccessHopMonitored_IsTotalWithoutAttribution()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Transit("transit-a", TransitIp, 3, failing: true),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [TransitIp]),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Total);
+        verdict.AccessDown.Should().BeFalse();
+        verdict.LastReachableHop.Should().BeNull();
+        verdict.BrokenNetwork.Should().BeNull();
+    }
+
+    [Fact]
+    public void Classify_FirstHopAnswersAndEverythingBeyondFails_IsTotalAttributedToTheFirstHop()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, failing: true, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Total);
+        verdict.AccessDown.Should().BeFalse();
+        verdict.LastReachableHop.Should().Be("Acme Fiber");
+        verdict.FailingCount.Should().Be(3);
+        verdict.TotalCount.Should().Be(4);
+    }
+
+    /// <summary>
+    /// A transit hop dark WITH a destination behind it also dark is the corroborated branch: the
+    /// hop is the branch head, and it names the partial.
+    /// </summary>
+    [Fact]
+    public void Classify_TransitHopAndTheDestinationBehindItFailing_IsPartialNamingTheTransit()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, failing: true, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", asnLabel: "Beta Cloud", asnNumber: 64520,
+                ancestors: [AccessIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().Be("TransitNet");
+        verdict.FailingCount.Should().Be(2);
+        verdict.TotalCount.Should().Be(4);
+    }
+
+    /// <summary>
+    /// The break just past a hop that still answers: every failing destination sits behind the
+    /// transit and no reachable one does, so the transit is where the picture narrows.
+    /// </summary>
+    [Fact]
+    public void Classify_DestinationsSharingAReachableAncestor_IsPartialNamingThatAncestor()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().Be("TransitNet");
+    }
+
+    /// <summary>
+    /// The ancestor healthy traffic also crosses cannot be the branch - naming the first hop
+    /// while other destinations behind it are perfectly reachable would blame the wrong network.
+    /// </summary>
+    [Fact]
+    public void Classify_AncestorHealthyTrafficAlsoCrosses_IsPartialWithoutABranch()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp]),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [AccessIp]),
+            Internet("resolver-c", "203.0.113.30", asnLabel: "Gamma Cloud", asnNumber: 64530,
+                ancestors: [AccessIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().BeNull();
+        verdict.FailingCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void Classify_UnrelatedDestinationsFailing_IsPartialWithoutABranch()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [TransitIp]),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [SecondTransitIp]),
+            Internet("resolver-c", "203.0.113.30", asnLabel: "Gamma Cloud", asnNumber: 64530)
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().BeNull();
+    }
+
+    /// <summary>
+    /// Several endpoints of one provider are one network, not several independent ones, so with
+    /// no monitored hop to anchor on the network itself is what the partial is named after.
+    /// </summary>
+    [Fact]
+    public void Classify_TwoDestinationsOfOneUnlabeledAsn_IsPartialNamingTheAsn()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Internet("resolver-a", "203.0.113.10", failing: true, asnLabel: null, asnNumber: 64540),
+            Internet("resolver-b", "203.0.113.20", failing: true, asnLabel: null, asnNumber: 64540),
+            Internet("resolver-c", "203.0.113.30", asnLabel: "Gamma Cloud", asnNumber: 64530)
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().Be("AS64540");
+    }
+
+    /// <summary>
+    /// One dark destination is nearly always the destination's own problem, and alerting on it
+    /// would rebuild exactly the per-target noise this alert class exists to remove.
+    /// </summary>
+    [Fact]
+    public void Classify_OneDestinationFailing_ReturnsNone()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", failing: true, ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", asnLabel: "Beta Cloud", asnNumber: 64520,
+                ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.None);
+    }
+
+    [Fact]
+    public void Classify_OneTransitHopFailingAlone_ReturnsNone()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, failing: true, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.None);
+    }
+
+    /// <summary>
+    /// Transit routers rate-limit ICMP with nothing wrong, so a transit-only picture with every
+    /// destination still reachable is never an outage however many hops stop answering.
+    /// </summary>
+    [Fact]
+    public void Classify_TransitHopsDarkWithEveryDestinationReachable_ReturnsNone()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Transit("transit-a", TransitIp, 3, failing: true, ancestors: [AccessIp]),
+            Transit("transit-b", SecondTransitIp, 4, failing: true, asnLabel: "Delta Transit",
+                asnNumber: 64502, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", asnLabel: "Beta Cloud", asnNumber: 64520,
+                ancestors: [AccessIp, SecondTransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.None);
+    }
+
+    /// <summary>
+    /// Sustained loss counts toward a partial without the target ever going fully dark - a branch
+    /// can be out or degraded without every probe failing outright.
+    /// </summary>
+    [Fact]
+    public void Classify_DegradedButNotOfflineDestinations_IsPartial()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(),
+            Internet("resolver-a", "203.0.113.10", degraded: true, ancestors: [TransitIp]),
+            Internet("resolver-b", "203.0.113.20", degraded: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [SecondTransitIp]),
+            Internet("resolver-c", "203.0.113.30", asnLabel: "Gamma Cloud", asnNumber: 64530)
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.BranchLabel.Should().BeNull();
+        verdict.FailingCount.Should().Be(2);
+    }
+
+    /// <summary>
+    /// Degraded is not offline: a WAN losing packets everywhere still passes traffic, so however
+    /// wide the degradation it must not read as the connection being down.
+    /// </summary>
+    [Fact]
+    public void Classify_EveryTargetDegradedButNoneFailing_IsNeverTotal()
+    {
+        var verdict = WanOutageClassifier.Classify([
+            Access(degraded: true),
+            Transit("transit-a", TransitIp, 3, degraded: true, ancestors: [AccessIp]),
+            Internet("resolver-a", "203.0.113.10", degraded: true, ancestors: [AccessIp, TransitIp]),
+            Internet("resolver-b", "203.0.113.20", degraded: true, asnLabel: "Beta Cloud",
+                asnNumber: 64520, ancestors: [AccessIp, TransitIp])
+        ]);
+
+        verdict.Kind.Should().Be(WanVerdictKind.Partial);
+        verdict.AccessDown.Should().BeFalse();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
@@ -28,12 +28,15 @@ namespace NetworkOptimizer.Web.Tests.Monitoring;
 public class WanOutageEvaluatorTests
 {
     /// <summary>
-    /// Probe rounds needed to open or close an alert: three to move each per-target machine, then
-    /// three confirming passes, plus the one-round lag from a pass seeing the round it interrupts.
+    /// Probe rounds comfortably past what it takes to open or close an alert. Opening needs two
+    /// failed probes per target and two confirming passes; closing needs three successes to clear
+    /// each per-target machine and three passes, so this is sized for the slower of the two. Extra
+    /// rounds are harmless - the state machine only publishes on transitions.
     /// </summary>
     private const int RoundsToConfirm = 8;
 
-    private const int SecondsPerPass = 31;
+    /// <summary>A hair over the evaluator's pass interval, so each round runs exactly one pass.</summary>
+    private const int SecondsPerPass = 11;
 
     private static readonly DateTime Start = new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
 
@@ -77,9 +80,14 @@ public class WanOutageEvaluatorTests
 
     public WanOutageEvaluatorTests()
     {
+        _evaluator = BuildEvaluator(BuildContext());
+    }
+
+    private MonitoringAlertEvaluator BuildEvaluator(WanOutageContext context)
+    {
         var wanOutages = new WanOutageEvaluator(_bus, NullLogger<WanOutageEvaluator>.Instance,
-            new FakeContextSource(BuildContext()), timeProvider: _time);
-        _evaluator = new MonitoringAlertEvaluator(_bus, NullLogger<MonitoringAlertEvaluator>.Instance,
+            new FakeContextSource(context), timeProvider: _time);
+        return new MonitoringAlertEvaluator(_bus, NullLogger<MonitoringAlertEvaluator>.Instance,
             new DeviceTransitionTracker(), wanOutages);
     }
 
@@ -218,6 +226,30 @@ public class WanOutageEvaluatorTests
         evt.DeviceId.Should().Be("aabbccddeeff");
     }
 
+    /// <summary>
+    /// Under load balancing every WAN carries live sessions, so a backup going dark is a real
+    /// service loss rather than lost redundancy - it grades the same as the primary would.
+    /// </summary>
+    [Fact]
+    public async Task NonPrimaryWanDownOnALoadBalancingSite_IsCritical()
+    {
+        var evaluator = BuildEvaluator(BuildContext(loadBalances: true));
+
+        for (var round = 0; round < RoundsToConfirm; round++)
+        {
+            foreach (var target in Wan2Targets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: false));
+            foreach (var target in WanTargets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+
+        var evt = _bus.Published.Should().ContainSingle().Subject;
+        evt.EventType.Should().Be("monitoring.wan_outage");
+        evt.DeviceId.Should().Be("wan2");
+        evt.Severity.Should().Be(AlertSeverity.Critical);
+    }
+
     #endregion
 
     #region Silences
@@ -230,26 +262,17 @@ public class WanOutageEvaluatorTests
     [Fact]
     public async Task VerdictThatDoesNotHoldLongEnough_PublishesNothing()
     {
-        // Three failed probes inside one evaluation window: every target is offline, and only the
-        // very first probe ran a pass (which saw nothing wrong yet).
-        await ProbeAsync(WanTargets, success: false);
-        _time.Advance(TimeSpan.FromSeconds(5));
-        await ProbeAsync(WanTargets, success: false);
-        _time.Advance(TimeSpan.FromSeconds(5));
+        // First failed probe: the pass it triggers has nothing recorded to judge yet.
         await ProbeAsync(WanTargets, success: false);
 
-        // Two confirming passes - one short of what it takes to open.
-        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
-        await ProbeAsync(WanTargets, success: false);
+        // Second failed probe puts every target over the failing threshold, and the pass that
+        // comes with it reaches a Total verdict - one confirming pass, one short of opening.
         _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
         await ProbeAsync(WanTargets, success: false);
 
-        // Back up inside the same window, so the next pass already sees a healthy WAN.
-        for (var i = 0; i < 3; i++)
-        {
-            _time.Advance(TimeSpan.FromSeconds(5));
-            await ProbeAsync(WanTargets, success: true);
-        }
+        // Back up before the next pass. A success resets the failure count immediately (the
+        // targets never reached the per-target offline threshold), so that pass sees a healthy
+        // WAN and the pending Total never gets its second confirmation.
         _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
         await ProbeAsync(WanTargets, success: true);
 
@@ -263,14 +286,7 @@ public class WanOutageEvaluatorTests
     [Fact]
     public async Task WanWhoseTargetsStopReporting_PublishesNothing()
     {
-        await ProbeAsync(WanTargets, success: false);
-        _time.Advance(TimeSpan.FromSeconds(5));
-        await ProbeAsync(WanTargets, success: false);
-        _time.Advance(TimeSpan.FromSeconds(5));
-        await ProbeAsync(WanTargets, success: false);
-
-        // Two confirming passes, then wan stops reporting entirely.
-        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        // One confirming pass on a failing WAN, then wan stops reporting entirely.
         await ProbeAsync(WanTargets, success: false);
         _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
         await ProbeAsync(WanTargets, success: false);
@@ -332,12 +348,13 @@ public class WanOutageEvaluatorTests
     /// the monitored transit; resolver-b reaches the internet another way, so a pair of dark
     /// destinations has no shared branch to be named after.
     /// </summary>
-    private static WanOutageContext BuildContext() => new(
+    private static WanOutageContext BuildContext(bool loadBalances = false) => new(
         PrimaryWanKey: "wan",
         Wans: new Dictionary<string, WanOutageWanInfo>(StringComparer.OrdinalIgnoreCase)
         {
-            ["wan"] = new("wan", "Acme Fiber WAN1", TreatAsPrimary: true, ConsoleUp: null),
-            ["wan2"] = new("wan2", "Beta Cable WAN2", TreatAsPrimary: false, ConsoleUp: null)
+            ["wan"] = new("wan", "Acme Fiber WAN1", TreatAsPrimary: true, CarriesTraffic: true, ConsoleUp: null),
+            ["wan2"] = new("wan2", "Beta Cable WAN2", TreatAsPrimary: false,
+                CarriesTraffic: loadBalances, ConsoleUp: null)
         },
         HopsByTargetId: new Dictionary<string, WanOutageHopInfo>
         {

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
@@ -1,0 +1,404 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Probes;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// The state-machine half of the WAN outage alert family, driven the way production drives it:
+/// probe results into <see cref="MonitoringAlertEvaluator"/>, which runs the per-target machines
+/// and hands the WAN-facing ones to <see cref="WanOutageEvaluator"/>. What these pin down is the
+/// promise the feature makes - one notification per event instead of one per target: an outage
+/// publishes once, a partial that becomes total is superseded rather than stacked, a whole site
+/// going dark collapses into a single rollup that releases back to per-WAN alerts as soon as the
+/// WANs differ again, and both a flap and a monitoring gap publish nothing at all. Fabric and
+/// custom targets keep their per-target events throughout.
+///
+/// Time is faked because both machines are cadence-driven: a target needs three consecutive
+/// failed probes, and the WAN verdict then has to hold three evaluation passes 30 seconds apart.
+/// Probes arrive faster than passes run, exactly as they do in production (10 s polling against
+/// the 30 s pass throttle), which is what lets the flap test move a verdict in and out inside a
+/// single evaluation window.
+/// </summary>
+public class WanOutageEvaluatorTests
+{
+    /// <summary>
+    /// Probe rounds needed to open or close an alert: three to move each per-target machine, then
+    /// three confirming passes, plus the one-round lag from a pass seeing the round it interrupts.
+    /// </summary>
+    private const int RoundsToConfirm = 8;
+
+    private const int SecondsPerPass = 31;
+
+    private static readonly DateTime Start = new(2026, 7, 25, 12, 0, 0, DateTimeKind.Utc);
+
+    private static readonly MonitoringTarget WanAccess =
+        Target("wan-access", "Acme Fiber first hop", "192.0.2.1", MonitoringTargetType.AccessIsp,
+            "wan", 64500, "Acme Fiber");
+    private static readonly MonitoringTarget WanTransit =
+        Target("wan-transit", "TransitNet", "198.51.100.1", MonitoringTargetType.Transit,
+            "wan", 64501, "TransitNet");
+    private static readonly MonitoringTarget WanResolverA =
+        Target("wan-resolver-a", "resolver-a", "203.0.113.10", MonitoringTargetType.InternetService,
+            "wan", 64510, "Alpha Cloud");
+    private static readonly MonitoringTarget WanResolverB =
+        Target("wan-resolver-b", "resolver-b", "203.0.113.20", MonitoringTargetType.InternetService,
+            "wan", 64520, "Beta Cloud");
+
+    private static readonly MonitoringTarget Wan2Access =
+        Target("wan2-access", "Beta Cable first hop", "192.0.2.65", MonitoringTargetType.AccessIsp,
+            "wan2", 64600, "Beta Cable");
+    private static readonly MonitoringTarget Wan2Transit =
+        Target("wan2-transit", "TransitNet via Beta Cable", "198.51.100.65", MonitoringTargetType.Transit,
+            "wan2", 64501, "TransitNet");
+    private static readonly MonitoringTarget Wan2ResolverA =
+        Target("wan2-resolver-a", "resolver-c", "203.0.113.65", MonitoringTargetType.InternetService,
+            "wan2", 64510, "Alpha Cloud");
+    private static readonly MonitoringTarget Wan2ResolverB =
+        Target("wan2-resolver-b", "resolver-d", "203.0.113.75", MonitoringTargetType.InternetService,
+            "wan2", 64520, "Beta Cloud");
+
+    private static readonly MonitoringTarget[] WanTargets =
+        [WanAccess, WanTransit, WanResolverA, WanResolverB];
+    private static readonly MonitoringTarget[] Wan2Targets =
+        [Wan2Access, Wan2Transit, Wan2ResolverA, Wan2ResolverB];
+    private static readonly MonitoringTarget[] WanDestinations = [WanResolverA, WanResolverB];
+    private static readonly MonitoringTarget[] WanPath = [WanAccess, WanTransit];
+    private static readonly MonitoringTarget[] NoTargets = [];
+
+    private readonly CapturingAlertEventBus _bus = new();
+    private readonly FakeTimeProvider _time = new(Start);
+    private readonly MonitoringAlertEvaluator _evaluator;
+
+    public WanOutageEvaluatorTests()
+    {
+        var wanOutages = new WanOutageEvaluator(_bus, NullLogger<WanOutageEvaluator>.Instance,
+            new FakeContextSource(BuildContext()), timeProvider: _time);
+        _evaluator = new MonitoringAlertEvaluator(_bus, NullLogger<MonitoringAlertEvaluator>.Instance,
+            new DeviceTransitionTracker(), wanOutages);
+    }
+
+    #region Per-WAN outages
+
+    [Fact]
+    public async Task EveryTargetOnOneWanFailing_PublishesOneOutageAndNoPerTargetEvents()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: WanTargets, passing: Wan2Targets);
+
+        _bus.Published.Should().ContainSingle();
+        var evt = _bus.Published.Single();
+        evt.EventType.Should().Be("monitoring.wan_outage");
+        evt.Severity.Should().Be(AlertSeverity.Critical);
+        evt.DeviceId.Should().Be("wan");
+        evt.Title.Should().StartWith("Internet down on Acme Fiber WAN1");
+        _bus.Published.Should().NotContain(e => e.EventType == "monitoring.target_offline");
+    }
+
+    [Fact]
+    public async Task DestinationsFailingWhileThePathAnswers_PublishesOnePartialOutage()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: WanDestinations,
+            passing: [.. WanPath, .. Wan2Targets]);
+
+        _bus.Published.Should().ContainSingle();
+        var evt = _bus.Published.Single();
+        evt.EventType.Should().Be("monitoring.wan_outage_partial");
+        evt.Severity.Should().Be(AlertSeverity.Warning);
+        evt.DeviceId.Should().Be("wan");
+    }
+
+    /// <summary>
+    /// A partial that grows into the whole connection is superseded, never stacked: the total
+    /// follows once, and the partial is not repeated as the picture worsens.
+    /// </summary>
+    [Fact]
+    public async Task PartialThatBecomesTotal_IsFollowedByExactlyOneOutage()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: WanDestinations,
+            passing: [.. WanPath, .. Wan2Targets]);
+        await RoundsAsync(RoundsToConfirm, failing: WanTargets, passing: Wan2Targets);
+
+        _bus.Published.Select(e => e.EventType).Should()
+            .Equal("monitoring.wan_outage_partial", "monitoring.wan_outage");
+        _bus.Published[1].DeviceId.Should().Be("wan");
+    }
+
+    [Fact]
+    public async Task WanThatComesBack_PublishesOneRecoveryAndThenStaysQuiet()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: WanTargets, passing: Wan2Targets);
+        await RoundsAsync(RoundsToConfirm, failing: NoTargets, passing: [.. WanTargets, .. Wan2Targets]);
+
+        _bus.Published.Select(e => e.EventType).Should()
+            .Equal("monitoring.wan_outage", "monitoring.wan_recovered");
+        var recovered = _bus.Published[1];
+        recovered.Severity.Should().Be(AlertSeverity.Info);
+        recovered.DeviceId.Should().Be("wan");
+
+        await RoundsAsync(RoundsToConfirm, failing: NoTargets, passing: [.. WanTargets, .. Wan2Targets]);
+
+        _bus.Published.Should().HaveCount(2);
+    }
+
+    /// <summary>
+    /// A backup WAN going dark matters, but not at the severity of the connection the site is
+    /// actually using - and it says nothing about the WAN that is still passing traffic.
+    /// </summary>
+    [Fact]
+    public async Task NonPrimaryWanDown_AlertsOnThatWanOnlyAndAtWarning()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: Wan2Targets, passing: WanTargets);
+
+        _bus.Published.Should().ContainSingle();
+        var evt = _bus.Published.Single();
+        evt.EventType.Should().Be("monitoring.wan_outage");
+        evt.Severity.Should().Be(AlertSeverity.Warning);
+        evt.DeviceId.Should().Be("wan2");
+        evt.Title.Should().StartWith("Internet down on Beta Cable WAN2");
+    }
+
+    #endregion
+
+    #region Site rollup
+
+    [Fact]
+    public async Task EveryWanDownTogether_PublishesOneSiteRollupInsteadOfPerWanOutages()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: [.. WanTargets, .. Wan2Targets], passing: NoTargets);
+
+        _bus.Published.Should().ContainSingle();
+        var evt = _bus.Published.Single();
+        evt.EventType.Should().Be("monitoring.wan_outage");
+        evt.Severity.Should().Be(AlertSeverity.Critical);
+        evt.DeviceId.Should().Be("all-wans");
+        _bus.Published.Should().NotContain(e => e.DeviceId == "wan" || e.DeviceId == "wan2");
+    }
+
+    /// <summary>
+    /// The rollup's premise is that every WAN is out. The moment one comes back the picture goes
+    /// back to per-WAN: the rollup closes and the WAN still dark opens its own alert.
+    /// </summary>
+    [Fact]
+    public async Task OneWanRecoveringUnderTheRollup_ClosesItAndOpensTheWanStillDown()
+    {
+        await RoundsAsync(RoundsToConfirm, failing: [.. WanTargets, .. Wan2Targets], passing: NoTargets);
+        await RoundsAsync(RoundsToConfirm, failing: Wan2Targets, passing: WanTargets);
+
+        _bus.Published.Should().HaveCount(3);
+        _bus.Published[0].DeviceId.Should().Be("all-wans");
+        _bus.Published.Single(e => e.EventType == "monitoring.wan_recovered")
+            .DeviceId.Should().Be("wan");
+        _bus.Published.Skip(1).Single(e => e.EventType == "monitoring.wan_outage")
+            .DeviceId.Should().Be("wan2");
+    }
+
+    #endregion
+
+    #region What the WAN alerts must not change
+
+    [Theory]
+    [InlineData(MonitoringTargetType.Fabric)]
+    [InlineData(MonitoringTargetType.Custom)]
+    public async Task TargetOutsideTheWanCategories_StillPublishesPerTarget(MonitoringTargetType type)
+    {
+        var target = Target("lan-switch", "Switch 1", "192.0.2.10", type, deviceMac: "aabbccddeeff");
+
+        await RoundsAsync(3, failing: [target], passing: NoTargets);
+
+        _bus.Published.Should().ContainSingle();
+        var evt = _bus.Published.Single();
+        evt.EventType.Should().Be("monitoring.target_offline");
+        evt.Severity.Should().Be(AlertSeverity.Warning);
+        evt.Title.Should().Be("Switch 1 is offline");
+        evt.DeviceId.Should().Be("aabbccddeeff");
+    }
+
+    #endregion
+
+    #region Silences
+
+    /// <summary>
+    /// A verdict that does not hold long enough is not an outage. Probes run faster than passes,
+    /// so a WAN can go dark and come back inside a couple of evaluation windows - which is what
+    /// the confirmation count exists to swallow.
+    /// </summary>
+    [Fact]
+    public async Task VerdictThatDoesNotHoldLongEnough_PublishesNothing()
+    {
+        // Three failed probes inside one evaluation window: every target is offline, and only the
+        // very first probe ran a pass (which saw nothing wrong yet).
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(5));
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(5));
+        await ProbeAsync(WanTargets, success: false);
+
+        // Two confirming passes - one short of what it takes to open.
+        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        await ProbeAsync(WanTargets, success: false);
+
+        // Back up inside the same window, so the next pass already sees a healthy WAN.
+        for (var i = 0; i < 3; i++)
+        {
+            _time.Advance(TimeSpan.FromSeconds(5));
+            await ProbeAsync(WanTargets, success: true);
+        }
+        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        await ProbeAsync(WanTargets, success: true);
+
+        _bus.Published.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Targets that stop reporting say nothing about the WAN: a monitoring gap (agent gone,
+    /// collection stopped) must not confirm an outage out of stale states.
+    /// </summary>
+    [Fact]
+    public async Task WanWhoseTargetsStopReporting_PublishesNothing()
+    {
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(5));
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(5));
+        await ProbeAsync(WanTargets, success: false);
+
+        // Two confirming passes, then wan stops reporting entirely.
+        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        await ProbeAsync(WanTargets, success: false);
+        _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        await ProbeAsync(WanTargets, success: false);
+
+        // The other WAN keeps reporting, so passes keep running with wan's states long stale.
+        _time.Advance(TimeSpan.FromMinutes(10));
+        await RoundsAsync(RoundsToConfirm, failing: NoTargets, passing: Wan2Targets);
+
+        _bus.Published.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Harness
+
+    private async Task RoundsAsync(int rounds, IReadOnlyList<MonitoringTarget> failing,
+        IReadOnlyList<MonitoringTarget> passing)
+    {
+        for (var round = 0; round < rounds; round++)
+        {
+            await ProbeAsync(failing, success: false);
+            await ProbeAsync(passing, success: true);
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+    }
+
+    private async Task ProbeAsync(IReadOnlyList<MonitoringTarget> targets, bool success)
+    {
+        foreach (var target in targets)
+            await _evaluator.EvaluateAsync(target, Probe(target, success));
+    }
+
+    private PingProbeResult Probe(MonitoringTarget target, bool success) => new()
+    {
+        Target = new ProbeTarget(target.Address, ProbeMode.Icmp),
+        Vantage = ProbeVantage.Server,
+        Sent = 10,
+        Received = success ? 10 : 0,
+        Timestamp = _time.GetUtcNow().UtcDateTime,
+        RttAvgMs = success ? 12.5 : (double?)null
+    };
+
+    private static MonitoringTarget Target(string targetId, string name, string address,
+        MonitoringTargetType type, string? wanInterface = null, int? asnNumber = null,
+        string? asnName = null, string? deviceMac = null) => new()
+        {
+            TargetId = targetId,
+            Name = name,
+            Address = address,
+            TargetType = type,
+            WanInterface = wanInterface,
+            AsnNumber = asnNumber,
+            AsnName = asnName,
+            DeviceMac = deviceMac
+        };
+
+    /// <summary>
+    /// Two WANs with a first hop, a transit hop and two destinations each. resolver-a sits behind
+    /// the monitored transit; resolver-b reaches the internet another way, so a pair of dark
+    /// destinations has no shared branch to be named after.
+    /// </summary>
+    private static WanOutageContext BuildContext() => new(
+        PrimaryWanKey: "wan",
+        Wans: new Dictionary<string, WanOutageWanInfo>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wan"] = new("wan", "Acme Fiber WAN1", TreatAsPrimary: true, ConsoleUp: null),
+            ["wan2"] = new("wan2", "Beta Cable WAN2", TreatAsPrimary: false, ConsoleUp: null)
+        },
+        HopsByTargetId: new Dictionary<string, WanOutageHopInfo>
+        {
+            ["wan-access"] = Hop(1),
+            ["wan-transit"] = Hop(3, "192.0.2.1"),
+            ["wan-resolver-a"] = Hop(6, "192.0.2.1", "198.51.100.1"),
+            ["wan-resolver-b"] = Hop(6, "192.0.2.1"),
+            ["wan2-access"] = Hop(1),
+            ["wan2-transit"] = Hop(3, "192.0.2.65"),
+            ["wan2-resolver-a"] = Hop(6, "192.0.2.65", "198.51.100.65"),
+            ["wan2-resolver-b"] = Hop(6, "192.0.2.65")
+        },
+        AccessNeighborIpByWan: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["wan"] = "192.0.2.1",
+            ["wan2"] = "192.0.2.65"
+        });
+
+    private static WanOutageHopInfo Hop(int depth, params string[] ancestors) =>
+        new(depth, new HashSet<string>(ancestors, StringComparer.OrdinalIgnoreCase));
+
+    private sealed class FakeContextSource : WanOutageContextSource
+    {
+        private readonly WanOutageContext _context;
+
+        public FakeContextSource(WanOutageContext context)
+            : base(null!, null!, NullLogger<WanOutageContextSource>.Instance) => _context = context;
+
+        internal override Task<WanOutageContext> LoadAsync(string siteSlug,
+            IReadOnlyCollection<string> wanKeysInUse, CancellationToken ct = default) =>
+            Task.FromResult(_context);
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public FakeTimeProvider(DateTime start) => _utcNow = new DateTimeOffset(start);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan by) => _utcNow = _utcNow.Add(by);
+    }
+
+    private sealed class CapturingAlertEventBus : IAlertEventBus
+    {
+        public List<AlertEvent> Published { get; } = new();
+
+        public ValueTask PublishAsync(AlertEvent alertEvent, CancellationToken ct = default)
+        {
+            Published.Add(alertEvent);
+            return ValueTask.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<AlertEvent> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
One outage on a WAN used to send a notification per monitored target - a dozen messages naming
hosts you have no relationship with, from which you had to reconstruct "my internet is down". The
WAN-facing targets now alert as one connection, and the Alerts & Schedule page they land on had a
few things worth fixing while we were in there.

## Monitoring - ISP Health

- **Per-WAN outage alerts** - Access ISP, transit and internet targets are no longer alerted one by
  one. Their failures are classified per WAN into one of three events: the connection is down, part
  of the path beyond the access layer is out, or the WAN is back. One open alert per WAN at a time,
  and a partial that grows into a total replaces it rather than stacking a second alert beside it.
  Severity follows user impact rather than which link failed: a WAN that is carrying traffic - the
  primary, or any WAN on a load-balancing site - is Critical when it goes dark, while an idle
  failover backup is a Warning.
- **One alert when the whole site is down** - if every WAN is out together, that is one site-level
  alert rather than one per WAN. When the WANs stop matching each other, they go back to
  individual alerts.
- **Attribution comes from the existing detectors** - the classifier reuses ISP Health's break
  attribution and its network-independence rule, so an alert can say the path is fine up to a named
  hop without inventing a second opinion about the same data.
- **Alerting is quick enough to be worth reading** - around 30 to 60 seconds from the first lost
  packet, depending on how often the WAN's targets are polled.
- **Recovery closes the alert** - the three new event types are an open/close family: a recovery
  resolves whatever that WAN had open, so Active Alerts empties itself instead of accumulating
  outages nobody closed by hand.
- **Collecting data now points somewhere** - a WAN still gathering history says so, and if it has no
  scheduled speed tests it offers to set them up. Shown only to those who can create schedules.
- **LAN and Custom targets are untouched** - they alert per target exactly as before.

## Monitoring - Live View

- **Live tiles stop reading off stale results** - a target that stops reporting kept presenting the
  reading it carried before it went quiet, so ISP RTT and Loss read healthy straight through an
  outage. Readings now expire, and with no hop answering the tile takes loss from what did report
  rather than from a hop that has not spoken in minutes.
- **The WAN live chart keeps latency and loss across a throughput gap** - chart rows came only from
  the throughput series, so any span without it dropped that span's latency and loss too, even
  though both were recorded.

## Monitoring - Network Performance

- **Deep links land where they say they will** - a link naming a WAN was applied from a block that
  ran once, and gave up if the WAN list had not loaded yet, so the same link kept or lost its WAN
  depending on which finished first. It is now held until there is something to resolve it against.
- **Ordinary interactions stop resetting the WAN filter** - changing the time filter or resuming Live
  drops the link's WAN from the address bar, which was re-reading the saved filter over the top of
  whatever was on screen.

## Dashboard

- **The live tiles carry their WAN when you click through** - the ISP and Transit tiles are shared
  with Monitoring, where they jump within the page and keep the filter by staying put. From the
  Dashboard the same tiles navigate, and the link had no WAN on it, so clicking one WAN's tile
  opened Latency and Packet Loss showing every WAN.

## Alerts & Schedule

- **Alerts link to the moment and the WAN they are about** - following one used to land on the
  default view of now, by which time the window that shows what happened has scrolled off.
- **Acknowledge All and Resolve All are immediate** - each alert was written in its own database
  transaction and its incident re-derived once per alert, so a few hundred alerts locked the page
  up. Both are now single round trips, and the buttons disable and spin while they work.
- **Resolve Acknowledged says what it resolves** - the Acknowledged section's button was labelled
  Resolve All and took the whole unresolved list.
- **Active Alerts and Incidents refresh without moving under you** - new entries wait behind a count
  you can take when ready, rather than pushing the list down past what you were reading. Refreshing
  pauses entirely while a bulk action or an edit is open, and Incidents is refreshed at all now.
- **Incidents shows the incidents that are open** - the tab read the newest fifty whatever their
  status and filtered afterwards, so an unresolved incident vanished once fifty newer ones had been
  resolved. On a site that has been running a while, that was all of them.
- **History pages through everything** - it showed the newest slice with nothing to say the rest
  existed.
- **A deleted alert rule stays deleted** - seeding inserted any default whose event type was missing,
  so a rule you removed came back on the next restart. Seeded rules are now recorded once per
  database, and existing installs are backfilled from what they already have.

## Fixes

- **Agent batches no longer disappear silently** - two paths could drop a relayed batch of probe
  results with nothing in the log: an agent that owns no WAN context, and a batch arriving while the
  site's InfluxDB client is unconfigured, whose writes quietly do nothing.
