### PR TITLE
Starlink: alert on what the dish reports about itself

### DIFF
--- a/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
+++ b/src/NetworkOptimizer.Alerts/AlertProcessingService.cs
@@ -128,8 +128,8 @@ public class AlertProcessingService : BackgroundService
         var repository = scope.ServiceProvider.GetRequiredService<IAlertRepository>();
 
         // Close whatever this event supersedes before any rule is consulted, so an install with
-        // no rule for the recovery event still gets its outage alerts closed.
-        await ResolveSupersededWanAlertsAsync(alertEvent, repository, cancellationToken);
+        // no rule for the recovery event still gets its open alerts closed.
+        await ResolveSupersededAlertsAsync(alertEvent, repository, cancellationToken);
 
         var siteKey = alertEvent.SiteSlug ?? "";
         var rules = await GetRulesAsync(repository, siteKey, cancellationToken);
@@ -164,7 +164,7 @@ public class AlertProcessingService : BackgroundService
         }
     }
 
-    // --- WAN outage alerts: an open/close family, unlike the rest of the alert catalog ---
+    // --- WAN outage alerts: one of two open/close families, unlike the rest of the alert catalog ---
     //
     // The three monitoring.wan_* event types maintain at most one open alert per (WAN, kind).
     // A WAN raises a partial outage while part of the path out is unreachable but traffic still
@@ -175,7 +175,8 @@ public class AlertProcessingService : BackgroundService
     // than stacking a second open alert on the same WAN.
     //
     // Per-target monitoring alerts (monitoring.target_offline and friends) have no such pairing and
-    // stay open until a user resolves them, so this closing step applies to the WAN family only.
+    // stay open until a user resolves them, so this closing step applies to the two families that
+    // do: monitoring.wan_* here and starlink.* below.
 
     internal const string WanOutageEventType = "monitoring.wan_outage";
     internal const string WanOutagePartialEventType = "monitoring.wan_outage_partial";
@@ -220,17 +221,66 @@ public class AlertProcessingService : BackgroundService
         return targets;
     }
 
+    // --- Starlink dish alerts: the other open/close family ---
+    //
+    // The dish poll keeps at most one open alert per (dish, condition). A condition that is
+    // already alerting republishes only on new evidence, and a starlink.recovered event names the
+    // condition it closes in its context, so a dish that clears its obstruction keeps whatever
+    // other alert it still has open.
+
+    internal const string StarlinkRecoveredEventType = "starlink.recovered";
+
     /// <summary>
-    /// Closes the open WAN outage alerts this event supersedes and re-derives the status of any
-    /// incident they belonged to. Failures are logged and swallowed: resolution is housekeeping and
-    /// must never stop the event from being processed into an alert.
+    /// Context key on a starlink.recovered event naming the event type it closes. Written by
+    /// StarlinkAlertEvaluator.RecoveredTypeKey, which lives in the Web project and so cannot be
+    /// shared with this one; the two must stay in step.
     /// </summary>
-    internal async Task ResolveSupersededWanAlertsAsync(
+    internal const string StarlinkRecoveredTypeKey = "recovered_type";
+
+    private const string StarlinkEventPrefix = "starlink.";
+
+    /// <summary>
+    /// Which open Starlink alerts an incoming starlink.* event closes. A recovery closes the one
+    /// condition it names on that dish; any other Starlink event supersedes the open alert of its
+    /// own type on the same dish, which is what keeps one condition to one open alert. Empty for
+    /// every event outside the family, and for one carrying no dish.
+    /// </summary>
+    internal static List<(string[] EventTypes, string? DeviceId)> GetStarlinkAlertsToResolve(
+        string eventType, string? deviceId, IReadOnlyDictionary<string, string>? context)
+    {
+        var targets = new List<(string[] EventTypes, string? DeviceId)>();
+        var dishId = deviceId?.Trim();
+        if (string.IsNullOrEmpty(dishId) || !eventType.StartsWith(StarlinkEventPrefix, StringComparison.Ordinal))
+            return targets;
+
+        if (eventType == StarlinkRecoveredEventType)
+        {
+            if (context != null
+                && context.TryGetValue(StarlinkRecoveredTypeKey, out var recovered)
+                && !string.IsNullOrWhiteSpace(recovered))
+            {
+                targets.Add(([recovered], dishId));
+            }
+            return targets;
+        }
+
+        targets.Add(([eventType], dishId));
+        return targets;
+    }
+
+    /// <summary>
+    /// Closes the open alerts this event supersedes and re-derives the status of any incident they
+    /// belonged to. Failures are logged and swallowed: resolution is housekeeping and must never
+    /// stop the event from being processed into an alert.
+    /// </summary>
+    internal async Task ResolveSupersededAlertsAsync(
         AlertEvent alertEvent,
         IAlertRepository repository,
         CancellationToken cancellationToken)
     {
         var targets = GetWanAlertsToResolve(alertEvent.EventType, alertEvent.DeviceId);
+        targets.AddRange(GetStarlinkAlertsToResolve(
+            alertEvent.EventType, alertEvent.DeviceId, alertEvent.Context));
         if (targets.Count == 0)
             return;
 
@@ -244,7 +294,7 @@ public class AlertProcessingService : BackgroundService
                 if (resolved.Count == 0)
                     continue;
 
-                _logger.LogDebug("Closed {Count} open WAN alert(s) for {DeviceId} on {EventType}",
+                _logger.LogDebug("Closed {Count} open alert(s) for {DeviceId} on {EventType}",
                     resolved.Count, deviceId, alertEvent.EventType);
 
                 foreach (var alert in resolved)
@@ -253,7 +303,7 @@ public class AlertProcessingService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to close open WAN alerts for event {EventType} ({DeviceId})",
+            _logger.LogWarning(ex, "Failed to close open alerts for event {EventType} ({DeviceId})",
                 alertEvent.EventType, alertEvent.DeviceId);
         }
     }

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -483,6 +483,23 @@ public static class DefaultAlertRules
         // Severity here does NOT follow the per-WAN outage table, which rates a backup's troubles
         // lower. Starlink is usually the backup, and a backup that nothing else monitors is
         // discovered broken at the moment it is needed - so its problems keep real severity.
+        //
+        // EVERY rule in this block carries NO cooldown, which is deliberate and load-bearing.
+        // Two reasons:
+        //
+        //  1. It would silently drop the alert that replaces a superseded one. These types keep
+        //     one open alert per (dish, condition) by having a re-publish supersede its own
+        //     predecessor, and AlertProcessingService resolves the old row BEFORE rules are
+        //     consulted. Cooldown keys are per (site, rule, device), so a replacement shares the
+        //     key of the alert it just closed: an obstruction escalating Warning -> Critical
+        //     inside the cooldown would resolve the Warning and then have the Critical suppressed,
+        //     leaving a critically obstructed dish with no open alert at all. The WAN outage family
+        //     is immune only because a total supersedes a PARTIAL - a different rule, a different
+        //     key.
+        //  2. It is redundant anyway. StarlinkAlertEvaluator publishes on state changes only, and
+        //     is where the real throttling lives: sustain windows and hysteresis on the gated
+        //     conditions, "new evidence only" on the dish's own codes, and edge-triggering on
+        //     restriction. Nothing here can produce a stream to damp.
         new AlertRule
         {
             // The dish's own verdict on itself: its alert codes, a self-test that started failing,
@@ -492,7 +509,7 @@ public static class DefaultAlertRules
             EventTypePattern = "starlink.dish_alert",
             Source = "starlink",
             MinSeverity = AlertSeverity.Warning,
-            CooldownSeconds = 1800 // 30 minutes - the evaluator only republishes on new evidence
+            CooldownSeconds = 0 // republishes only when a new code appears or it goes out of service
         },
         new AlertRule
         {
@@ -501,17 +518,16 @@ public static class DefaultAlertRules
             EventTypePattern = "starlink.obstructed",
             Source = "starlink",
             MinSeverity = AlertSeverity.Warning,
-            CooldownSeconds = 3600 // 1 hour
+            CooldownSeconds = 0 // 15 minute sustain to open, and at most one escalation per episode
         },
         new AlertRule
         {
-            // Nobody can act on this twice in a day: it needs somebody to physically re-aim the dish.
             Name = "Starlink: Alignment Drift",
             IsEnabled = false,
             EventTypePattern = "starlink.alignment_drift",
             Source = "starlink",
             MinSeverity = AlertSeverity.Warning,
-            CooldownSeconds = 86400 // 24 hours
+            CooldownSeconds = 0 // opens once per episode; it cannot raise again without recovering first
         },
         new AlertRule
         {
@@ -520,17 +536,16 @@ public static class DefaultAlertRules
             EventTypePattern = "starlink.eth_speed_degraded",
             Source = "starlink",
             MinSeverity = AlertSeverity.Warning,
-            CooldownSeconds = 3600 // 1 hour
+            CooldownSeconds = 0 // 5 minute sustain to open, then once per episode
         },
         new AlertRule
         {
-            // The metric is outage seconds per day, so a shorter cooldown would say the same thing twice.
             Name = "Starlink: Repeated Outages",
             IsEnabled = false,
             EventTypePattern = "starlink.outage_burst",
             Source = "starlink",
             MinSeverity = AlertSeverity.Warning,
-            CooldownSeconds = 86400 // 24 hours
+            CooldownSeconds = 0 // opens once when the rolling day crosses the bar, closes when it drops back
         },
         new AlertRule
         {
@@ -541,16 +556,19 @@ public static class DefaultAlertRules
             EventTypePattern = "starlink.service_restricted",
             Source = "starlink",
             MinSeverity = AlertSeverity.Info,
-            CooldownSeconds = 3600 // 1 hour
+            CooldownSeconds = 0 // edge-triggered; a permanently restricted dish never publishes at all
         },
         new AlertRule
         {
+            // Unlike every other recovery rule, this one type closes SIX different conditions and
+            // they all share the dish's device id - so a cooldown here would swallow the second
+            // condition's recovery whenever two clear together.
             Name = "Starlink: Recovered",
             IsEnabled = false,
             EventTypePattern = "starlink.recovered",
             Source = "starlink",
             MinSeverity = AlertSeverity.Info,
-            CooldownSeconds = 60 // 1 minute - recoveries are paired with the alert they close
+            CooldownSeconds = 0
         }
     ];
 }

--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -477,6 +477,80 @@ public static class DefaultAlertRules
             Source = "cellular",
             MinSeverity = AlertSeverity.Warning,
             CooldownSeconds = 3600 // 1 hour
+        },
+
+        // --- Starlink dish (disabled until user configures a dish) ---
+        // Severity here does NOT follow the per-WAN outage table, which rates a backup's troubles
+        // lower. Starlink is usually the backup, and a backup that nothing else monitors is
+        // discovered broken at the moment it is needed - so its problems keep real severity.
+        new AlertRule
+        {
+            // The dish's own verdict on itself: its alert codes, a self-test that started failing,
+            // and being taken out of service. Warning, or Critical when it publishes as disabled.
+            Name = "Starlink: Dish Fault",
+            IsEnabled = false,
+            EventTypePattern = "starlink.dish_alert",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 1800 // 30 minutes - the evaluator only republishes on new evidence
+        },
+        new AlertRule
+        {
+            Name = "Starlink: Obstructed",
+            IsEnabled = false,
+            EventTypePattern = "starlink.obstructed",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+        new AlertRule
+        {
+            // Nobody can act on this twice in a day: it needs somebody to physically re-aim the dish.
+            Name = "Starlink: Alignment Drift",
+            IsEnabled = false,
+            EventTypePattern = "starlink.alignment_drift",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 86400 // 24 hours
+        },
+        new AlertRule
+        {
+            Name = "Starlink: Ethernet Speed Degraded",
+            IsEnabled = false,
+            EventTypePattern = "starlink.eth_speed_degraded",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 3600 // 1 hour
+        },
+        new AlertRule
+        {
+            // The metric is outage seconds per day, so a shorter cooldown would say the same thing twice.
+            Name = "Starlink: Repeated Outages",
+            IsEnabled = false,
+            EventTypePattern = "starlink.outage_burst",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 86400 // 24 hours
+        },
+        new AlertRule
+        {
+            // Info on purpose: crossing into a rate limit is a change worth a quiet note, not a
+            // fault, and this rule has to match the Info the evaluator publishes.
+            Name = "Starlink: Service Rate Limited",
+            IsEnabled = false,
+            EventTypePattern = "starlink.service_restricted",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 3600 // 1 hour
+        },
+        new AlertRule
+        {
+            Name = "Starlink: Recovered",
+            IsEnabled = false,
+            EventTypePattern = "starlink.recovered",
+            Source = "starlink",
+            MinSeverity = AlertSeverity.Info,
+            CooldownSeconds = 60 // 1 minute - recoveries are paired with the alert they close
         }
     ];
 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1803,6 +1803,19 @@
                     </div>
                 </div>
                 <div>
+                    <h4 class="event-type-group-header">Starlink</h4>
+                    <div class="event-type-key-list">
+                        <div @onclick='() => SelectEventType("starlink.dish_alert")'><code>starlink.dish_alert</code> <span>Dish reporting a fault or out of service</span></div>
+                        <div @onclick='() => SelectEventType("starlink.obstructed")'><code>starlink.obstructed</code> <span>Sky view blocked or signal persistently low</span></div>
+                        <div @onclick='() => SelectEventType("starlink.alignment_drift")'><code>starlink.alignment_drift</code> <span>Dish pointing away from where it normally sits</span></div>
+                        <div @onclick='() => SelectEventType("starlink.eth_speed_degraded")'><code>starlink.eth_speed_degraded</code> <span>Ethernet link negotiated below its usual speed</span></div>
+                        <div @onclick='() => SelectEventType("starlink.outage_burst")'><code>starlink.outage_burst</code> <span>Dish outage seconds piling up over a day</span></div>
+                        <div @onclick='() => SelectEventType("starlink.service_restricted")'><code>starlink.service_restricted</code> <span>Service became rate limited</span></div>
+                        <div @onclick='() => SelectEventType("starlink.recovered")'><code>starlink.recovered</code> <span>A dish condition cleared</span></div>
+                        <div @onclick='() => SelectEventType("starlink.*")'><code>starlink.*</code> <span>All Starlink events</span></div>
+                    </div>
+                </div>
+                <div>
                     <h4 class="event-type-group-header">WAN Data Usage</h4>
                     <div class="event-type-key-list">
                         <div @onclick='() => SelectEventType("wan.data_usage_warning")'><code>wan.data_usage_warning</code> <span>Monthly data cap approaching</span></div>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1044,6 +1044,7 @@ using (var scope = app.Services.CreateScope())
                 AlertRuleAutoEnable.EnableFreshlySeeded(siteDb, "cable_modem", siteSeededPatterns, () => siteDb.CmConfigurations.Any());
                 AlertRuleAutoEnable.EnableFreshlySeeded(siteDb, "ont", siteSeededPatterns, () => siteDb.OntConfigurations.Any());
                 AlertRuleAutoEnable.EnableFreshlySeeded(siteDb, "cellular", siteSeededPatterns, () => siteDb.ModemConfigurations.Any());
+                AlertRuleAutoEnable.EnableFreshlySeeded(siteDb, "starlink", siteSeededPatterns, () => siteDb.StarlinkConfigurations.Any());
             }
 
             if (NetworkOptimizer.Core.FeatureFlags.SchedulingEnabled && !siteDb.ScheduledTasks.Any())
@@ -1120,6 +1121,7 @@ using (var scope = app.Services.CreateScope())
             AlertRuleAutoEnable.EnableFreshlySeeded(db, "cable_modem", seededPatterns, () => db.CmConfigurations.Any());
             AlertRuleAutoEnable.EnableFreshlySeeded(db, "ont", seededPatterns, () => db.OntConfigurations.Any());
             AlertRuleAutoEnable.EnableFreshlySeeded(db, "cellular", seededPatterns, () => db.ModemConfigurations.Any());
+            AlertRuleAutoEnable.EnableFreshlySeeded(db, "starlink", seededPatterns, () => db.StarlinkConfigurations.Any());
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
@@ -312,7 +312,7 @@ public class StarlinkAlertEvaluator
             "Starlink {Dish} alerting: wan={Wan} obstruction={Obstruction} snrLow={SnrLow} " +
             "align={Current}/{Baseline}deg drift={Drift} samples={Samples} uncertainty={Uncertainty}{Gated} " +
             "eth={Eth}/{Capable}Mbps outages24h={Outage}s restricted={Restricted} open=[{Open}]",
-            subject.DishName,
+            subject.ShortName,
             subject.WanLabel ?? "unbound",
             Show(stats.FractionObstructed),
             stats.IsSnrPersistentlyLow?.ToString() ?? "n/a",
@@ -327,6 +327,34 @@ public class StarlinkAlertEvaluator
             Show(state.OutageSamples.Sum(s => s.Seconds)),
             state.WasRestricted?.ToString() ?? "n/a",
             open.Count == 0 ? "none" : string.Join(",", open));
+    }
+
+    /// <summary>
+    /// Drops a leading or trailing "Starlink" from a name, so wording that already says Starlink
+    /// does not say it twice. Both ends matter: our own templates put the word in front, so
+    /// "Starlink Roof" and "Roof Starlink" double up identically.
+    ///
+    /// <para>
+    /// A name that is nothing BUT "Starlink" - a plausible thing to call your only dish - strips to
+    /// nothing, and falls back to a generic noun rather than leaving a hole in the sentence.
+    /// </para>
+    ///
+    /// <para>
+    /// The word is left alone anywhere else in the name. "My Starlink Dish" still reads a little
+    /// redundant, but cutting from the middle mangles names far more often than it tidies them.
+    /// </para>
+    /// </summary>
+    private static string WithoutStarlinkMention(string name, string fallback)
+    {
+        const string word = "Starlink";
+        var trimmed = name.Trim();
+
+        if (trimmed.StartsWith(word, StringComparison.OrdinalIgnoreCase))
+            trimmed = trimmed[word.Length..].TrimStart(' ', '-', ':');
+        else if (trimmed.EndsWith(word, StringComparison.OrdinalIgnoreCase))
+            trimmed = trimmed[..^word.Length].TrimEnd(' ', '-', ':');
+
+        return trimmed.Length == 0 ? fallback : trimmed;
     }
 
     /// <summary>A number for the diagnostic line, or "n/a" where the dish reported none.</summary>
@@ -410,7 +438,7 @@ public class StarlinkAlertEvaluator
         var codeList = string.Join(", ", codes);
         var sentences = new List<string>();
         if (disabled)
-            sentences.Add($"Starlink has taken {subject.Label} out of service (disablement code {disablement}).");
+            sentences.Add($"Starlink has taken {subject.ShortLabel} out of service (disablement code {disablement}).");
         if (codes.Count > 0)
             sentences.Add($"The dish reports: {codeList}.");
         if (state.SelfTestRegressed)
@@ -418,7 +446,7 @@ public class StarlinkAlertEvaluator
         var message = string.Join(" ", sentences);
 
         _logger.LogDebug("Starlink dish {Name} reporting {Codes} (disablement {Disablement})",
-            subject.DishName, codeList, disablement);
+            subject.ShortName, codeList, disablement);
 
         await _eventBus.PublishAsync(new AlertEvent
         {
@@ -491,7 +519,7 @@ public class StarlinkAlertEvaluator
                 : $"The dish has been {FormatPercent(fraction)} obstructed";
 
         _logger.LogDebug("Starlink dish {Name} obstructed: fraction={Fraction} snrLow={SnrLow}",
-            subject.DishName, fraction, snrLow);
+            subject.ShortName, fraction, snrLow);
 
         await _eventBus.PublishAsync(new AlertEvent
         {
@@ -590,7 +618,7 @@ public class StarlinkAlertEvaluator
         if (transition != GateTransition.Opened) return;
 
         _logger.LogDebug("Starlink dish {Name} alignment drifted: current={Current} baseline={Baseline}",
-            subject.DishName, current, baseline);
+            subject.ShortName, current, baseline);
 
         await _eventBus.PublishAsync(new AlertEvent
         {
@@ -647,7 +675,7 @@ public class StarlinkAlertEvaluator
         if (transition != GateTransition.Opened) return;
 
         _logger.LogDebug("Starlink dish {Name} Ethernet negotiated {Current} Mbps against {Capable} Mbps",
-            subject.DishName, current, capable);
+            subject.ShortName, current, capable);
 
         await _eventBus.PublishAsync(new AlertEvent
         {
@@ -702,7 +730,7 @@ public class StarlinkAlertEvaluator
 
         var cause = string.IsNullOrWhiteSpace(stats.LastOutageCause) ? null : stats.LastOutageCause;
         _logger.LogDebug("Starlink dish {Name} outage burst: {Seconds}s in the last day (last cause {Cause})",
-            subject.DishName, total, cause);
+            subject.ShortName, total, cause);
 
         await _eventBus.PublishAsync(new AlertEvent
         {
@@ -766,7 +794,7 @@ public class StarlinkAlertEvaluator
                 up == null ? null : $"uplink {up}",
             }.Where(r => r != null));
 
-            _logger.LogDebug("Starlink dish {Name} entered a restricted state: {Reasons}", subject.DishName, reasons);
+            _logger.LogDebug("Starlink dish {Name} entered a restricted state: {Reasons}", subject.ShortName, reasons);
 
             await _eventBus.PublishAsync(new AlertEvent
             {
@@ -803,7 +831,7 @@ public class StarlinkAlertEvaluator
     private ValueTask PublishRecovered(DishSubject subject, string recoveredType, string what, string detail,
         CancellationToken ct)
     {
-        _logger.LogDebug("Starlink dish {Name} recovered from {Type}", subject.DishName, recoveredType);
+        _logger.LogDebug("Starlink dish {Name} recovered from {Type}", subject.ShortName, recoveredType);
 
         return _eventBus.PublishAsync(new AlertEvent
         {
@@ -881,6 +909,21 @@ public class StarlinkAlertEvaluator
     private readonly record struct DishSubject(int Id, string DishName, string? WanLabel)
     {
         public string Label => string.IsNullOrWhiteSpace(WanLabel) ? DishName : WanLabel!;
+
+        /// <summary>
+        /// <see cref="Label"/> for the few sentences whose own wording already says Starlink.
+        /// Dishes and Starlink WANs are commonly named "Starlink Roof" or just "Starlink", which
+        /// would otherwise render as "Starlink has taken Starlink Roof out of service".
+        /// <para>
+        /// Only for those. Titles keep the full name: a title is often all that reaches a
+        /// notification channel, and trimming the service out of it would lose what the alert is
+        /// even about.
+        /// </para>
+        /// </summary>
+        public string ShortLabel => WithoutStarlinkMention(Label, "the dish");
+
+        /// <summary>The dish's own name for log templates that already open with "Starlink".</summary>
+        public string ShortName => WithoutStarlinkMention(DishName, "dish");
 
         public string DeviceId => $"{DeviceIdPrefix}{Id}";
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
@@ -69,13 +69,23 @@ public class StarlinkAlertEvaluator
     /// How long a condition must hold before an obstruction alert opens, and how long its clear
     /// condition must hold before one closes. Obstruction is momentary by design - the dish loses
     /// a satellite behind a branch and picks up another - so a window is mandatory here, not a
-    /// nicety.
+    /// nicety. It costs little on <c>FractionObstructed</c>, which is already a long rolling
+    /// average and cannot spike and recover inside the window, and does the real work on
+    /// <c>IsSnrPersistentlyLow</c>, which is a bare boolean that can.
+    ///
+    /// <para>
+    /// The same rolling average means RECOVERY lags: when the branch finally comes down the
+    /// fraction decays over hours, so the alert closes long after the sky cleared. That is the
+    /// metric's nature rather than a bug, and shortening the window would not change it.
+    /// </para>
     /// </summary>
     private static readonly TimeSpan ObstructionSustain = TimeSpan.FromMinutes(15);
 
     /// <summary>
     /// Obstruction fraction an open alert has to fall back under to close. Set below the raise
-    /// bar so a dish sitting right at 2% does not alternate between alert and recovery.
+    /// bar so a dish sitting right at 2% does not alternate between alert and recovery. There is
+    /// room for both: the reference dish runs at a median 0.06% obstructed and never exceeded
+    /// 0.1% in 30 days, so the raise bar sits some twenty times above anything healthy.
     /// </summary>
     private const double ObstructionClearFraction = StarlinkHealthThresholds.ObstructionFractionPoor * 0.75;
 
@@ -101,18 +111,43 @@ public class StarlinkAlertEvaluator
     /// </summary>
     private static readonly TimeSpan AlignmentSampleWindow = TimeSpan.FromHours(1);
 
-    /// <summary>Samples needed in the window before a median means anything. Five covers a dish polled every 5 minutes.</summary>
+    /// <summary>
+    /// Samples needed in the window before a median means anything. The reference dish lands about
+    /// 730 points a day, one every two minutes, so an hour holds around thirty and this floor is
+    /// only ever reached while the window is filling or after a gap in polling.
+    /// </summary>
     private const int MinAlignmentSamples = 5;
 
     /// <summary>
     /// Attitude uncertainty above which the dish does not know where it is pointing, so a computed
-    /// drift is measuring its confusion rather than its aim. An uncertainty of half the trigger
-    /// already makes the two indistinguishable, hence 1 degree. Sustained high uncertainty is a GPS
-    /// or IMU problem in its own right; it is not alerted here.
+    /// drift is measuring its confusion rather than its aim.
+    ///
+    /// <para>
+    /// Set from the reference dish's own 30 day distribution, because the intuitive value is badly
+    /// wrong. A healthy dish is nowhere near certain of its attitude: p50 0.70, p95 1.49, p99 1.83,
+    /// max 2.71 degrees. A bar anywhere near the 2 degree drift trigger would gate out most healthy
+    /// samples, and since a gated poll stalls the sustain, the drift alert would never survive its
+    /// 30 minute window - it would be dead rather than quiet. Four degrees sits about 1.5x the
+    /// observed maximum, so ordinary operation never gates and only genuine confusion does.
+    /// </para>
+    ///
+    /// <para>
+    /// The gate earns its place: mean uncertainty rises monotonically with how far the offset has
+    /// strayed from its median (0.77 within 0.15 degrees, 0.90 to 0.3, 1.10 to 0.6, 1.19 beyond),
+    /// so the excursions this rule must not mistake for movement do come with the dish saying it is
+    /// less sure. Note that uncertainty is NOT the noise on the computed offset, which is far
+    /// tighter (98% of readings within 0.27 degrees of the median) - it is the dish's own stated
+    /// confidence, and it is conservative. Sustained high uncertainty is a GPS or IMU problem in
+    /// its own right; it is not alerted here.
+    /// </para>
     /// </summary>
-    private const double AttitudeUncertaintyMaxDeg = 1.0;
+    private const double AttitudeUncertaintyMaxDeg = 4.0;
 
-    /// <summary>Rolling window the outage-burst rule sums the dish's own outage seconds over.</summary>
+    /// <summary>
+    /// Rolling window the outage-burst rule sums the dish's own outage seconds over. The bar it is
+    /// summed against has room: the reference dish logged between 1 and 31 seconds of outage a day
+    /// over 30 days, a median of 13, against a 300 second bar.
+    /// </summary>
     private static readonly TimeSpan OutageWindow = TimeSpan.FromDays(1);
 
     /// <summary>Outage seconds per day an open burst alert has to fall back under to close.</summary>
@@ -126,17 +161,31 @@ public class StarlinkAlertEvaluator
     private static readonly TimeSpan EthSpeedSustain = TimeSpan.FromMinutes(5);
 
     /// <summary>
-    /// Dish alert codes a healthy terminal reports as a matter of course. Each is a state, not a
-    /// fault, and each would otherwise alert continuously:
+    /// Dish alert codes that describe a state rather than a fault, and so must never raise one.
     /// <list type="bullet">
-    /// <item><c>install_pending</c> - continuous for the whole 7 day reference window on a dish with nothing wrong.</item>
+    /// <item>
+    /// <c>install_pending</c> - MEASURED. The only code the reference dish raised in 30 days, and
+    /// it raised it continuously while nothing was wrong. Without this entry the product would
+    /// alert on day one and never stop, which is the failure this whole list exists to prevent.
+    /// </item>
     /// <item><c>is_heating</c> - the dish heating itself in cold weather, which is it working.</item>
     /// <item><c>is_power_save_idle</c> - a power-save setting the owner chose.</item>
     /// <item><c>roaming</c> - a service mode, and mobility is deliberately never treated as a fault here.</item>
     /// <item><c>obstruction_map_reset</c> - housekeeping after a move or reboot, not damage.</item>
     /// </list>
-    /// Everything else the dish raises is passed through verbatim: these are SpaceX's own
-    /// judgment about its hardware, and translating them would only lose information.
+    /// Only the first is measured; the other four are judged on what the code means, since nothing
+    /// has been observed raising them. Everything else the dish reports is passed through verbatim:
+    /// these are SpaceX's own judgment about its own hardware, and translating them would only lose
+    /// what a search for the exact string turns up.
+    ///
+    /// <para>
+    /// The reference dish is fixed-tilt, motorless and permanently rate restricted, and raised
+    /// NOTHING else across 30 days - which is real evidence that codes like
+    /// <c>mast_not_near_vertical</c>, <c>motors_stuck</c> and <c>low_motor_current</c> are not
+    /// simply always-on for that class of install, and so belong outside this list. If some other
+    /// hardware or firmware does report a code continuously while healthy, the symptom is one
+    /// alert per app restart on that install, and the fix is an entry here.
+    /// </para>
     /// </summary>
     private static readonly HashSet<string> BenignDishAlerts = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -479,8 +528,8 @@ public class StarlinkAlertEvaluator
             Source = "starlink",
             Severity = AlertSeverity.Warning,
             Title = $"{subject.Label} dish alignment has drifted{_siteSuffix}",
-            Message = $"The dish is pointing {drift:0.#} degrees away from where it has been sitting " +
-                      $"({current:0.#} degrees off its target, against a long-run {baseline:0.#}), and has held there " +
+            Message = $"The dish is pointing {drift:0.#} degrees further from its ideal aim than it normally does " +
+                      $"({current:0.#} degrees off ideal now, against a long-run {baseline:0.#}), and has held there " +
                       $"for {FormatDuration(AlignmentSustain)}. A fixed mount does not correct itself, so this needs re-aiming by hand.",
             DeviceId = subject.DeviceId,
             DeviceName = subject.Label,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
@@ -1,0 +1,852 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Turns a Starlink dish's own reporting into alerts. Everything here hangs off the dish poll
+/// rather than off <see cref="MonitoringAlertEvaluator"/>, because Starlink is usually a backup
+/// WAN with no vantage, no agent and no monitored targets at all: the dish is the only sensor on
+/// that link, so these must fire for a WAN nothing else watches.
+///
+/// <para>
+/// Nothing here correlates with per-WAN outage alerting, deliberately. A dish outage that also
+/// darkens monitored targets should raise both: they carry different evidence, and "the dish says
+/// it is obstructed" alongside "the WAN is down" is a better story than either alone.
+/// </para>
+///
+/// <para>
+/// Severity does NOT follow the per-WAN outage table, which rates a backup's troubles lower
+/// because service is unaffected. The opposite applies to a dish: a degraded primary announces
+/// itself, while a degraded backup is silent by construction and is discovered at the moment it
+/// is needed. Knowing the backup is unhealthy before the primary drops is the point of watching
+/// it, so backup dish problems keep real severity.
+/// </para>
+///
+/// <para>
+/// Every rule is written against a VALUE, never against "the field is set". On the reference dish
+/// (fixed tilt, permanently rate-restricted subscription) <c>disablement_code</c> reads
+/// <c>Okay</c>, <c>alerts</c> carries <c>install_pending</c> continuously, <c>hardware_self_test</c>
+/// reads <c>Failed</c> continuously, and both restriction reasons are permanently populated -
+/// all while nothing is wrong. Any "has a value" test would fire on day one and never stop.
+/// </para>
+///
+/// <para>
+/// State is in memory only, so a restart re-arms every rule: an already-open condition raises its
+/// alert once more, and the windowed rules (alignment, outage burst) stay quiet until they have
+/// gathered enough samples again. That is the accepted cost of never persisting a verdict that
+/// could go stale against a dish that has since recovered.
+/// </para>
+/// </summary>
+public class StarlinkAlertEvaluator
+{
+    // --- Event types -------------------------------------------------------------------------
+
+    internal const string DishAlertEvent = "starlink.dish_alert";
+    internal const string ObstructedEvent = "starlink.obstructed";
+    internal const string AlignmentDriftEvent = "starlink.alignment_drift";
+    internal const string EthSpeedDegradedEvent = "starlink.eth_speed_degraded";
+    internal const string OutageBurstEvent = "starlink.outage_burst";
+    internal const string ServiceRestrictedEvent = "starlink.service_restricted";
+    internal const string RecoveredEvent = "starlink.recovered";
+
+    /// <summary>
+    /// Context key on a <see cref="RecoveredEvent"/> naming the event type it closes. Matched by
+    /// <c>AlertProcessingService.StarlinkRecoveredTypeKey</c>, which cannot reference this project;
+    /// the two must stay in step, exactly as the WAN outage family's rollup device id does.
+    /// </summary>
+    internal const string RecoveredTypeKey = "recovered_type";
+
+    /// <summary>Prefix of the AlertEvent.DeviceId these alerts carry, so one dish's alerts close only its own.</summary>
+    internal const string DeviceIdPrefix = "starlink:";
+
+    // --- Tuning ------------------------------------------------------------------------------
+
+    /// <summary>
+    /// How long a condition must hold before an obstruction alert opens, and how long its clear
+    /// condition must hold before one closes. Obstruction is momentary by design - the dish loses
+    /// a satellite behind a branch and picks up another - so a window is mandatory here, not a
+    /// nicety.
+    /// </summary>
+    private static readonly TimeSpan ObstructionSustain = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Obstruction fraction an open alert has to fall back under to close. Set below the raise
+    /// bar so a dish sitting right at 2% does not alternate between alert and recovery.
+    /// </summary>
+    private const double ObstructionClearFraction = StarlinkHealthThresholds.ObstructionFractionPoor * 0.75;
+
+    /// <summary>
+    /// How far the dish's current alignment may sit from its own baseline before it needs
+    /// re-aiming. Measured on the reference dish over 30 days, 98% of readings fall within 0.27
+    /// degrees of the median, so 2 degrees is about seven times the healthy band: nothing but real
+    /// movement reaches it. This is the operator's bar and should not be moved to accommodate a
+    /// noisier install - lengthen <see cref="AlignmentSustain"/> instead.
+    /// </summary>
+    private const double AlignmentDriftDeg = 2.0;
+
+    /// <summary>Drift an open alignment alert has to fall back under to close, below the raise bar so it cannot flap.</summary>
+    private const double AlignmentClearDeg = AlignmentDriftDeg * 0.75;
+
+    /// <summary>How long the drift has to hold, both to open the alert and to close it.</summary>
+    private static readonly TimeSpan AlignmentSustain = TimeSpan.FromMinutes(30);
+
+    /// <summary>
+    /// The current alignment is the median of this window rather than the latest sample: single
+    /// samples wander up to ~1.6 degrees from the median on a perfectly healthy dish, which would
+    /// put a spurious trigger within reach of the 2 degree bar. Comparing medians does not.
+    /// </summary>
+    private static readonly TimeSpan AlignmentSampleWindow = TimeSpan.FromHours(1);
+
+    /// <summary>Samples needed in the window before a median means anything. Five covers a dish polled every 5 minutes.</summary>
+    private const int MinAlignmentSamples = 5;
+
+    /// <summary>
+    /// Attitude uncertainty above which the dish does not know where it is pointing, so a computed
+    /// drift is measuring its confusion rather than its aim. An uncertainty of half the trigger
+    /// already makes the two indistinguishable, hence 1 degree. Sustained high uncertainty is a GPS
+    /// or IMU problem in its own right; it is not alerted here.
+    /// </summary>
+    private const double AttitudeUncertaintyMaxDeg = 1.0;
+
+    /// <summary>Rolling window the outage-burst rule sums the dish's own outage seconds over.</summary>
+    private static readonly TimeSpan OutageWindow = TimeSpan.FromDays(1);
+
+    /// <summary>Outage seconds per day an open burst alert has to fall back under to close.</summary>
+    private const double OutageClearSecondsPerDay = StarlinkHealthThresholds.OutageSecondsPerDayPoor * 0.5;
+
+    /// <summary>
+    /// How long a downshifted Ethernet link has to hold before it alerts. A renegotiation during a
+    /// reboot or a cable reseat settles well inside this, and the rule is about a link that stays
+    /// capped.
+    /// </summary>
+    private static readonly TimeSpan EthSpeedSustain = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Dish alert codes a healthy terminal reports as a matter of course. Each is a state, not a
+    /// fault, and each would otherwise alert continuously:
+    /// <list type="bullet">
+    /// <item><c>install_pending</c> - continuous for the whole 7 day reference window on a dish with nothing wrong.</item>
+    /// <item><c>is_heating</c> - the dish heating itself in cold weather, which is it working.</item>
+    /// <item><c>is_power_save_idle</c> - a power-save setting the owner chose.</item>
+    /// <item><c>roaming</c> - a service mode, and mobility is deliberately never treated as a fault here.</item>
+    /// <item><c>obstruction_map_reset</c> - housekeeping after a move or reboot, not damage.</item>
+    /// </list>
+    /// Everything else the dish raises is passed through verbatim: these are SpaceX's own
+    /// judgment about its hardware, and translating them would only lose information.
+    /// </summary>
+    private static readonly HashSet<string> BenignDishAlerts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "install_pending",
+        "is_heating",
+        "is_power_save_idle",
+        "roaming",
+        "obstruction_map_reset",
+    };
+
+    private readonly IAlertEventBus _eventBus;
+    private readonly ILogger<StarlinkAlertEvaluator> _logger;
+    private readonly TimeProvider _time;
+    private readonly ConcurrentDictionary<int, DishState> _states = new();
+    private readonly string _siteSuffix;
+
+    /// <param name="siteSlug">
+    /// Site this instance evaluates for (one instance per site, owned by
+    /// <see cref="MonitoringAlertRegistry"/> - Starlink configuration ids are per-site database
+    /// sequences, so state must not be shared). Non-default sites get their slug appended to
+    /// alert titles.
+    /// </param>
+    /// <param name="timeProvider">Injected in tests so the sustain windows can be driven without waiting.</param>
+    public StarlinkAlertEvaluator(IAlertEventBus eventBus, ILogger<StarlinkAlertEvaluator> logger,
+        string siteSlug = SiteManagementService.DefaultSiteSlug,
+        TimeProvider? timeProvider = null)
+    {
+        _eventBus = eventBus;
+        _logger = logger;
+        _time = timeProvider ?? TimeProvider.System;
+        _siteSuffix = string.IsNullOrEmpty(siteSlug) || siteSlug == SiteManagementService.DefaultSiteSlug
+            ? "" : $" (site {siteSlug})";
+    }
+
+    /// <summary>
+    /// Evaluates one poll of one dish and publishes whatever changed.
+    /// </summary>
+    /// <param name="starlinkId">Configuration id of the dish (per-site database sequence).</param>
+    /// <param name="dishName">The dish's configured name, used when no WAN could be bound to it.</param>
+    /// <param name="stats">This poll's reading.</param>
+    /// <param name="alignmentOffsetDeg">
+    /// This poll's boresight offset from desired, as
+    /// <see cref="StarlinkMonitorService.ComputeAlignmentOffsetDeg"/> computes it. Null when the
+    /// dish did not report the geometry.
+    /// </param>
+    /// <param name="alignmentBaselineDeg">
+    /// The dish's own long-run median offset. Alignment is judged against this rather than against
+    /// zero: a hand-aimed fixed dish sits wherever it was mounted, several degrees off ideal from
+    /// day one, and works perfectly there. Null when there is not enough history yet, which
+    /// disables the drift rule rather than guessing.
+    /// </param>
+    /// <param name="ethCapableMbps">
+    /// The fastest Ethernet speed this dish has been seen to negotiate, which is the only evidence
+    /// available for what it is capable of. Null disables the degraded-speed rule.
+    /// </param>
+    /// <param name="wanLabel">
+    /// The WAN the dish was bound to, already formatted by <c>GatewayWanHelper.FormatWanLabel</c>.
+    /// Null when the binding is unknown, in which case alerts name the dish and still fire.
+    /// </param>
+    public async ValueTask EvaluateAsync(
+        int starlinkId,
+        string dishName,
+        StarlinkStats stats,
+        double? alignmentOffsetDeg = null,
+        double? alignmentBaselineDeg = null,
+        int? ethCapableMbps = null,
+        string? wanLabel = null,
+        CancellationToken ct = default)
+    {
+        var state = _states.GetOrAdd(starlinkId, _ => new DishState());
+        var now = _time.GetUtcNow().UtcDateTime;
+        var subject = new DishSubject(starlinkId, dishName, wanLabel);
+
+        await CheckDishAlerts(state, subject, stats, ct);
+        await CheckObstruction(state, subject, stats, now, ct);
+        await CheckAlignmentDrift(state, subject, stats, alignmentOffsetDeg, alignmentBaselineDeg, now, ct);
+        await CheckEthSpeed(state, subject, stats, ethCapableMbps, now, ct);
+        await CheckOutageBurst(state, subject, stats, now, ct);
+        await CheckServiceRestriction(state, subject, stats, ct);
+    }
+
+    // --- starlink.dish_alert -----------------------------------------------------------------
+
+    /// <summary>
+    /// The dish's own verdict on itself, folded into one event: the alert codes it raises, a
+    /// self-test that has started failing, and a disablement code other than <c>Okay</c>. Three
+    /// separate types would all have meant the same thing to an operator ("go look at the dish"),
+    /// so they share one, and the alert names whichever of them is live.
+    ///
+    /// <para>
+    /// The self-test is a TRANSITION from passing to failing, never a standing state. The
+    /// reference dish reports <c>Failed</c> continuously while entirely healthy, so what a healthy
+    /// dish of a given hardware revision and firmware reports is not knowable in general - only
+    /// that a dish which was passing and is now failing has changed. A dish that has always failed
+    /// its self-test therefore never raises this on that account alone.
+    /// </para>
+    /// </summary>
+    private async ValueTask CheckDishAlerts(DishState state, DishSubject subject, StarlinkStats stats,
+        CancellationToken ct)
+    {
+        var selfTest = Normalize(stats.HardwareSelfTest);
+        if (selfTest == "passed")
+        {
+            state.SelfTestHasPassed = true;
+            state.SelfTestRegressed = false;
+        }
+        else if (selfTest == "failed" && state.SelfTestHasPassed)
+        {
+            state.SelfTestRegressed = true;
+        }
+
+        var disablement = stats.DisablementCode;
+        var disabled = IsDisabled(disablement);
+
+        // The dish's codes verbatim - they are SpaceX's own vocabulary for its own hardware, and
+        // paraphrasing them would only lose what a search for the exact string turns up.
+        var codes = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var code in stats.ActiveAlerts)
+        {
+            if (!string.IsNullOrWhiteSpace(code) && !BenignDishAlerts.Contains(code))
+                codes.Add(code);
+        }
+
+        // The signature the open alert was raised for. It carries the disablement code and the
+        // self-test regression alongside the dish's codes so that either one arriving counts as
+        // new evidence, but neither is presented to the reader as a dish alert code.
+        var signature = new SortedSet<string>(codes, StringComparer.OrdinalIgnoreCase);
+        if (state.SelfTestRegressed) signature.Add("hardware_self_test:failed");
+        if (disabled) signature.Add($"disablement:{disablement}");
+
+        if (signature.Count == 0)
+        {
+            if (state.OpenDishAlertCodes.Count > 0)
+            {
+                state.OpenDishAlertCodes.Clear();
+                await PublishRecovered(subject, DishAlertEvent, "dish fault",
+                    "The dish is no longer reporting a fault.", ct);
+            }
+            return;
+        }
+
+        // Only new evidence republishes: a standing set stays as the one open alert it already
+        // raised. Something appearing on top of the open set, or the dish going from "complaining"
+        // to "out of service", is new evidence and supersedes it.
+        var severity = disabled ? AlertSeverity.Critical : AlertSeverity.Warning;
+        if (state.OpenDishAlertCodes.Count > 0
+            && signature.IsSubsetOf(state.OpenDishAlertCodes)
+            && severity == state.OpenDishAlertSeverity)
+        {
+            return;
+        }
+
+        state.OpenDishAlertCodes = new HashSet<string>(signature, StringComparer.OrdinalIgnoreCase);
+        state.OpenDishAlertSeverity = severity;
+
+        var codeList = string.Join(", ", codes);
+        var sentences = new List<string>();
+        if (disabled)
+            sentences.Add($"Starlink has taken {subject.Label} out of service (disablement code {disablement}).");
+        if (codes.Count > 0)
+            sentences.Add($"The dish reports: {codeList}.");
+        if (state.SelfTestRegressed)
+            sentences.Add("Its hardware self-test was passing and is now failing.");
+        var message = string.Join(" ", sentences);
+
+        _logger.LogDebug("Starlink dish {Name} reporting {Codes} (disablement {Disablement})",
+            subject.DishName, codeList, disablement);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = DishAlertEvent,
+            Source = "starlink",
+            Severity = severity,
+            Title = disabled
+                ? $"{subject.Label} is out of service{_siteSuffix}"
+                : $"{subject.Label} dish reports a fault{_siteSuffix}",
+            Message = message,
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "dish"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                ["dish_alerts"] = codeList,
+                ["disablement_code"] = disablement ?? "",
+                ["hardware_self_test"] = stats.HardwareSelfTest ?? "",
+            })
+        }, ct);
+    }
+
+    // --- starlink.obstructed -----------------------------------------------------------------
+
+    /// <summary>
+    /// One type for both ways the dish can lose its view of the sky, because the remedy is the
+    /// same either way: it cannot see enough of it. A sustained obstruction fraction is the
+    /// measured version; the dish's own persistently-low-SNR flag is its version.
+    /// </summary>
+    private async ValueTask CheckObstruction(DishState state, DishSubject subject, StarlinkStats stats,
+        DateTime now, CancellationToken ct)
+    {
+        var fraction = stats.FractionObstructed;
+        var snrLow = stats.IsSnrPersistentlyLow == true;
+
+        // A poll that reported neither signal says nothing either way, so it neither advances a
+        // pending run nor counts against one - otherwise a run interrupted by a gap in reporting
+        // would confirm on the far side of it as if it had held throughout.
+        if (fraction is null && stats.IsSnrPersistentlyLow is null)
+        {
+            state.Obstruction.Stall();
+            return;
+        }
+
+        var raise = snrLow || fraction >= StarlinkHealthThresholds.ObstructionFractionPoor;
+        var clear = !snrLow && (fraction is null || fraction < ObstructionClearFraction);
+        var critical = fraction >= StarlinkHealthThresholds.ObstructionFractionCritical;
+
+        var transition = state.Obstruction.Observe(raise, clear, now, ObstructionSustain);
+        var escalated = state.Obstruction.Open && critical && !state.ObstructionCritical;
+
+        if (transition == GateTransition.Closed)
+        {
+            state.ObstructionCritical = false;
+            await PublishRecovered(subject, ObstructedEvent, "obstruction",
+                "The dish has a clear enough view of the sky again.", ct);
+            return;
+        }
+
+        if (transition != GateTransition.Opened && !escalated) return;
+
+        state.ObstructionCritical = critical;
+
+        var reason = snrLow && fraction >= StarlinkHealthThresholds.ObstructionFractionPoor
+            ? $"The dish has been {FormatPercent(fraction)} obstructed and reports persistently low signal"
+            : snrLow
+                ? "The dish reports persistently low signal"
+                : $"The dish has been {FormatPercent(fraction)} obstructed";
+
+        _logger.LogDebug("Starlink dish {Name} obstructed: fraction={Fraction} snrLow={SnrLow}",
+            subject.DishName, fraction, snrLow);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = ObstructedEvent,
+            Source = "starlink",
+            Severity = critical ? AlertSeverity.Critical : AlertSeverity.Warning,
+            Title = $"{subject.Label} dish is obstructed{_siteSuffix}",
+            Message = $"{reason} for at least {FormatDuration(ObstructionSustain)}. " +
+                      "Something in its view of the sky is cutting satellites off; the obstruction map on Starlink Stats shows where.",
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            MetricValue = fraction,
+            ThresholdValue = StarlinkHealthThresholds.ObstructionFractionPoor,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "obstruction"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                ["fraction_obstructed"] = Format(fraction),
+                ["snr_persistently_low"] = snrLow ? "true" : "false",
+            })
+        }, ct);
+    }
+
+    // --- starlink.alignment_drift ------------------------------------------------------------
+
+    /// <summary>
+    /// A phased array steers electronically well off boresight, so a misaligned dish does not fail
+    /// loudly - it loses margin, and drops concentrate at the times of day when satellites transit
+    /// the part of the corridor now beyond its steering range. Nobody diagnoses that, because at
+    /// any given moment everything looks fine. A fixed dish stays wrong until a human climbs up to
+    /// it, so this alert is the only way anyone learns the mount slipped after wind, snow load or
+    /// a knock.
+    ///
+    /// <para>
+    /// Judged against the dish's OWN baseline, never against desired: the reference dish sits at a
+    /// steady 3.69 degrees off desired and works fine there, so an absolute threshold would flag a
+    /// healthy install permanently.
+    /// </para>
+    ///
+    /// <para>
+    /// Deliberately NOT gated on mobility class. The obvious design suppresses drift on a roaming
+    /// dish, but the reference dish is fixed-tilt, bolted down, and reports <c>Mobile</c> - that
+    /// gate would have silenced the alert on exactly the installation it was written for. A
+    /// genuinely moving dish is handled by the baseline instead: one whose attitude changes
+    /// constantly has a baseline that moves with it and never accumulates a sustained departure.
+    /// </para>
+    /// </summary>
+    private async ValueTask CheckAlignmentDrift(DishState state, DishSubject subject, StarlinkStats stats,
+        double? offsetDeg, double? baselineDeg, DateTime now, CancellationToken ct)
+    {
+        if (offsetDeg is not double offset)
+        {
+            state.Alignment.Stall();
+            return;
+        }
+
+        // Above the uncertainty bar the dish does not know where it is pointing, so any drift
+        // computed from it measures its confusion. Neither open nor close while that holds: the
+        // sample is dropped and the sustain stalls, and an already-open alert stays open because
+        // uncertainty says nothing about whether the dish moved back.
+        if (stats.AttitudeUncertaintyDeg > AttitudeUncertaintyMaxDeg)
+        {
+            state.Alignment.Stall();
+            return;
+        }
+
+        state.AlignmentSamples.Enqueue((now, offset));
+        while (state.AlignmentSamples.Count > 0 && now - state.AlignmentSamples.Peek().At > AlignmentSampleWindow)
+            state.AlignmentSamples.Dequeue();
+
+        // No baseline (too little history, or Influx unreachable) and too few samples in the
+        // window are both "cannot judge", not "judged fine": the pending run is discarded so it
+        // cannot confirm across the gap on the strength of readings taken before it.
+        if (baselineDeg is not double baseline || state.AlignmentSamples.Count < MinAlignmentSamples)
+        {
+            state.Alignment.Stall();
+            return;
+        }
+
+        var current = Median(state.AlignmentSamples.Select(s => s.Offset));
+        var drift = Math.Abs(current - baseline);
+
+        var transition = state.Alignment.Observe(
+            drift > AlignmentDriftDeg, drift <= AlignmentClearDeg, now, AlignmentSustain);
+
+        if (transition == GateTransition.Closed)
+        {
+            await PublishRecovered(subject, AlignmentDriftEvent, "alignment drift",
+                $"The dish is pointing within {AlignmentClearDeg:0.#} degrees of where it normally sits again.", ct);
+            return;
+        }
+
+        if (transition != GateTransition.Opened) return;
+
+        _logger.LogDebug("Starlink dish {Name} alignment drifted: current={Current} baseline={Baseline}",
+            subject.DishName, current, baseline);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = AlignmentDriftEvent,
+            Source = "starlink",
+            Severity = AlertSeverity.Warning,
+            Title = $"{subject.Label} dish alignment has drifted{_siteSuffix}",
+            Message = $"The dish is pointing {drift:0.#} degrees away from where it has been sitting " +
+                      $"({current:0.#} degrees off its target, against a long-run {baseline:0.#}), and has held there " +
+                      $"for {FormatDuration(AlignmentSustain)}. A fixed mount does not correct itself, so this needs re-aiming by hand.",
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            MetricValue = drift,
+            ThresholdValue = AlignmentDriftDeg,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "alignment"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                ["alignment_offset_deg"] = Format(current),
+                ["alignment_baseline_deg"] = Format(baseline),
+                ["alignment_drift_deg"] = Format(drift),
+            })
+        }, ct);
+    }
+
+    // --- starlink.eth_speed_degraded ---------------------------------------------------------
+
+    /// <summary>
+    /// A bad cable or a bad port silently capping the service. The dish negotiates a clean
+    /// constant (1000 on the reference dish), so a drop below what it has been seen to reach is
+    /// unambiguous - and it is the only evidence available for what the dish is capable of, since
+    /// nothing reports a nameplate rate.
+    /// </summary>
+    private async ValueTask CheckEthSpeed(DishState state, DishSubject subject, StarlinkStats stats,
+        int? capableMbps, DateTime now, CancellationToken ct)
+    {
+        // A poll with no negotiated speed, or no known capable rate to compare it against, is not
+        // evidence in either direction, so the pending run is discarded rather than carried over.
+        if (stats.EthSpeedMbps is not int current || capableMbps is not int capable || capable <= 0)
+        {
+            state.EthSpeed.Stall();
+            return;
+        }
+
+        var transition = state.EthSpeed.Observe(current < capable, current >= capable, now, EthSpeedSustain);
+
+        if (transition == GateTransition.Closed)
+        {
+            await PublishRecovered(subject, EthSpeedDegradedEvent, "Ethernet speed",
+                $"The dish is negotiating {capable} Mbps again.", ct);
+            return;
+        }
+
+        if (transition != GateTransition.Opened) return;
+
+        _logger.LogDebug("Starlink dish {Name} Ethernet negotiated {Current} Mbps against {Capable} Mbps",
+            subject.DishName, current, capable);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = EthSpeedDegradedEvent,
+            Source = "starlink",
+            Severity = AlertSeverity.Warning,
+            Title = $"{subject.Label} dish Ethernet link degraded{_siteSuffix}",
+            Message = $"The dish has negotiated {current} Mbps, where it normally reaches {capable} Mbps. " +
+                      "A cable or a port is capping the connection below what the service can deliver.",
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            MetricValue = current,
+            ThresholdValue = capable,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "ethernet"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                ["eth_speed_mbps"] = current.ToString(CultureInfo.InvariantCulture),
+                ["eth_capable_mbps"] = capable.ToString(CultureInfo.InvariantCulture),
+            })
+        }, ct);
+    }
+
+    // --- starlink.outage_burst ---------------------------------------------------------------
+
+    /// <summary>
+    /// The dish's own outage log, summed over a rolling day. Individual dish outages are short and
+    /// routine; what an operator can act on is the day they stop being routine. The most recent
+    /// cause travels with the alert, which is what makes it self-explaining.
+    /// </summary>
+    private async ValueTask CheckOutageBurst(DishState state, DishSubject subject, StarlinkStats stats,
+        DateTime now, CancellationToken ct)
+    {
+        if (stats.OutageSecondsDelta > 0)
+            state.OutageSamples.Enqueue((now, stats.OutageSecondsDelta));
+        while (state.OutageSamples.Count > 0 && now - state.OutageSamples.Peek().At > OutageWindow)
+            state.OutageSamples.Dequeue();
+
+        var total = state.OutageSamples.Sum(s => s.Seconds);
+
+        if (state.OutageBurstOpen)
+        {
+            if (total >= OutageClearSecondsPerDay) return;
+            state.OutageBurstOpen = false;
+            await PublishRecovered(subject, OutageBurstEvent, "outages",
+                "The dish is back under a normal amount of downtime for the day.", ct);
+            return;
+        }
+
+        if (total < StarlinkHealthThresholds.OutageSecondsPerDayPoor) return;
+        state.OutageBurstOpen = true;
+
+        var cause = string.IsNullOrWhiteSpace(stats.LastOutageCause) ? null : stats.LastOutageCause;
+        _logger.LogDebug("Starlink dish {Name} outage burst: {Seconds}s in the last day (last cause {Cause})",
+            subject.DishName, total, cause);
+
+        await _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = OutageBurstEvent,
+            Source = "starlink",
+            Severity = AlertSeverity.Warning,
+            Title = $"{subject.Label} dish keeps dropping out{_siteSuffix}",
+            Message = $"The dish has logged {total:0} seconds of outage in the last day, past the " +
+                      $"{StarlinkHealthThresholds.OutageSecondsPerDayPoor:0} second mark." +
+                      (cause == null ? "" : $" It gave {cause} as the reason for the most recent one."),
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            MetricValue = total,
+            ThresholdValue = StarlinkHealthThresholds.OutageSecondsPerDayPoor,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "outage"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                ["outage_seconds_per_day"] = Format(total),
+                ["last_outage_cause"] = cause ?? "",
+            })
+        }, ct);
+    }
+
+    // --- starlink.service_restricted ---------------------------------------------------------
+
+    /// <summary>
+    /// Reported as a TRANSITION, never as a state. Some subscriptions are throttled by design and
+    /// report the restriction permanently - the reference dish sits at <c>LowSpeedPolicyLimit</c>
+    /// downstream and <c>PolicyLimit</c> upstream continuously, with nothing wrong - so an alert
+    /// on the standing condition would fire forever at someone who bought exactly that service.
+    /// Class of service does not separate the two cases either: that same permanently restricted
+    /// dish reads <c>Consumer</c>.
+    ///
+    /// <para>
+    /// Watching the edge instead serves both. For anyone on a plan with a data allotment, crossing
+    /// from unrestricted into restricted is the moment the allotment ran out and everything slowed
+    /// down, which is exactly when they would want to know. For a dish that is always restricted,
+    /// nothing ever transitions and nothing is ever sent.
+    /// </para>
+    /// </summary>
+    private async ValueTask CheckServiceRestriction(DishState state, DishSubject subject, StarlinkStats stats,
+        CancellationToken ct)
+    {
+        var down = RestrictionReason(stats.DownlinkRestrictedReason);
+        var up = RestrictionReason(stats.UplinkRestrictedReason);
+        var restricted = down != null || up != null;
+
+        var previous = state.WasRestricted;
+        state.WasRestricted = restricted;
+
+        // The first reading only establishes what normal looks like for this dish. Without it, a
+        // permanently restricted dish would announce its own subscription on every restart.
+        if (previous is null) return;
+
+        if (restricted && previous == false)
+        {
+            var reasons = string.Join(", ", new[]
+            {
+                down == null ? null : $"downlink {down}",
+                up == null ? null : $"uplink {up}",
+            }.Where(r => r != null));
+
+            _logger.LogDebug("Starlink dish {Name} entered a restricted state: {Reasons}", subject.DishName, reasons);
+
+            await _eventBus.PublishAsync(new AlertEvent
+            {
+                EventType = ServiceRestrictedEvent,
+                Source = "starlink",
+                Severity = AlertSeverity.Info,
+                Title = $"{subject.Label} service is now rate limited{_siteSuffix}",
+                Message = $"Starlink started limiting this connection ({reasons}). On a plan with a data " +
+                          "allotment this is the moment it ran out.",
+                DeviceId = subject.DeviceId,
+                DeviceName = subject.Label,
+                SourceUrl = subject.SourceUrl,
+                Tags = ["starlink", "restriction"],
+                Context = subject.Context(new Dictionary<string, string>
+                {
+                    ["dl_restricted_reason"] = stats.DownlinkRestrictedReason ?? "",
+                    ["ul_restricted_reason"] = stats.UplinkRestrictedReason ?? "",
+                })
+            }, ct);
+        }
+        else if (!restricted && previous == true)
+        {
+            await PublishRecovered(subject, ServiceRestrictedEvent, "rate limit",
+                "Starlink is no longer limiting this connection.", ct);
+        }
+    }
+
+    // --- starlink.recovered ------------------------------------------------------------------
+
+    /// <summary>
+    /// Closes exactly one open alert, named in <see cref="RecoveredTypeKey"/> so the processor can
+    /// resolve that dish's alert of that type and leave its other conditions alone.
+    /// </summary>
+    private ValueTask PublishRecovered(DishSubject subject, string recoveredType, string what, string detail,
+        CancellationToken ct)
+    {
+        _logger.LogDebug("Starlink dish {Name} recovered from {Type}", subject.DishName, recoveredType);
+
+        return _eventBus.PublishAsync(new AlertEvent
+        {
+            EventType = RecoveredEvent,
+            Source = "starlink",
+            Severity = AlertSeverity.Info,
+            Title = $"{subject.Label} {what} cleared{_siteSuffix}",
+            Message = detail,
+            DeviceId = subject.DeviceId,
+            DeviceName = subject.Label,
+            SourceUrl = subject.SourceUrl,
+            Tags = ["starlink", "recovered"],
+            Context = subject.Context(new Dictionary<string, string>
+            {
+                [RecoveredTypeKey] = recoveredType,
+            })
+        }, ct);
+    }
+
+    // --- Helpers ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// Whether the terminal has been taken out of service. Tested against the value, not against
+    /// "is set": a healthy dish reports <c>Okay</c> here on every poll. An unknown or absent code
+    /// is no signal at all rather than a fault.
+    /// </summary>
+    private static bool IsDisabled(string? disablementCode)
+    {
+        var value = Normalize(disablementCode);
+        return value.Length > 0 && value != "okay" && value != "unknownstate" && value != "unknown";
+    }
+
+    /// <summary>
+    /// The restriction reason when the dish is actually being limited, null when it is not.
+    /// <c>NoLimit</c> is the healthy value and an unknown reason carries no information, so
+    /// neither counts as restricted.
+    /// </summary>
+    private static string? RestrictionReason(string? reason)
+    {
+        var value = Normalize(reason);
+        return value.Length == 0 || value == "nolimit" || value == "unknown" ? null : reason;
+    }
+
+    /// <summary>
+    /// Folds a protobuf enum name to a comparable form, so <c>LOW_SPEED_POLICY_LIMIT</c> and
+    /// <c>LowSpeedPolicyLimit</c> are the same value however a provider chose to render it.
+    /// </summary>
+    private static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "" : value.Replace("_", "").Trim().ToLowerInvariant();
+
+    private static double Median(IEnumerable<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        if (sorted.Count == 0) return 0;
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2.0;
+    }
+
+    private static string Format(double? value) =>
+        value?.ToString("0.####", CultureInfo.InvariantCulture) ?? "";
+
+    private static string FormatPercent(double? fraction) =>
+        fraction is null ? "" : (fraction.Value * 100).ToString("0.##", CultureInfo.InvariantCulture) + "%";
+
+    private static string FormatDuration(TimeSpan span) =>
+        span.TotalMinutes < 60
+            ? $"{span.TotalMinutes:0} minutes"
+            : span.TotalHours == 1 ? "an hour" : $"{span.TotalHours:0} hours";
+
+    /// <summary>
+    /// How one dish is named and linked in its alerts. The WAN label wins when the dish could be
+    /// bound to one, because that is the name the rest of the product uses for a connection; the
+    /// dish's own name is the fallback, and the alert fires either way.
+    /// </summary>
+    private readonly record struct DishSubject(int Id, string DishName, string? WanLabel)
+    {
+        public string Label => string.IsNullOrWhiteSpace(WanLabel) ? DishName : WanLabel!;
+
+        public string DeviceId => $"{DeviceIdPrefix}{Id}";
+
+        public string SourceUrl => $"/monitoring?tab=starlink&starlink={Id}";
+
+        public Dictionary<string, string> Context(Dictionary<string, string> extra)
+        {
+            extra["starlink_id"] = Id.ToString(CultureInfo.InvariantCulture);
+            extra["dish_name"] = DishName;
+            if (!string.IsNullOrWhiteSpace(WanLabel)) extra["wan_label"] = WanLabel!;
+            return extra;
+        }
+    }
+
+    private enum GateTransition { None, Opened, Closed }
+
+    /// <summary>
+    /// Two-sided sustain. A condition must hold for the window to open an alert, and its clear
+    /// condition must hold just as long to close one, so a value hovering at the bar produces one
+    /// alert and one recovery rather than a stream of both.
+    /// </summary>
+    private sealed class SustainGate
+    {
+        private DateTime? _raiseSince;
+        private DateTime? _clearSince;
+
+        public bool Open { get; private set; }
+
+        public GateTransition Observe(bool raise, bool clear, DateTime now, TimeSpan window)
+        {
+            _raiseSince = raise ? _raiseSince ?? now : null;
+            _clearSince = clear ? _clearSince ?? now : null;
+
+            if (!Open && _raiseSince is { } raiseSince && now - raiseSince >= window)
+            {
+                Open = true;
+                _clearSince = null;
+                return GateTransition.Opened;
+            }
+
+            if (Open && _clearSince is { } clearSince && now - clearSince >= window)
+            {
+                Open = false;
+                _raiseSince = null;
+                return GateTransition.Closed;
+            }
+
+            return GateTransition.None;
+        }
+
+        /// <summary>
+        /// Discards both pending runs without changing whether the alert is open, for a poll whose
+        /// reading says nothing either way.
+        /// </summary>
+        public void Stall()
+        {
+            _raiseSince = null;
+            _clearSince = null;
+        }
+    }
+
+    private sealed class DishState
+    {
+        /// <summary>Codes the currently open dish_alert was raised for, so a standing set does not republish.</summary>
+        public HashSet<string> OpenDishAlertCodes = new(StringComparer.OrdinalIgnoreCase);
+
+        public AlertSeverity OpenDishAlertSeverity;
+
+        /// <summary>Whether this dish has ever been seen to pass its self-test, which is what makes a later failure a change.</summary>
+        public bool SelfTestHasPassed;
+
+        public bool SelfTestRegressed;
+
+        public readonly SustainGate Obstruction = new();
+        public bool ObstructionCritical;
+
+        public readonly SustainGate Alignment = new();
+        public readonly Queue<(DateTime At, double Offset)> AlignmentSamples = new();
+
+        public readonly SustainGate EthSpeed = new();
+
+        public readonly Queue<(DateTime At, double Seconds)> OutageSamples = new();
+        public bool OutageBurstOpen;
+
+        /// <summary>Null until the first poll: the first reading only establishes what normal looks like.</summary>
+        public bool? WasRestricted;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
@@ -259,12 +259,26 @@ public class StarlinkAlertEvaluator
         var now = _time.GetUtcNow().UtcDateTime;
         var subject = new DishSubject(starlinkId, dishName, wanLabel);
 
-        await CheckDishAlerts(state, subject, stats, ct);
-        await CheckObstruction(state, subject, stats, now, ct);
-        await CheckAlignmentDrift(state, subject, stats, alignmentOffsetDeg, alignmentBaselineDeg, now, ct);
-        await CheckEthSpeed(state, subject, stats, ethCapableMbps, now, ct);
-        await CheckOutageBurst(state, subject, stats, now, ct);
-        await CheckServiceRestriction(state, subject, stats, ct);
+        // One evaluation per dish at a time. The timer poll is single-flighted against itself, but
+        // the Starlink Stats panel calls PollStarlinkAsync directly (Refresh, moving between
+        // terminals, first paint on an empty cache) and that path has no such guard - so two polls
+        // of the SAME dish can be in flight together. This state is not thread-safe: the sample
+        // windows are plain Queues, whose concurrent Enqueue/Dequeue corrupts their internal
+        // indices rather than merely racing. A lock cannot span the awaits, hence the semaphore.
+        await state.Gate.WaitAsync(ct);
+        try
+        {
+            await CheckDishAlerts(state, subject, stats, ct);
+            await CheckObstruction(state, subject, stats, now, ct);
+            await CheckAlignmentDrift(state, subject, stats, alignmentOffsetDeg, alignmentBaselineDeg, now, ct);
+            await CheckEthSpeed(state, subject, stats, ethCapableMbps, now, ct);
+            await CheckOutageBurst(state, subject, stats, now, ct);
+            await CheckServiceRestriction(state, subject, stats, ct);
+        }
+        finally
+        {
+            state.Gate.Release();
+        }
     }
 
     // --- starlink.dish_alert -----------------------------------------------------------------
@@ -417,7 +431,8 @@ public class StarlinkAlertEvaluator
 
         state.ObstructionCritical = critical;
 
-        var reason = snrLow && fraction >= StarlinkHealthThresholds.ObstructionFractionPoor
+        var fractionTripped = fraction >= StarlinkHealthThresholds.ObstructionFractionPoor;
+        var reason = snrLow && fractionTripped
             ? $"The dish has been {FormatPercent(fraction)} obstructed and reports persistently low signal"
             : snrLow
                 ? "The dish reports persistently low signal"
@@ -436,8 +451,11 @@ public class StarlinkAlertEvaluator
                       "Something in its view of the sky is cutting satellites off; the obstruction map on Starlink Stats shows where.",
             DeviceId = subject.DeviceId,
             DeviceName = subject.Label,
-            MetricValue = fraction,
-            ThresholdValue = StarlinkHealthThresholds.ObstructionFractionPoor,
+            // Only when the fraction is what tripped it. On an SNR-only alert the obstruction
+            // fraction is healthy, and pairing that number with the poor-obstruction threshold
+            // would render as "0.0006 against 0.02" beside a message about low signal.
+            MetricValue = fractionTripped ? fraction : null,
+            ThresholdValue = fractionTripped ? StarlinkHealthThresholds.ObstructionFractionPoor : null,
             SourceUrl = subject.SourceUrl,
             Tags = ["starlink", "obstruction"],
             Context = subject.Context(new Dictionary<string, string>
@@ -874,6 +892,13 @@ public class StarlinkAlertEvaluator
 
     private sealed class DishState
     {
+        /// <summary>
+        /// Serializes evaluation of this dish, since nothing below is thread-safe and a UI-driven
+        /// poll can overlap the timer's. Never disposed: a dish's state lives as long as the
+        /// evaluator, and the semaphore is uncontended in the ordinary single-poll case.
+        /// </summary>
+        public readonly SemaphoreSlim Gate = new(1, 1);
+
         /// <summary>Codes the currently open dish_alert was raised for, so a standing set does not republish.</summary>
         public HashSet<string> OpenDishAlertCodes = new(StringComparer.OrdinalIgnoreCase);
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/StarlinkAlertEvaluator.cs
@@ -274,12 +274,64 @@ public class StarlinkAlertEvaluator
             await CheckEthSpeed(state, subject, stats, ethCapableMbps, now, ct);
             await CheckOutageBurst(state, subject, stats, now, ct);
             await CheckServiceRestriction(state, subject, stats, ct);
+
+            // Logged after the checks so the open set reflects this poll. Built only when Debug is
+            // on, since it medians the alignment window and sums the outage window to do it.
+            if (_logger.IsEnabled(LogLevel.Debug))
+                LogEvaluation(state, subject, stats, alignmentBaselineDeg, ethCapableMbps);
         }
         finally
         {
             state.Gate.Release();
         }
     }
+
+    /// <summary>
+    /// One line per poll describing everything the rules just judged, because a healthy dish is
+    /// silent by construction: no alert fires, so nothing otherwise proves the chain is live. This
+    /// is what confirms the baseline came back from Influx, the dish got bound to a WAN, and each
+    /// condition is being evaluated against real numbers - none of which can be told apart from a
+    /// broken evaluator by the absence of alerts.
+    /// </summary>
+    private void LogEvaluation(DishState state, DishSubject subject, StarlinkStats stats,
+        double? baselineDeg, int? capableMbps)
+    {
+        var samples = state.AlignmentSamples.Count;
+        double? current = samples > 0 ? Median(state.AlignmentSamples.Select(s => s.Offset)) : null;
+        double? drift = current is { } c && baselineDeg is { } b ? Math.Abs(c - b) : null;
+        var gated = stats.AttitudeUncertaintyDeg > AttitudeUncertaintyMaxDeg;
+
+        var open = new List<string>();
+        if (state.OpenDishAlertCodes.Count > 0) open.Add("dish_alert");
+        if (state.Obstruction.Open) open.Add("obstructed");
+        if (state.Alignment.Open) open.Add("alignment_drift");
+        if (state.EthSpeed.Open) open.Add("eth_speed_degraded");
+        if (state.OutageBurstOpen) open.Add("outage_burst");
+
+        _logger.LogDebug(
+            "Starlink {Dish} alerting: wan={Wan} obstruction={Obstruction} snrLow={SnrLow} " +
+            "align={Current}/{Baseline}deg drift={Drift} samples={Samples} uncertainty={Uncertainty}{Gated} " +
+            "eth={Eth}/{Capable}Mbps outages24h={Outage}s restricted={Restricted} open=[{Open}]",
+            subject.DishName,
+            subject.WanLabel ?? "unbound",
+            Show(stats.FractionObstructed),
+            stats.IsSnrPersistentlyLow?.ToString() ?? "n/a",
+            Show(current),
+            Show(baselineDeg),
+            Show(drift),
+            samples,
+            Show(stats.AttitudeUncertaintyDeg),
+            gated ? " (gated)" : "",
+            stats.EthSpeedMbps?.ToString(CultureInfo.InvariantCulture) ?? "n/a",
+            capableMbps?.ToString(CultureInfo.InvariantCulture) ?? "n/a",
+            Show(state.OutageSamples.Sum(s => s.Seconds)),
+            state.WasRestricted?.ToString() ?? "n/a",
+            open.Count == 0 ? "none" : string.Join(",", open));
+    }
+
+    /// <summary>A number for the diagnostic line, or "n/a" where the dish reported none.</summary>
+    private static string Show(double? value) =>
+        value?.ToString("0.####", CultureInfo.InvariantCulture) ?? "n/a";
 
     // --- starlink.dish_alert -----------------------------------------------------------------
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
@@ -26,6 +26,7 @@ public class MonitoringAlertRegistry : ISiteScopedRegistry
         CableModemAlertEvaluator CableModem,
         OntAlertEvaluator Ont,
         CellularAlertEvaluator Cellular,
+        StarlinkAlertEvaluator Starlink,
         DeviceRebootAlertEvaluator DeviceReboot,
         DeviceStateAlertEvaluator DeviceState);
 
@@ -55,6 +56,7 @@ public class MonitoringAlertRegistry : ISiteScopedRegistry
                 ActivatorUtilities.CreateInstance<CableModemAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<OntAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<CellularAlertEvaluator>(_serviceProvider, s, bus),
+                ActivatorUtilities.CreateInstance<StarlinkAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<DeviceRebootAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<DeviceStateAlertEvaluator>(_serviceProvider, s, bus));
         });

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -389,6 +389,18 @@ public sealed class StarlinkMonitorService : IDisposable
 
         var baseline = new DishBaseline(median, capable, to);
         _baselines[configId] = baseline;
+
+        // Says which of the two baseline-dependent rules are armed and why. A null median here is
+        // the difference between "alignment drift is watching" and "alignment drift is off", and
+        // without this line the two look identical from outside.
+        _logger.LogDebug(
+            "Starlink {Id} baseline over {Days}d: alignment={Median} from {Offsets} points, " +
+            "capable={Capable} Mbps from {Speeds} points",
+            configId, BaselineWindow.TotalDays,
+            median?.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture) ?? "none",
+            offsets.Count, capable?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "none",
+            speeds.Count);
+
         return baseline;
     }
 

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -1,9 +1,12 @@
 using System.Collections.Concurrent;
+using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.UniFi;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -21,9 +24,36 @@ public sealed class StarlinkMonitorService : IDisposable
     /// <summary>How often the obstruction sky map is refreshed; it changes slowly and is a ~60 KB payload.</summary>
     private static readonly TimeSpan ObstructionMapRefresh = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// How far back the alerting baselines look. Seven days is long enough that a re-aim or a
+    /// cable change is followed rather than flagged, and short enough that the median still
+    /// describes how the dish is behaving now.
+    /// </summary>
+    private static readonly TimeSpan BaselineWindow = TimeSpan.FromDays(7);
+
+    /// <summary>How often the baselines are recomputed. They move over days, so this is a cheap once-per-poll-cycle read at worst.</summary>
+    private static readonly TimeSpan BaselineRefresh = TimeSpan.FromHours(6);
+
+    /// <summary>
+    /// Aggregation the baseline query asks Influx for. Fifteen minutes gives ~670 points over the
+    /// window, plenty for a stable median without pulling every raw sample across the wire.
+    /// </summary>
+    private static readonly TimeSpan BaselineAggregate = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Alignment samples needed in the window before its median is worth comparing against. A
+    /// fresh install has none, and the drift alert stays disabled rather than baselining off three
+    /// readings taken while the dish was still settling.
+    /// </summary>
+    private const int MinBaselineSamples = 24;
+
+    /// <summary>How long a resolved WAN binding is reused. It only changes when someone renames a WAN or adds a dish.</summary>
+    private static readonly TimeSpan WanBindingTtl = TimeSpan.FromMinutes(30);
+
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly SiteTunnelRouting _tunnelRouting;
     private readonly MonitoringInfluxClient _influx;
+    private readonly StarlinkAlertEvaluator _alertEvaluator;
     private readonly ILogger<StarlinkMonitorService> _logger;
     private readonly Dictionary<string, IStarlinkProvider> _providers;
     private readonly Timer _pollingTimer;
@@ -31,7 +61,11 @@ public sealed class StarlinkMonitorService : IDisposable
 
     private readonly ConcurrentDictionary<int, StarlinkStats> _statsCache = new();
     private readonly ConcurrentDictionary<int, StarlinkObstructionMap> _obstructionMapCache = new();
+    private readonly ConcurrentDictionary<int, DishBaseline> _baselines = new();
     private volatile bool _hasPrimedOnce;
+
+    private string? _wanLabel;
+    private DateTime _wanLabelLoadedAt = DateTime.MinValue;
 
     private bool _isPolling;
 
@@ -47,6 +81,7 @@ public sealed class StarlinkMonitorService : IDisposable
         IEnumerable<IStarlinkProvider> providers,
         SiteTunnelRouting tunnelRouting,
         MonitoringInfluxRegistry influxRegistry,
+        MonitoringAlertRegistry alertRegistry,
         ILogger<StarlinkMonitorService> logger,
         string siteSlug = SiteManagementService.DefaultSiteSlug)
     {
@@ -55,6 +90,7 @@ public sealed class StarlinkMonitorService : IDisposable
         _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
         Active = _siteSlug == SiteManagementService.DefaultSiteSlug;
         _influx = influxRegistry.GetFor(_siteSlug);
+        _alertEvaluator = alertRegistry.GetFor(_siteSlug).Starlink;
         _logger = logger;
         _providers = providers.ToDictionary(p => p.ProviderKey, StringComparer.OrdinalIgnoreCase);
 
@@ -164,6 +200,7 @@ public sealed class StarlinkMonitorService : IDisposable
 
         _statsCache.TryRemove(id, out _);
         _obstructionMapCache.TryRemove(id, out _);
+        _baselines.TryRemove(id, out _);
     }
 
     /// <summary>
@@ -253,6 +290,7 @@ public sealed class StarlinkMonitorService : IDisposable
                 {
                     _statsCache[config.Id] = stats;
                     WriteToInflux(config, stats);
+                    await EvaluateAlertsAsync(config, stats);
                     await RefreshObstructionMapAsync(provider, context, config.Id);
                 }
             }
@@ -266,6 +304,123 @@ public sealed class StarlinkMonitorService : IDisposable
             _logger.LogWarning(ex, "Error polling Starlink terminal {Name} ({Id})", config.Name, config.Id);
             await UpdateConfigErrorAsync(config.Id, ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Hands this poll to the alert evaluator along with the two things it cannot derive from a
+    /// single reading: the dish's own long-run baselines, and which WAN it serves. Failures here
+    /// are logged and swallowed - alerting must never cost a poll its stats, its chart point, or
+    /// its sky map.
+    /// </summary>
+    private async Task EvaluateAlertsAsync(StarlinkConfiguration config, StarlinkStats stats)
+    {
+        try
+        {
+            var baseline = await GetBaselineAsync(config.Id);
+            await _alertEvaluator.EvaluateAsync(
+                config.Id,
+                config.Name,
+                stats,
+                ComputeAlignmentOffsetDeg(stats),
+                baseline.AlignmentMedianDeg,
+                baseline.EthCapableMbps,
+                await ResolveWanLabelAsync());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Starlink alert evaluation failed for {Name} ({Id})", config.Name, config.Id);
+        }
+    }
+
+    /// <summary>
+    /// The dish's own long-run behavior, from the series already in Influx: the median boresight
+    /// offset it normally sits at, and the fastest Ethernet speed it has been seen to negotiate.
+    /// Both are self-calibrating by design - a hand-aimed fixed dish is several degrees off ideal
+    /// from day one and works perfectly there, so drift is judged against where this dish sits
+    /// rather than against where one ideally would.
+    ///
+    /// <para>
+    /// Reads the LONGTERM bucket, which is where <c>QueryStarlinkAsync</c> looks. An install with
+    /// no Influx, or a dish with too little history, comes back empty and simply leaves the two
+    /// rules that need a baseline disabled.
+    /// </para>
+    /// </summary>
+    private async Task<DishBaseline> GetBaselineAsync(int configId)
+    {
+        if (_baselines.TryGetValue(configId, out var cached) &&
+            DateTime.UtcNow - cached.ComputedAt < BaselineRefresh)
+        {
+            return cached;
+        }
+
+        var to = DateTime.UtcNow;
+        var series = await _influx.QueryStarlinkAsync(
+            to - BaselineWindow, to, configId.ToString(), BaselineAggregate);
+        var points = series.Values.FirstOrDefault() ?? new List<MonitoringInfluxClient.StarlinkPoint>();
+
+        var offsets = points
+            .Where(p => p.AlignmentOffsetDeg.HasValue)
+            .Select(p => p.AlignmentOffsetDeg!.Value)
+            .OrderBy(v => v)
+            .ToList();
+        double? median = offsets.Count >= MinBaselineSamples
+            ? offsets.Count % 2 == 1
+                ? offsets[offsets.Count / 2]
+                : (offsets[offsets.Count / 2 - 1] + offsets[offsets.Count / 2]) / 2.0
+            : null;
+
+        var speeds = points.Where(p => p.EthSpeedMbps > 0).Select(p => p.EthSpeedMbps!.Value).ToList();
+        int? capable = speeds.Count > 0 ? speeds.Max() : null;
+
+        var baseline = new DishBaseline(median, capable, to);
+        _baselines[configId] = baseline;
+        return baseline;
+    }
+
+    /// <summary>
+    /// Best-effort binding of the dish to a WAN, so its alerts carry the same label everything
+    /// else uses for that connection. Binds only when the answer is unambiguous: exactly one WAN
+    /// that <see cref="StarlinkWanDetector"/> recognizes, and exactly one dish configured to sit
+    /// behind it. With two dishes, or two Starlink WANs, nothing in the data says which serves
+    /// which, and a confidently wrong WAN name on an alert is worse than none - the alerts then
+    /// name the dish instead and fire regardless.
+    /// </summary>
+    private async Task<string?> ResolveWanLabelAsync()
+    {
+        if (DateTime.UtcNow - _wanLabelLoadedAt < WanBindingTtl) return _wanLabel;
+
+        try
+        {
+            using var scope = CreateSiteScope();
+            var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
+
+            var dishCount = await db.StarlinkConfigurations.CountAsync(c => c.Enabled);
+            var matches = dishCount == 1
+                ? await db.WanProfiles.AsNoTracking()
+                    .Select(p => new { p.WanNetworkgroup, p.Name })
+                    .ToListAsync()
+                : [];
+
+            var starlinkWans = matches
+                .Where(p => StarlinkWanDetector.IsStarlinkWan(p.Name))
+                .ToList();
+
+            _wanLabel = starlinkWans.Count == 1
+                ? GatewayWanHelper.FormatWanLabel(
+                    starlinkWans[0].Name,
+                    GatewayWanHelper.WanIndexFromKey(
+                        GatewayWanHelper.WanInterfaceKeyFromKey(starlinkWans[0].WanNetworkgroup)),
+                    null, null)
+                : null;
+        }
+        catch (Exception ex)
+        {
+            // Keep whatever was resolved last: a failed lookup should cost the label, not the alert.
+            _logger.LogDebug(ex, "Could not resolve the Starlink WAN binding for site {Site}", _siteSlug);
+        }
+
+        _wanLabelLoadedAt = DateTime.UtcNow;
+        return _wanLabel;
     }
 
     private async Task RefreshObstructionMapAsync(
@@ -447,4 +602,13 @@ public sealed class StarlinkMonitorService : IDisposable
     {
         _pollingTimer.Dispose();
     }
+
+    /// <summary>
+    /// One dish's long-run behavior, as the alert rules that cannot judge from a single reading
+    /// need it. Null members mean "not enough history", which disables the rule that reads them.
+    /// </summary>
+    /// <param name="AlignmentMedianDeg">Median boresight offset over the baseline window, degrees.</param>
+    /// <param name="EthCapableMbps">Fastest Ethernet speed seen over the baseline window, Mbps.</param>
+    /// <param name="ComputedAt">When this was computed, for the refresh interval.</param>
+    private sealed record DishBaseline(double? AlignmentMedianDeg, int? EthCapableMbps, DateTime ComputedAt);
 }

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -163,6 +163,11 @@ public sealed class StarlinkMonitorService : IDisposable
         var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
         await repo.SaveStarlinkConfigurationAsync(config);
 
+        // Adding or disabling a dish changes whether the WAN binding is unambiguous, so the
+        // cached answer is dropped rather than left to age out and label a second dish with the
+        // first one's WAN.
+        InvalidateWanBinding();
+
         if (isNew)
             await AlertRuleAutoEnable.EnableBySourceAsync(scope, "starlink", _logger);
     }
@@ -177,6 +182,8 @@ public sealed class StarlinkMonitorService : IDisposable
         using var scope = CreateSiteScope();
         var repo = scope.ServiceProvider.GetRequiredService<IStarlinkRepository>();
         await repo.SetStarlinkEnabledAsync(id, enabled);
+
+        InvalidateWanBinding();
     }
 
     /// <summary>
@@ -201,7 +208,11 @@ public sealed class StarlinkMonitorService : IDisposable
         _statsCache.TryRemove(id, out _);
         _obstructionMapCache.TryRemove(id, out _);
         _baselines.TryRemove(id, out _);
+        InvalidateWanBinding();
     }
+
+    /// <summary>Forces the next poll to re-resolve which WAN the dish sits behind.</summary>
+    private void InvalidateWanBinding() => _wanLabelLoadedAt = DateTime.MinValue;
 
     /// <summary>
     /// Test connectivity to a terminal using the configured provider.
@@ -369,6 +380,10 @@ public sealed class StarlinkMonitorService : IDisposable
                 : (offsets[offsets.Count / 2 - 1] + offsets[offsets.Count / 2]) / 2.0
             : null;
 
+        // The maximum is the right statistic: eth_speed_mbps is the NEGOTIATED rate, so it cannot
+        // read higher than the link actually reached, and a dish that has ever done 1000 is
+        // 1000-capable. A genuine permanent downgrade (the dish moved onto a 100 Mbps segment for
+        // good) alerts until the old speed ages out of the window, then stops on its own.
         var speeds = points.Where(p => p.EthSpeedMbps > 0).Select(p => p.EthSpeedMbps!.Value).ToList();
         int? capable = speeds.Count > 0 ? speeds.Max() : null;
 

--- a/tests/NetworkOptimizer.Alerts.Tests/StarlinkAlertResolutionTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/StarlinkAlertResolutionTests.cs
@@ -131,6 +131,25 @@ public class StarlinkAlertResolutionTests
         _resolveCalls.Select(c => c.DeviceId).Should().Equal("starlink:3");
     }
 
+    /// <summary>
+    /// Every Starlink rule must ship with no cooldown, and this is not a style preference.
+    /// A re-published condition supersedes its own open alert, and the resolution runs BEFORE
+    /// rules are consulted - while the cooldown key is per (site, rule, device), which a
+    /// replacement shares with the alert it just closed. Give any of these a cooldown and an
+    /// obstruction escalating Warning -> Critical inside it resolves the Warning and has the
+    /// Critical suppressed, leaving a critically obstructed dish with no open alert.
+    /// </summary>
+    [Fact]
+    public void EveryStarlinkRule_ShipsWithNoCooldown()
+    {
+        var starlink = DefaultAlertRules.GetDefaults()
+            .Where(r => r.Source == "starlink")
+            .ToList();
+
+        starlink.Should().NotBeEmpty();
+        starlink.Should().OnlyContain(r => r.CooldownSeconds == 0);
+    }
+
     [Fact]
     public async Task ResolveSupersededAlertsAsync_RepositoryThrows_DoesNotPropagate()
     {

--- a/tests/NetworkOptimizer.Alerts.Tests/StarlinkAlertResolutionTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/StarlinkAlertResolutionTests.cs
@@ -1,0 +1,149 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Alerts.Interfaces;
+using NetworkOptimizer.Alerts.Models;
+using NetworkOptimizer.Core.Enums;
+using Xunit;
+
+namespace NetworkOptimizer.Alerts.Tests;
+
+/// <summary>
+/// The open/close half of the Starlink dish alert family: which open alerts an incoming
+/// starlink.* event closes. The promise is one open alert per (dish, condition) - a condition
+/// that raises again supersedes its own open alert rather than stacking a second, a recovery
+/// closes only the condition it names, and one dish's alerts never touch another's.
+/// </summary>
+public class StarlinkAlertResolutionTests
+{
+    private readonly AlertProcessingService _service;
+    private readonly Mock<IAlertRepository> _repository = new();
+    private readonly List<(string[] EventTypes, string DeviceId)> _resolveCalls = [];
+
+    public StarlinkAlertResolutionTests()
+    {
+        _repository
+            .Setup(r => r.ResolveActiveAlertsAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<IReadOnlyCollection<string>, string, CancellationToken>(
+                (types, deviceId, _) => _resolveCalls.Add((types.ToArray(), deviceId)))
+            .ReturnsAsync(new List<AlertHistoryEntry>());
+
+        var configuration = new Mock<IConfiguration>();
+        configuration.Setup(c => c["HOST_NAME"]).Returns("host.example");
+
+        var cooldownTracker = new AlertCooldownTracker();
+        _service = new AlertProcessingService(
+            NullLogger<AlertProcessingService>.Instance,
+            Mock.Of<IAlertEventBus>(),
+            Mock.Of<IServiceScopeFactory>(),
+            new AlertRuleEvaluator(cooldownTracker, NullLogger<AlertRuleEvaluator>.Instance),
+            new AlertCorrelationService(NullLogger<AlertCorrelationService>.Instance),
+            [],
+            cooldownTracker,
+            Mock.Of<IAlertSiteNameResolver>(),
+            configuration.Object);
+    }
+
+    private static AlertEvent CreateEvent(string eventType, string? deviceId,
+        Dictionary<string, string>? context = null) => new()
+        {
+            EventType = eventType,
+            Severity = AlertSeverity.Warning,
+            Source = "starlink",
+            Title = "Test alert",
+            DeviceId = deviceId,
+            Context = context ?? new Dictionary<string, string>()
+        };
+
+    [Fact]
+    public void ConditionRaisingAgain_SupersedesItsOwnOpenAlert()
+    {
+        var targets = AlertProcessingService.GetStarlinkAlertsToResolve(
+            "starlink.obstructed", "starlink:3", null);
+
+        targets.Should().ContainSingle();
+        targets[0].DeviceId.Should().Be("starlink:3");
+        targets[0].EventTypes.Should().Equal("starlink.obstructed");
+    }
+
+    /// <summary>A dish that clears its obstruction keeps any other alert it still has open.</summary>
+    [Fact]
+    public void Recovery_ClosesOnlyTheConditionItNames()
+    {
+        var targets = AlertProcessingService.GetStarlinkAlertsToResolve(
+            "starlink.recovered", "starlink:3",
+            new Dictionary<string, string> { ["recovered_type"] = "starlink.obstructed" });
+
+        targets.Should().ContainSingle();
+        targets[0].DeviceId.Should().Be("starlink:3");
+        targets[0].EventTypes.Should().Equal("starlink.obstructed");
+    }
+
+    [Fact]
+    public void RecoveryNamingNoCondition_ClosesNothing()
+    {
+        AlertProcessingService.GetStarlinkAlertsToResolve("starlink.recovered", "starlink:3", null)
+            .Should().BeEmpty();
+        AlertProcessingService.GetStarlinkAlertsToResolve("starlink.recovered", "starlink:3",
+            new Dictionary<string, string> { ["recovered_type"] = "" }).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EventWithoutADish_ClosesNothing()
+    {
+        AlertProcessingService.GetStarlinkAlertsToResolve("starlink.obstructed", null, null).Should().BeEmpty();
+        AlertProcessingService.GetStarlinkAlertsToResolve("starlink.obstructed", "", null).Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("monitoring.wan_outage")]
+    [InlineData("cellular.signal_poor")]
+    [InlineData("device.offline")]
+    public void EventOutsideTheStarlinkFamily_ClosesNothing(string eventType)
+    {
+        AlertProcessingService.GetStarlinkAlertsToResolve(eventType, "starlink:3", null).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ResolveSupersededAlertsAsync_Recovery_ResolvesTheNamedConditionOnThatDishOnly()
+    {
+        var evt = CreateEvent("starlink.recovered", "starlink:3",
+            new Dictionary<string, string> { ["recovered_type"] = "starlink.alignment_drift" });
+
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        _resolveCalls.Should().ContainSingle();
+        _resolveCalls[0].DeviceId.Should().Be("starlink:3");
+        _resolveCalls[0].EventTypes.Should().Equal("starlink.alignment_drift");
+    }
+
+    [Fact]
+    public async Task ResolveSupersededAlertsAsync_NeverTouchesAnotherDishsAlerts()
+    {
+        var evt = CreateEvent("starlink.obstructed", "starlink:3");
+
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        _resolveCalls.Select(c => c.DeviceId).Should().Equal("starlink:3");
+    }
+
+    [Fact]
+    public async Task ResolveSupersededAlertsAsync_RepositoryThrows_DoesNotPropagate()
+    {
+        _repository
+            .Setup(r => r.ResolveActiveAlertsAsync(
+                It.IsAny<IReadOnlyCollection<string>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("DB error"));
+
+        var evt = CreateEvent("starlink.recovered", "starlink:3",
+            new Dictionary<string, string> { ["recovered_type"] = "starlink.obstructed" });
+
+        var act = async () => await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
+++ b/tests/NetworkOptimizer.Alerts.Tests/WanOutageAlertResolutionTests.cs
@@ -133,14 +133,14 @@ public class WanOutageAlertResolutionTests
 
     #endregion
 
-    #region ResolveSupersededWanAlertsAsync
+    #region ResolveSupersededAlertsAsync
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_TotalOutage_ResolvesOnlyThatWansPartial()
+    public async Task ResolveSupersededAlertsAsync_TotalOutage_ResolvesOnlyThatWansPartial()
     {
         var evt = CreateEvent("monitoring.wan_outage", "wan2");
 
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         _resolveCalls.Should().ContainSingle();
         _resolveCalls[0].DeviceId.Should().Be("wan2");
@@ -148,11 +148,11 @@ public class WanOutageAlertResolutionTests
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_Recovery_ResolvesOutagePartialAndRollup()
+    public async Task ResolveSupersededAlertsAsync_Recovery_ResolvesOutagePartialAndRollup()
     {
         var evt = CreateEvent("monitoring.wan_recovered", "wan2");
 
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         _resolveCalls.Should().HaveCount(2);
         _resolveCalls.Select(c => c.DeviceId).Should().Equal("wan2", "all-wans");
@@ -161,11 +161,11 @@ public class WanOutageAlertResolutionTests
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_NeverTouchesAnotherWansAlerts()
+    public async Task ResolveSupersededAlertsAsync_NeverTouchesAnotherWansAlerts()
     {
         var evt = CreateEvent("monitoring.wan_recovered", "wan2");
 
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         // Only this WAN and the site rollup - "wan" and "wan3" keep their open alerts, and the
         // repository handed in is already pinned to the event's site, so other sites are untouched.
@@ -173,11 +173,11 @@ public class WanOutageAlertResolutionTests
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_EventOutsideTheWanFamily_ResolvesNothing()
+    public async Task ResolveSupersededAlertsAsync_EventOutsideTheWanFamily_ResolvesNothing()
     {
         var evt = CreateEvent("monitoring.target_offline", "wan2");
 
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         _resolveCalls.Should().BeEmpty();
         _repository.Verify(r => r.ResolveActiveAlertsAsync(
@@ -185,7 +185,7 @@ public class WanOutageAlertResolutionTests
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_ResolvedAlertInIncident_RecalculatesIncidentStatus()
+    public async Task ResolveSupersededAlertsAsync_ResolvedAlertInIncident_RecalculatesIncidentStatus()
     {
         var resolved = new AlertHistoryEntry
         {
@@ -203,7 +203,7 @@ public class WanOutageAlertResolutionTests
             .ReturnsAsync(new List<AlertHistoryEntry> { resolved });
 
         var evt = CreateEvent("monitoring.wan_outage", "wan2");
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         incident.Status.Should().Be(AlertStatus.Resolved);
         incident.ResolvedAt.Should().NotBeNull();
@@ -211,7 +211,7 @@ public class WanOutageAlertResolutionTests
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_IncidentStillHasActiveAlerts_LeavesIncidentOpen()
+    public async Task ResolveSupersededAlertsAsync_IncidentStillHasActiveAlerts_LeavesIncidentOpen()
     {
         var resolved = new AlertHistoryEntry
         {
@@ -229,14 +229,14 @@ public class WanOutageAlertResolutionTests
             .ReturnsAsync(new List<AlertHistoryEntry> { resolved, new() { Id = 6, Status = AlertStatus.Active } });
 
         var evt = CreateEvent("monitoring.wan_outage", "wan2");
-        await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         incident.Status.Should().Be(AlertStatus.Active);
         _repository.Verify(r => r.UpdateIncidentAsync(It.IsAny<AlertIncident>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task ResolveSupersededWanAlertsAsync_RepositoryThrows_DoesNotPropagate()
+    public async Task ResolveSupersededAlertsAsync_RepositoryThrows_DoesNotPropagate()
     {
         _repository
             .Setup(r => r.ResolveActiveAlertsAsync(
@@ -245,7 +245,7 @@ public class WanOutageAlertResolutionTests
 
         var evt = CreateEvent("monitoring.wan_recovered", "wan2");
 
-        var act = async () => await _service.ResolveSupersededWanAlertsAsync(evt, _repository.Object, CancellationToken.None);
+        var act = async () => await _service.ResolveSupersededAlertsAsync(evt, _repository.Object, CancellationToken.None);
 
         await act.Should().NotThrowAsync();
     }

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
@@ -669,6 +669,28 @@ public class StarlinkAlertEvaluatorTests
         evt.Context["dish_name"].Should().Be(DishName);
     }
 
+    /// <summary>
+    /// Dishes get called "Starlink Roof", "Roof Starlink", or just "Starlink", and the
+    /// out-of-service sentence opens with the word itself - so the name is trimmed there and only
+    /// there. Titles keep the full name: a title is often all that reaches a notification channel.
+    /// </summary>
+    [Theory]
+    [InlineData("Starlink Roof", "Starlink has taken Roof out of service")]
+    [InlineData("Roof Starlink", "Starlink has taken Roof out of service")]
+    [InlineData("Starlink", "Starlink has taken the dish out of service")]
+    [InlineData("Dishy McFlatface", "Starlink has taken Dishy McFlatface out of service")]
+    public async Task OutOfServiceSentence_DoesNotSayStarlinkTwice(string dishName, string expected)
+    {
+        var stats = Healthy();
+        stats.DisablementCode = "NoActiveAccount";
+
+        await _evaluator.EvaluateAsync(DishId, dishName, stats);
+
+        var evt = Of("starlink.dish_alert").Should().ContainSingle().Subject;
+        evt.Message.Should().Contain(expected);
+        evt.Title.Should().StartWith(dishName, "the title keeps the name whole");
+    }
+
     [Fact]
     public async Task WithAWanBinding_TheAlertNamesTheWan()
     {

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
@@ -1,0 +1,713 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// The Starlink alert rules, driven the way the dish poll drives them: one <see cref="StarlinkStats"/>
+/// reading at a time, with time advanced between them so the sustain windows are exercised rather
+/// than waited out.
+///
+/// <para>
+/// The load-bearing cases are the ones that must stay SILENT. Every "problem" field on the
+/// reference dish is populated while nothing is wrong - it reports install_pending continuously,
+/// fails its hardware self-test continuously, sits at a permanent rate limit, and points a steady
+/// 3.69 degrees off desired - so a rule written as "the field has a value" would fire on day one
+/// and never stop. Each of those has a test here that asserts nothing is published.
+/// </para>
+/// </summary>
+public class StarlinkAlertEvaluatorTests
+{
+    private const int DishId = 1;
+    private const string DishName = "Starlink Roof";
+
+    private static readonly DateTime Start = new(2026, 8, 5, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly FakeTimeProvider _time = new(Start);
+    private readonly CapturingBus _bus = new();
+    private readonly StarlinkAlertEvaluator _evaluator;
+
+    public StarlinkAlertEvaluatorTests()
+    {
+        _evaluator = new StarlinkAlertEvaluator(
+            _bus, NullLogger<StarlinkAlertEvaluator>.Instance, timeProvider: _time);
+    }
+
+    /// <summary>
+    /// A reading from a dish with nothing wrong, matching what the reference dish actually
+    /// reports: a benign standing alert code, a self-test that has always failed, a permanent
+    /// rate limit on both directions, mobility class Mobile on a bolted-down dish, and a gigabit
+    /// Ethernet link.
+    /// </summary>
+    private static StarlinkStats Healthy() => new()
+    {
+        ActiveAlerts = ["install_pending"],
+        HardwareSelfTest = "Failed",
+        DisablementCode = "Okay",
+        DownlinkRestrictedReason = "LowSpeedPolicyLimit",
+        UplinkRestrictedReason = "PolicyLimit",
+        ClassOfService = "Consumer",
+        MobilityClass = "Mobile",
+        SoftwareUpdateState = "Idle",
+        EthSpeedMbps = 1000,
+        FractionObstructed = 0.0001,
+        IsSnrPersistentlyLow = false,
+        AttitudeUncertaintyDeg = 0.2,
+    };
+
+    private ValueTask Feed(StarlinkStats stats, double? alignmentOffsetDeg = null,
+        double? baselineDeg = null, int? ethCapableMbps = 1000, string? wanLabel = null) =>
+        _evaluator.EvaluateAsync(DishId, DishName, stats,
+            alignmentOffsetDeg, baselineDeg, ethCapableMbps, wanLabel);
+
+    private List<AlertEvent> Of(string eventType) =>
+        _bus.Published.Where(e => e.EventType == eventType).ToList();
+
+    private List<AlertEvent> RecoveriesOf(string recoveredType) =>
+        _bus.Published
+            .Where(e => e.EventType == "starlink.recovered"
+                        && e.Context.TryGetValue("recovered_type", out var t) && t == recoveredType)
+            .ToList();
+
+    // --- The silence cases ---------------------------------------------------------------
+
+    [Fact]
+    public async Task HealthyDish_PublishesNothing()
+    {
+        for (var i = 0; i < 200; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 3.69, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        _bus.Published.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PermanentlyRestrictedSubscription_NeverAlerts()
+    {
+        // The reference dish is rate limited on both directions continuously and always has been.
+        for (var i = 0; i < 10; i++)
+        {
+            await Feed(Healthy());
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.service_restricted").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task SelfTestThatHasAlwaysFailed_IsNotAFault()
+    {
+        for (var i = 0; i < 10; i++)
+        {
+            await Feed(Healthy());
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.dish_alert").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task DishSittingAtASteadyNonZeroOffset_NeverAlerts()
+    {
+        // 30 days of the reference dish: median 3.69, with the measured p1/p99 spread and the two
+        // isolated outliers that are exactly why the current value is a median and not a sample.
+        double[] wander = [3.69, 3.42, 3.96, 3.53, 3.84, 2.04, 3.69, 4.64, 3.61, 3.75];
+
+        for (var i = 0; i < 300; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: wander[i % wander.Length], baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task BenignDishAlertCodes_AreIgnored()
+    {
+        var stats = Healthy();
+        stats.ActiveAlerts = ["install_pending", "is_heating", "is_power_save_idle", "roaming", "obstruction_map_reset"];
+
+        await Feed(stats);
+
+        Of("starlink.dish_alert").Should().BeEmpty();
+    }
+
+    // --- starlink.dish_alert -------------------------------------------------------------
+
+    [Fact]
+    public async Task NonBenignDishAlertCode_PublishesOnceAndCarriesTheCodeVerbatim()
+    {
+        var stats = Healthy();
+        stats.ActiveAlerts = ["install_pending", "thermal_shutdown"];
+
+        await Feed(stats);
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(stats);
+
+        var events = Of("starlink.dish_alert");
+        events.Should().ContainSingle("a standing set of codes is one open alert, not one per poll");
+        events[0].Severity.Should().Be(AlertSeverity.Warning);
+        events[0].Source.Should().Be("starlink");
+        events[0].Message.Should().Contain("thermal_shutdown").And.NotContain("install_pending");
+        events[0].Context["dish_alerts"].Should().Be("thermal_shutdown");
+    }
+
+    [Fact]
+    public async Task ANewCodeOnTopOfAnOpenDishAlert_Republishes()
+    {
+        var stats = Healthy();
+        stats.ActiveAlerts = ["thermal_shutdown"];
+        await Feed(stats);
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        var worse = Healthy();
+        worse.ActiveAlerts = ["thermal_shutdown", "motors_stuck"];
+        await Feed(worse);
+
+        Of("starlink.dish_alert").Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task DisablementCodeOtherThanOkay_IsCritical()
+    {
+        var stats = Healthy();
+        stats.DisablementCode = "NoActiveAccount";
+
+        await Feed(stats);
+
+        var events = Of("starlink.dish_alert");
+        events.Should().ContainSingle();
+        events[0].Severity.Should().Be(AlertSeverity.Critical);
+        events[0].Message.Should().Contain("NoActiveAccount");
+        events[0].Context["disablement_code"].Should().Be("NoActiveAccount");
+    }
+
+    [Fact]
+    public async Task SelfTestGoingFromPassingToFailing_IsAFault()
+    {
+        var passing = Healthy();
+        passing.HardwareSelfTest = "Passed";
+        await Feed(passing);
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(Healthy()); // back to "Failed"
+
+        var events = Of("starlink.dish_alert");
+        events.Should().ContainSingle();
+        events[0].Message.Should().Contain("self-test");
+    }
+
+    [Fact]
+    public async Task DishAlertClearing_PublishesRecoveryAndReArms()
+    {
+        var faulted = Healthy();
+        faulted.ActiveAlerts = ["thermal_shutdown"];
+        await Feed(faulted);
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(Healthy());
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(faulted);
+
+        RecoveriesOf("starlink.dish_alert").Should().ContainSingle();
+        Of("starlink.dish_alert").Should().HaveCount(2, "the condition cleared, so it can raise again");
+    }
+
+    // --- starlink.obstructed -------------------------------------------------------------
+
+    [Fact]
+    public async Task ObstructionBelowTheSustainWindow_DoesNotAlert()
+    {
+        var stats = Healthy();
+        stats.FractionObstructed = 0.05;
+
+        for (var i = 0; i < 10; i++)
+        {
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.obstructed").Should().BeEmpty("obstruction is momentary by design");
+    }
+
+    [Fact]
+    public async Task SustainedObstruction_AlertsOnce()
+    {
+        var stats = Healthy();
+        stats.FractionObstructed = 0.05;
+
+        for (var i = 0; i < 40; i++)
+        {
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        var events = Of("starlink.obstructed");
+        events.Should().ContainSingle();
+        events[0].Severity.Should().Be(AlertSeverity.Warning);
+        events[0].MetricValue.Should().Be(0.05);
+    }
+
+    [Fact]
+    public async Task ObstructionPastTheCriticalBar_PublishesCritical()
+    {
+        var stats = Healthy();
+        stats.FractionObstructed = 0.2;
+
+        for (var i = 0; i < 40; i++)
+        {
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.obstructed").Should().ContainSingle()
+            .Which.Severity.Should().Be(AlertSeverity.Critical);
+    }
+
+    [Fact]
+    public async Task ObstructionEscalatingFromPoorToCritical_Republishes()
+    {
+        var poor = Healthy();
+        poor.FractionObstructed = 0.05;
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(poor);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        var critical = Healthy();
+        critical.FractionObstructed = 0.2;
+        await Feed(critical);
+
+        var events = Of("starlink.obstructed");
+        events.Should().HaveCount(2);
+        events[0].Severity.Should().Be(AlertSeverity.Warning);
+        events[1].Severity.Should().Be(AlertSeverity.Critical);
+    }
+
+    [Fact]
+    public async Task PersistentlyLowSnr_AlertsAsObstruction()
+    {
+        var stats = Healthy();
+        stats.IsSnrPersistentlyLow = true;
+
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.obstructed").Should().ContainSingle()
+            .Which.Context["snr_persistently_low"].Should().Be("true");
+    }
+
+    [Fact]
+    public async Task ObstructionClearing_PublishesRecovery()
+    {
+        var stats = Healthy();
+        stats.FractionObstructed = 0.05;
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(Healthy());
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        RecoveriesOf("starlink.obstructed").Should().ContainSingle();
+    }
+
+    // --- starlink.alignment_drift ---------------------------------------------------------
+
+    [Fact]
+    public async Task SustainedStepBeyondTwoDegrees_AlertsOnce()
+    {
+        await Settle(offset: 3.69, baseline: 3.69);
+
+        for (var i = 0; i < 120; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        var events = Of("starlink.alignment_drift");
+        events.Should().ContainSingle();
+        events[0].Severity.Should().Be(AlertSeverity.Warning);
+        events[0].ThresholdValue.Should().Be(2.0);
+    }
+
+    [Fact]
+    public async Task StepBeyondTwoDegreesThatDoesNotHold_DoesNotAlert()
+    {
+        await Settle(offset: 3.69, baseline: 3.69);
+
+        // Ten minutes of departure, well inside the 30 minute window.
+        for (var i = 0; i < 10; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task StepBeyondTwoDegreesWithHighAttitudeUncertainty_DoesNotAlert()
+    {
+        await Settle(offset: 3.69, baseline: 3.69);
+
+        var confused = Healthy();
+        confused.AttitudeUncertaintyDeg = 5;
+        for (var i = 0; i < 120; i++)
+        {
+            await Feed(confused, alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().BeEmpty(
+            "above the uncertainty bar the dish does not know where it is pointing");
+    }
+
+    [Fact]
+    public async Task DriftReturningToBaseline_ClosesTheAlert()
+    {
+        await Settle(offset: 3.69, baseline: 3.69);
+
+        for (var i = 0; i < 120; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().ContainSingle();
+
+        for (var i = 0; i < 180; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 3.69, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        RecoveriesOf("starlink.alignment_drift").Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// A run of drift interrupted by polls that could not be judged must start over, not confirm
+    /// on the far side of the gap as if it had held throughout.
+    /// </summary>
+    [Fact]
+    public async Task DriftRunInterruptedByUnjudgeablePolls_StartsOver()
+    {
+        await Settle(offset: 3.69, baseline: 3.69);
+
+        for (var i = 0; i < 40; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        // The dish stops reporting its geometry for a while, then comes straight back drifted.
+        for (var i = 0; i < 5; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: null, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        await Feed(Healthy(), alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+
+        Of("starlink.alignment_drift").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NoBaselineYet_LeavesTheDriftRuleDisabled()
+    {
+        for (var i = 0; i < 120; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: 40, baselineDeg: null);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().BeEmpty();
+    }
+
+    // --- starlink.eth_speed_degraded ------------------------------------------------------
+
+    [Fact]
+    public async Task EthernetNegotiatedBelowWhatTheDishReaches_AlertsOnce()
+    {
+        var stats = Healthy();
+        stats.EthSpeedMbps = 100;
+
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(stats, ethCapableMbps: 1000);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        var events = Of("starlink.eth_speed_degraded");
+        events.Should().ContainSingle();
+        events[0].MetricValue.Should().Be(100);
+        events[0].ThresholdValue.Should().Be(1000);
+    }
+
+    [Fact]
+    public async Task BriefEthernetRenegotiation_DoesNotAlert()
+    {
+        var stats = Healthy();
+        stats.EthSpeedMbps = 100;
+
+        await Feed(stats, ethCapableMbps: 1000);
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(Healthy(), ethCapableMbps: 1000);
+
+        Of("starlink.eth_speed_degraded").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task NoKnownCapableRate_LeavesTheEthernetRuleDisabled()
+    {
+        var stats = Healthy();
+        stats.EthSpeedMbps = 100;
+
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(stats, ethCapableMbps: null);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.eth_speed_degraded").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task EthernetComingBackUpToSpeed_PublishesRecovery()
+    {
+        var slow = Healthy();
+        slow.EthSpeedMbps = 100;
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(slow, ethCapableMbps: 1000);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        for (var i = 0; i < 20; i++)
+        {
+            await Feed(Healthy(), ethCapableMbps: 1000);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        RecoveriesOf("starlink.eth_speed_degraded").Should().ContainSingle();
+    }
+
+    // --- starlink.outage_burst ------------------------------------------------------------
+
+    [Fact]
+    public async Task OutageSecondsPassingTheDailyBar_AlertsOnceWithTheCause()
+    {
+        for (var i = 0; i < 12; i++)
+        {
+            var stats = Healthy();
+            stats.OutageSecondsDelta = 30;
+            stats.LastOutageCause = "OBSTRUCTED";
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(10));
+        }
+
+        var events = Of("starlink.outage_burst");
+        events.Should().ContainSingle();
+        events[0].MetricValue.Should().Be(300, "it fires on the poll that crosses the bar, not on the last one fed");
+        events[0].Message.Should().Contain("OBSTRUCTED");
+    }
+
+    [Fact]
+    public async Task OutageSecondsUnderTheDailyBar_DoesNotAlert()
+    {
+        for (var i = 0; i < 9; i++)
+        {
+            var stats = Healthy();
+            stats.OutageSecondsDelta = 30;
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(10));
+        }
+
+        Of("starlink.outage_burst").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task OutagesAgingOutOfTheWindow_PublishRecovery()
+    {
+        for (var i = 0; i < 12; i++)
+        {
+            var stats = Healthy();
+            stats.OutageSecondsDelta = 30;
+            await Feed(stats);
+            _time.Advance(TimeSpan.FromMinutes(10));
+        }
+
+        Of("starlink.outage_burst").Should().ContainSingle();
+
+        _time.Advance(TimeSpan.FromDays(2));
+        await Feed(Healthy());
+
+        RecoveriesOf("starlink.outage_burst").Should().ContainSingle();
+    }
+
+    // --- starlink.service_restricted -------------------------------------------------------
+
+    [Fact]
+    public async Task CrossingFromUnrestrictedIntoRestricted_PublishesInfo()
+    {
+        var free = Healthy();
+        free.DownlinkRestrictedReason = "NoLimit";
+        free.UplinkRestrictedReason = "NoLimit";
+        await Feed(free);
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(Healthy()); // permanently-restricted reference values
+
+        var events = Of("starlink.service_restricted");
+        events.Should().ContainSingle();
+        events[0].Severity.Should().Be(AlertSeverity.Info);
+        events[0].Context["dl_restricted_reason"].Should().Be("LowSpeedPolicyLimit");
+    }
+
+    [Fact]
+    public async Task RestrictionLifting_PublishesRecovery()
+    {
+        var free = Healthy();
+        free.DownlinkRestrictedReason = "NoLimit";
+        free.UplinkRestrictedReason = "NoLimit";
+
+        await Feed(free);
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(Healthy());
+        _time.Advance(TimeSpan.FromMinutes(1));
+        await Feed(free);
+
+        RecoveriesOf("starlink.service_restricted").Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task RestrictionReportedInScreamingSnakeCase_ReadsTheSameValues()
+    {
+        var free = Healthy();
+        free.DownlinkRestrictedReason = "NO_LIMIT";
+        free.UplinkRestrictedReason = "NO_LIMIT";
+        await Feed(free);
+
+        _time.Advance(TimeSpan.FromMinutes(1));
+        var limited = Healthy();
+        limited.DownlinkRestrictedReason = "LOW_SPEED_POLICY_LIMIT";
+        limited.UplinkRestrictedReason = "NO_LIMIT";
+        await Feed(limited);
+
+        Of("starlink.service_restricted").Should().ContainSingle();
+    }
+
+    // --- Labelling ------------------------------------------------------------------------
+
+    [Fact]
+    public async Task WithNoWanBinding_TheAlertNamesTheDish()
+    {
+        var stats = Healthy();
+        stats.ActiveAlerts = ["thermal_shutdown"];
+
+        await Feed(stats, wanLabel: null);
+
+        var evt = Of("starlink.dish_alert").Should().ContainSingle().Subject;
+        evt.Title.Should().StartWith(DishName);
+        evt.DeviceName.Should().Be(DishName);
+        evt.DeviceId.Should().Be("starlink:1");
+        evt.SourceUrl.Should().Be("/monitoring?tab=starlink&starlink=1");
+        evt.Context["dish_name"].Should().Be(DishName);
+    }
+
+    [Fact]
+    public async Task WithAWanBinding_TheAlertNamesTheWan()
+    {
+        var stats = Healthy();
+        stats.ActiveAlerts = ["thermal_shutdown"];
+
+        await Feed(stats, wanLabel: "Starlink WAN2");
+
+        var evt = Of("starlink.dish_alert").Should().ContainSingle().Subject;
+        evt.Title.Should().StartWith("Starlink WAN2");
+        evt.Context["wan_label"].Should().Be("Starlink WAN2");
+        evt.Context["dish_name"].Should().Be(DishName, "the dish is still identified in the context");
+    }
+
+    /// <summary>
+    /// A dish on a WAN with nothing else watching it is the PRIMARY case, not an edge case: no
+    /// vantage, no agent, no monitored targets, and the evaluator is fed by the dish poll alone.
+    /// This test is that shape - nothing but readings goes in - and it still alerts.
+    /// </summary>
+    [Fact]
+    public async Task DishOnAWanWithNoMonitoredTargets_AlertsNormally()
+    {
+        var stats = Healthy();
+        stats.FractionObstructed = 0.05;
+
+        for (var i = 0; i < 40; i++)
+        {
+            await Feed(stats, wanLabel: null);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.obstructed").Should().ContainSingle();
+    }
+
+    // --- Fixtures -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Fills the alignment sample window at a steady offset, so a following step change is
+    /// measured against a settled median rather than against a half-empty window.
+    /// </summary>
+    private async Task Settle(double offset, double baseline)
+    {
+        for (var i = 0; i < 60; i++)
+        {
+            await Feed(Healthy(), alignmentOffsetDeg: offset, baselineDeg: baseline);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+    }
+
+    private sealed class FakeTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public FakeTimeProvider(DateTime start) => _utcNow = new DateTimeOffset(start);
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+
+        public void Advance(TimeSpan by) => _utcNow = _utcNow.Add(by);
+    }
+
+    private sealed class CapturingBus : IAlertEventBus
+    {
+        public List<AlertEvent> Published { get; } = new();
+
+        public ValueTask PublishAsync(AlertEvent alertEvent, CancellationToken ct = default)
+        {
+            Published.Add(alertEvent);
+            return ValueTask.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<AlertEvent> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
@@ -40,9 +40,10 @@ public class StarlinkAlertEvaluatorTests
 
     /// <summary>
     /// A reading from a dish with nothing wrong, matching what the reference dish actually
-    /// reports: a benign standing alert code, a self-test that has always failed, a permanent
-    /// rate limit on both directions, mobility class Mobile on a bolted-down dish, and a gigabit
-    /// Ethernet link.
+    /// reports over 30 days: a benign standing alert code and no other, a self-test that has
+    /// always failed, a permanent rate limit on both directions, mobility class Mobile on a
+    /// bolted-down dish, a constant gigabit Ethernet link, a median 0.06% obstructed, and the
+    /// median 0.70 degrees of attitude uncertainty a healthy dish carries.
     /// </summary>
     private static StarlinkStats Healthy() => new()
     {
@@ -55,9 +56,9 @@ public class StarlinkAlertEvaluatorTests
         MobilityClass = "Mobile",
         SoftwareUpdateState = "Idle",
         EthSpeedMbps = 1000,
-        FractionObstructed = 0.0001,
+        FractionObstructed = 0.0006,
         IsSnrPersistentlyLow = false,
-        AttitudeUncertaintyDeg = 0.2,
+        AttitudeUncertaintyDeg = 0.70,
     };
 
     private ValueTask Feed(StarlinkStats stats, double? alignmentOffsetDeg = null,
@@ -362,6 +363,37 @@ public class StarlinkAlertEvaluatorTests
         }
 
         Of("starlink.alignment_drift").Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A healthy dish is nowhere near certain of its attitude - the reference dish runs p50 0.70,
+    /// p95 1.49, p99 1.83 degrees of uncertainty over 30 days - so the gate must sit above that
+    /// whole range. An earlier 1 degree bar gated out most healthy polls, and because a gated poll
+    /// stalls the sustain, the drift alert could never hold its 30 minute window: the rule was
+    /// dead rather than quiet. This pins the gate open across the real healthy distribution.
+    /// </summary>
+    [Theory]
+    [InlineData(0.70)]
+    [InlineData(1.49)]
+    [InlineData(1.83)]
+    [InlineData(2.71)]
+    public async Task RealDriftAtHealthyAttitudeUncertainty_StillAlerts(double uncertaintyDeg)
+    {
+        var dish = Healthy();
+        dish.AttitudeUncertaintyDeg = uncertaintyDeg;
+
+        for (var i = 0; i < 60; i++)
+        {
+            await Feed(dish, alignmentOffsetDeg: 3.69, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+        for (var i = 0; i < 120; i++)
+        {
+            await Feed(dish, alignmentOffsetDeg: 6.5, baselineDeg: 3.69);
+            _time.Advance(TimeSpan.FromMinutes(1));
+        }
+
+        Of("starlink.alignment_drift").Should().ContainSingle();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/StarlinkAlertEvaluatorTests.cs
@@ -307,8 +307,12 @@ public class StarlinkAlertEvaluatorTests
             _time.Advance(TimeSpan.FromMinutes(1));
         }
 
-        Of("starlink.obstructed").Should().ContainSingle()
-            .Which.Context["snr_persistently_low"].Should().Be("true");
+        var evt = Of("starlink.obstructed").Should().ContainSingle().Subject;
+        evt.Context["snr_persistently_low"].Should().Be("true");
+        // The obstruction fraction is healthy here, so quoting it against the poor-obstruction
+        // threshold would read as "0.0006 against 0.02" beside a message about low signal.
+        evt.MetricValue.Should().BeNull();
+        evt.ThresholdValue.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/RegistryConstructionTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/RegistryConstructionTests.cs
@@ -41,6 +41,7 @@ public class RegistryConstructionTests
         { typeof(CableModemMonitorService), new[] { typeof(string) } },
         { typeof(OntMonitorService), new[] { typeof(string) } },
         { typeof(CellularModemService), new[] { typeof(string), typeof(UniFiSshService), typeof(List<ICellularModemProvider>) } },
+        { typeof(StarlinkMonitorService), new[] { typeof(string), typeof(List<IStarlinkProvider>) } },
         // IspHealthRegistry
         { typeof(PhysicalLinkResolver), new[] { typeof(string) } },
         { typeof(IspHealthService), new[] { typeof(string), typeof(PhysicalLinkResolver) } },
@@ -51,6 +52,7 @@ public class RegistryConstructionTests
         { typeof(CableModemAlertEvaluator), new[] { typeof(string), typeof(SiteAlertEventBus) } },
         { typeof(OntAlertEvaluator), new[] { typeof(string), typeof(SiteAlertEventBus) } },
         { typeof(CellularAlertEvaluator), new[] { typeof(string), typeof(SiteAlertEventBus) } },
+        { typeof(StarlinkAlertEvaluator), new[] { typeof(string), typeof(SiteAlertEventBus) } },
         // MonitoringCollectionRegistry
         { typeof(MonitoringCollectionAgent), new[] { typeof(string) } },
         // MonitoringInfluxRegistry / MonitoringLiveStatsRegistry


### PR DESCRIPTION
We collect a great deal from a Starlink dish and alert on none of it. Every other physical source has alerting - SFP RX power, cellular signal, ONT optical power - while the dish, which reports more about itself than any of them, is silent. It can be obstructed, thermally shut down, taken out of service, negotiated at 100 Mbps on a gigabit service, or knocked out of alignment, and the product says nothing.

Six new alert types plus a closer, all off by default until a dish is configured.

The constraint that shapes all of it: Starlink is usually a **backup** WAN with no vantage, no agent and no monitored targets, so the dish is the only sensor on that link. These hang off the dish poll rather than the monitoring pipeline, and fire for a WAN nothing else watches. There is deliberately no correlation with per-WAN outage alerting - when a dish outage also darkens monitored targets, both firing is correct, because they carry different evidence.

Severity deliberately does not follow the per-WAN outage table, which rates a backup's troubles lower because service is unaffected. The opposite applies here: a degraded primary announces itself, while a degraded backup is silent by construction and gets discovered at the moment it is needed. Knowing the backup is unhealthy before the primary drops is the point of watching it.

## Monitoring - Starlink Stats

- **Dish fault** - the dish's own verdict on itself, folded into one alert: the alert codes it raises (passed through verbatim - they are SpaceX's vocabulary for SpaceX's hardware), a self-test that has started failing, and a disablement code other than Okay. Warning, or Critical when the terminal is out of service.
- **Obstructed** - a sustained obstruction fraction, or the dish's own persistently-low-signal flag. One alert for both, because the remedy is the same either way: it cannot see enough sky. Warning, Critical once the obstruction is severe.
- **Alignment drift** - the failure nobody diagnoses. A phased array steers electronically well off boresight, so a slipped mount does not fail loudly, it loses margin - and drops concentrate at the times of day when satellites transit the part of the corridor now out of reach. At any given moment everything looks fine. A fixed dish stays wrong until somebody climbs up to it.
- **Ethernet speed degraded** - a cable or a port silently capping the service below what the dish normally negotiates.
- **Repeated outages** - the dish's own outage log summed over a rolling day, carrying the most recent cause so the alert explains itself.
- **Service rate limited** - Info, and only on the **transition** into a rate limit. Some subscriptions are throttled by design and report it permanently; for anyone on a data allotment, crossing into restriction is the moment it ran out, which is exactly when they would want to know. A dish that has always been restricted never says anything.
- **Recovered** - closes the one condition it names, so a dish that clears its obstruction keeps whatever else it still has open.

Where the dish can be tied to a WAN unambiguously the alerts carry the usual WAN label; otherwise they name the dish and fire regardless.

## Alerts & Schedule - Rules

- Seven new rules, seeded disabled and enabled automatically once a dish exists - on the next start for an install that already has one, or on the spot when the first is added. A rule that has been turned off by hand is never turned back on.
- Each event type is listed in the pattern reference alongside the cellular and ONT families.

## Calibration

Every rule is written against a **value**, never against "the field is set", and the values come from 30 days of a real dish rather than from assumption. On that dish - fixed tilt, permanently rate restricted - `disablement_code` reads Okay, `alerts` carries `install_pending` continuously, `hardware_self_test` reads Failed continuously, both restriction reasons are permanently populated, `mobility_class` reads Mobile on a bolted-down dish, and the boresight sits a steady 3.69 degrees off ideal. All while nothing is wrong. Any "has a value" rule would fire on day one and never stop, so the tests that matter most here are the ones asserting silence.

Two consequences worth calling out:

- **Alignment is judged against the dish's own baseline**, a rolling 7-day median, never against ideal - a hand-aimed fixed dish sits wherever it was mounted and works perfectly there. The current value is an hourly median too, because single samples wander up to ~1.6 degrees on a healthy dish.
- **It is gated on attitude uncertainty but explicitly not on mobility class.** The obvious design suppresses drift on a roaming dish; the reference dish is bolted down and reports Mobile, so that gate would have silenced the alert on exactly the installation it was written for.

The uncertainty gate itself was set from the measured distribution after an intuitive value proved badly wrong - a healthy dish carries p50 0.70, p95 1.49, max 2.71 degrees of attitude uncertainty, so a bar near the drift threshold would have gated out most healthy polls and left the alert unable to fire at all.
