### PR TITLE
Mark restarts and alerts on the Monitoring charts

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -377,6 +377,31 @@ all - it is collected and never shown. Either surface it or drop the field.
 
 ## Monitoring
 
+### Device reboot records: one boot writes several points
+One restart can leave up to nine stored records instead of the one the design intends. Measured on
+the NAS site 2026-08-05: **77 records over 90 days describe 11 real boots**, a 7x inflation. Every
+duplicate burst spans under a second (min 0.737s, median 0.801s, max 0.980s), and the records inside
+a burst carry different `classifier_version` values (2, 3, 4, 6, 7, and one blank) and sometimes
+contradict each other on the category - the same boot stored as both `CommandedReboot` and
+`FirmwareUpgrade`. Nine devices, eleven boots in ninety days: nothing is flapping, so this is ours.
+
+Invisible until now because every reader took the latest record per device.
+`QueryLatestDeviceRebootsAsync` collapses with `last()`, so the Uptime tooltip and the tracker's own
+seed only ever saw one. The Device Health event marks were the first thing to read the full range,
+and reported one restart as nine.
+
+`DeviceRebootTracker.StoreAsync` already tries to prevent exactly this: `_storedBootAt` reuses the
+timestamp a boot is already stored under so a re-probe **overwrites** the point instead of landing
+beside it, and `BootMatchTolerance` is five minutes against sub-second drift. It is demonstrably not
+holding. Worth establishing before changing anything: whether the surviving duplicates are historical
+(accumulated across classifier bumps before the mitigation shipped) or still being written, since
+several v7 records inside one burst suggest the latter and would point at a live race rather than a
+backlog.
+
+Not fixed by the chart work. `DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot` folds the records
+on read, keeping the one classified by the newest rules, so the marks are correct while the stored
+data is not. Any fix here should also decide whether to clean up what is already written.
+
 ### PON supplemental counters: wrap-aware deltas (SFP Stats)
 The augmented PON provider's frame/allocation counters (GEM tx/rx, LAN frames, allocations) are 32-bit
 on the ONT and wrap (~4.29B unsigned, or ~2.15B if signed). Every path handles the wrap **safely**

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1207,6 +1207,57 @@ from(bucket: ""{_longtermBucket}"")
         return results;
     }
 
+    /// <summary>
+    /// Every reboot record whose boot instant falls inside a window, for all devices.
+    ///
+    /// The sibling <see cref="QueryLatestDeviceRebootsAsync"/> collapses to one row per device
+    /// because it only cares about the boot each device is running now. Charting wants the
+    /// opposite: every boot in the window, so a device that restarted three times shows three
+    /// marks. Absolute range bounds rather than a lookback, since the chart window can be a
+    /// historic one that does not end at now.
+    /// </summary>
+    /// <param name="from">Window start.</param>
+    /// <param name="to">Window end.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public async Task<IReadOnlyList<DeviceRebootPoint>> QueryDeviceRebootsInRangeAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured || string.IsNullOrEmpty(_longtermBucket))
+            return Array.Empty<DeviceRebootPoint>();
+
+        var flux = $@"
+from(bucket: ""{_longtermBucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""events"")
+  |> filter(fn: (r) => r.event_type == ""{DeviceRebootEventType}"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+";
+        var results = new List<DeviceRebootPoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            var deviceMac = record.GetValueByKey("device_mac") as string ?? "";
+            if (deviceMac.Length == 0) continue;
+
+            results.Add(new DeviceRebootPoint
+            {
+                DeviceMac = deviceMac,
+                Category = record.GetValueByKey("reason_category") as string ?? "",
+                Summary = record.GetValueByKey("reason_summary") as string ?? "",
+                Detail = record.GetValueByKey("detail") as string,
+                Source = record.GetValueByKey("reason_source") as string ?? "",
+                FirmwareVersion = record.GetValueByKey("firmware_version") as string,
+                ClassifierVersion = (int)(AsDoubleOrNull(record.GetValueByKey("classifier_version")) ?? 0),
+                BootedAt = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
+            });
+        }
+        // Same pivot caveat as the sibling query: the Flux result is not globally ordered.
+        results.Sort((a, b) => a.BootedAt.CompareTo(b.BootedAt));
+
+        return results;
+    }
+
     // ---- Read API (Flux queries) ----
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -707,7 +707,9 @@
             </div>
             <div class="card-body">
                 <div class="health-filter-badges wan-filter-badges"></div>
-                <div class="chart-card">
+                @* The tour anchor lands on a chart rather than the card: the marks are the
+                   feature, and they only read as marks with a plotted line behind them. *@
+                <div class="chart-card" data-tour="device-health-events">
                     <div class="chart-header"><h3 class="chart-title">Temperature</h3></div>
                     <div class="health-temp-chart"></div>
                 </div>

--- a/src/NetworkOptimizer.Web/Endpoints/ChartEventMarks.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/ChartEventMarks.cs
@@ -1,0 +1,57 @@
+using NetworkOptimizer.Core.Enums;
+
+namespace NetworkOptimizer.Web.Endpoints;
+
+/// <summary>
+/// Shared pieces of the chart event marks, so the tabs that draw them agree on what an event is
+/// called and how bad it looks. The marks themselves are assembled per endpoint, because what
+/// identifies a series differs by tab (a device MAC, a device and port, an ONT config).
+/// </summary>
+internal static class ChartEventMarks
+{
+    /// <summary>ONT alert types. Raised against an attached module on SFP Stats, a standalone one on ONT Stats.</summary>
+    internal static readonly HashSet<string> OntEventTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ont.rx_power_low",
+        "ont.high_temperature",
+        "ont.pon_link_down",
+        "ont.bip_errors",
+        "ont.fec_errors",
+        "ont.hec_errors",
+    };
+
+    /// <summary>Severity as the mark layer colours it.</summary>
+    internal static string Severity(AlertSeverity severity) => severity switch
+    {
+        AlertSeverity.Critical or AlertSeverity.Error => "critical",
+        AlertSeverity.Warning => "warning",
+        _ => "info",
+    };
+
+    /// <summary>
+    /// Short label for an ONT mark: the alert's own title with the ONT name and any site suffix
+    /// taken off the ends, since the tooltip carries the ONT on its own row. Derived from the
+    /// stored copy rather than reworded, so the two cannot drift.
+    /// </summary>
+    internal static string OntEventLabel(string title, string? ontName)
+    {
+        var label = title;
+
+        var siteSuffix = label.LastIndexOf(" (site ", StringComparison.Ordinal);
+        if (siteSuffix > 0 && label.EndsWith(')')) label = label[..siteSuffix];
+
+        if (!string.IsNullOrEmpty(ontName) && label.StartsWith(ontName + " ", StringComparison.OrdinalIgnoreCase))
+            label = label[(ontName.Length + 1)..];
+
+        if (label.Length == 0) return title;
+        label = char.ToUpperInvariant(label[0]) + label[1..];
+
+        // The ONT copy words this one the other way round from every other mark. Normalized here
+        // rather than at the source so the alert itself keeps the wording it has always had, and
+        // only the mark is brought into line. Everything else the ONT titles produce - "RX power
+        // low", "PON link down", the error spikes - already matches.
+        return label.Equals("Temperature high", StringComparison.OrdinalIgnoreCase)
+            ? "High temperature"
+            : label;
+    }
+}

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -100,10 +100,15 @@ public static class DeviceHealthChartEndpoints
                 });
             }
 
-            var events = await BuildAnnotationsAsync(influx, db, targets
+            // Grouped rather than ToDictionary'd: two Fabric targets can carry the same DeviceMac,
+            // and a duplicate key would throw out of the whole response - charts included, not
+            // just the marks.
+            var macsByNormalized = targets
                 .Where(t => !string.IsNullOrEmpty(t.DeviceMac))
-                .ToDictionary(t => NormalizeMac(t.DeviceMac!), t => t.DeviceMac!),
-                queryFrom, queryTo, ct);
+                .GroupBy(t => NormalizeMac(t.DeviceMac!))
+                .ToDictionary(g => g.Key, g => g.First().DeviceMac!);
+
+            var events = await BuildAnnotationsAsync(influx, db, macsByNormalized, queryFrom, queryTo, ct);
 
             return Results.Ok(new { devices = result, customFields = customFieldDefs, events });
         });
@@ -156,9 +161,12 @@ public static class DeviceHealthChartEndpoints
         var events = new List<(DateTime At, object Payload)>();
         if (macsByNormalized.Count == 0) return new List<object>();
 
-        // Reboots. Influx holds one record per boot in the long-term bucket, so this reaches as
-        // far back as the chart's 30d preset does.
-        var reboots = await influx.QueryDeviceRebootsInRangeAsync(from, to, ct);
+        // Reboots. Influx holds these in the long-term bucket, so this reaches as far back as the
+        // chart's 30d preset does - but "one record per boot" is the intent, not the reality, so
+        // the raw rows are collapsed to one mark per boot first.
+        var reboots = CollapseToOneRecordPerBoot(
+            await influx.QueryDeviceRebootsInRangeAsync(from, to, ct));
+
         foreach (var reboot in reboots)
         {
             if (!macsByNormalized.TryGetValue(NormalizeMac(reboot.DeviceMac), out var mac)) continue;
@@ -204,10 +212,15 @@ public static class DeviceHealthChartEndpoints
             if (AlertTypesCoveredElsewhere.Contains(alert.EventType)) continue;
             if (!macsByNormalized.TryGetValue(NormalizeMac(alert.DeviceId!), out var mac)) continue;
 
-            events.Add((alert.TriggeredAt, new
+            // TriggeredAt is written as UtcNow but comes back from SQLite as Unspecified, and "o"
+            // on an Unspecified value emits no zone - which the browser then reads as LOCAL time,
+            // putting every alert mark hours away from the event it describes.
+            var triggeredAtUtc = DateTime.SpecifyKind(alert.TriggeredAt, DateTimeKind.Utc);
+
+            events.Add((triggeredAtUtc, new
             {
                 mac,
-                time = alert.TriggeredAt.ToString("o"),
+                time = triggeredAtUtc.ToString("o"),
                 kind = "alert",
                 severity = alert.Severity switch
                 {
@@ -224,6 +237,65 @@ public static class DeviceHealthChartEndpoints
         }
 
         return events.OrderBy(e => e.At).Select(e => e.Payload).ToList();
+    }
+
+    /// <summary>
+    /// Two reboot records this far apart describe the same boot. Matches the tolerance
+    /// DeviceRebootTracker itself uses to decide whether a device is still on the boot it
+    /// last saw, so the chart and the tracker agree on what "one boot" means.
+    /// </summary>
+    private static readonly TimeSpan BootMatchTolerance = TimeSpan.FromMinutes(5);
+
+    /// <summary>
+    /// Collapses the stored reboot records to one per boot.
+    ///
+    /// A boot is supposed to occupy a single point, rewritten in place when it is re-probed. In
+    /// practice one boot can hold several: on the NAS site, 77 stored records over 90 days
+    /// describe 11 real boots, in bursts spanning under a second, carrying different classifier
+    /// versions and sometimes contradicting each other on the category. That is a write-path
+    /// defect and it is not fixed here; the read side just has to stop reporting one restart as
+    /// nine, which is what the reboot-reason display already gets for free by taking only the
+    /// latest record per device.
+    ///
+    /// The survivor is the one classified by the newest rules, since a bumped classifier means
+    /// the older records were re-probed precisely because their verdict was not trusted; ties go
+    /// to the latest instant, which is what the tracker's own seed query picks.
+    /// </summary>
+    internal static List<MonitoringInfluxClient.DeviceRebootPoint> CollapseToOneRecordPerBoot(
+        IReadOnlyList<MonitoringInfluxClient.DeviceRebootPoint> records)
+    {
+        var kept = new List<MonitoringInfluxClient.DeviceRebootPoint>();
+
+        foreach (var group in records.GroupBy(r => NormalizeMac(r.DeviceMac)))
+        {
+            MonitoringInfluxClient.DeviceRebootPoint? best = null;
+            // Measured from the boot the cluster opened with, not from whichever record is
+            // currently winning it - otherwise the window slides forward with every swap and a
+            // long enough run of records would swallow a genuinely separate restart.
+            DateTime clusterStart = default;
+
+            foreach (var record in group.OrderBy(r => r.BootedAt))
+            {
+                if (best is not null && record.BootedAt - clusterStart <= BootMatchTolerance)
+                {
+                    if (record.ClassifierVersion > best.ClassifierVersion
+                        || (record.ClassifierVersion == best.ClassifierVersion
+                            && record.BootedAt >= best.BootedAt))
+                    {
+                        best = record;
+                    }
+                    continue;
+                }
+
+                if (best is not null) kept.Add(best);
+                best = record;
+                clusterStart = record.BootedAt;
+            }
+
+            if (best is not null) kept.Add(best);
+        }
+
+        return kept;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -1,8 +1,11 @@
 using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Authorization;
+using NetworkOptimizer.Web.Services.Monitoring;
+using NetworkOptimizer.Web.Services.Monitoring.RebootReason;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
@@ -97,7 +100,147 @@ public static class DeviceHealthChartEndpoints
                 });
             }
 
-            return Results.Ok(new { devices = result, customFields = customFieldDefs });
+            var events = await BuildAnnotationsAsync(influx, db, targets
+                .Where(t => !string.IsNullOrEmpty(t.DeviceMac))
+                .ToDictionary(t => NormalizeMac(t.DeviceMac!), t => t.DeviceMac!),
+                queryFrom, queryTo, ct);
+
+            return Results.Ok(new { devices = result, customFields = customFieldDefs, events });
         });
     }
+
+    /// <summary>
+    /// Alert event types that are already covered by a richer source and must not be annotated twice.
+    /// The reboot alert and the Influx reboot record describe the same restart, but only the Influx
+    /// record carries the category, the evidence and the firmware - and it is written for every boot,
+    /// not just the ones recent enough to alert on.
+    /// </summary>
+    private static readonly HashSet<string> AlertTypesCoveredElsewhere =
+        new(StringComparer.OrdinalIgnoreCase) { DeviceRebootAlertEvaluator.RebootEventType };
+
+    /// <summary>
+    /// Reboot categories the operator did not ask for. Mirrors DeviceRebootReason.IsUnexpected,
+    /// which lives in the Web services tier and works on the enum rather than the stored string.
+    /// </summary>
+    private static readonly HashSet<string> UnexpectedRebootCategories =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            nameof(RebootCategory.PowerLoss), nameof(RebootCategory.AbruptStop),
+            nameof(RebootCategory.KernelPanic), nameof(RebootCategory.HardwareHang),
+            nameof(RebootCategory.Watchdog),
+        };
+
+    /// <summary>
+    /// The events worth marking on a device's health charts, over the same window as the series.
+    /// </summary>
+    /// <param name="influx">Time-series client, source of the reboot records.</param>
+    /// <param name="db">Site database, source of the device-scoped alert history.</param>
+    /// <param name="macsByNormalized">
+    /// Charted devices, keyed by normalized MAC so both sources can be matched against them, with
+    /// the target's own MAC spelling as the value - that is the key the chart filters on.
+    /// </param>
+    /// <param name="from">Window start.</param>
+    /// <param name="to">Window end.</param>
+    /// <param name="ct">Cancellation token.</param>
+    private static async Task<List<object>> BuildAnnotationsAsync(
+        MonitoringInfluxClient influx,
+        NetworkOptimizerDbContext db,
+        Dictionary<string, string> macsByNormalized,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        // Carried alongside the payload so the two sources can be merged into one time-ordered
+        // list; the payload itself stays an anonymous object to keep the JSON property names
+        // literal, the way the rest of this endpoint's response is built.
+        var events = new List<(DateTime At, object Payload)>();
+        if (macsByNormalized.Count == 0) return new List<object>();
+
+        // Reboots. Influx holds one record per boot in the long-term bucket, so this reaches as
+        // far back as the chart's 30d preset does.
+        var reboots = await influx.QueryDeviceRebootsInRangeAsync(from, to, ct);
+        foreach (var reboot in reboots)
+        {
+            if (!macsByNormalized.TryGetValue(NormalizeMac(reboot.DeviceMac), out var mac)) continue;
+
+            var unexpected = UnexpectedRebootCategories.Contains(reboot.Category);
+            events.Add((reboot.BootedAt, new
+            {
+                mac,
+                time = reboot.BootedAt.ToString("o"),
+                kind = "reboot",
+                severity = unexpected ? "warning" : "info",
+                title = string.IsNullOrWhiteSpace(reboot.Summary) ? "Restarted" : reboot.Summary,
+                detail = string.IsNullOrWhiteSpace(reboot.FirmwareVersion)
+                    ? reboot.Detail
+                    : string.IsNullOrWhiteSpace(reboot.Detail)
+                        ? $"Firmware {reboot.FirmwareVersion}"
+                        : $"{reboot.Detail}. Firmware {reboot.FirmwareVersion}",
+            }));
+        }
+
+        // Device-scoped alerts. DeviceId holds a MAC for the device evaluators but an unrelated
+        // key for others ("all-wans", a WAN key, "network-audit"), and the MAC spelling is
+        // whatever the publishing evaluator had. Narrowing in SQL to the spellings a charted
+        // device could plausibly be stored under keeps a noisy 30d window from being pulled into
+        // memory just to be discarded; the normalized compare below is still the decider.
+        var macCandidates = macsByNormalized
+            .SelectMany(kvp => new[]
+            {
+                kvp.Value, kvp.Value.ToLowerInvariant(), kvp.Value.ToUpperInvariant(),
+                kvp.Key, kvp.Key.ToUpperInvariant(),
+            })
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        var alerts = await db.AlertHistory.AsNoTracking()
+            .Where(a => a.DeviceId != null && macCandidates.Contains(a.DeviceId)
+                && a.TriggeredAt >= from && a.TriggeredAt <= to)
+            .Select(a => new { a.EventType, a.Severity, a.Title, a.Message, a.DeviceId, a.TriggeredAt })
+            .ToListAsync(ct);
+
+        foreach (var alert in alerts)
+        {
+            if (AlertTypesCoveredElsewhere.Contains(alert.EventType)) continue;
+            if (!macsByNormalized.TryGetValue(NormalizeMac(alert.DeviceId!), out var mac)) continue;
+
+            events.Add((alert.TriggeredAt, new
+            {
+                mac,
+                time = alert.TriggeredAt.ToString("o"),
+                kind = "alert",
+                severity = alert.Severity switch
+                {
+                    AlertSeverity.Critical or AlertSeverity.Error => "critical",
+                    AlertSeverity.Warning => "warning",
+                    _ => "info",
+                },
+                // Titles carry the device name and a site suffix, which the chart already knows
+                // from the series it sits on; the event type is what distinguishes one mark
+                // from the next.
+                title = AlertLabel(alert.EventType, alert.Title),
+                detail = alert.Message,
+            }));
+        }
+
+        return events.OrderBy(e => e.At).Select(e => e.Payload).ToList();
+    }
+
+    /// <summary>
+    /// Short label for an alert mark: the alert's own noun, without the device name the chart
+    /// already shows. Falls back to the stored title when the event type is not one we name.
+    /// </summary>
+    private static string AlertLabel(string eventType, string title) => eventType switch
+    {
+        "device.offline" => "Offline",
+        "device.recovered" => "Recovered",
+        "device.gateway_high_cpu" => "High CPU",
+        "device.gateway_high_memory" => "High memory",
+        "device.high_temperature" => "High temperature",
+        _ => title,
+    };
+
+    /// <summary>Strips MAC separators and case so spellings from different sources compare equal.</summary>
+    private static string NormalizeMac(string mac) =>
+        mac.Replace(":", "").Replace("-", "").ToLowerInvariant();
 }

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -106,7 +106,7 @@ public static class DeviceHealthChartEndpoints
             var macsByNormalized = targets
                 .Where(t => !string.IsNullOrEmpty(t.DeviceMac))
                 .GroupBy(t => NormalizeMac(t.DeviceMac!))
-                .ToDictionary(g => g.Key, g => g.First().DeviceMac!);
+                .ToDictionary(g => g.Key, g => (Key: g.First().DeviceMac!, Name: g.First().Name));
 
             var events = await BuildAnnotationsAsync(influx, db, macsByNormalized, queryFrom, queryTo, ct);
 
@@ -141,8 +141,10 @@ public static class DeviceHealthChartEndpoints
     /// <param name="influx">Time-series client, source of the reboot records.</param>
     /// <param name="db">Site database, source of the device-scoped alert history.</param>
     /// <param name="macsByNormalized">
-    /// Charted devices, keyed by normalized MAC so both sources can be matched against them, with
-    /// the target's own MAC spelling as the value - that is the key the chart filters on.
+    /// Charted devices, keyed by normalized MAC so both sources can be matched against them. The
+    /// value carries the series key the chart filters on (the target's own MAC spelling) and the
+    /// device's display name, which rides down with each event so the mark layer never has to
+    /// look a series up.
     /// </param>
     /// <param name="from">Window start.</param>
     /// <param name="to">Window end.</param>
@@ -150,7 +152,7 @@ public static class DeviceHealthChartEndpoints
     private static async Task<List<object>> BuildAnnotationsAsync(
         MonitoringInfluxClient influx,
         NetworkOptimizerDbContext db,
-        Dictionary<string, string> macsByNormalized,
+        Dictionary<string, (string Key, string Name)> macsByNormalized,
         DateTime from,
         DateTime to,
         CancellationToken ct)
@@ -169,12 +171,13 @@ public static class DeviceHealthChartEndpoints
 
         foreach (var reboot in reboots)
         {
-            if (!macsByNormalized.TryGetValue(NormalizeMac(reboot.DeviceMac), out var mac)) continue;
+            if (!macsByNormalized.TryGetValue(NormalizeMac(reboot.DeviceMac), out var series)) continue;
 
             var unexpected = UnexpectedRebootCategories.Contains(reboot.Category);
             events.Add((reboot.BootedAt, new
             {
-                mac,
+                key = series.Key,
+                device = series.Name,
                 time = reboot.BootedAt.ToString("o"),
                 kind = "reboot",
                 severity = unexpected ? "warning" : "info",
@@ -195,7 +198,7 @@ public static class DeviceHealthChartEndpoints
         var macCandidates = macsByNormalized
             .SelectMany(kvp => new[]
             {
-                kvp.Value, kvp.Value.ToLowerInvariant(), kvp.Value.ToUpperInvariant(),
+                kvp.Value.Key, kvp.Value.Key.ToLowerInvariant(), kvp.Value.Key.ToUpperInvariant(),
                 kvp.Key, kvp.Key.ToUpperInvariant(),
             })
             .Distinct(StringComparer.Ordinal)
@@ -210,7 +213,7 @@ public static class DeviceHealthChartEndpoints
         foreach (var alert in alerts)
         {
             if (AlertTypesCoveredElsewhere.Contains(alert.EventType)) continue;
-            if (!macsByNormalized.TryGetValue(NormalizeMac(alert.DeviceId!), out var mac)) continue;
+            if (!macsByNormalized.TryGetValue(NormalizeMac(alert.DeviceId!), out var series)) continue;
 
             // TriggeredAt is written as UtcNow but comes back from SQLite as Unspecified, and "o"
             // on an Unspecified value emits no zone - which the browser then reads as LOCAL time,
@@ -219,7 +222,8 @@ public static class DeviceHealthChartEndpoints
 
             events.Add((triggeredAtUtc, new
             {
-                mac,
+                key = series.Key,
+                device = series.Name,
                 time = triggeredAtUtc.ToString("o"),
                 kind = "alert",
                 severity = alert.Severity switch

--- a/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/OntChartEndpoints.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Authorization;
@@ -20,6 +23,8 @@ public static class OntChartEndpoints
         group.MapGet("/api/monitoring/ont-chart", async (
             MonitoringInfluxClient influx,
             OntMonitorService ontService,
+            SiteDbContextFactory siteDbFactory,
+            SiteContextService siteContext,
             int? rangeHours,
             DateTime? from,
             DateTime? to,
@@ -83,10 +88,82 @@ public static class OntChartEndpoints
                     label = name,
                     data = items,
                 };
-            });
+            }).ToList();
 
-            return Results.Ok(new { devices = result });
+            // Only the ONTs that actually became a series can be marked. An event keyed to
+            // anything else would pass the chart's visibility filter, which treats an unknown key
+            // as visible, and draw a mark belonging to no line on the plot.
+            var chartedOnts = data.Keys
+                .Where(nameMap.ContainsKey)
+                .ToDictionary(id => id, id => nameMap[id]);
+
+            var events = await BuildOntEventsAsync(siteDbFactory, siteContext, chartedOnts, queryFrom, queryTo, ct);
+
+            return Results.Ok(new { devices = result, events });
         });
+    }
+
+    /// <summary>
+    /// Marks for the charted ONTs over the same window as the series.
+    ///
+    /// ONT alerts carry their config id in the event context, which is the same id the series is
+    /// keyed by, so the match needs nothing else. Attached ONTs drop out for free: this tab only
+    /// charts standalone configs, so an attached one matches no series and its alerts stay on SFP
+    /// Stats where its charts are.
+    /// </summary>
+    private static async Task<List<object>> BuildOntEventsAsync(
+        SiteDbContextFactory siteDbFactory,
+        SiteContextService siteContext,
+        Dictionary<string, string> chartedOnts,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        if (chartedOnts.Count == 0) return new List<object>();
+
+        await using var db = siteDbFactory.CreateForSite(siteContext.Slug, siteContext.IsDefault);
+
+        var alerts = await db.AlertHistory.AsNoTracking()
+            .Where(a => a.ContextJson != null && a.TriggeredAt >= from && a.TriggeredAt <= to
+                && ChartEventMarks.OntEventTypes.Contains(a.EventType))
+            .Select(a => new { a.EventType, a.Severity, a.Title, a.Message, a.DeviceName, a.ContextJson, a.TriggeredAt })
+            .ToListAsync(ct);
+
+        var events = new List<(DateTime At, object Payload)>();
+        foreach (var alert in alerts)
+        {
+            string? ontId = null;
+            try
+            {
+                var context = JsonSerializer.Deserialize<Dictionary<string, string>>(alert.ContextJson!);
+                context?.TryGetValue("ont_id", out ontId);
+            }
+            catch (JsonException)
+            {
+                // A context we cannot read costs one mark, not the whole tab.
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(ontId) || !chartedOnts.TryGetValue(ontId, out var ontName)) continue;
+
+            // Written as UtcNow but read back from SQLite as Unspecified, and "o" on an
+            // Unspecified value emits no zone - which the browser then reads as local time.
+            var triggeredAtUtc = DateTime.SpecifyKind(alert.TriggeredAt, DateTimeKind.Utc);
+
+            events.Add((triggeredAtUtc, new
+            {
+                key = ontId,
+                device = ontName,
+                time = triggeredAtUtc.ToString("o"),
+                kind = "alert",
+                severity = ChartEventMarks.Severity(alert.Severity),
+                title = ChartEventMarks.OntEventLabel(alert.Title, alert.DeviceName),
+                detail = alert.Message,
+            }));
+        }
+
+        // The mark layer folds by proximity, which assumes time order.
+        return events.OrderBy(e => e.At).Select(e => e.Payload).ToList();
     }
 
     private static long? Delta(long? cur, long? prev) =>

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -121,7 +121,7 @@ public static class SfpChartEndpoints
     };
 
     /// <summary>
-    /// ONT alerts for a module attached to an SFP. These mark the PON charts only: they describe
+    /// ONT alerts for a module attached to an SFP. Most mark the PON charts only: they describe
     /// the PON layer, not the optics the power and temperature charts plot.
     /// </summary>
     private static readonly HashSet<string> OntEventTypes = new(StringComparer.OrdinalIgnoreCase)
@@ -133,6 +133,19 @@ public static class SfpChartEndpoints
         "ont.fec_errors",
         "ont.hec_errors",
     };
+
+    /// <summary>
+    /// The exception to that: a PON link going down is the one ONT condition worth seeing while
+    /// reading the optics, since it is what the RX and TX traces are usually being checked
+    /// against.
+    /// </summary>
+    private const string PonLinkDownEventType = "ont.pon_link_down";
+
+    /// <summary>Marks every chart on the tab.</summary>
+    private const string ScopeAll = "all";
+
+    /// <summary>Marks the PON charts alone.</summary>
+    private const string ScopePon = "pon";
 
     /// <summary>Module identity used by both the series and the marks: device MAC plus port.</summary>
     private static string ModuleKey(string deviceMac, string portName) =>
@@ -181,7 +194,16 @@ public static class SfpChartEndpoints
         if (!string.IsNullOrEmpty(ontName) && label.StartsWith(ontName + " ", StringComparison.OrdinalIgnoreCase))
             label = label[(ontName.Length + 1)..];
 
-        return label.Length > 0 ? char.ToUpperInvariant(label[0]) + label[1..] : title;
+        if (label.Length == 0) return title;
+        label = char.ToUpperInvariant(label[0]) + label[1..];
+
+        // The ONT copy words this one the other way round from every other mark. Normalized here
+        // rather than at the source so the alert itself keeps the wording it has always had, and
+        // only the mark is brought into line. Everything else the ONT titles produce - "RX power
+        // low", "PON link down", the error spikes - already matches.
+        return label.Equals("Temperature high", StringComparison.OrdinalIgnoreCase)
+            ? "High temperature"
+            : label;
     }
 
     /// <summary>
@@ -236,7 +258,7 @@ public static class SfpChartEndpoints
             events.Add((triggeredAtUtc, new
             {
                 key,
-                scope = "sfp",
+                scope = ScopeAll,
                 device = module.Device,
                 port = module.Port,
                 time = triggeredAtUtc.ToString("o"),
@@ -268,7 +290,9 @@ public static class SfpChartEndpoints
             events.Add((triggeredAtUtc, new
             {
                 key,
-                scope = "pon",
+                scope = alert.EventType.Equals(PonLinkDownEventType, StringComparison.OrdinalIgnoreCase)
+                    ? ScopeAll
+                    : ScopePon,
                 device = module.Device,
                 port = module.Port,
                 time = triggeredAtUtc.ToString("o"),

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -157,8 +157,12 @@ public static class SfpChartEndpoints
             var eq = pair.IndexOf('=');
             if (eq <= 0 || pair[..eq] != "sfp") continue;
 
+            // Compared verbatim, NOT lower-cased: the agent builds this value with the same
+            // expression ModuleKey uses, which lower-cases the MAC but leaves the port name as
+            // the device spells it. Lower-casing the whole thing here would silently stop
+            // matching the moment a port name carried an upper-case character.
             var value = Uri.UnescapeDataString(pair[(eq + 1)..]);
-            return string.IsNullOrEmpty(value) ? null : value.ToLowerInvariant();
+            return string.IsNullOrEmpty(value) ? null : value;
         }
 
         return null;

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -120,9 +120,69 @@ public static class SfpChartEndpoints
         "monitoring.sfp_tx_power",
     };
 
+    /// <summary>
+    /// ONT alerts for a module attached to an SFP. These mark the PON charts only: they describe
+    /// the PON layer, not the optics the power and temperature charts plot.
+    /// </summary>
+    private static readonly HashSet<string> OntEventTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "ont.rx_power_low",
+        "ont.high_temperature",
+        "ont.pon_link_down",
+        "ont.bip_errors",
+        "ont.fec_errors",
+        "ont.hec_errors",
+    };
+
     /// <summary>Module identity used by both the series and the marks: device MAC plus port.</summary>
     private static string ModuleKey(string deviceMac, string portName) =>
         $"{deviceMac.Replace("-", ":").ToLowerInvariant()}:{portName}";
+
+    /// <summary>
+    /// The module an ONT alert belongs to, read from the link the alert already carries.
+    ///
+    /// ONT alerts identify themselves by ont_id, which says nothing about which SFP the ONT is
+    /// attached to - but the collection agent sets SourceUrl to that module's deep link precisely
+    /// because attached ONTs surface on SFP Stats. That also makes this the right discriminator
+    /// rather than a shortcut: a standalone ONT gets a <c>tab=ont</c> link instead and is left
+    /// alone, which is what should happen on a tab about SFP modules.
+    /// </summary>
+    private static string? ModuleKeyFromSourceUrl(string? sourceUrl)
+    {
+        if (string.IsNullOrEmpty(sourceUrl)) return null;
+
+        var queryStart = sourceUrl.IndexOf('?');
+        if (queryStart < 0) return null;
+
+        foreach (var pair in sourceUrl[(queryStart + 1)..].Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq <= 0 || pair[..eq] != "sfp") continue;
+
+            var value = Uri.UnescapeDataString(pair[(eq + 1)..]);
+            return string.IsNullOrEmpty(value) ? null : value.ToLowerInvariant();
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Short label for an ONT mark: the alert's own title with the ONT name and any site suffix
+    /// taken off the ends, since the tooltip carries the module on its own rows. Derived from the
+    /// stored copy rather than reworded, so the two cannot drift.
+    /// </summary>
+    private static string OntEventLabel(string title, string? ontName)
+    {
+        var label = title;
+
+        var siteSuffix = label.LastIndexOf(" (site ", StringComparison.Ordinal);
+        if (siteSuffix > 0 && label.EndsWith(')')) label = label[..siteSuffix];
+
+        if (!string.IsNullOrEmpty(ontName) && label.StartsWith(ontName + " ", StringComparison.OrdinalIgnoreCase))
+            label = label[(ontName.Length + 1)..];
+
+        return label.Length > 0 ? char.ToUpperInvariant(label[0]) + label[1..] : title;
+    }
 
     /// <summary>
     /// Marks for the charted modules over the same window as the series.
@@ -176,6 +236,7 @@ public static class SfpChartEndpoints
             events.Add((triggeredAtUtc, new
             {
                 key,
+                scope = "sfp",
                 device = module.Device,
                 port = module.Port,
                 time = triggeredAtUtc.ToString("o"),
@@ -188,6 +249,38 @@ public static class SfpChartEndpoints
                 },
                 title = SfpEventLabel(alert.EventType, alert.Title),
                 detail = TrimTrailingLocation(alert.Message, module.Device, module.Port),
+            }));
+        }
+
+        var ontAlerts = await db.AlertHistory.AsNoTracking()
+            .Where(a => a.SourceUrl != null && a.TriggeredAt >= from && a.TriggeredAt <= to
+                && OntEventTypes.Contains(a.EventType))
+            .Select(a => new { a.EventType, a.Severity, a.Title, a.Message, a.DeviceName, a.SourceUrl, a.TriggeredAt })
+            .ToListAsync(ct);
+
+        foreach (var alert in ontAlerts)
+        {
+            var key = ModuleKeyFromSourceUrl(alert.SourceUrl);
+            if (key is null || !modulesById.TryGetValue(key, out var module)) continue;
+
+            var triggeredAtUtc = DateTime.SpecifyKind(alert.TriggeredAt, DateTimeKind.Utc);
+
+            events.Add((triggeredAtUtc, new
+            {
+                key,
+                scope = "pon",
+                device = module.Device,
+                port = module.Port,
+                time = triggeredAtUtc.ToString("o"),
+                kind = "alert",
+                severity = alert.Severity switch
+                {
+                    AlertSeverity.Critical or AlertSeverity.Error => "critical",
+                    AlertSeverity.Warning => "warning",
+                    _ => "info",
+                },
+                title = OntEventLabel(alert.Title, alert.DeviceName),
+                detail = alert.Message,
             }));
         }
 

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
-using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
@@ -121,20 +120,6 @@ public static class SfpChartEndpoints
     };
 
     /// <summary>
-    /// ONT alerts for a module attached to an SFP. Most mark the PON charts only: they describe
-    /// the PON layer, not the optics the power and temperature charts plot.
-    /// </summary>
-    private static readonly HashSet<string> OntEventTypes = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "ont.rx_power_low",
-        "ont.high_temperature",
-        "ont.pon_link_down",
-        "ont.bip_errors",
-        "ont.fec_errors",
-        "ont.hec_errors",
-    };
-
-    /// <summary>
     /// The exception to that: a PON link going down is the one ONT condition worth seeing while
     /// reading the optics, since it is what the RX and TX traces are usually being checked
     /// against.
@@ -179,32 +164,6 @@ public static class SfpChartEndpoints
         return null;
     }
 
-    /// <summary>
-    /// Short label for an ONT mark: the alert's own title with the ONT name and any site suffix
-    /// taken off the ends, since the tooltip carries the module on its own rows. Derived from the
-    /// stored copy rather than reworded, so the two cannot drift.
-    /// </summary>
-    private static string OntEventLabel(string title, string? ontName)
-    {
-        var label = title;
-
-        var siteSuffix = label.LastIndexOf(" (site ", StringComparison.Ordinal);
-        if (siteSuffix > 0 && label.EndsWith(')')) label = label[..siteSuffix];
-
-        if (!string.IsNullOrEmpty(ontName) && label.StartsWith(ontName + " ", StringComparison.OrdinalIgnoreCase))
-            label = label[(ontName.Length + 1)..];
-
-        if (label.Length == 0) return title;
-        label = char.ToUpperInvariant(label[0]) + label[1..];
-
-        // The ONT copy words this one the other way round from every other mark. Normalized here
-        // rather than at the source so the alert itself keeps the wording it has always had, and
-        // only the mark is brought into line. Everything else the ONT titles produce - "RX power
-        // low", "PON link down", the error spikes - already matches.
-        return label.Equals("Temperature high", StringComparison.OrdinalIgnoreCase)
-            ? "High temperature"
-            : label;
-    }
 
     /// <summary>
     /// Marks for the charted modules over the same window as the series.
@@ -263,12 +222,7 @@ public static class SfpChartEndpoints
                 port = module.Port,
                 time = triggeredAtUtc.ToString("o"),
                 kind = "alert",
-                severity = alert.Severity switch
-                {
-                    AlertSeverity.Critical or AlertSeverity.Error => "critical",
-                    AlertSeverity.Warning => "warning",
-                    _ => "info",
-                },
+                severity = ChartEventMarks.Severity(alert.Severity),
                 title = SfpEventLabel(alert.EventType, alert.Title),
                 detail = TrimTrailingLocation(alert.Message, module.Device, module.Port),
             }));
@@ -276,7 +230,7 @@ public static class SfpChartEndpoints
 
         var ontAlerts = await db.AlertHistory.AsNoTracking()
             .Where(a => a.SourceUrl != null && a.TriggeredAt >= from && a.TriggeredAt <= to
-                && OntEventTypes.Contains(a.EventType))
+                && ChartEventMarks.OntEventTypes.Contains(a.EventType))
             .Select(a => new { a.EventType, a.Severity, a.Title, a.Message, a.DeviceName, a.SourceUrl, a.TriggeredAt })
             .ToListAsync(ct);
 
@@ -297,13 +251,8 @@ public static class SfpChartEndpoints
                 port = module.Port,
                 time = triggeredAtUtc.ToString("o"),
                 kind = "alert",
-                severity = alert.Severity switch
-                {
-                    AlertSeverity.Critical or AlertSeverity.Error => "critical",
-                    AlertSeverity.Warning => "warning",
-                    _ => "info",
-                },
-                title = OntEventLabel(alert.Title, alert.DeviceName),
+                severity = ChartEventMarks.Severity(alert.Severity),
+                title = ChartEventMarks.OntEventLabel(alert.Title, alert.DeviceName),
                 detail = alert.Message,
             }));
         }

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
@@ -44,7 +46,7 @@ public static class SfpChartEndpoints
                 .ToListAsync(ct);
 
             if (sfps.Count == 0)
-                return Results.Ok(new { modules = Array.Empty<object>() });
+                return Results.Ok(new { modules = Array.Empty<object>(), events = Array.Empty<object>() });
 
             var modules = sfps.Select(s => (s.DeviceMac, s.PortName)).ToList();
             var data = await influx.QuerySfpByModulesAsync(modules, queryFrom, queryTo, ct: ct);
@@ -89,8 +91,134 @@ public static class SfpChartEndpoints
                 };
             });
 
-            return Results.Ok(new { modules = result });
+            // Grouped rather than ToDictionary'd: a duplicate module row would otherwise throw
+            // out of the whole response, series included, for the sake of the marks.
+            var modulesById = sfps
+                .GroupBy(s => ModuleKey(s.DeviceMac, s.PortName))
+                .ToDictionary(g => g.Key, g => (
+                    Port: g.First().PortName,
+                    Device: nameMap.TryGetValue(
+                        g.First().DeviceMac.Replace("-", ":").ToLowerInvariant(), out var dn)
+                            ? dn
+                            : g.First().DeviceMac));
+
+            var events = await BuildSfpEventsAsync(db, modulesById, queryFrom, queryTo, ct);
+
+            return Results.Ok(new { modules = result, events });
         });
+    }
+
+    /// <summary>
+    /// The SFP alerts, and only those. A restart or a device-wide alert belongs to the device
+    /// rather than to any one module, so it is left to Device Stats instead of being repeated
+    /// against every module the device happens to carry.
+    /// </summary>
+    private static readonly HashSet<string> SfpEventTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "monitoring.sfp_temperature",
+        "monitoring.sfp_rx_power",
+        "monitoring.sfp_tx_power",
+    };
+
+    /// <summary>Module identity used by both the series and the marks: device MAC plus port.</summary>
+    private static string ModuleKey(string deviceMac, string portName) =>
+        $"{deviceMac.Replace("-", ":").ToLowerInvariant()}:{portName}";
+
+    /// <summary>
+    /// Marks for the charted modules over the same window as the series.
+    ///
+    /// An SFP alert names its module in the event context rather than in a column, so the match
+    /// is made there: DeviceId alone would put a mark on every module of a multi-SFP device.
+    /// </summary>
+    private static async Task<List<object>> BuildSfpEventsAsync(
+        NetworkOptimizerDbContext db,
+        Dictionary<string, (string Port, string Device)> modulesById,
+        DateTime from,
+        DateTime to,
+        CancellationToken ct)
+    {
+        // Time carried alongside the payload so the list can be ordered without reflecting over
+        // the anonymous type; the payload stays anonymous to keep the JSON names literal, the way
+        // the rest of this endpoint's response is built.
+        var events = new List<(DateTime At, object Payload)>();
+        if (modulesById.Count == 0) return new List<object>();
+
+        var alerts = await db.AlertHistory.AsNoTracking()
+            .Where(a => a.ContextJson != null && a.TriggeredAt >= from && a.TriggeredAt <= to
+                && SfpEventTypes.Contains(a.EventType))
+            .Select(a => new { a.EventType, a.Severity, a.Title, a.Message, a.ContextJson, a.TriggeredAt })
+            .ToListAsync(ct);
+
+        foreach (var alert in alerts)
+        {
+            string? deviceMac = null, portName = null;
+            try
+            {
+                var context = JsonSerializer.Deserialize<Dictionary<string, string>>(alert.ContextJson!);
+                context?.TryGetValue("device_mac", out deviceMac);
+                context?.TryGetValue("port_name", out portName);
+            }
+            catch (JsonException)
+            {
+                // A context we cannot read costs one mark, not the whole tab.
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(deviceMac) || string.IsNullOrEmpty(portName)) continue;
+
+            var key = ModuleKey(deviceMac, portName);
+            if (!modulesById.TryGetValue(key, out var module)) continue;
+
+            // Written as UtcNow but read back from SQLite as Unspecified, and "o" on an
+            // Unspecified value emits no zone - which the browser then reads as local time.
+            var triggeredAtUtc = DateTime.SpecifyKind(alert.TriggeredAt, DateTimeKind.Utc);
+
+            events.Add((triggeredAtUtc, new
+            {
+                key,
+                device = module.Device,
+                port = module.Port,
+                time = triggeredAtUtc.ToString("o"),
+                kind = "alert",
+                severity = alert.Severity switch
+                {
+                    AlertSeverity.Critical or AlertSeverity.Error => "critical",
+                    AlertSeverity.Warning => "warning",
+                    _ => "info",
+                },
+                title = SfpEventLabel(alert.EventType, alert.Title),
+                detail = TrimTrailingLocation(alert.Message, module.Device, module.Port),
+            }));
+        }
+
+        // The mark layer folds by proximity, which assumes time order.
+        return events.OrderBy(e => e.At).Select(e => e.Payload).ToList();
+    }
+
+    /// <summary>
+    /// Short label for a mark. The stored title spells out the device and port, which the
+    /// tooltip already carries in its own rows, so the mark names the condition alone.
+    /// </summary>
+    private static string SfpEventLabel(string eventType, string title) => eventType switch
+    {
+        "monitoring.sfp_temperature" => "High temperature",
+        "monitoring.sfp_rx_power" => "RX power low",
+        "monitoring.sfp_tx_power" => "TX power high",
+        _ => title,
+    };
+
+    /// <summary>
+    /// Drops the trailing "on &lt;device&gt; port &lt;n&gt;" the alert message ends with, since the
+    /// tooltip states both on their own rows directly above it.
+    /// </summary>
+    private static string TrimTrailingLocation(string message, string device, string port)
+    {
+        foreach (var suffix in new[] { $" on {device} port {port}", $" on port {port}" })
+        {
+            if (message.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                return message[..^suffix.Length];
+        }
+        return message;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7355,6 +7355,12 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-primary);
 }
 
+/* Semi-bold on the mark tooltips only. The shared .device-tooltip-label stays at its own weight
+   so the speed test and Wi-Fi tooltips are untouched. */
+.tippy-box[data-theme~='custom'] .chart-mark-row .device-tooltip-label {
+    font-weight: 600;
+}
+
 /* Detail is prose rather than a value, so it wraps under its label instead of being squeezed
    into the value column beside it. */
 .tippy-box[data-theme~='custom'] .chart-mark-detail {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7340,7 +7340,8 @@ a.path-hop.hop-clickable:hover {
    the WAN live chart draw annotations too and must keep the library's behaviour, so a card earns
    the unlock by being added here. The id also wins on specificity without !important. */
 #device-health-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark,
-#sfp-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark {
+#sfp-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark,
+#ont-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark {
     pointer-events: auto;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7335,6 +7335,12 @@ a.path-hop.hop-clickable:hover {
     max-width: 360px;
 }
 
+/* ApexCharts sets pointer-events: none on every annotation label, which leaves the event marks
+   unhoverable and their tooltips dead. Two classes beat their one, so no !important needed. */
+.apexcharts-xaxis-annotation-label.chart-event-mark {
+    pointer-events: auto;
+}
+
 /* Folded chart event marks list every event it covers, so it scrolls rather than truncates */
 .chart-annotation-list {
     max-height: 12rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7335,6 +7335,17 @@ a.path-hop.hop-clickable:hover {
     max-width: 360px;
 }
 
+/* Folded chart event marks list every event it covers, so it scrolls rather than truncates */
+.chart-annotation-list {
+    max-height: 12rem;
+    overflow-y: auto;
+    margin-top: 0.25rem;
+}
+
+.chart-annotation-time {
+    color: var(--text-muted);
+}
+
 /* ============================================
    Login Page Styles
    ============================================ */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7336,19 +7336,22 @@ a.path-hop.hop-clickable:hover {
 }
 
 /* ApexCharts sets pointer-events: none on every annotation label, which leaves the event marks
-   unhoverable and their tooltips dead. Two classes beat their one, so no !important needed. */
-.apexcharts-xaxis-annotation-label.chart-event-mark {
+   unhoverable and their tooltips dead. Confined to the Device Health card so annotations on any
+   other chart keep the library's behaviour; the id also wins on specificity without !important. */
+#device-health-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark {
     pointer-events: auto;
 }
 
-/* Folded chart event marks list every event it covers, so it scrolls rather than truncates */
-.chart-annotation-list {
+/* Tooltip content for a folded mark. Scoped to the tooltip rather than the card because Tippy
+   renders the popper on document.body, outside the chart container entirely. The list scrolls
+   because a fold names every event it covers. */
+.tippy-box[data-theme~='custom'] .chart-annotation-list {
     max-height: 12rem;
     overflow-y: auto;
     margin-top: 0.25rem;
 }
 
-.chart-annotation-time {
+.tippy-box[data-theme~='custom'] .chart-annotation-time {
     color: var(--text-muted);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7336,9 +7336,11 @@ a.path-hop.hop-clickable:hover {
 }
 
 /* ApexCharts sets pointer-events: none on every annotation label, which leaves the event marks
-   unhoverable and their tooltips dead. Confined to the Device Health card so annotations on any
-   other chart keep the library's behaviour; the id also wins on specificity without !important. */
-#device-health-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark {
+   unhoverable and their tooltips dead. Listed per container on purpose: ISP Health, latency and
+   the WAN live chart draw annotations too and must keep the library's behaviour, so a card earns
+   the unlock by being added here. The id also wins on specificity without !important. */
+#device-health-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark,
+#sfp-charts-container .apexcharts-xaxis-annotation-label.chart-event-mark {
     pointer-events: auto;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -7342,17 +7342,57 @@ a.path-hop.hop-clickable:hover {
     pointer-events: auto;
 }
 
-/* Tooltip content for a folded mark. Scoped to the tooltip rather than the card because Tippy
-   renders the popper on document.body, outside the chart container entirely. The list scrolls
-   because a fold names every event it covers. */
-.tippy-box[data-theme~='custom'] .chart-annotation-list {
-    max-height: 12rem;
-    overflow-y: auto;
-    margin-top: 0.25rem;
+/* Chart event mark tooltips. Scoped to the tooltip rather than the chart card because Tippy
+   renders the popper on document.body, outside the container entirely. Rows themselves reuse
+   .device-tooltip-row / .device-tooltip-label, so a mark reads like the speed test and Wi-Fi
+   tooltips do. */
+.tippy-box[data-theme~='custom'] .chart-mark-title {
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0.35rem;
+    color: var(--text-primary);
 }
 
-.tippy-box[data-theme~='custom'] .chart-annotation-time {
+/* Detail is prose rather than a value, so it wraps under its label instead of being squeezed
+   into the value column beside it. */
+.tippy-box[data-theme~='custom'] .chart-mark-detail {
+    display: block;
+    margin-top: 0.3rem;
+}
+
+/* A fold names every event it covers, so the list scrolls rather than truncating. */
+.tippy-box[data-theme~='custom'] .chart-mark-list {
+    max-height: 12rem;
+    overflow-y: auto;
+    margin-top: 0.35rem;
+    border-top: 1px solid var(--border-color);
+    padding-top: 0.35rem;
+}
+
+.tippy-box[data-theme~='custom'] .chart-mark-item {
+    display: flex;
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    padding: 0.15rem 0;
+}
+
+.tippy-box[data-theme~='custom'] .chart-mark-item-time {
     color: var(--text-muted);
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.tippy-box[data-theme~='custom'] .chart-mark-item-body {
+    display: flex;
+    flex-direction: column;
+}
+
+.tippy-box[data-theme~='custom'] .chart-mark-item-title {
+    color: var(--text-primary);
+}
+
+.tippy-box[data-theme~='custom'] .chart-mark-item-where {
+    color: var(--text-secondary);
 }
 
 /* ============================================

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.6.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.6.0.json
@@ -71,6 +71,18 @@
       "body": "Smart Queues (SQM) can read as on in UniFi Network while no shaper is running on your gateway. **Analyze** now catches that and tells you how to fix it.",
       "placement": "top",
       "requires": ["smart-queues"]
+    },
+    {
+      "id": "device-event-marks",
+      "level": "minor",
+      "url": "/monitoring?tab=devices",
+      "selector": "[data-tour=\"device-health-events\"]",
+      "title": "Restarts and alerts, on the charts",
+      "listLabel": "See what happened to a device right where its numbers changed",
+      "badge": "improved",
+      "body": "Marks on **Device Health** show every restart and alert. Hover one for the reason - power loss, a firmware upgrade, a crash or kernel panic - and **SFP Stats** and **ONT Stats** carry their own. (Check **7d** or **30d** to see recent restarts or firmware upgrades.)",
+      "placement": "bottom",
+      "optional": true
     }
   ]
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-colors.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-colors.js
@@ -10,3 +10,12 @@ function resolve(name, fallback) {
 
 export const downloadColor = () => resolve('--speed-download-color', '#2E79C4');
 export const uploadColor = () => resolve('--speed-upload-color', '#24bc70');
+
+// Event annotation colors, by the severity the server assigns each mark. Muted is deliberate
+// for the info tier: a planned restart should read as background, not as something to chase.
+export const eventColor = (severity) =>
+    severity === 'critical' ? resolve('--danger-color', '#ee6368')
+        : severity === 'warning' ? resolve('--warning-color', '#e79613')
+            : resolve('--text-muted', '#5c5c66');
+
+export const chartSurfaceColor = () => resolve('--bg-tertiary', '#232326');

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
@@ -1,0 +1,220 @@
+// Event marks for the Monitoring time-series charts: a mark on the time axis for something that
+// happened to a charted series, hoverable for what it was.
+//
+// Shared because the chart sets that want them are the same shape - Device Stats and SFP Stats
+// differ only in what a series IS. A series is identified here by an opaque key the server
+// supplies (a device MAC for Device Health, device + port for SFP), and every display value the
+// tooltip needs comes down with the event, so this module knows nothing about devices or ports.
+//
+// Event shape from the server:
+//   { key, time, kind: 'reboot'|'alert', severity: 'info'|'warning'|'critical',
+//     title, detail, device, port? }
+
+import { eventColor, chartSurfaceColor } from './chart-colors.js?v=2';
+
+// The glyph says which kind it is and the colour says how bad, so the two read independently -
+// a planned firmware restart and a panic are both ↻, in different colours, which is the
+// distinction the operator is actually scanning for.
+const EVENT_GLYPH = { reboot: '↻', alert: '⚠' };
+
+const SEVERITY_RANK = { info: 0, warning: 1, critical: 2 };
+
+// Two marks closer together than this overlap into an unreadable smear - the label box is about
+// 20px wide once padded. Folding at that distance is what keeps a flapping series from laying a
+// solid row of glyphs across the 30d view, and it bounds the mark count at plotWidth/24 however
+// many events land in the window. Nothing is dropped: a folded event is still listed in its
+// cluster's tooltip.
+const MARK_COLLISION_PX = 24;
+
+const _esc = document.createElement('span');
+function escapeHtml(s) { _esc.textContent = s ?? ''; return _esc.innerHTML; }
+
+const DATE_TIME = { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' };
+const TIME_ONLY = { hour: '2-digit', minute: '2-digit' };
+
+function formatTime(time, opts) {
+    return new Date(time).toLocaleString(undefined, opts);
+}
+
+function row(label, value) {
+    return `<div class="device-tooltip-row"><span class="device-tooltip-label">${label}:</span> `
+        + `${escapeHtml(value)}</div>`;
+}
+
+// Colour and glyph both come from the worst event in the fold so they can never disagree: a
+// cluster holding one kernel panic reads as a panic, not as the routine restart beside it.
+function dominant(marks) {
+    return marks.reduce((worst, m) =>
+        (SEVERITY_RANK[m.severity] ?? 0) > (SEVERITY_RANK[worst.severity] ?? 0) ? m : worst);
+}
+
+function singleTooltip(mark) {
+    const rows = [`<div class="chart-mark-title">${escapeHtml(mark.title)}</div>`];
+    if (mark.device) rows.push(row('Device', mark.device));
+    if (mark.port) rows.push(row('Port', mark.port));
+    rows.push(row('When', formatTime(mark.time, DATE_TIME)));
+    // Detail is prose, not a value, so it wraps full width under its own label rather than
+    // being squeezed into the value column beside it.
+    if (mark.detail) {
+        rows.push(`<div class="device-tooltip-row chart-mark-detail">`
+            + `<span class="device-tooltip-label">Detail:</span> ${escapeHtml(mark.detail)}</div>`);
+    }
+    return rows.join('');
+}
+
+function foldedTooltip(marks) {
+    // Time alone is ambiguous once a fold spans days, which it will at the 30d range.
+    const days = new Set(marks.map(m => new Date(m.time).toDateString()));
+    const opts = days.size > 1 ? DATE_TIME : TIME_ONLY;
+
+    const items = marks.map(mark => {
+        const where = [mark.device, mark.port ? `port ${mark.port}` : null].filter(Boolean).join(' . ');
+        return `<div class="chart-mark-item">`
+            + `<span class="chart-mark-item-time">${escapeHtml(formatTime(mark.time, opts))}</span>`
+            + `<span class="chart-mark-item-body">`
+            + `<span class="chart-mark-item-title">${escapeHtml(mark.title)}</span>`
+            + (where ? `<span class="chart-mark-item-where">${escapeHtml(where)}</span>` : '')
+            + `</span></div>`;
+    }).join('');
+
+    return `<div class="chart-mark-title">${marks.length} events</div>`
+        + `<div class="chart-mark-list">${items}</div>`;
+}
+
+/**
+ * Creates the mark layer for one chart set.
+ *
+ * @param {object} options
+ * @param {() => Array<[object, Element]>} options.charts Every chart to mark, paired with the
+ *   element it rendered into - ApexCharts draws annotation labels as SVG text, so the tooltip is
+ *   attached by walking that SVG afterwards.
+ */
+export function createMarkLayer({ charts }) {
+    let lastSignature = null;
+
+    // Milliseconds per pixel of plot, from the charts' own geometry rather than the requested
+    // range: gridWidth excludes the y-axis gutter, and minX/maxX are the extents ApexCharts
+    // actually drew. Every chart in a set shares a width and an x-window, so the first that can
+    // answer speaks for all of them - which also keeps the folds lined up vertically instead of
+    // each chart clustering to its own slightly different answer.
+    //
+    // Asking every chart rather than a nominated one matters: a series that is null throughout
+    // renders empty, so a set whose first chart has no data would otherwise lose folding on the
+    // charts that do.
+    function msPerPx() {
+        for (const [chart] of charts()) {
+            const g = chart?.w?.globals;
+            if (!g || !(g.gridWidth > 0) || !(g.maxX > g.minX)) continue;
+            return (g.maxX - g.minX) / g.gridWidth;
+        }
+        return null;
+    }
+
+    // Events arrive time-ordered from the server, so one pass does it. The gap is measured from
+    // the cluster's FIRST member so the mark stays anchored where the run started rather than
+    // drifting rightward as the cluster absorbs more.
+    function cluster(marks) {
+        const perPx = msPerPx();
+        // No geometry yet (first paint, or nothing drawn to scale against) means no folding,
+        // which is the un-folded behaviour rather than a guess.
+        if (perPx == null) return marks.map(m => ({ at: new Date(m.time).getTime(), marks: [m] }));
+
+        const gapMs = MARK_COLLISION_PX * perPx;
+        const clusters = [];
+        for (const mark of marks) {
+            const at = new Date(mark.time).getTime();
+            const open = clusters[clusters.length - 1];
+            if (open && at - open.at <= gapMs) open.marks.push(mark);
+            else clusters.push({ at, marks: [mark] });
+        }
+        return clusters;
+    }
+
+    // ApexCharts stamps each label with rel="<index into the annotation array>", so each cluster
+    // is matched to its own label by that rather than by trusting NodeList order.
+    //
+    // Setting the attribute is all that is needed to get a tooltip: App.razor rescans for
+    // [data-tooltip] and initializes Tippy on anything new, which is how the other dynamically
+    // drawn badges work.
+    function tag(el, clusters) {
+        if (!el) return;
+        clusters.forEach((c, i) => {
+            const label = el.querySelector(`.apexcharts-xaxis-annotation-label[rel='${i}']`);
+            if (!label) return;
+            label.setAttribute('data-tooltip',
+                c.marks.length === 1 ? singleTooltip(c.marks[0]) : foldedTooltip(c.marks));
+            label.setAttribute('data-tooltip-interactive', '');
+            label.style.cursor = 'help';
+        });
+    }
+
+    // Each redraw replaces the label elements, so the Tippy instances bound to the outgoing ones
+    // have to go with them - otherwise a 5s poll leaves an orphan per mark per tick.
+    function untag(el) {
+        if (!el) return;
+        el.querySelectorAll('.apexcharts-xaxis-annotation-label')
+            .forEach(label => label._tippy?.destroy());
+    }
+
+    return {
+        /**
+         * Draws the marks for the currently visible series.
+         *
+         * @param {Array<object>} events Events from the server, time-ordered.
+         * @param {object} visibility Series key to false when hidden; anything else is visible.
+         */
+        apply(events, visibility) {
+            // Filtering here rather than server-side keeps the badge toggles instant: hiding a
+            // series drops its marks without a refetch, the same way it drops its line.
+            const clusters = cluster((events || []).filter(e => visibility[e.key] !== false));
+
+            // A poll usually returns the same events over the same geometry, and redrawing then
+            // costs a full annotation teardown - and a Tippy rebuild - for no visible change.
+            // The signature covers what the marks are drawn FROM, so a new event, a filter
+            // toggle or a resize still gets through.
+            const signature = JSON.stringify([msPerPx(), clusters.map(c => [c.at, c.marks.length])]);
+            if (signature === lastSignature) return;
+            lastSignature = signature;
+
+            const surface = chartSurfaceColor();
+            const xaxis = clusters.map(c => {
+                const lead = dominant(c.marks);
+                const color = eventColor(lead.severity);
+                const glyph = EVENT_GLYPH[lead.kind] || EVENT_GLYPH.alert;
+                return {
+                    x: c.at,
+                    borderColor: color,
+                    strokeDashArray: 4,
+                    label: {
+                        text: c.marks.length > 1 ? `${glyph}${c.marks.length}` : glyph,
+                        borderColor: color,
+                        // ApexCharts' own stylesheet puts pointer-events: none on every
+                        // annotation label, which would leave these unhoverable and the
+                        // tooltips dead. The class is concatenated onto theirs, not swapped
+                        // for it, so app.css can win on specificity without !important.
+                        style: {
+                            cssClass: 'chart-event-mark',
+                            color,
+                            background: surface,
+                            fontSize: '11px',
+                            padding: { left: 4, right: 4, top: 2, bottom: 2 },
+                        },
+                    },
+                };
+            });
+
+            for (const [chart, el] of charts()) {
+                if (!chart) continue;
+                untag(el);
+                // Wrapped rather than chained directly: the labels only exist once the update
+                // has rendered, and updateOptions is not promise-returning in every build.
+                Promise.resolve(chart.updateOptions({ annotations: { xaxis } }, false, false))
+                    .then(() => tag(el, clusters))
+                    .catch(e => console.warn('Chart event marks failed to draw', e));
+            }
+        },
+
+        /** Forgets the last drawn state, so the next apply always redraws. */
+        reset() { lastSignature = null; },
+    };
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
@@ -37,8 +37,8 @@ function formatTime(time, opts) {
 }
 
 function row(label, value) {
-    return `<div class="device-tooltip-row"><span class="device-tooltip-label">${label}:</span> `
-        + `${escapeHtml(value)}</div>`;
+    return `<div class="device-tooltip-row chart-mark-row">`
+        + `<span class="device-tooltip-label">${label}:</span> ${escapeHtml(value)}</div>`;
 }
 
 // Colour and glyph both come from the worst event in the fold so they can never disagree: a
@@ -56,7 +56,7 @@ function singleTooltip(mark) {
     // Detail is prose, not a value, so it wraps full width under its own label rather than
     // being squeezed into the value column beside it.
     if (mark.detail) {
-        rows.push(`<div class="device-tooltip-row chart-mark-detail">`
+        rows.push(`<div class="device-tooltip-row chart-mark-row chart-mark-detail">`
             + `<span class="device-tooltip-label">Detail:</span> ${escapeHtml(mark.detail)}</div>`);
     }
     return rows.join('');

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -5,7 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
-import { eventColor, chartSurfaceColor } from './chart-colors.js?v=2';
+import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 // A device answers SNMP but can still miss a single field on a poll - a temperature or
 // memory OID that times out is written as no value rather than a zero, so the row arrives
@@ -57,7 +57,6 @@ let lastData = null;
 let lastEvents = [];
 let chartEls = {};
 let markResizeTimer = null;
-let lastMarkSignature = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -177,15 +176,8 @@ function updateVisibility() {
     applyAnnotations();
 }
 
-// Marks on the time axis for things that happened to a charted device: restarts, and the
-// device's own alerts. The glyph says which kind it is and the colour says how bad, so the
-// two read independently - a planned firmware restart and a panic are both ↻, in different
-// colours, which is the distinction the operator is actually scanning for.
-const EVENT_GLYPH = { reboot: '↻', alert: '⚠' };
-
-// Every chart on the tab paired with the element it rendered into. ApexCharts draws annotation
-// labels as SVG text, and the tooltip is attached by walking that SVG afterwards, so the
-// element is needed as well as the instance.
+// Every chart on the tab paired with the element it rendered into, which is what the mark
+// layer needs to reach the annotation labels it draws.
 function chartEntries() {
     return [
         [tempChart, chartEls.temp],
@@ -195,169 +187,12 @@ function chartEntries() {
     ];
 }
 
-const SEVERITY_RANK = { info: 0, warning: 1, critical: 2 };
-
-// Two marks closer together than this overlap into an unreadable smear - the label box is
-// about 20px wide once padded. Folding at that distance is what keeps a flapping device from
-// laying a solid row of glyphs across the 30d view, and it bounds the mark count at
-// plotWidth/24 however many events land in the window. Nothing is dropped: a folded event is
-// still listed in its cluster's tooltip.
-const MARK_COLLISION_PX = 24;
-
-// Milliseconds per pixel of plot, taken from the chart's own geometry rather than from the
-// requested range: gridWidth excludes the y-axis gutter, and minX/maxX are the extents
-// ApexCharts actually drew, including its own padding. Every chart on the tab shares a width
-// and an x-window, so the first one that can answer speaks for all of them - which also
-// guarantees the folds line up vertically instead of each chart clustering to its own
-// slightly different answer.
-//
-// Asking every chart rather than only the temperature one matters: alignedPoints returns an
-// empty series when a field is null throughout, so a site whose switch temperatures never
-// arrive has an empty temperature chart - and reading geometry from that alone would silently
-// disable folding on the CPU and Memory charts, which are exactly the ones carrying marks.
-function markMsPerPx() {
-    for (const [chart] of chartEntries()) {
-        const g = chart?.w?.globals;
-        if (!g || !(g.gridWidth > 0) || !(g.maxX > g.minX)) continue;
-        return (g.maxX - g.minX) / g.gridWidth;
-    }
-    return null;
-}
-
-// Colour and glyph both come from the worst thing in the cluster so they can never disagree:
-// a fold containing one kernel panic reads as a panic, not as the routine restart next to it.
-function dominantMark(marks) {
-    return marks.reduce((worst, m) =>
-        (SEVERITY_RANK[m.severity] ?? 0) > (SEVERITY_RANK[worst.severity] ?? 0) ? m : worst);
-}
-
-// Events arrive time-ordered from the endpoint, so one pass does it. The gap is measured from
-// the cluster's FIRST member, not its last, so the mark stays anchored where the run started
-// rather than drifting rightward as the cluster absorbs more.
-function clusterMarks(marks) {
-    const msPerPx = markMsPerPx();
-    // No geometry yet (first paint, or a range with no series to scale) means no clustering,
-    // which is the pre-fold behaviour rather than a guess.
-    if (msPerPx == null) return marks.map(m => ({ at: new Date(m.time).getTime(), marks: [m] }));
-
-    const gapMs = MARK_COLLISION_PX * msPerPx;
-    const clusters = [];
-    for (const mark of marks) {
-        const at = new Date(mark.time).getTime();
-        const open = clusters[clusters.length - 1];
-        if (open && at - open.at <= gapMs) open.marks.push(mark);
-        else clusters.push({ at, marks: [mark] });
-    }
-    return clusters;
-}
-
-function markTime(time) {
-    return new Date(time).toLocaleString(undefined,
-        { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-}
-
-function deviceNameFor(mac) {
-    return deviceMeta.find(d => d.mac === mac)?.name;
-}
-
-function annotationTooltip(cluster) {
-    if (cluster.marks.length === 1) {
-        const mark = cluster.marks[0];
-        const device = deviceNameFor(mark.mac);
-        const lines = [`<strong>${escapeHtml(mark.title)}</strong>`];
-        if (device) lines.push(escapeHtml(device));
-        lines.push(escapeHtml(markTime(mark.time)));
-        if (mark.detail) lines.push(escapeHtml(mark.detail));
-        return lines.join('<br>');
-    }
-
-    // Every member is listed. The list scrolls rather than truncating, because a folded event
-    // that is neither on the chart nor in the tooltip is simply lost.
-    const rows = cluster.marks.map(mark => {
-        const device = deviceNameFor(mark.mac);
-        return `<div><span class="chart-annotation-time">${escapeHtml(markTime(mark.time))}</span> `
-            + `${escapeHtml(mark.title)}${device ? ` - ${escapeHtml(device)}` : ''}</div>`;
-    }).join('');
-
-    return `<strong>${cluster.marks.length} events</strong>`
-        + `<div class="chart-annotation-list">${rows}</div>`;
-}
-
-// ApexCharts stamps each label with rel="<index into the annotation array>", so each cluster is
-// matched to its own label by that rather than by trusting NodeList order.
-//
-// Setting the attribute is all that is needed to get a tooltip: App.razor rescans for
-// [data-tooltip] and initializes Tippy on anything new, which is how the other dynamically
-// drawn badges work.
-function tagAnnotationTooltips(el, clusters) {
-    if (!el) return;
-    clusters.forEach((cluster, i) => {
-        const label = el.querySelector(`.apexcharts-xaxis-annotation-label[rel='${i}']`);
-        if (!label) return;
-        label.setAttribute('data-tooltip', annotationTooltip(cluster));
-        label.setAttribute('data-tooltip-interactive', '');
-        label.style.cursor = 'help';
-    });
-}
-
-// Each redraw replaces the label elements, so the Tippy instances bound to the outgoing ones
-// have to go with them - otherwise a 5s poll leaves an orphan per mark per tick.
-function destroyAnnotationTooltips(el) {
-    if (!el) return;
-    el.querySelectorAll('.apexcharts-xaxis-annotation-label').forEach(label => label._tippy?.destroy());
-}
+const markLayer = createMarkLayer({ charts: chartEntries });
 
 function applyAnnotations() {
-    // Filtering here rather than server-side keeps the badge toggles instant: hiding a device
-    // drops its marks without a refetch, the same way it drops its line.
-    const visible = lastEvents.filter(e => visibility[e.mac] !== false);
-    const clusters = clusterMarks(visible);
-
-    // A poll usually returns the same events over the same geometry, and redrawing then costs a
-    // full annotation teardown - and a Tippy rebuild - for no visible change. The signature
-    // covers what the marks are drawn FROM, so a new event, a badge toggle or a resize still
-    // gets through.
-    const signature = JSON.stringify([markMsPerPx(), clusters.map(c => [c.at, c.marks.length])]);
-    if (signature === lastMarkSignature) return;
-    lastMarkSignature = signature;
-
-    const surface = chartSurfaceColor();
-    const xaxis = clusters.map(cluster => {
-        const lead = dominantMark(cluster.marks);
-        const color = eventColor(lead.severity);
-        const glyph = EVENT_GLYPH[lead.kind] || EVENT_GLYPH.alert;
-        return {
-            x: cluster.at,
-            borderColor: color,
-            strokeDashArray: 4,
-            label: {
-                text: cluster.marks.length > 1 ? `${glyph}${cluster.marks.length}` : glyph,
-                borderColor: color,
-                // ApexCharts' own stylesheet puts pointer-events: none on every annotation
-                // label, which would leave these unhoverable and the tooltips dead. The class
-                // is concatenated onto theirs, not swapped for it, so app.css can win on
-                // specificity without !important.
-                style: {
-                    cssClass: 'chart-event-mark',
-                    color,
-                    background: surface,
-                    fontSize: '11px',
-                    padding: { left: 4, right: 4, top: 2, bottom: 2 },
-                },
-            },
-        };
-    });
-
-    for (const [chart, el] of chartEntries()) {
-        if (!chart) continue;
-        destroyAnnotationTooltips(el);
-        // Wrapped rather than chained directly: the labels only exist once the update has
-        // rendered, and updateOptions is not promise-returning in every ApexCharts build.
-        Promise.resolve(chart.updateOptions({ annotations: { xaxis } }, false, false))
-            .then(() => tagAnnotationTooltips(el, clusters))
-            .catch(e => console.warn('Device health annotations failed to draw', e));
-    }
+    markLayer.apply(lastEvents, visibility);
 }
+
 
 // A narrower plot fits fewer marks before they collide, so the folds have to be recomputed.
 // Debounced because ApexCharts is redrawing on the same events, and left to settle after it.
@@ -743,7 +578,7 @@ export function unmount() {
     visibility = {};
     lastData = null;
     lastEvents = [];
-    lastMarkSignature = null;
+    markLayer.reset();
     currentRangeHours = 1;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -57,6 +57,7 @@ let lastData = null;
 let lastEvents = [];
 let chartEls = {};
 let markResizeTimer = null;
+let lastMarkSignature = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -205,14 +206,22 @@ const MARK_COLLISION_PX = 24;
 
 // Milliseconds per pixel of plot, taken from the chart's own geometry rather than from the
 // requested range: gridWidth excludes the y-axis gutter, and minX/maxX are the extents
-// ApexCharts actually drew, including its own padding. Every chart on the tab is the same
-// width, so this is measured once and reused, which also guarantees the folds line up
-// vertically across Temperature, CPU, Memory and the custom charts instead of each chart
-// clustering to its own slightly different answer.
+// ApexCharts actually drew, including its own padding. Every chart on the tab shares a width
+// and an x-window, so the first one that can answer speaks for all of them - which also
+// guarantees the folds line up vertically instead of each chart clustering to its own
+// slightly different answer.
+//
+// Asking every chart rather than only the temperature one matters: alignedPoints returns an
+// empty series when a field is null throughout, so a site whose switch temperatures never
+// arrive has an empty temperature chart - and reading geometry from that alone would silently
+// disable folding on the CPU and Memory charts, which are exactly the ones carrying marks.
 function markMsPerPx() {
-    const g = tempChart?.w?.globals;
-    if (!g || !(g.gridWidth > 0) || !(g.maxX > g.minX)) return null;
-    return (g.maxX - g.minX) / g.gridWidth;
+    for (const [chart] of chartEntries()) {
+        const g = chart?.w?.globals;
+        if (!g || !(g.gridWidth > 0) || !(g.maxX > g.minX)) continue;
+        return (g.maxX - g.minX) / g.gridWidth;
+    }
+    return null;
 }
 
 // Colour and glyph both come from the worst thing in the cluster so they can never disagree:
@@ -274,18 +283,28 @@ function annotationTooltip(cluster) {
         + `<div class="chart-annotation-list">${rows}</div>`;
 }
 
-// Labels come back in the order the annotations went in, which is how each mark finds its
-// own text. The attribute is all that is needed: App.razor rescans for [data-tooltip] and
-// initializes Tippy on anything new, which is how the other dynamically drawn badges work.
+// ApexCharts stamps each label with rel="<index into the annotation array>", so each cluster is
+// matched to its own label by that rather than by trusting NodeList order.
+//
+// Setting the attribute is all that is needed to get a tooltip: App.razor rescans for
+// [data-tooltip] and initializes Tippy on anything new, which is how the other dynamically
+// drawn badges work.
 function tagAnnotationTooltips(el, clusters) {
     if (!el) return;
-    el.querySelectorAll('.apexcharts-xaxis-annotation-label').forEach((label, i) => {
-        const cluster = clusters[i];
-        if (!cluster) return;
+    clusters.forEach((cluster, i) => {
+        const label = el.querySelector(`.apexcharts-xaxis-annotation-label[rel='${i}']`);
+        if (!label) return;
         label.setAttribute('data-tooltip', annotationTooltip(cluster));
         label.setAttribute('data-tooltip-interactive', '');
         label.style.cursor = 'help';
     });
+}
+
+// Each redraw replaces the label elements, so the Tippy instances bound to the outgoing ones
+// have to go with them - otherwise a 5s poll leaves an orphan per mark per tick.
+function destroyAnnotationTooltips(el) {
+    if (!el) return;
+    el.querySelectorAll('.apexcharts-xaxis-annotation-label').forEach(label => label._tippy?.destroy());
 }
 
 function applyAnnotations() {
@@ -293,6 +312,15 @@ function applyAnnotations() {
     // drops its marks without a refetch, the same way it drops its line.
     const visible = lastEvents.filter(e => visibility[e.mac] !== false);
     const clusters = clusterMarks(visible);
+
+    // A poll usually returns the same events over the same geometry, and redrawing then costs a
+    // full annotation teardown - and a Tippy rebuild - for no visible change. The signature
+    // covers what the marks are drawn FROM, so a new event, a badge toggle or a resize still
+    // gets through.
+    const signature = JSON.stringify([markMsPerPx(), clusters.map(c => [c.at, c.marks.length])]);
+    if (signature === lastMarkSignature) return;
+    lastMarkSignature = signature;
+
     const surface = chartSurfaceColor();
     const xaxis = clusters.map(cluster => {
         const lead = dominantMark(cluster.marks);
@@ -305,7 +333,12 @@ function applyAnnotations() {
             label: {
                 text: cluster.marks.length > 1 ? `${glyph}${cluster.marks.length}` : glyph,
                 borderColor: color,
+                // ApexCharts' own stylesheet puts pointer-events: none on every annotation
+                // label, which would leave these unhoverable and the tooltips dead. The class
+                // is concatenated onto theirs, not swapped for it, so app.css can win on
+                // specificity without !important.
                 style: {
+                    cssClass: 'chart-event-mark',
                     color,
                     background: surface,
                     fontSize: '11px',
@@ -317,6 +350,7 @@ function applyAnnotations() {
 
     for (const [chart, el] of chartEntries()) {
         if (!chart) continue;
+        destroyAnnotationTooltips(el);
         // Wrapped rather than chained directly: the labels only exist once the update has
         // rendered, and updateOptions is not promise-returning in every ApexCharts build.
         Promise.resolve(chart.updateOptions({ annotations: { xaxis } }, false, false))
@@ -709,6 +743,7 @@ export function unmount() {
     visibility = {};
     lastData = null;
     lastEvents = [];
+    lastMarkSignature = null;
     currentRangeHours = 1;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -5,6 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { eventColor, chartSurfaceColor } from './chart-colors.js?v=2';
 
 // A device answers SNMP but can still miss a single field on a poll - a temperature or
 // memory OID that times out is written as no value rather than a zero, so the row arrives
@@ -53,6 +54,8 @@ let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
 let lastData = null;
+let lastEvents = [];
+let chartEls = {};
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -169,6 +172,83 @@ function updateVisibility() {
             else chart.hideSeries(d.name);
         }
     });
+    applyAnnotations();
+}
+
+// Marks on the time axis for things that happened to a charted device: restarts, and the
+// device's own alerts. The glyph says which kind it is and the colour says how bad, so the
+// two read independently - a planned firmware restart and a panic are both ↻, in different
+// colours, which is the distinction the operator is actually scanning for.
+const EVENT_GLYPH = { reboot: '↻', alert: '⚠' };
+
+// Every chart on the tab paired with the element it rendered into. ApexCharts draws annotation
+// labels as SVG text, and the tooltip is attached by walking that SVG afterwards, so the
+// element is needed as well as the instance.
+function chartEntries() {
+    return [
+        [tempChart, chartEls.temp],
+        [cpuChart, chartEls.cpu],
+        [memChart, chartEls.mem],
+        ...Object.keys(customCharts).map(k => [customCharts[k], chartEls[`custom:${k}`]]),
+    ];
+}
+
+function annotationTooltip(mark) {
+    const device = deviceMeta.find(d => d.mac === mark.mac);
+    const when = new Date(mark.time).toLocaleString(undefined,
+        { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
+    const lines = [`<strong>${escapeHtml(mark.title)}</strong>`];
+    if (device) lines.push(escapeHtml(device.name));
+    lines.push(escapeHtml(when));
+    if (mark.detail) lines.push(escapeHtml(mark.detail));
+    return lines.join('<br>');
+}
+
+// Labels come back in the order the annotations went in, which is how each mark finds its
+// own text. The attribute is all that is needed: App.razor rescans for [data-tooltip] and
+// initializes Tippy on anything new, which is how the other dynamically drawn badges work.
+function tagAnnotationTooltips(el, marks) {
+    if (!el) return;
+    el.querySelectorAll('.apexcharts-xaxis-annotation-label').forEach((label, i) => {
+        const mark = marks[i];
+        if (!mark) return;
+        label.setAttribute('data-tooltip', annotationTooltip(mark));
+        label.style.cursor = 'help';
+    });
+}
+
+function applyAnnotations() {
+    // Filtering here rather than server-side keeps the badge toggles instant: hiding a device
+    // drops its marks without a refetch, the same way it drops its line.
+    const marks = lastEvents.filter(e => visibility[e.mac] !== false);
+    const surface = chartSurfaceColor();
+    const xaxis = marks.map(mark => {
+        const color = eventColor(mark.severity);
+        return {
+            x: new Date(mark.time).getTime(),
+            borderColor: color,
+            strokeDashArray: 4,
+            label: {
+                text: EVENT_GLYPH[mark.kind] || EVENT_GLYPH.alert,
+                borderColor: color,
+                style: {
+                    color,
+                    background: surface,
+                    fontSize: '11px',
+                    padding: { left: 4, right: 4, top: 2, bottom: 2 },
+                },
+            },
+        };
+    });
+
+    for (const [chart, el] of chartEntries()) {
+        if (!chart) continue;
+        // Wrapped rather than chained directly: the labels only exist once the update has
+        // rendered, and updateOptions is not promise-returning in every ApexCharts build.
+        Promise.resolve(chart.updateOptions({ annotations: { xaxis } }, false, false))
+            .then(() => tagAnnotationTooltips(el, marks))
+            .catch(e => console.warn('Device health annotations failed to draw', e));
+    }
 }
 
 const fmtCustom = v => v != null ? (Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2)) : '-';
@@ -179,6 +259,8 @@ async function loadAndUpdate() {
     deviceMeta = data.devices.map(d => ({
         name: d.name, mac: d.mac, color: hashColor(d.name),
     }));
+    // Set before updateVisibility below, which is what draws the marks.
+    lastEvents = data.events || [];
     const makeSeries = (field) => data.devices.map(d => ({
         name: d.name,
         color: hashColor(d.name),
@@ -211,6 +293,7 @@ async function syncCustomCharts(container, devices, defs) {
         if (!newKeys.has(key)) {
             customCharts[key].destroy();
             delete customCharts[key];
+            delete chartEls[`custom:${key}`];
         }
     }
 
@@ -241,6 +324,7 @@ async function syncCustomCharts(container, devices, defs) {
             });
             await chart.render();
             customCharts[def.fieldName] = chart;
+            chartEls[`custom:${def.fieldName}`] = chartDiv;
         }
     }
 
@@ -434,6 +518,8 @@ export async function mount(elId) {
     if (cpuChart) { cpuChart.destroy(); cpuChart = null; }
     if (memChart) { memChart.destroy(); memChart = null; }
 
+    chartEls = { temp: tempEl, cpu: cpuEl, mem: memEl };
+
     tempChart = new ApexCharts(tempEl, { ...baseOpts(200, '°C', v => v != null ? v.toFixed(0) + ' °C' : ''), series: [], colors: PALETTE });
     cpuChart = new ApexCharts(cpuEl, {
         ...baseOpts(200, 'CPU %', v => v != null ? v.toFixed(0) + '%' : ''),
@@ -531,10 +617,12 @@ export function unmount() {
     for (const chart of Object.values(customCharts)) chart.destroy();
     customCharts = {};
     customFieldDefs = [];
+    chartEls = {};
     containerId = null;
     deviceMeta = [];
     visibility = {};
     lastData = null;
+    lastEvents = [];
     currentRangeHours = 1;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -56,6 +56,7 @@ let isInViewport = true;
 let lastData = null;
 let lastEvents = [];
 let chartEls = {};
+let markResizeTimer = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -193,26 +194,96 @@ function chartEntries() {
     ];
 }
 
-function annotationTooltip(mark) {
-    const device = deviceMeta.find(d => d.mac === mark.mac);
-    const when = new Date(mark.time).toLocaleString(undefined,
+const SEVERITY_RANK = { info: 0, warning: 1, critical: 2 };
+
+// Two marks closer together than this overlap into an unreadable smear - the label box is
+// about 20px wide once padded. Folding at that distance is what keeps a flapping device from
+// laying a solid row of glyphs across the 30d view, and it bounds the mark count at
+// plotWidth/24 however many events land in the window. Nothing is dropped: a folded event is
+// still listed in its cluster's tooltip.
+const MARK_COLLISION_PX = 24;
+
+// Milliseconds per pixel of plot, taken from the chart's own geometry rather than from the
+// requested range: gridWidth excludes the y-axis gutter, and minX/maxX are the extents
+// ApexCharts actually drew, including its own padding. Every chart on the tab is the same
+// width, so this is measured once and reused, which also guarantees the folds line up
+// vertically across Temperature, CPU, Memory and the custom charts instead of each chart
+// clustering to its own slightly different answer.
+function markMsPerPx() {
+    const g = tempChart?.w?.globals;
+    if (!g || !(g.gridWidth > 0) || !(g.maxX > g.minX)) return null;
+    return (g.maxX - g.minX) / g.gridWidth;
+}
+
+// Colour and glyph both come from the worst thing in the cluster so they can never disagree:
+// a fold containing one kernel panic reads as a panic, not as the routine restart next to it.
+function dominantMark(marks) {
+    return marks.reduce((worst, m) =>
+        (SEVERITY_RANK[m.severity] ?? 0) > (SEVERITY_RANK[worst.severity] ?? 0) ? m : worst);
+}
+
+// Events arrive time-ordered from the endpoint, so one pass does it. The gap is measured from
+// the cluster's FIRST member, not its last, so the mark stays anchored where the run started
+// rather than drifting rightward as the cluster absorbs more.
+function clusterMarks(marks) {
+    const msPerPx = markMsPerPx();
+    // No geometry yet (first paint, or a range with no series to scale) means no clustering,
+    // which is the pre-fold behaviour rather than a guess.
+    if (msPerPx == null) return marks.map(m => ({ at: new Date(m.time).getTime(), marks: [m] }));
+
+    const gapMs = MARK_COLLISION_PX * msPerPx;
+    const clusters = [];
+    for (const mark of marks) {
+        const at = new Date(mark.time).getTime();
+        const open = clusters[clusters.length - 1];
+        if (open && at - open.at <= gapMs) open.marks.push(mark);
+        else clusters.push({ at, marks: [mark] });
+    }
+    return clusters;
+}
+
+function markTime(time) {
+    return new Date(time).toLocaleString(undefined,
         { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' });
-    const lines = [`<strong>${escapeHtml(mark.title)}</strong>`];
-    if (device) lines.push(escapeHtml(device.name));
-    lines.push(escapeHtml(when));
-    if (mark.detail) lines.push(escapeHtml(mark.detail));
-    return lines.join('<br>');
+}
+
+function deviceNameFor(mac) {
+    return deviceMeta.find(d => d.mac === mac)?.name;
+}
+
+function annotationTooltip(cluster) {
+    if (cluster.marks.length === 1) {
+        const mark = cluster.marks[0];
+        const device = deviceNameFor(mark.mac);
+        const lines = [`<strong>${escapeHtml(mark.title)}</strong>`];
+        if (device) lines.push(escapeHtml(device));
+        lines.push(escapeHtml(markTime(mark.time)));
+        if (mark.detail) lines.push(escapeHtml(mark.detail));
+        return lines.join('<br>');
+    }
+
+    // Every member is listed. The list scrolls rather than truncating, because a folded event
+    // that is neither on the chart nor in the tooltip is simply lost.
+    const rows = cluster.marks.map(mark => {
+        const device = deviceNameFor(mark.mac);
+        return `<div><span class="chart-annotation-time">${escapeHtml(markTime(mark.time))}</span> `
+            + `${escapeHtml(mark.title)}${device ? ` - ${escapeHtml(device)}` : ''}</div>`;
+    }).join('');
+
+    return `<strong>${cluster.marks.length} events</strong>`
+        + `<div class="chart-annotation-list">${rows}</div>`;
 }
 
 // Labels come back in the order the annotations went in, which is how each mark finds its
 // own text. The attribute is all that is needed: App.razor rescans for [data-tooltip] and
 // initializes Tippy on anything new, which is how the other dynamically drawn badges work.
-function tagAnnotationTooltips(el, marks) {
+function tagAnnotationTooltips(el, clusters) {
     if (!el) return;
     el.querySelectorAll('.apexcharts-xaxis-annotation-label').forEach((label, i) => {
-        const mark = marks[i];
-        if (!mark) return;
-        label.setAttribute('data-tooltip', annotationTooltip(mark));
+        const cluster = clusters[i];
+        if (!cluster) return;
+        label.setAttribute('data-tooltip', annotationTooltip(cluster));
+        label.setAttribute('data-tooltip-interactive', '');
         label.style.cursor = 'help';
     });
 }
@@ -220,16 +291,19 @@ function tagAnnotationTooltips(el, marks) {
 function applyAnnotations() {
     // Filtering here rather than server-side keeps the badge toggles instant: hiding a device
     // drops its marks without a refetch, the same way it drops its line.
-    const marks = lastEvents.filter(e => visibility[e.mac] !== false);
+    const visible = lastEvents.filter(e => visibility[e.mac] !== false);
+    const clusters = clusterMarks(visible);
     const surface = chartSurfaceColor();
-    const xaxis = marks.map(mark => {
-        const color = eventColor(mark.severity);
+    const xaxis = clusters.map(cluster => {
+        const lead = dominantMark(cluster.marks);
+        const color = eventColor(lead.severity);
+        const glyph = EVENT_GLYPH[lead.kind] || EVENT_GLYPH.alert;
         return {
-            x: new Date(mark.time).getTime(),
+            x: cluster.at,
             borderColor: color,
             strokeDashArray: 4,
             label: {
-                text: EVENT_GLYPH[mark.kind] || EVENT_GLYPH.alert,
+                text: cluster.marks.length > 1 ? `${glyph}${cluster.marks.length}` : glyph,
                 borderColor: color,
                 style: {
                     color,
@@ -246,9 +320,16 @@ function applyAnnotations() {
         // Wrapped rather than chained directly: the labels only exist once the update has
         // rendered, and updateOptions is not promise-returning in every ApexCharts build.
         Promise.resolve(chart.updateOptions({ annotations: { xaxis } }, false, false))
-            .then(() => tagAnnotationTooltips(el, marks))
+            .then(() => tagAnnotationTooltips(el, clusters))
             .catch(e => console.warn('Device health annotations failed to draw', e));
     }
+}
+
+// A narrower plot fits fewer marks before they collide, so the folds have to be recomputed.
+// Debounced because ApexCharts is redrawing on the same events, and left to settle after it.
+function onMarkResize() {
+    clearTimeout(markResizeTimer);
+    markResizeTimer = setTimeout(applyAnnotations, 200);
 }
 
 const fmtCustom = v => v != null ? (Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2)) : '-';
@@ -585,6 +666,8 @@ export async function mount(elId) {
         popover.classList.remove('open');
     });
 
+    window.addEventListener('resize', onMarkResize);
+
     visibilityObserver = new IntersectionObserver(([entry]) => {
         const was = isVisible();
         isInViewport = entry.isIntersecting;
@@ -609,6 +692,9 @@ export function soloDevice(mac) {
 
 export function unmount() {
     stopPoll();
+    window.removeEventListener('resize', onMarkResize);
+    clearTimeout(markResizeTimer);
+    markResizeTimer = null;
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -8,7 +8,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 import { valueSortedTooltip, tooltipHeld } from './chart-tooltip.js?v=8';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
-import { downloadColor, uploadColor } from './chart-colors.js?v=1';
+import { downloadColor, uploadColor } from './chart-colors.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _colorCache = {};

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -5,6 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -27,6 +28,9 @@ let customTo = null;
 let containerId = null;
 let fetchController = null;
 let deviceMeta = [];
+let lastEvents = [];
+let chartEls = {};
+let markResizeTimer = null;
 let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
@@ -145,7 +149,34 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); });
 }
 
+// Every chart on the tab paired with the element it rendered into, which is what the mark layer
+// needs to reach the annotation labels it draws. The errors chart is created lazily, so the
+// pairs are built on demand rather than captured once.
+function chartEntries() {
+    return [
+        [powerChart, chartEls.power],
+        [tempChart, chartEls.temp],
+        [errorsChart, chartEls.errors],
+    ].filter(([chart]) => chart);
+}
+
+const markLayer = createMarkLayer({ charts: chartEntries });
+
+function applyAnnotations() {
+    markLayer.apply(lastEvents, visibility);
+}
+
+// A narrower plot fits fewer marks before they collide, so the folds have to be recomputed.
+// Debounced because ApexCharts is redrawing on the same events, and left to settle after it.
+function onMarkResize() {
+    clearTimeout(markResizeTimer);
+    markResizeTimer = setTimeout(applyAnnotations, 200);
+}
+
 function updateVisibility() {
+    // Ahead of the single-ONT short-circuit below: the marks are drawn whether or not there is
+    // more than one series to show and hide.
+    applyAnnotations();
     if (deviceMeta.length <= 1) return;
     deviceMeta.forEach(m => {
         const vis = visibility[m.id] !== false;
@@ -172,6 +203,8 @@ async function loadAndUpdate() {
     deviceMeta = data.devices.map((d, i) => ({
         id: d.id, label: d.label, color: PALETTE[i % PALETTE.length],
     }));
+    // Set before updateVisibility below, which is what draws the marks.
+    lastEvents = data.events || [];
 
     const powerSeries = [];
     const tempSeries = [];
@@ -231,7 +264,11 @@ async function ensureErrorsChartMounted() {
     const errorsEl = container?.querySelector('.ont-errors-chart');
     if (!errorsEl) return;
     errorsChart = new ApexCharts(errorsEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    chartEls.errors = errorsEl;
     await errorsChart.render();
+    // It arrives after the first draw, so it starts with no marks on it.
+    markLayer.reset();
+    applyAnnotations();
 }
 
 async function updateErrorsChart(data) {
@@ -434,6 +471,8 @@ export async function mount(elId) {
     const tempEl = container.querySelector('.ont-temp-chart');
     if (!powerEl || !tempEl) return;
 
+    chartEls = { power: powerEl, temp: tempEl };
+
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
     if (errorsChart) { errorsChart.destroy(); errorsChart = null; }
@@ -500,6 +539,8 @@ export async function mount(elId) {
         popover.classList.remove('open');
     });
 
+    window.addEventListener('resize', onMarkResize);
+
     visibilityObserver = new IntersectionObserver(([entry]) => {
         const was = isVisible();
         isInViewport = entry.isIntersecting;
@@ -522,6 +563,9 @@ export function soloDevice(deviceId) {
 
 export function unmount() {
     stopPoll();
+    window.removeEventListener('resize', onMarkResize);
+    clearTimeout(markResizeTimer);
+    markResizeTimer = null;
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (powerChart) { powerChart.destroy(); powerChart = null; }
@@ -531,7 +575,10 @@ export function unmount() {
     deviceMeta = [];
     visibility = {};
     errorsSeriesByDevice = {};
+    chartEls = {};
     lastData = null;
+    lastEvents = [];
+    markLayer.reset();
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -158,20 +158,32 @@ function renderBadges(container) {
 // Every chart on the tab paired with the element it rendered into, which is what the mark
 // layer needs to reach the annotation labels it draws. The PON charts are created lazily, so
 // the pairs are built on demand rather than captured once.
-function chartEntries() {
+function opticsChartEntries() {
     return [
         [powerChart, chartEls.power],
         [tempChart, chartEls.temp],
+    ].filter(([chart]) => chart);
+}
+
+function ponChartEntries() {
+    return [
         [ponErrChart, chartEls.ponErr],
         [ponGemChart, chartEls.ponGem],
         [ponHostChart, chartEls.ponHost],
     ].filter(([chart]) => chart);
 }
 
-const markLayer = createMarkLayer({ charts: chartEntries });
+// Two layers rather than one, because the two chart groups do not mark the same events. The
+// optics charts plot what the module's own transceiver reports, so they carry the SFP alerts
+// alone; the PON charts plot the link riding over it, where an ONT's own alerts are the most
+// useful thing on the page - and the SFP alerts still belong there too, since an RX power dip is
+// often the explanation for the BIP errors beside it.
+const opticsMarkLayer = createMarkLayer({ charts: opticsChartEntries });
+const ponMarkLayer = createMarkLayer({ charts: ponChartEntries });
 
 function applyAnnotations() {
-    markLayer.apply(lastEvents, visibility);
+    opticsMarkLayer.apply(lastEvents.filter(e => e.scope !== 'pon'), visibility);
+    ponMarkLayer.apply(lastEvents, visibility);
 }
 
 // A narrower plot fits fewer marks before they collide, so the folds have to be recomputed.
@@ -336,7 +348,7 @@ async function ensurePonChartsMounted() {
     chartEls.ponHost = ponHostEl;
     await Promise.all([ponErrChart.render(), ponGemChart.render(), ponHostChart.render()]);
     // These three arrive after the first draw, so they start with no marks on them.
-    markLayer.reset();
+    ponMarkLayer.reset();
     applyAnnotations();
 }
 
@@ -663,7 +675,8 @@ export function unmount() {
     chartEls = {};
     lastData = null;
     lastEvents = [];
-    markLayer.reset();
+    opticsMarkLayer.reset();
+    ponMarkLayer.reset();
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -5,6 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
 const _esc = document.createElement('span');
@@ -36,6 +37,9 @@ let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
 let lastData = null;
+let lastEvents = [];
+let chartEls = {};
+let markResizeTimer = null;
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     const base = {
@@ -151,6 +155,32 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); renderStatsTable(container, false); });
 }
 
+// Every chart on the tab paired with the element it rendered into, which is what the mark
+// layer needs to reach the annotation labels it draws. The PON charts are created lazily, so
+// the pairs are built on demand rather than captured once.
+function chartEntries() {
+    return [
+        [powerChart, chartEls.power],
+        [tempChart, chartEls.temp],
+        [ponErrChart, chartEls.ponErr],
+        [ponGemChart, chartEls.ponGem],
+        [ponHostChart, chartEls.ponHost],
+    ].filter(([chart]) => chart);
+}
+
+const markLayer = createMarkLayer({ charts: chartEntries });
+
+function applyAnnotations() {
+    markLayer.apply(lastEvents, visibility);
+}
+
+// A narrower plot fits fewer marks before they collide, so the folds have to be recomputed.
+// Debounced because ApexCharts is redrawing on the same events, and left to settle after it.
+function onMarkResize() {
+    clearTimeout(markResizeTimer);
+    markResizeTimer = setTimeout(applyAnnotations, 200);
+}
+
 function updateVisibility() {
     moduleMeta.forEach(m => {
         const vis = visibility[m.id] !== false;
@@ -163,6 +193,7 @@ function updateVisibility() {
             else tempChart.hideSeries(m.label);
         }
     });
+    applyAnnotations();
     // Fire-and-forget: rebuilds the PON charts/section for the selected modules. Kept
     // off the synchronous path so a chart error can never break chip re-rendering.
     refreshPonSection();
@@ -218,6 +249,8 @@ async function loadAndUpdate() {
     moduleMeta = data.modules.map((m, i) => ({
         id: m.id, label: m.label, color: PALETTE[i % PALETTE.length],
     }));
+    // Set before updateVisibility below, which is what draws the marks.
+    lastEvents = data.events || [];
 
     const powerSeries = [];
     const tSeries = [];
@@ -298,7 +331,13 @@ async function ensurePonChartsMounted() {
     ponErrChart = new ApexCharts(ponErrEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
     ponGemChart = new ApexCharts(ponGemEl, { ...baseOpts(160, 'frames', fmtCount), series: [], colors: PALETTE });
     ponHostChart = new ApexCharts(ponHostEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    chartEls.ponErr = ponErrEl;
+    chartEls.ponGem = ponGemEl;
+    chartEls.ponHost = ponHostEl;
     await Promise.all([ponErrChart.render(), ponGemChart.render(), ponHostChart.render()]);
+    // These three arrive after the first draw, so they start with no marks on them.
+    markLayer.reset();
+    applyAnnotations();
 }
 
 async function updatePonCharts(data) {
@@ -492,6 +531,8 @@ export async function mount(elId) {
     const tempEl = container.querySelector('.sfp-temp-chart');
     if (!powerEl || !tempEl) return;
 
+    chartEls = { power: powerEl, temp: tempEl };
+
     if (powerChart) { powerChart.destroy(); powerChart = null; }
     if (tempChart) { tempChart.destroy(); tempChart = null; }
     if (ponErrChart) { ponErrChart.destroy(); ponErrChart = null; }
@@ -561,6 +602,8 @@ export async function mount(elId) {
         popover.classList.remove('open');
     });
 
+    window.addEventListener('resize', onMarkResize);
+
     visibilityObserver = new IntersectionObserver(([entry]) => {
         const was = isVisible();
         isInViewport = entry.isIntersecting;
@@ -603,6 +646,9 @@ export function soloModule(id) {
 
 export function unmount() {
     stopPoll();
+    window.removeEventListener('resize', onMarkResize);
+    clearTimeout(markResizeTimer);
+    markResizeTimer = null;
     if (visibilityObserver) { visibilityObserver.disconnect(); visibilityObserver = null; }
     if (fetchController) { fetchController.abort(); fetchController = null; }
     if (powerChart) { powerChart.destroy(); powerChart = null; }
@@ -614,7 +660,10 @@ export function unmount() {
     moduleMeta = [];
     visibility = {};
     ponCapableModules = [];
+    chartEls = {};
     lastData = null;
+    lastEvents = [];
+    markLayer.reset();
     currentRangeHours = 24;
     windowOffset = 0;
     isCustomRange = false;

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -165,19 +165,20 @@ function opticsChartEntries() {
     ].filter(([chart]) => chart);
 }
 
+// GEM Frames is deliberately absent. It plots per-interval frame counts whose shape is the
+// traffic itself, so a mark on it reads as a comment on throughput rather than on the link.
 function ponChartEntries() {
     return [
         [ponErrChart, chartEls.ponErr],
-        [ponGemChart, chartEls.ponGem],
         [ponHostChart, chartEls.ponHost],
     ].filter(([chart]) => chart);
 }
 
 // Two layers rather than one, because the two chart groups do not mark the same events. The
-// optics charts plot what the module's own transceiver reports, so they carry the SFP alerts
-// alone; the PON charts plot the link riding over it, where an ONT's own alerts are the most
-// useful thing on the page - and the SFP alerts still belong there too, since an RX power dip is
-// often the explanation for the BIP errors beside it.
+// server says which is which: an event scoped 'pon' describes the link riding over the module
+// and stays on the PON charts, while everything scoped 'all' - the SFP alerts, and a PON link
+// going down - is worth seeing while reading the optics too. The PON charts carry both, since an
+// RX power dip is often the explanation for the BIP errors beside it.
 const opticsMarkLayer = createMarkLayer({ charts: opticsChartEntries });
 const ponMarkLayer = createMarkLayer({ charts: ponChartEntries });
 
@@ -347,7 +348,7 @@ async function ensurePonChartsMounted() {
     chartEls.ponGem = ponGemEl;
     chartEls.ponHost = ponHostEl;
     await Promise.all([ponErrChart.render(), ponGemChart.render(), ponHostChart.render()]);
-    // These three arrive after the first draw, so they start with no marks on them.
+    // These arrive after the first draw, so they start with no marks on them.
     ponMarkLayer.reset();
     applyAnnotations();
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -344,8 +344,8 @@ async function ensurePonChartsMounted() {
     ponErrChart = new ApexCharts(ponErrEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
     ponGemChart = new ApexCharts(ponGemEl, { ...baseOpts(160, 'frames', fmtCount), series: [], colors: PALETTE });
     ponHostChart = new ApexCharts(ponHostEl, { ...baseOpts(160, 'errors', fmtCount), series: [], colors: PALETTE });
+    // No ponGem: GEM Frames takes no marks, so the layer never needs to reach it.
     chartEls.ponErr = ponErrEl;
-    chartEls.ponGem = ponGemEl;
     chartEls.ponHost = ponHostEl;
     await Promise.all([ponErrChart.render(), ponGemChart.render(), ponHostChart.render()]);
     // These arrive after the first draw, so they start with no marks on them.

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -5,7 +5,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import * as flowData from './lan-flow-data.js?v=7';
 import { valueSortedTooltip } from './chart-tooltip.js?v=8';
-import { downloadColor, uploadColor } from './chart-colors.js?v=1';
+import { downloadColor, uploadColor } from './chart-colors.js?v=2';
 
 const HISTORY_MINUTES = 5;
 // Poll at twice the site's SNMP sample rate so no sample is missed when the two

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceRebootMarkCollapseTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceRebootMarkCollapseTests.cs
@@ -1,0 +1,126 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Endpoints;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// One boot must produce one chart mark, however many records the write path left behind for it.
+/// </summary>
+public class DeviceRebootMarkCollapseTests
+{
+    private static readonly DateTime Boot = new(2026, 7, 24, 12, 40, 27, DateTimeKind.Utc);
+
+    private static MonitoringInfluxClient.DeviceRebootPoint Record(
+        string mac, DateTime bootedAt, int classifierVersion, string category = "PowerLoss") =>
+        new()
+        {
+            DeviceMac = mac,
+            BootedAt = bootedAt,
+            ClassifierVersion = classifierVersion,
+            Category = category,
+            Summary = category,
+        };
+
+    [Fact]
+    public void SubSecondBurstForOneBootCollapsesToOneMark()
+    {
+        // The shape actually on file: one restart, several records under a second apart,
+        // written by different classifier versions and disagreeing on the category.
+        var records = new[]
+        {
+            Record("aabbccddee01", Boot.AddMilliseconds(0), 4, "FirmwareUpgrade"),
+            Record("aabbccddee01", Boot.AddMilliseconds(18), 7, "FirmwareUpgrade"),
+            Record("aabbccddee01", Boot.AddMilliseconds(38), 6, "FirmwareUpgrade"),
+            Record("aabbccddee01", Boot.AddMilliseconds(196), 0, "CommandedReboot"),
+            Record("aabbccddee01", Boot.AddMilliseconds(384), 2, "CommandedReboot"),
+            Record("aabbccddee01", Boot.AddMilliseconds(802), 3, "FirmwareUpgrade"),
+        };
+
+        var collapsed = DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records);
+
+        collapsed.Should().ContainSingle();
+        collapsed[0].ClassifierVersion.Should().Be(7, "the newest rules re-probed the older verdicts");
+        collapsed[0].Category.Should().Be("FirmwareUpgrade");
+    }
+
+    [Fact]
+    public void SeparateBootsStaySeparate()
+    {
+        var records = new[]
+        {
+            Record("aabbccddee02", Boot, 7),
+            Record("aabbccddee02", Boot.AddMilliseconds(500), 7),
+            Record("aabbccddee02", Boot.AddDays(1), 7),
+        };
+
+        DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BootsJustOutsideToleranceAreNotMerged()
+    {
+        var records = new[]
+        {
+            Record("aabbccddee02", Boot, 7),
+            Record("aabbccddee02", Boot.AddMinutes(5).AddSeconds(1), 7),
+        };
+
+        DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records).Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void ClusterWindowDoesNotSlideWithEachAbsorbedRecord()
+    {
+        // Records four minutes apart are each within tolerance of the one before, so measuring
+        // from the previous record would chain all five into a single mark spanning sixteen
+        // minutes. Measuring from the boot each cluster opened with closes it at five, leaving
+        // the run as the separate restarts it is.
+        var records = new[]
+        {
+            Record("aabbccddee03", Boot, 7),
+            Record("aabbccddee03", Boot.AddMinutes(4), 7),
+            Record("aabbccddee03", Boot.AddMinutes(8), 7),
+            Record("aabbccddee03", Boot.AddMinutes(12), 7),
+            Record("aabbccddee03", Boot.AddMinutes(16), 7),
+        };
+
+        DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records).Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void DevicesAreCollapsedIndependently()
+    {
+        var records = new[]
+        {
+            Record("aabbccddee01", Boot, 7),
+            Record("aabbccddee01", Boot.AddMilliseconds(300), 7),
+            Record("aabbccddee02", Boot.AddMilliseconds(100), 7),
+            Record("aabbccddee02", Boot.AddMilliseconds(400), 7),
+        };
+
+        var collapsed = DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records);
+
+        collapsed.Should().HaveCount(2);
+        collapsed.Select(r => r.DeviceMac).Should().BeEquivalentTo(["aabbccddee01", "aabbccddee02"]);
+    }
+
+    [Fact]
+    public void MacSpellingDifferencesDoNotSplitABoot()
+    {
+        var records = new[]
+        {
+            Record("AA:BB:CC:DD:EE:01", Boot, 6),
+            Record("aabbccddee01", Boot.AddMilliseconds(200), 7),
+        };
+
+        DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot(records).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void EmptyInputYieldsNoMarks()
+    {
+        DeviceHealthChartEndpoints.CollapseToOneRecordPerBoot([]).Should().BeEmpty();
+    }
+}


### PR DESCRIPTION
The Monitoring charts show what a device was doing, but not what happened to it. A temperature step, a memory reset or a counter spike had to be lined up by hand against the Alerts page to find out why. Every chart on these three tabs now carries a mark on the time axis for each event, hoverable for the reason behind it.

Marks fold together when they would collide, so a device that restarted repeatedly reads as one mark carrying a count rather than a smear of glyphs, and the fold lists every event it covers. They filter with the legend badges, so hiding a series drops its marks the same way it drops its line.

## Monitoring

### Device Stats

- **Restarts on Device Health** - Every boot is marked with the reason behind it: power loss, a firmware upgrade, a kernel panic, a watchdog reset. Unexpected restarts read in the warning colour, planned ones stay muted.
- **Device alerts on Device Health** - Offline and recovered, high CPU, high memory and high temperature are marked alongside the restarts, coloured by severity.
- **One mark per boot** - Reboot records are collapsed to the boot they describe before they are drawn, keeping the record classified by the newest rules. On a site with a year of history this is the difference between a restart reading as one mark and as nine (#1103).

### SFP Stats

- **SFP alerts on every module chart** - Temperature, RX power and TX power breaches are marked on the module they belong to, matched on device and port rather than on device alone so a switch with several modules marks only the one that breached.
- **ONT alerts on the PON charts** - An attached ONT's own alerts sit on the PON error and host charts, where the counters they explain are plotted.
- **PON link down everywhere** - The one ONT condition worth seeing while reading the optics, so it marks the RX/TX power and temperature charts too.
- **GEM Frames stays unmarked** - It plots per-interval frame counts whose shape is the traffic itself, where a mark would read as a comment on throughput rather than on the link.

### ONT Stats

- **ONT alerts on the standalone ONT charts** - RX/TX power, temperature and the errors chart. Attached ONTs stay on SFP Stats, where their charts are.

## Guided Tours

- **A step for v2.6.0** - Anchored on the Temperature chart on Device Stats, since the marks only read as marks with a plotted line behind them.

## Notes

The reboot records themselves are still being written several times per boot; that is recorded in TODO.md and tracked as #1103, and is deliberately untouched here. This branch collapses them on read, so the marks are correct while the stored data is not.

No write path changed. Attached ONTs are matched to their SFP module through the deep link the alert already carries, which doubles as the discriminator that keeps standalone ONTs off the SFP tab and attached ones off the ONT tab.
