### PR TITLE
Multi-Site: an agent on the UniFi gateway gets the gateway update instructions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1220,6 +1220,17 @@ two primitives look interchangeable and are not, not because it is hurting anyon
 - [ ] `AgentProbeResultSink` self-target skipping - needs the matched ADDRESS rather than a yes/no,
   so it needs the overload to persist the address too, or to stay as it is.
 
+One caller has the right primitive but asks the wrong question of it:
+
+- [ ] `Settings.ClientSpeedTestPlaceholder` asks `SiteHasGatewayAgent`, which is true when ANY of the
+  site's agents is on the gateway. Its job is to mirror what a blank override resolves to, and
+  `SiteSpeedTestTargetResolver` resolves against ONE agent - the most-recently-seen reachable one. A
+  site with a gateway agent and a real-box agent makes them disagree: the placeholder says "none,
+  enter a separate box" while the resolver points at the box. Ask the resolver's question rather than
+  `Any`. Not a regression - the site-level verdict it replaced picked whichever agent enrollment
+  answered with, so that site was already a coin flip - and the main site never renders the field at
+  all, so this is secondary sites only.
+
 Separately, the comparison set itself is narrow, and this one stands on its own merits:
 
 - [ ] `ResolveGatewayIpsAsync` takes exactly one LAN address, because `ResolveGatewayLanIpAsync` is

--- a/TODO.md
+++ b/TODO.md
@@ -1197,3 +1197,34 @@ Later defers it for the whole install, and a new user added later never sees any
 - [ ] Move the offer/defer state per user, keeping the install-level version stamps where they are -
   `FirstSeenVersion` is a fact about the install, but "has this person been offered 2.5.0" is a fact
   about the person.
+
+## Agent-on-gateway detection: finish the cleanup (#1106)
+
+`AgentOnGatewayDetector` now has two ways to answer "does this agent run on the UniFi gateway", and
+only one of them is durable.
+
+- `IsAgentOnGatewayAsync(slug)` and `IsAgentOnGatewayAsync(slug, agentId, candidates)` seed from a
+  persisted verdict before refreshing, and keep the last answer when the console cannot be reached.
+- `MatchGatewayAddressAsync` / `IsIpOnGatewayAsync` resolve live with no memory. The addresses to
+  compare against come from the site's UniFi Console, which on an agent site reconnects through that
+  agent's own tunnel, so a caller that asks too early gets a silent no.
+
+Severity is low. In practice the live path is only wrong if someone is parked on the page across a
+Network Optimizer server restart - every later ask resolves and persists. Worth tidying because the
+two primitives look interchangeable and are not, not because it is hurting anyone.
+
+- [ ] `WanContextsCard.LoadBindCapableAgentsAsync` - move to the per-agent overload. Wrong answer
+  offers source-address binding where interface binding belongs.
+- [ ] `MonitoringTools` probe-vantage list - same, mislabels the vantage.
+- [ ] `AgentProbeResultSink` unbound-context healing - a yes/no, so the overload drops straight in.
+- [ ] `AgentProbeResultSink` self-target skipping - needs the matched ADDRESS rather than a yes/no,
+  so it needs the overload to persist the address too, or to stay as it is.
+
+Separately, the comparison set itself is narrow, and this one stands on its own merits:
+
+- [ ] `ResolveGatewayIpsAsync` takes exactly one LAN address, because `ResolveGatewayLanIpAsync` is
+  `FirstOrDefault()` over the corporate networks. A multi-VLAN gateway contributes its default LAN
+  and nothing else - on the Honeybee gateway that is 2 of the 6 addresses the box actually holds.
+  An agent reporting `local_ips` (2.6.0+) always hits one of the two, but an older single-address
+  agent matches only if it named one of them. `NetworkInfo.Gateway` is already mapped for EVERY
+  network in `UniFiConnectionService` and `UniFiDiscovery`, so the full set is there for the taking.

--- a/TODO.md
+++ b/TODO.md
@@ -1224,7 +1224,7 @@ Separately, the comparison set itself is narrow, and this one stands on its own 
 
 - [ ] `ResolveGatewayIpsAsync` takes exactly one LAN address, because `ResolveGatewayLanIpAsync` is
   `FirstOrDefault()` over the corporate networks. A multi-VLAN gateway contributes its default LAN
-  and nothing else - on the Honeybee gateway that is 2 of the 6 addresses the box actually holds.
+  and nothing else - on a gateway with a handful of VLANs that is 2 of the 6 addresses it holds.
   An agent reporting `local_ips` (2.6.0+) always hits one of the two, but an older single-address
   agent matches only if it named one of them. `NetworkInfo.Gateway` is already mapped for EVERY
   network in `UniFiConnectionService` and `UniFiDiscovery`, so the full set is there for the taking.

--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -63,6 +63,12 @@ public static class SystemSettingKeys
     // connection comes back up.
     public const string AgentOnGateway = "agent.on_gateway";
 
+    // Per-AGENT counterpart of the above, for the questions that are about one agent rather than
+    // the site: a site has one gateway and only one of its agents may be sitting on it. Serves the
+    // same purpose - a verdict that survives a restart, so the answer is right before the site's
+    // console (which on an agent site reconnects through the agent's own tunnel) is back up.
+    public static string AgentOnGatewayFor(int agentId) => $"agent.on_gateway.{agentId}";
+
     // UI preferences (legacy - no longer used)
     public const string SponsorshipBannerDismissed = "ui.sponsorship_banner_dismissed";
 

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -705,6 +705,10 @@ else if (_diagResult != null && !string.IsNullOrEmpty(_diagResult.InterfaceError
                 agents.Add(new ProbeVantageAgent(
                     connection.AgentId,
                     agentNames.GetValueOrDefault(connection.AgentId, connection.AgentName),
+                    // TODO(#1106): use the durable per-agent overload
+                    // IsAgentOnGatewayAsync(slug, agentId, candidates) instead - this one has no
+                    // persisted verdict, so a console that has not answered yet mislabels the
+                    // vantage.
                     await OnGatewayDetector.MatchGatewayAddressAsync(SiteContext.Slug, connection.HostAddresses) != null,
                     bindings));
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -4586,6 +4586,13 @@
     /// reports every address its host holds, which is the reliable answer; an agent with no open
     /// tunnel falls back to its last known LAN IP, since an outdated agent - exactly the one whose
     /// upgrade command this drives - may well be the one that is down.
+    /// <para>
+    /// Never blocks on the site's UniFi Console. The addresses to compare against come from it, and
+    /// on an agent site it reconnects through the agent's own tunnel, so this panel routinely opens
+    /// ahead of it - but a site whose console is broken or unconfigured is exactly where an
+    /// operator goes to fix it, and it has to stay responsive. The detector answers from its
+    /// persisted verdict meanwhile.
+    /// </para>
     /// </summary>
     private async Task LoadAgentsOnGatewayAsync(Site site)
     {
@@ -4595,10 +4602,7 @@
             var candidates = connections.FirstOrDefault(c => c.AgentId == agent.Id)?.HostAddresses;
             if (candidates is not { Count: > 0 })
                 candidates = string.IsNullOrEmpty(agent.LanIp) ? Array.Empty<string>() : new[] { agent.LanIp! };
-            var match = candidates.Count > 0
-                ? await OnGatewayDetector.MatchGatewayAddressAsync(site.Slug, candidates)
-                : null;
-            return (agent.Id, OnGateway: match != null);
+            return (agent.Id, OnGateway: await OnGatewayDetector.IsAgentOnGatewayAsync(site.Slug, agent.Id, candidates));
         }));
         foreach (var (agentId, onGateway) in resolved)
             _agentOnGateway[agentId] = onGateway;

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -4578,6 +4578,10 @@
 
     // Any of the site's agents on the gateway - for the questions that are about the SITE rather
     // than one agent row.
+    // TODO(#1106): its one caller wants a narrower question than ANY. The placeholder mirrors what a
+    // blank override resolves to, and SiteSpeedTestTargetResolver resolves against ONE agent, so a
+    // site with a gateway agent and a real-box agent makes the two disagree. Secondary sites only:
+    // the main site does not render the field.
     private bool SiteHasGatewayAgent(int siteId) =>
         AgentsFor(siteId).Any(a => AgentOnGateway(a.Id));
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3601,7 +3601,7 @@
                                                                 @if (_upgradeCommandAgentId == agent.Id)
                                                                 {
                                                                     <div class="agent-upgrade-cmd">
-                                                                        @if (AgentOnGateway(site.Id))
+                                                                        @if (AgentOnGateway(agent.Id))
                                                                         {
                                                                             <p class="form-help">On the UniFi gateway - enrollment is preserved, only the binary updates:</p>
                                                                             <CopyableCommand Text="@GatewayUpgradeCommand()" Tooltip="Copy the gateway upgrade command" />
@@ -4428,8 +4428,7 @@
                 await LoadSshViaAgentAsync(site);
                 await LoadAgentCoversSiteAsync(site);
                 await LoadClientSpeedTestTargetAsync(site);
-                _agentOnGateway[site.Id] = !site.IsDefault
-                    && await OnGatewayDetector.IsAgentOnGatewayAsync(site.Slug);
+                await LoadAgentsOnGatewayAsync(site);
                 _collectorAgentIds[site.Slug] = await ProbeSink.GetCollectorAgentIdAsync(site.Slug);
             }
         }
@@ -4546,7 +4545,7 @@
     // example when no agent has reported in.
     private string ClientSpeedTestPlaceholder(Site site)
     {
-        if (AgentOnGateway(site.Id))
+        if (SiteHasGatewayAgent(site.Id))
             return "none - the agent runs on the UniFi gateway; enter a separate box hosting the speed test";
         var lanIp = AgentsFor(site.Id)
             .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsReachable(a))
@@ -4562,16 +4561,48 @@
             : "e.g. 192.168.1.50 or https://speed.example.com";
     }
 
-    // The site's agent runs on the UniFi gateway itself (per AgentOnGatewayDetector),
-    // loaded when the site's agent panel expands.
+    // Which agents run on the UniFi gateway itself, keyed by AGENT id and loaded when the site's
+    // agent panel expands. Per agent rather than per site because a site with several agents has
+    // one gateway and only one of them may be sitting on it, and because the site-level verdict
+    // (AgentOnGatewayDetector.IsAgentOnGatewayAsync) answers false for the default site by
+    // contract - a contract its speed-test consumers rely on, so this asks the per-address
+    // question instead and a main-site gateway agent is recognized as one.
     private readonly Dictionary<int, bool> _agentOnGateway = new();
 
     // Which agent currently collects for each site, keyed by slug. Derived rather than configured,
     // and asked of the same code the push path acts on so the page cannot claim otherwise.
     private readonly Dictionary<string, int?> _collectorAgentIds = new();
 
-    private bool AgentOnGateway(int siteId) =>
-        _agentOnGateway.TryGetValue(siteId, out var onGateway) && onGateway;
+    private bool AgentOnGateway(int agentId) =>
+        _agentOnGateway.TryGetValue(agentId, out var onGateway) && onGateway;
+
+    // Any of the site's agents on the gateway - for the questions that are about the SITE rather
+    // than one agent row.
+    private bool SiteHasGatewayAgent(int siteId) =>
+        AgentsFor(siteId).Any(a => AgentOnGateway(a.Id));
+
+    /// <summary>
+    /// Resolves each of the site's agents against the site's gateway addresses. The live tunnel
+    /// reports every address its host holds, which is the reliable answer; an agent with no open
+    /// tunnel falls back to its last known LAN IP, since an outdated agent - exactly the one whose
+    /// upgrade command this drives - may well be the one that is down.
+    /// </summary>
+    private async Task LoadAgentsOnGatewayAsync(Site site)
+    {
+        var connections = TunnelRegistry.GetForSite(site.Slug);
+        var resolved = await Task.WhenAll(AgentsFor(site.Id).Select(async agent =>
+        {
+            var candidates = connections.FirstOrDefault(c => c.AgentId == agent.Id)?.HostAddresses;
+            if (candidates is not { Count: > 0 })
+                candidates = string.IsNullOrEmpty(agent.LanIp) ? Array.Empty<string>() : new[] { agent.LanIp! };
+            var match = candidates.Count > 0
+                ? await OnGatewayDetector.MatchGatewayAddressAsync(site.Slug, candidates)
+                : null;
+            return (agent.Id, OnGateway: match != null);
+        }));
+        foreach (var (agentId, onGateway) in resolved)
+            _agentOnGateway[agentId] = onGateway;
+    }
 
     private async Task LoadClientSpeedTestTargetAsync(Site site)
         => _clientSpeedTestTarget[site.Id] = (await SiteConfig.GetAsync(site.Slug)).ClientSpeedTestTarget;

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -701,6 +701,11 @@
             foreach (var connection in TunnelRegistry.GetForSite(SiteCtx.Slug))
             {
                 if (connection.SupportsSourceBind != true) continue;
+                // TODO(#1106): use the durable per-agent overload
+                // IsAgentOnGatewayAsync(slug, agentId, candidates) instead. This resolves live and
+                // has no persisted verdict, so a console that is not up yet - the norm on an agent
+                // site, where it reconnects through the agent's own tunnel - reads as "not on the
+                // gateway" and offers source-address binding where interface binding belongs.
                 if (await OnGatewayDetector.MatchGatewayAddressAsync(SiteCtx.Slug, connection.HostAddresses) != null)
                     byInterface.Add(connection.AgentId);
                 else

--- a/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
@@ -46,6 +46,11 @@ public class AgentOnGatewayDetector
     // work without a system scope.
     private readonly ConcurrentDictionary<string, string> _agentIp = new();
     private readonly ConcurrentDictionary<string, Task> _refreshing = new();
+    // Per-agent verdicts and their in-flight refreshes, for the per-agent overload. Separate from
+    // the site-level pair above rather than replacing it: the two answer different questions and
+    // the site-level one keeps its own contract.
+    private readonly ConcurrentDictionary<(string Slug, int AgentId), (bool OnGateway, DateTime At)> _agentCache = new();
+    private readonly ConcurrentDictionary<(string Slug, int AgentId), Task> _agentRefreshing = new();
     // The site's gateway addresses from the last resolution, so the per-connection check below can
     // answer for an agent the site-level verdict never considered. Cached and refreshed on the same
     // TTL as the verdict itself; a site with 2+ agents has one gateway either way.
@@ -90,7 +95,7 @@ public class AgentOnGatewayDetector
         // invented false into the empty cache.
         if (!hasCached)
         {
-            var persisted = await LoadPersistedAsync(siteSlug);
+            var persisted = await LoadPersistedAsync(siteSlug, SystemSettingKeys.AgentOnGateway);
             if (persisted != null)
             {
                 _cache.TryAdd(siteSlug, (persisted.Value, DateTime.MinValue));
@@ -112,6 +117,101 @@ public class AgentOnGatewayDetector
         }
         return _cache.TryGetValue(siteSlug, out var fresh) && fresh.OnGateway;
     }
+
+    /// <summary>
+    /// Whether ONE agent runs on its site's gateway, given the addresses that agent is known by.
+    /// The per-agent counterpart of <see cref="IsAgentOnGatewayAsync(string, CancellationToken)"/>,
+    /// carrying the same durability: a persisted verdict seeds the answer before the console can be
+    /// asked, and a refresh that cannot reach the console keeps the last answer rather than
+    /// inventing a no.
+    /// <para>
+    /// That durability is the whole point. The addresses to compare against come from the site's
+    /// UniFi Console, which on an agent site reconnects through that agent's own tunnel - so a
+    /// caller asking right after a restart, an agent update, or a page switch would otherwise get a
+    /// silent no and show a gateway agent the wrong instructions. Callers must not block on the
+    /// console to avoid that: a site with a broken or unconfigured console is exactly where someone
+    /// goes to fix it, and it has to stay responsive.
+    /// </para>
+    /// <para>
+    /// Deliberately not gated on the site being non-default, unlike the site-level verdict whose
+    /// "false for the default site" contract its speed-test consumers rely on.
+    /// </para>
+    /// </summary>
+    public async Task<bool> IsAgentOnGatewayAsync(
+        string siteSlug, int agentId, IReadOnlyList<string> candidates, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(siteSlug))
+            return false;
+
+        var key = (siteSlug, agentId);
+        var hasCached = _agentCache.TryGetValue(key, out var cached);
+        if (hasCached && DateTime.UtcNow - cached.At < CacheTtl)
+            return cached.OnGateway;
+
+        // Seeded before the refresh starts, for the same reason the site-level path does it: a
+        // refresh that finds the console down must keep this answer rather than race a made-up
+        // false into an empty cache.
+        if (!hasCached)
+        {
+            var persisted = await LoadPersistedAsync(siteSlug, SystemSettingKeys.AgentOnGatewayFor(agentId));
+            if (persisted != null)
+            {
+                _agentCache.TryAdd(key, (persisted.Value, DateTime.MinValue));
+                hasCached = _agentCache.TryGetValue(key, out cached);
+            }
+        }
+
+        // Nothing to compare: an agent that has never reported an address. Never persisted, so a
+        // known verdict is kept and an unknown one stays unknown.
+        if (candidates.Count == 0)
+            return hasCached && cached.OnGateway;
+
+        var refresh = StartOrJoinAgentRefresh(siteSlug, agentId, candidates);
+        if (hasCached)
+            return cached.OnGateway;
+
+        try
+        {
+            await refresh.WaitAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller gave up (panel closed) - the refresh itself continues and fills the cache.
+        }
+        return _agentCache.TryGetValue(key, out var fresh) && fresh.OnGateway;
+    }
+
+    /// <summary>One in-flight refresh per agent; the result lands in the cache and is persisted.</summary>
+    private Task StartOrJoinAgentRefresh(string siteSlug, int agentId, IReadOnlyList<string> candidates) =>
+        _agentRefreshing.GetOrAdd((siteSlug, agentId), key => Task.Run(async () =>
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(RefreshTimeout);
+                var connection = _siteConnections.GetFor(key.Slug);
+                if (!connection.IsConnected || connection.Client == null)
+                {
+                    // Console not up (the norm on an agent site right after a restart, since it
+                    // reconnects through the agent's tunnel).
+                    if (_agentCache.TryGetValue(key, out var last))
+                        _agentCache[key] = (last.OnGateway, DateTime.UtcNow);
+                    return;
+                }
+
+                await ResolveGatewayIpsAsync(key.Slug, connection.Client, cts.Token);
+                var onGateway = await MatchGatewayAddressAsync(key.Slug, candidates, cts.Token) != null;
+                _agentCache[key] = (onGateway, DateTime.UtcNow);
+                await PersistAsync(key.Slug, SystemSettingKeys.AgentOnGatewayFor(key.AgentId), onGateway);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Agent-on-gateway detection failed for agent {AgentId} at site {Slug}", key.AgentId, key.Slug);
+            }
+            finally
+            {
+                _agentRefreshing.TryRemove(key, out _);
+            }
+        }));
 
     /// <summary>
     /// The address the site's agent reported at the last detection, or null if none has completed.
@@ -254,7 +354,7 @@ public class AgentOnGatewayDetector
         var onGateway = gatewayIps.Contains(agentIp!, StringComparer.OrdinalIgnoreCase);
         _cache[siteSlug] = (onGateway, DateTime.UtcNow);
         _agentIp[siteSlug] = agentIp!;
-        await PersistAsync(siteSlug, onGateway);
+        await PersistAsync(siteSlug, SystemSettingKeys.AgentOnGateway, onGateway);
     }
 
     /// <summary>
@@ -334,13 +434,13 @@ public class AgentOnGatewayDetector
             _cache[siteSlug] = (cached.OnGateway, DateTime.UtcNow);
     }
 
-    /// <summary>The persisted last verdict for a site, or null when never detected.</summary>
-    private async Task<bool?> LoadPersistedAsync(string siteSlug)
+    /// <summary>The persisted last verdict under the given key, or null when never detected.</summary>
+    private async Task<bool?> LoadPersistedAsync(string siteSlug, string settingKey)
     {
         try
         {
-            await using var db = _siteDbFactory.CreateForSite(siteSlug, isDefault: false);
-            var value = (await db.SystemSettings.FindAsync(SystemSettingKeys.AgentOnGateway))?.Value;
+            await using var db = _siteDbFactory.CreateForSite(siteSlug, IsDefaultSite(siteSlug));
+            var value = (await db.SystemSettings.FindAsync(settingKey))?.Value;
             return value == null ? null : value == "true";
         }
         catch (Exception ex)
@@ -350,18 +450,26 @@ public class AgentOnGatewayDetector
         }
     }
 
+    /// <summary>
+    /// The default site keeps its settings in the main database rather than a per-site one. The
+    /// site-level verdict never reaches here for it (it answers false and returns), but the
+    /// per-agent one does, and asking for a site database it does not have would write the verdict
+    /// somewhere nothing reads it back from.
+    /// </summary>
+    private static bool IsDefaultSite(string siteSlug) => siteSlug == SiteManagementService.DefaultSiteSlug;
+
     /// <summary>Persists a real (console-backed) verdict; writes only on change to spare the site DB.</summary>
-    private async Task PersistAsync(string siteSlug, bool onGateway)
+    private async Task PersistAsync(string siteSlug, string settingKey, bool onGateway)
     {
         try
         {
             var value = onGateway ? "true" : "false";
-            await using var db = _siteDbFactory.CreateForSite(siteSlug, isDefault: false);
-            var setting = await db.SystemSettings.FindAsync(SystemSettingKeys.AgentOnGateway);
+            await using var db = _siteDbFactory.CreateForSite(siteSlug, IsDefaultSite(siteSlug));
+            var setting = await db.SystemSettings.FindAsync(settingKey);
             if (setting == null)
                 db.SystemSettings.Add(new SystemSetting
                 {
-                    Key = SystemSettingKeys.AgentOnGateway,
+                    Key = settingKey,
                     Value = value
                 });
             else if (setting.Value != value)

--- a/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
@@ -166,6 +166,10 @@ public class AgentOnGatewayDetector
         if (candidates.Count == 0)
             return hasCached && cached.OnGateway;
 
+        // TODO(#1106): the FIRST resolve for an agent has no verdict to fall back on, so if the
+        // console cannot answer at that moment this returns a no and the caller renders it. It
+        // self-corrects on the next ask (the refresh persists), and in practice only a page parked
+        // through a server restart sees it, so it is low severity rather than none.
         var refresh = StartOrJoinAgentRefresh(siteSlug, agentId, candidates);
         if (hasCached)
             return cached.OnGateway;
@@ -386,6 +390,12 @@ public class AgentOnGatewayDetector
             foreach (var port in device.PortTable ?? new())
                 AddHostIp(hostIps, port.Ip);
         }
+        // TODO(#1106): this takes ONE LAN address - ResolveGatewayLanIpAsync is FirstOrDefault()
+        // over the corporate networks - so a multi-VLAN gateway contributes its default LAN and
+        // nothing else (a real case: 2 of the 6 addresses the box holds). Harmless for an agent
+        // reporting local_ips, since one of those will hit, but an older single-address agent
+        // matches only if it happened to name one of the two. NetworkInfo.Gateway is already
+        // mapped for EVERY network in UniFiConnectionService / UniFiDiscovery and closes it.
         try
         {
             var lanIp = await Monitoring.SnmpDeviceRules.ResolveGatewayLanIpAsync(client, ct);

--- a/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
@@ -170,6 +170,11 @@ public class AgentOnGatewayDetector
         // console cannot answer at that moment this returns a no and the caller renders it. It
         // self-corrects on the next ask (the refresh persists), and in practice only a page parked
         // through a server restart sees it, so it is low severity rather than none.
+        // Every agent enrolled before this key existed gets one pass through that window too: the
+        // site-level verdict persists under AgentOnGateway and nothing reads it back under the
+        // per-agent key. Backfilling it is not worth building - the site-level row does not record
+        // WHICH agent it was about, so it is only unambiguous on a single-agent site, and the main
+        // site (the one this overload exists for) never persisted a row at all.
         var refresh = StartOrJoinAgentRefresh(siteSlug, agentId, candidates);
         if (hasCached)
             return cached.OnGateway;

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -368,6 +368,10 @@ public class AgentProbeResultSink
             // The MATCHED address, not the agent's own reported one: the site's target for the
             // gateway carries the address the console knows it by, which is not necessarily the
             // address the agent named itself with.
+            // TODO(#1106): this one needs the matched ADDRESS, not a yes/no, so the durable
+            // per-agent overload does not drop in - it would have to persist the address too.
+            // Same exposure as the others: no console, no match, and the gateway's own target is
+            // handed back to the agent that sits on it.
             var selfAddress = await _onGatewayDetector.MatchGatewayAddressAsync(
                 connection.SiteSlug, connection.HostAddresses, ct);
             var skippedSelf = 0;
@@ -514,6 +518,7 @@ public class AgentProbeResultSink
         if (unbound.Count == 0) return false;
 
         // Asked only when there is something to heal: it can await a console round trip.
+        // TODO(#1106): a yes/no, so the durable per-agent overload does drop in here.
         if (await _onGatewayDetector.MatchGatewayAddressAsync(
                 connection.SiteSlug, connection.HostAddresses, ct) == null)
             return false;


### PR DESCRIPTION
## Multi-Site

- **A gateway-resident agent on the main site is recognized as one at all.** This was not a degraded answer, it was no answer: the agent list's check short-circuited on the site being the main one before the detector was ever consulted, and the detector it would have called answers no for the main site by contract. So an agent running on the UniFi gateway of the main site - a deployment where the server collects and an agent is added on the gateway alongside it - was always told it was somewhere else, and handed the bare metal, Docker and Proxmox LXC upgrade commands, none of which apply to it. The question is now asked per agent, which is also what a site with several agents needs: a site has one gateway and only one of its agents may be sitting on it.

- **The answer survives a UniFi Console that is not up yet.** The addresses an agent is matched against come from the site's console, and on a site with an agent the console reconnects through that agent's own tunnel - so the panel routinely opens ahead of it. The verdict is now remembered per agent and used while the console is unreachable, rather than an unanswerable question reading as "not on the gateway". Nothing waits on the console to do it: a site whose console is broken or unconfigured is exactly where an operator goes to fix it, so the page stays responsive.

- **The Client Speed Test placeholder follows the same answer** on the secondary sites that show the field, so a site whose agent sits on the gateway says so instead of advertising an auto value that resolves to nothing.

The existing site-level entry points are untouched, so the surfaces that gate on them - **WAN Speed Test**, **Client Speed Test** and **LAN Speed Test** - behave exactly as before.

## Follow-ups

Several call sites still ask the live, memoryless form of this question, and the set of gateway addresses it compares against is narrower than the addresses a gateway actually holds. Both are captured in `TODO.md` and tracked in #1106; neither is introduced here.

## Review notes

Properties of this change worth knowing, none of them blocking, none introduced as defects:

- **`StartOrJoinAgentRefresh` captures the first caller's candidate addresses.** `GetOrAdd` closes over whichever call created the in-flight task, so two concurrent asks for the same agent with different address sets - one from the live tunnel, one from the stored LAN IP - both resolve against the first one's. Not reachable today, since the agent list asks once per agent, but it matters for the call sites in #1106.
- **The panel's load path has no exception guard.** The equivalent call on **Alerts & Schedule** is wrapped; this one is not. It was not wrapped before either, and every path that can throw catches internally, so this is a known shape rather than a new risk.
- **Detector caches are not cleared when a site is removed.** True of the existing per-site dictionaries and of the per-agent ones added here, which deliberately follow the same pattern rather than diverging from it. Entries are keyed per agent, so a re-created site gets new keys rather than stale answers.

