### PR TITLE
v2.6.1 Release Changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1197,3 +1197,45 @@ Later defers it for the whole install, and a new user added later never sees any
 - [ ] Move the offer/defer state per user, keeping the install-level version stamps where they are -
   `FirstSeenVersion` is a fact about the install, but "has this person been offered 2.5.0" is a fact
   about the person.
+
+## Agent-on-gateway detection: finish the cleanup (#1106)
+
+`AgentOnGatewayDetector` now has two ways to answer "does this agent run on the UniFi gateway", and
+only one of them is durable.
+
+- `IsAgentOnGatewayAsync(slug)` and `IsAgentOnGatewayAsync(slug, agentId, candidates)` seed from a
+  persisted verdict before refreshing, and keep the last answer when the console cannot be reached.
+- `MatchGatewayAddressAsync` / `IsIpOnGatewayAsync` resolve live with no memory. The addresses to
+  compare against come from the site's UniFi Console, which on an agent site reconnects through that
+  agent's own tunnel, so a caller that asks too early gets a silent no.
+
+Severity is low. In practice the live path is only wrong if someone is parked on the page across a
+Network Optimizer server restart - every later ask resolves and persists. Worth tidying because the
+two primitives look interchangeable and are not, not because it is hurting anyone.
+
+- [ ] `WanContextsCard.LoadBindCapableAgentsAsync` - move to the per-agent overload. Wrong answer
+  offers source-address binding where interface binding belongs.
+- [ ] `MonitoringTools` probe-vantage list - same, mislabels the vantage.
+- [ ] `AgentProbeResultSink` unbound-context healing - a yes/no, so the overload drops straight in.
+- [ ] `AgentProbeResultSink` self-target skipping - needs the matched ADDRESS rather than a yes/no,
+  so it needs the overload to persist the address too, or to stay as it is.
+
+One caller has the right primitive but asks the wrong question of it:
+
+- [ ] `Settings.ClientSpeedTestPlaceholder` asks `SiteHasGatewayAgent`, which is true when ANY of the
+  site's agents is on the gateway. Its job is to mirror what a blank override resolves to, and
+  `SiteSpeedTestTargetResolver` resolves against ONE agent - the most-recently-seen reachable one. A
+  site with a gateway agent and a real-box agent makes them disagree: the placeholder says "none,
+  enter a separate box" while the resolver points at the box. Ask the resolver's question rather than
+  `Any`. Not a regression - the site-level verdict it replaced picked whichever agent enrollment
+  answered with, so that site was already a coin flip - and the main site never renders the field at
+  all, so this is secondary sites only.
+
+Separately, the comparison set itself is narrow, and this one stands on its own merits:
+
+- [ ] `ResolveGatewayIpsAsync` takes exactly one LAN address, because `ResolveGatewayLanIpAsync` is
+  `FirstOrDefault()` over the corporate networks. A multi-VLAN gateway contributes its default LAN
+  and nothing else - on a gateway with a handful of VLANs that is 2 of the 6 addresses it holds.
+  An agent reporting `local_ips` (2.6.0+) always hits one of the two, but an older single-address
+  agent matches only if it named one of them. `NetworkInfo.Gateway` is already mapped for EVERY
+  network in `UniFiConnectionService` and `UniFiDiscovery`, so the full set is there for the taking.

--- a/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkUtilities.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
@@ -346,6 +346,29 @@ public static class NetworkUtilities
     /// </summary>
     /// <param name="ipAddress">IP address string to check</param>
     /// <returns>True if the IP is private/non-routable, false if public or invalid</returns>
+    /// <summary>
+    /// The address to judge a resolved name by: the unusable ones discarded first, then IPv4
+    /// preferred among what is left.
+    /// <para>
+    /// Both steps, in that order. "::" and "0.0.0.0" are what a resolver returns for a name that
+    /// exists and has no address of its own - a search-domain suffix that answers nothing - and
+    /// they parse as addresses, so they have to be thrown out rather than merely out-ranked, or a
+    /// junk A record would beat a good AAAA. IPv4 wins the rest because the private-range tests
+    /// here are v4, and an AAAA taken because DNS listed it first is judged by a rule that cannot
+    /// see it.
+    /// </para>
+    /// </summary>
+    /// <param name="answers">Every address the name resolved to.</param>
+    /// <returns>The address to judge, or null when none of them is a host.</returns>
+    public static IPAddress? SelectUsableAddress(IEnumerable<IPAddress> answers)
+    {
+        var usable = answers
+            .Where(a => a is not null && !a.Equals(IPAddress.Any) && !a.Equals(IPAddress.IPv6Any))
+            .ToList();
+        return usable.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork)
+            ?? usable.FirstOrDefault();
+    }
+
     public static bool IsPrivateIpAddress(string ipAddress)
     {
         if (!IPAddress.TryParse(ipAddress, out var ip))

--- a/src/NetworkOptimizer.Storage/Migrations/20260806120000_RestoreMeteredClobberedIntervals.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260806120000_RestoreMeteredClobberedIntervals.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806120000_RestoreMeteredClobberedIntervals")]
+    partial class RestoreMeteredClobberedIntervals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -1911,9 +1914,6 @@ namespace NetworkOptimizer.Storage.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool?>("IsLocal")
                         .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("LanFlakyHintDismissedAt")

--- a/src/NetworkOptimizer.Storage/Migrations/20260806120000_RestoreMeteredClobberedIntervals.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260806120000_RestoreMeteredClobberedIntervals.cs
@@ -1,0 +1,85 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <summary>
+    /// Repairs the poll intervals a metered WAN's commit overwrote on targets that were never its
+    /// to touch (it owned every unpinned row, not just its own - fixed in
+    /// UpstreamTracerService.OwnsTargetRow), then names the unpinned state instead of leaving it
+    /// NULL for each reader to interpret.
+    /// <para>
+    /// The original cadences were never recorded, so they are inferred: only the two intervals a
+    /// metered plan produces are suspect (30s at rung 1, 60s at rung 2), and only on sites with a
+    /// metered WAN. Private addresses go back to the default - no data plan has a claim on LAN
+    /// traffic - and the rest take the modal cadence of their own type among rows still faster than
+    /// a metered plan allows, which is exactly the set that escaped. A hand-set 30s or 60s target
+    /// is indistinguishable from a clobbered one and gets sped up; that is the cost of the repair.
+    /// </para>
+    /// </summary>
+    public partial class RestoreMeteredClobberedIntervals : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // TargetType: 0=Fabric (excluded from the overwrite in the first place, so excluded
+            // here), 2=AccessIsp, 3=Transit, 4=Custom, 5=InternetService.
+            // AccessTechnology: 6=FixedWireless, 7=Satellite, 8=Cellular - the technologies
+            // MeteredProbePolicy assumes are metered. A DataCapGb above zero is the operator
+            // saying so outright.
+            //
+            // The metered WAN must hold a VANTAGE. Only a vantage-bound run could reach targets
+            // that were not its own, so a site without one - every single-WAN install - never had
+            // the bug. Slowing its own unpinned targets is the budget working, and undoing that
+            // would be the repair causing the damage.
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets
+SET PollIntervalSeconds = CASE
+        WHEN Address GLOB '10.*'
+          OR Address GLOB '192.168.*'
+          OR Address GLOB '127.*'
+          OR Address GLOB '172.1[6-9].*'
+          OR Address GLOB '172.2[0-9].*'
+          OR Address GLOB '172.3[01].*'
+        THEN 10
+        ELSE COALESCE((
+            SELECT s.PollIntervalSeconds
+            FROM MonitoringTargets s
+            WHERE s.TargetType = MonitoringTargets.TargetType
+              AND s.TargetType <> 0
+              AND s.PollIntervalSeconds < 30
+            GROUP BY s.PollIntervalSeconds
+            ORDER BY COUNT(*) DESC, s.PollIntervalSeconds ASC
+            LIMIT 1
+        ), 10)
+    END
+WHERE WanInterface IS NULL
+  AND TargetType <> 0
+  AND PollIntervalSeconds IN (30, 60)
+  AND EXISTS (
+        SELECT 1 FROM WanContexts c
+        WHERE c.WanInterface IS NOT NULL AND c.WanInterface <> ''
+          AND (EXISTS (SELECT 1 FROM WanDataUsageConfigs d
+                       WHERE lower(d.WanKey) = lower(c.WanInterface) AND d.DataCapGb > 0)
+            OR EXISTS (SELECT 1 FROM WanDiscoveryContexts w
+                       WHERE lower(w.WanInterface) = lower(c.WanInterface)
+                         AND w.AccessTechnology IN (6, 7, 8)))
+  );");
+
+            // Then name what the absent WAN meant: not pinned to one. Runs AFTER the restore,
+            // which keys on NULL.
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets SET WanInterface = 'unpinned'
+WHERE WanInterface IS NULL OR WanInterface = '';");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // The intervals were lost before this ran, so there is nothing to put back - re-slowing
+            // every row to a cadence it may never have had is a second guess, not a rollback. The
+            // unpinned marker does reverse cleanly.
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets SET WanInterface = NULL WHERE WanInterface = 'unpinned';");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260806160000_AddMonitoringTargetIsLocal.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260806160000_AddMonitoringTargetIsLocal.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260806160000_AddMonitoringTargetIsLocal")]
+    partial class AddMonitoringTargetIsLocal
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260806160000_AddMonitoringTargetIsLocal.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260806160000_AddMonitoringTargetIsLocal.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <summary>
+    /// Records whether a target sits on the local network, so it stops being re-guessed from the
+    /// text of its address on every read - and so a hostname can be answered at all.
+    /// <para>
+    /// Backfills the literal addresses here, since those need no lookup. Anything named by hostname
+    /// stays null and is resolved later; null means "not known yet", never "not local".
+    /// </para>
+    /// </summary>
+    public partial class AddMonitoringTargetIsLocal : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLocal", table: "MonitoringTargets", type: "INTEGER", nullable: true);
+
+            // Fabric is the discovered gateway, switches and APs - local by what it is, whatever
+            // address it wears.
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets SET IsLocal = 1 WHERE TargetType = 0;");
+
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets SET IsLocal = 1
+WHERE IsLocal IS NULL
+  AND (Address GLOB '10.*'
+    OR Address GLOB '192.168.*'
+    OR Address GLOB '127.*'
+    OR Address GLOB '172.1[6-9].*'
+    OR Address GLOB '172.2[0-9].*'
+    OR Address GLOB '172.3[01].*');");
+
+            // A literal address that is not private is settled too - only names need looking up.
+            migrationBuilder.Sql(@"
+UPDATE MonitoringTargets SET IsLocal = 0
+WHERE IsLocal IS NULL
+  AND Address GLOB '*.*.*.*'
+  AND Address NOT GLOB '*[a-zA-Z]*';");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "IsLocal", table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
@@ -89,12 +89,41 @@ public class MonitoringTarget
     public DiscoveryMethod? DiscoveryMethod { get; set; }
 
     /// <summary>
-    /// Which WAN this target was discovered against. Null for fabric and custom
-    /// targets that aren't tied to a specific WAN. The upstream tracer always sets
-    /// this on access-ISP and transit targets.
+    /// The WAN this target measures, or <see cref="UnpinnedWan"/> when the probe is pinned to none
+    /// - which measures the primary under failover and no single WAN under load balancing.
+    /// <para>
+    /// A pinned value is intent, not proof. An on-gateway agent binds its probe source, so its
+    /// stamp always holds - which is why multi-WAN monitoring steers users onto one. Steering an
+    /// on-LAN agent or the server takes gateway policy routing instead, and that re-routes when its
+    /// WAN drops, so a failover window reads as the pinned WAN's latency when it is another's.
+    /// Short of a kill switch on the policy, which costs the site its probes for the whole outage.
+    /// </para>
     /// </summary>
     [MaxLength(50)]
     public string? WanInterface { get; set; }
+
+    /// <summary>The <see cref="WanInterface"/> meaning "not pinned to a WAN" - stated, not inferred.</summary>
+    public const string UnpinnedWan = "unpinned";
+
+    /// <summary>
+    /// Whether this target sits on the local network, resolved rather than guessed from the text of
+    /// <see cref="Address"/>.
+    /// <para>
+    /// An address typed as a hostname says nothing on its own - "cloudkey.local" and
+    /// "speedtest.example.net" read the same - so it is resolved once and the answer kept. Null
+    /// means nobody has been able to resolve it yet, and readers fall back to testing the address
+    /// itself, which is right for a literal IP and silent for everything else.
+    /// </para>
+    /// </summary>
+    public bool? IsLocal { get; set; }
+
+    /// <summary>
+    /// Whether a WanInterface names no WAN. Null counts: rows predating the marker carry it, and
+    /// every reader must treat the two the same.
+    /// </summary>
+    public static bool IsUnpinned(string? wanInterface) =>
+        string.IsNullOrEmpty(wanInterface)
+        || string.Equals(wanInterface, UnpinnedWan, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// Multi-WAN monitoring context this target belongs to (loose reference to

--- a/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
+++ b/src/NetworkOptimizer.Storage/Models/SystemSetting.cs
@@ -63,6 +63,12 @@ public static class SystemSettingKeys
     // connection comes back up.
     public const string AgentOnGateway = "agent.on_gateway";
 
+    // Per-AGENT counterpart of the above, for the questions that are about one agent rather than
+    // the site: a site has one gateway and only one of its agents may be sitting on it. Serves the
+    // same purpose - a verdict that survives a restart, so the answer is right before the site's
+    // console (which on an agent site reconnects through the agent's own tunnel) is back up.
+    public static string AgentOnGatewayFor(int agentId) => $"agent.on_gateway.{agentId}";
+
     // UI preferences (legacy - no longer used)
     public const string SponsorshipBannerDismissed = "ui.sponsorship_banner_dismissed";
 

--- a/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
+++ b/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
@@ -157,6 +157,41 @@ public static class GatewayWanHelper
     }
 
     /// <summary>
+    /// The name a WAN should be shown under, from what the console reports for it.
+    /// <para>
+    /// The network's own name wins - it is the one someone typed. A stock "Internet 2" is not
+    /// that, so the port's name answers next, and only when the port has been renamed: "Port 5"
+    /// is no more a name than "Internet 2" is. Null when neither is real, which leaves the
+    /// caller with the plain "WANn" that <see cref="FormatWanLabel"/> already produces.
+    /// </para>
+    /// <para>
+    /// Here rather than at each call site because the precedence was being decided separately in
+    /// several of them, and one had it backwards - the port name shadowed the network's, so every
+    /// site that had not renamed its port showed "Port 5" where its WAN's name should be.
+    /// </para>
+    /// </summary>
+    /// <param name="networkName">The WAN network's configured name, if any.</param>
+    /// <param name="portName">The front-panel port's name, if any.</param>
+    public static string? ResolveWanName(string? networkName, string? portName)
+    {
+        if (!IsPlaceholderWanName(networkName)) return networkName!.Trim();
+        if (!IsPlaceholderWanName(portName)) return portName!.Trim();
+        return null;
+    }
+
+    /// <summary>
+    /// Whether a name is a stock label rather than one someone chose: a generic WAN name
+    /// ("Internet 2", "WAN3"), a default port label ("SFP+ 2"), or nothing at all.
+    /// <para>
+    /// Both halves matter and neither alone is enough - a WAN can arrive carrying either kind of
+    /// placeholder, so testing for one lets the other through as though it were a real name.
+    /// </para>
+    /// </summary>
+    public static bool IsPlaceholderWanName(string? name) =>
+        Core.Helpers.DisplayFormatters.IsGenericWanName(name)
+        || InterfaceLabelResolver.IsDefaultPortName(name);
+
+    /// <summary>
     /// Builds a human-readable WAN label from up to four identifiers
     /// (e.g. "Acme Fiber WAN1 (eth6 - Port 7)"), degrading gracefully when any
     /// piece is missing so it never emits empty parentheses, doubled spaces, or

--- a/src/NetworkOptimizer.UniFi/Models/UniFiTrafficRouteResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiTrafficRouteResponse.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+using NetworkOptimizer.Core;
+
+namespace NetworkOptimizer.UniFi.Models;
+
+/// <summary>
+/// A policy-based route from v2 trafficroutes: which devices' traffic, to which destinations,
+/// leaves by which network. Only the fields monitoring reads are modelled.
+/// </summary>
+[VendorSpecific("UniFi", "v2/api/site/{site}/trafficroutes")]
+public class UniFiTrafficRouteResponse
+{
+    [JsonPropertyName("_id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// What the route matches on: "INTERNET" is every destination, and the only value that makes
+    /// the route a statement about where a device's traffic leaves in general. "IP", "DOMAIN" and
+    /// "REGION" steer a slice of it, which says nothing about where a probe to somewhere else goes.
+    /// </summary>
+    [JsonPropertyName("matching_target")]
+    public string? MatchingTarget { get; set; }
+
+    /// <summary>The network the matched traffic leaves by; a WAN's id for the routes we care about.</summary>
+    [JsonPropertyName("network_id")]
+    public string? NetworkId { get; set; }
+
+    /// <summary>
+    /// Whether matched traffic is dropped rather than re-routed when the network is down. False
+    /// means a failover silently sends it out another WAN - see MonitoringTarget.WanInterface.
+    /// </summary>
+    [JsonPropertyName("kill_switch_enabled")]
+    [JsonConverter(typeof(FlexibleBoolConverter))]
+    public bool KillSwitchEnabled { get; set; }
+
+    [JsonPropertyName("target_devices")]
+    public List<UniFiTrafficRouteTargetDevice> TargetDevices { get; set; } = new();
+}
+
+/// <summary>One device a traffic route applies to, or the marker that it applies to all of them.</summary>
+[VendorSpecific("UniFi", "trafficroutes target_devices[]")]
+public class UniFiTrafficRouteTargetDevice
+{
+    [JsonPropertyName("client_mac")]
+    public string? ClientMac { get; set; }
+
+    /// <summary>"CLIENT" names a MAC in <see cref="ClientMac"/>; "ALL_CLIENTS" names every device.</summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+}

--- a/src/NetworkOptimizer.UniFi/TrafficRouteWanPinning.cs
+++ b/src/NetworkOptimizer.UniFi/TrafficRouteWanPinning.cs
@@ -1,0 +1,71 @@
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.UniFi;
+
+/// <summary>
+/// Which WAN a policy-based route pins a device's traffic to, if any.
+/// <para>
+/// Only useful on a load-balancing site, where an unpinned probe measures no single WAN and the
+/// route is the one thing that says otherwise. Best effort throughout: no match means the probing
+/// box stays unpinned, which is already the truthful answer, so nothing here needs to guess.
+/// </para>
+/// </summary>
+public static class TrafficRouteWanPinning
+{
+    /// <summary>Matches every destination - the only target that pins a device's traffic in general.</summary>
+    private const string InternetTarget = "INTERNET";
+    private const string ClientDevice = "CLIENT";
+    private const string AllClientsDevice = "ALL_CLIENTS";
+
+    /// <summary>What a route pins, and whether that survives the WAN going down.</summary>
+    /// <param name="NetworkId">The network the traffic leaves by.</param>
+    /// <param name="KillSwitchEnabled">
+    /// False means a failover re-routes the traffic while the readings keep this WAN's name.
+    /// </param>
+    /// <param name="Description">The route's name, for logs and anything shown to the operator.</param>
+    public sealed record Pin(string NetworkId, bool KillSwitchEnabled, string? Description);
+
+    /// <summary>
+    /// The route that pins this device's traffic wholesale, or null when none does. A route
+    /// qualifies only when it is enabled, matches every destination, names a network, and either
+    /// names this MAC or applies to all clients.
+    /// </summary>
+    /// <param name="routes">The site's traffic routes.</param>
+    /// <param name="deviceMac">The probing box's MAC.</param>
+    public static Pin? ResolvePin(IEnumerable<UniFiTrafficRouteResponse> routes, string? deviceMac)
+    {
+        if (string.IsNullOrWhiteSpace(deviceMac)) return null;
+        var mac = NormalizeMac(deviceMac);
+
+        // A MAC named explicitly beats a blanket all-clients route: both pin the same traffic, but
+        // the explicit one is the operator saying something about THIS box.
+        var matches = routes
+            .Where(r => r != null && r.Enabled && NamesEveryDestination(r) && !string.IsNullOrEmpty(r.NetworkId))
+            .Select(r => (Route: r, Targets: r.TargetDevices ?? new List<UniFiTrafficRouteTargetDevice>()))
+            .ToList();
+
+        var explicitMatch = matches.FirstOrDefault(m => m.Targets.Any(d =>
+            string.Equals(d.Type, ClientDevice, StringComparison.OrdinalIgnoreCase)
+            && NormalizeMac(d.ClientMac) == mac));
+        var chosen = explicitMatch.Route
+            ?? matches.FirstOrDefault(m => m.Targets.Any(d =>
+                string.Equals(d.Type, AllClientsDevice, StringComparison.OrdinalIgnoreCase))).Route;
+
+        return chosen == null
+            ? null
+            : new Pin(chosen.NetworkId!, chosen.KillSwitchEnabled, chosen.Description);
+    }
+
+    /// <summary>
+    /// Whether the route steers every destination. An IP, domain or region route steers a slice of
+    /// the device's traffic, which says nothing about where a probe to somewhere else leaves.
+    /// </summary>
+    private static bool NamesEveryDestination(UniFiTrafficRouteResponse route) =>
+        string.Equals(route.MatchingTarget, InternetTarget, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Lowercased, separators dropped, so 00:11:22 and 00-11-22 compare equal.</summary>
+    private static string NormalizeMac(string? mac) =>
+        string.IsNullOrEmpty(mac)
+            ? string.Empty
+            : new string(mac.Where(char.IsLetterOrDigit).ToArray()).ToLowerInvariant();
+}

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -1618,32 +1618,41 @@ public class UniFiApiClient : IDisposable
     #region Traffic Management APIs
 
     /// <summary>
-    /// GET v2/api/site/{site}/trafficroutes - Get traffic routes
-    /// This is a newer UniFi Network Application (v2) endpoint
+    /// GET v2/api/site/{site}/trafficroutes - the site's policy-based routes.
+    /// <para>
+    /// A v2 endpoint, so the payload is a bare array rather than the meta/data envelope the v1
+    /// calls unwrap. Best effort: an empty list whenever it cannot be read, since a caller asking
+    /// which WAN a device is pinned to treats "no route" and "could not look" the same way.
+    /// </para>
     /// </summary>
-    public async Task<JsonDocument?> GetTrafficRoutesAsync(CancellationToken cancellationToken = default)
+    public async Task<List<UniFiTrafficRouteResponse>> GetTrafficRoutesAsync(
+        CancellationToken cancellationToken = default)
     {
         _logger.LogDebug("Fetching traffic routes for site {Site}", _site);
 
         if (!await EnsureAuthenticatedAsync(cancellationToken))
         {
-            return null;
+            return new List<UniFiTrafficRouteResponse>();
         }
 
-        return await ExecuteRequestAsync(async () =>
+        var routes = await ExecuteRequestAsync(async () =>
         {
             var response = await _httpClient!.GetAsync(
                 BuildV2ApiPath($"site/{_site}/trafficroutes"),
                 cancellationToken);
 
-            if (response.IsSuccessStatusCode)
+            if (!response.IsSuccessStatusCode)
             {
-                var json = await response.Content.ReadAsStringAsync(cancellationToken);
-                return JsonDocument.Parse(json);
+                _logger.LogDebug("Traffic routes returned {Status}", response.StatusCode);
+                return null;
             }
 
-            return null;
+            var json = await response.Content.ReadAsStringAsync(cancellationToken);
+            return JsonSerializer.Deserialize<List<UniFiTrafficRouteResponse>>(json);
         });
+
+        _logger.LogDebug("Retrieved {Count} traffic route(s)", routes?.Count ?? 0);
+        return routes ?? new List<UniFiTrafficRouteResponse>();
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1,4 +1,4 @@
-@* TODO: Continue extracting Monitoring cards into standalone Razor components.
+﻿@* TODO: Continue extracting Monitoring cards into standalone Razor components.
    LatencyTargetsCard and SfpModulesCard are done. Remaining candidates:
    - Live View stat cards → MonitoringStatCards
    - Monitoring Status / Setup card → MonitoringSetupCard
@@ -16,6 +16,7 @@
 @using NetworkOptimizer.Web.Services.Authorization
 @inject IAuthorizationService Authz
 @using NetworkOptimizer.Web.Components.Shared.Monitoring
+@using static NetworkOptimizer.Web.Services.Monitoring.MonitoringLinks
 @using NetworkOptimizer.Web.Services.Monitoring.IspHealth
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Core.Enums
@@ -511,23 +512,29 @@
 
         <!-- Latency time-series charts -->
         <div class="card" id="latency-charts-container" style="margin-top: 1.5rem;">
-            <div class="card-header monitoring-chart-header @(_multiWanUiVisible && _wanOptions.Count > 1 ? "chart-header-stacked" : "")">
+            <div class="card-header monitoring-chart-header @(ScopeBarVisible ? "chart-header-stacked" : "")">
                 <h2 class="card-title">Latency &amp; Packet Loss</h2>
-                @if (_multiWanUiVisible && _wanOptions.Count > 1)
+                @if (ScopeBarVisible)
                 {
                     <div class="time-range-selector wan-selector @(_wanOptions.Count > 3 ? "wan-selector-many" : "")"
                          data-tooltip="@(_showWanCompareHint ? _wanCompareHint : null)" data-tooltip-hover-only>
+                        <button class="time-btn @(_lanScope || _allScope ? "active" : "")"
+                                @onclick="SelectLanScopeAsync"
+                                data-tooltip="This network's own devices and targets - not reached over any WAN"
+                                data-tooltip-hover-only>LAN</button>
                         @foreach (var w in _wanOptions)
                         {
-                            <button class="time-btn @(_selectedWanKeys.Contains(w.Key) ? "active" : "")"
+                            <button class="time-btn @(!_lanScope && _selectedWanKeys.Contains(w.Key) ? "active" : "")"
                                     @onclick="e => OnWanPillClickAsync(w.Key, e)">@{
                                 var wp = NetworkOptimizer.UniFi.GatewayWanHelper.SplitWanLabel(
                                     w.Label, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(w.Key));
                             }@(wp.Name ?? w.Label)@if (wp.WanToken != null && wp.Name != null)
                             {<span class="wan-pill-token">@wp.WanToken</span>}</button>
                         }
-                        <button class="time-btn wan-all-btn @(AllWansSelected ? "active" : "")"
-                                @onclick="SelectAllWansAsync">All</button>
+                        @if (!_allScope)
+                        {
+                            <button class="time-btn wan-all-btn" @onclick="SelectAllWansAsync">All</button>
+                        }
                         @if (WanFilterIsNarrowed)
                         {
                             <WanFilterResetButton OnReset="ResetWanFilterAsync" />
@@ -539,13 +546,13 @@
                        Blazor re-rendering this header for any other reason would otherwise assert a
                        stale one over it. The opening choice is passed to mount() instead. *@
                     <div class="time-range-selector">
-                        <button class="time-btn" data-category="Fabric">LAN</button>
+                        <button class="time-btn" data-category="Fabric">Fabric</button>
                         <button class="time-btn" data-category="AccessIsp">ISP</button>
                         <button class="time-btn" data-category="Transit">Transit</button>
                         <button class="time-btn" data-category="InternetService">Internet</button>
                         <button class="time-btn" data-category="Custom">Custom</button>
                     </div>
-                    <div style="display: flex; align-items: center; gap: 0.75rem;">
+                    <div class="time-window-controls">
                     <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
                     <div class="time-range-selector" style="position: relative;">
                         <button class="time-btn" data-range="0">15m</button>
@@ -653,6 +660,7 @@
         <div id="latency-targets" style="margin-top: 1.5rem;">
             <LatencyTargetsCard @ref="_latencyTargetsCard" Targets="_targets" WanContexts="_wanContexts" PrimaryWanLabel="@PrimaryWanProseLabel()"
                                  SelectedWanKeys="_selectedWanKeys" OnWanSelected="OnTargetsWanSelectedAsync"
+                                 LanScope="_lanScope" AllScope="_allScope" OnLanSelected="SelectLanScopeAsync"
                                  OnTargetsChanged="OnTargetsChanged" />
         </div>
 
@@ -673,36 +681,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Device Health</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn active" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn active" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                 </div>
             </div>
             <div class="card-body">
@@ -806,36 +816,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">SFP Diagnostics</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn active" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn active" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                 </div>
             </div>
             <div class="card-body">
@@ -1013,36 +1025,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Cable Modem Signal History</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn active" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn active" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     <SiteAdminOnly>
                         <a href="/settings#cable-modem" class="tooltip-icon settings-link" data-tooltip="Cable Modem settings">
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
@@ -1144,36 +1158,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">ONT Signal History</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn active" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn active" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     <SiteAdminOnly>
                         <a href="/settings#ont-monitoring" class="tooltip-icon settings-link" data-tooltip="ONT monitoring settings">
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
@@ -1299,36 +1315,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Cellular Signal History</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn active" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn active" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     <SiteAdminOnly>
                         <a href="/settings#cellular-modem" class="tooltip-icon settings-link" data-tooltip="Cellular Modem settings">
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
@@ -1404,36 +1422,38 @@
             <div class="card-header monitoring-chart-header">
                 <h2 class="card-title">Starlink Terminal History</h2>
                 <div class="chart-header-controls">
-                    <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
-                    <div class="time-range-selector" style="position: relative;">
-                        <button class="time-btn" data-range="0">15m</button>
-                        <button class="time-btn" data-range="1">1h</button>
-                        <button class="time-btn" data-range="6">6h</button>
-                        <button class="time-btn active" data-range="24">24h</button>
-                        <button class="time-btn" data-range="168">7d</button>
-                        <button class="time-btn" data-range="720">30d</button>
-                        <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
-                        </button>
-                        <div class="custom-range-popover" data-popover="custom-range">
-                            <div class="custom-range-form">
-                                <div class="custom-range-title">Custom Range</div>
-                                <div class="custom-range-field">
-                                    <label>From</label>
-                                    <input type="datetime-local" data-input="from" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-field">
-                                    <label>To</label>
-                                    <input type="datetime-local" data-input="to" class="custom-range-input" />
-                                </div>
-                                <div class="custom-range-actions">
-                                    <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
-                                    <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                    <div class="time-window-controls">
+                        <button class="time-btn" data-shift="back" data-tooltip="Shift window back">&#x25C0;</button>
+                        <div class="time-range-selector" style="position: relative;">
+                            <button class="time-btn" data-range="0">15m</button>
+                            <button class="time-btn" data-range="1">1h</button>
+                            <button class="time-btn" data-range="6">6h</button>
+                            <button class="time-btn active" data-range="24">24h</button>
+                            <button class="time-btn" data-range="168">7d</button>
+                            <button class="time-btn" data-range="720">30d</button>
+                            <button class="time-btn custom-range-btn" data-action="custom-range" data-tooltip="Custom date range" data-tooltip-hover-only>
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                            </button>
+                            <div class="custom-range-popover" data-popover="custom-range">
+                                <div class="custom-range-form">
+                                    <div class="custom-range-title">Custom Range</div>
+                                    <div class="custom-range-field">
+                                        <label>From</label>
+                                        <input type="datetime-local" data-input="from" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-field">
+                                        <label>To</label>
+                                        <input type="datetime-local" data-input="to" class="custom-range-input" />
+                                    </div>
+                                    <div class="custom-range-actions">
+                                        <button class="btn btn-sm btn-secondary" data-action="cancel-custom">Cancel</button>
+                                        <button class="btn btn-sm btn-primary" data-action="apply-custom">Apply</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     </div>
-                    <button class="time-btn" data-shift="forward" data-tooltip="Shift window forward">&#x25B6;</button>
                     <SiteAdminOnly>
                         <a href="/settings#starlink" class="tooltip-icon settings-link" data-tooltip="Starlink settings">
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
@@ -1878,6 +1898,15 @@
     // or contexts already configured (which can only exist on a site that had one). A single-WAN
     // install should never meet the concept at all.
     private bool _multiWanUiVisible;
+
+    /// <summary>
+    /// Whether the LAN / WAN scope bar is worth showing. One WAN is still a split - what is on this
+    /// network is not reached over it - so this asks for a LAN to separate rather than for a second
+    /// WAN. Comparing WANs is the thing that needs <see cref="_multiWanUiVisible"/>.
+    /// </summary>
+    private bool ScopeBarVisible => _wanOptions.Count > 1
+        || (_wanOptions.Count == 1
+            && _targets.Any(NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal));
     private bool _wanCountChecked;
     private List<MonitoredSfp> _monitoredSfps = new();
     private List<MonitoredSfp> _allSfps = new();
@@ -1920,6 +1949,22 @@
         || (_activeTab == "performance" && _multiWanUiVisible && _wanOptions.Count > 1);
     private string _wanCompareHint = "Ctrl-click to compare side by side";
     private string NpWanSetKey => SiteCtx.ScopeStorageKey("npWanSelection");
+    /// <summary>
+    /// Whether the analysis views are scoped to the LAN rather than to a WAN. Kept apart from the
+    /// WAN selection on purpose: ISP Health reads that one and LAN means nothing to it, and the
+    /// separation is also what lets picking LAN clear the WAN pills on screen without losing which
+    /// WAN the user was on.
+    /// </summary>
+    private string NpScopeKey => SiteCtx.ScopeStorageKey("npAnalysisScope");
+    private const string LanScopeToken = "lan";
+    private const string AllScopeToken = "all";
+    private bool _lanScope;
+    /// <summary>
+    /// Set by the All pill and by nothing else. Selecting every WAN by hand lands on the same set
+    /// of keys without being the same request: All asks for the whole site, the WANs included and
+    /// the LAN with them, where picking WANs one at a time asks for exactly those.
+    /// </summary>
+    private bool _allScope;
     private string SharedWanScopeKey => SiteCtx.ScopeStorageKey("monitoringWanScope");
 
     /// <summary>Solo-selected wan key, or the primary while comparing / unscoped.</summary>
@@ -1943,8 +1988,24 @@
         }
     }
 
+    /// <summary>
+    /// Scopes the analysis views to this network. The WAN selection is left exactly as it was -
+    /// only its pills go unlit - so returning to a WAN puts the user back where they were.
+    /// </summary>
+    private async Task SelectLanScopeAsync()
+    {
+        if (_lanScope) return;
+        _lanScope = true;
+        _allScope = false;
+        await ApplyWanSelectionAsync(persist: true);
+    }
+
     private async Task OnWanPillClickAsync(string key, MouseEventArgs e)
     {
+        // Picking a WAN is always a move off the LAN, whichever WAN it is - and off All, even when
+        // the WANs that end up selected are all of them.
+        _lanScope = false;
+        _allScope = false;
         if (e.CtrlKey || e.MetaKey)
         {
             // Toggle into/out of the comparison set; never empty the set.
@@ -1978,12 +2039,22 @@
             if (persist)
             {
                 await JS.InvokeVoidAsync("localStorage.setItem", NpWanSetKey, string.Join(",", _selectedWanKeys));
+                // Stored apart from the WAN set so the set never holds a value ISP Health cannot read.
+                await JS.InvokeVoidAsync("localStorage.setItem", NpScopeKey,
+                    _lanScope ? LanScopeToken : _allScope ? AllScopeToken : "wan");
                 await JS.InvokeVoidAsync("localStorage.setItem", SharedWanScopeKey, FocusedWanKeyOrNull ?? "");
                 // persist:true is the user's own pick - the link and the restore both pass false - so
                 // this is the moment the link's WAN stops describing what is on screen.
                 ClearLinkedWan();
             }
-            await JS.InvokeVoidAsync("eval", $"window.__latencyCharts?.setWanScope({WanScopeJson()});");
+            // Held rather than dropped when the module is not there yet: window.__latencyCharts is
+            // assigned inside the mount's own import, so a plain ?. swallowed every push that beat
+            // it - which on a cold load is the link's WAN. The mount drains it.
+            await JS.InvokeVoidAsync("eval",
+                "(window.__netoptSetWanScope ||= function (s) {"
+                + " if (window.__latencyCharts) window.__latencyCharts.setWanScope(s);"
+                + " else window.__netoptPendingWanScope = s; })("
+                + WanScopeJson() + ");");
         }
         catch { /* circuit going away, or charts not mounted yet - the mount push covers it */ }
         _discoveryWanKey = FirstSelectedWanKey();
@@ -2044,12 +2115,16 @@
 
     private async Task SelectAllWansAsync()
     {
+        _lanScope = false;
+        _allScope = true;
         _selectedWanKeys = new HashSet<string>(_wanOptions.Select(w => w.Key), StringComparer.OrdinalIgnoreCase);
         await ApplyWanSelectionAsync(persist: true);
     }
 
     private async Task ResetWanFilterAsync()
     {
+        _lanScope = false;
+        _allScope = false;
         _selectedWanKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { _primaryWanKey };
         await ApplyWanSelectionAsync(persist: true);
     }
@@ -2084,6 +2159,8 @@
     /// </summary>
     private async Task OnTargetsWanSelectedAsync(string key)
     {
+        _lanScope = false;
+        _allScope = key == LatencyTargetsCard.AllWansKey;
         _selectedWanKeys = key == LatencyTargetsCard.AllWansKey
             ? new HashSet<string>(_wanOptions.Select(w => w.Key), StringComparer.OrdinalIgnoreCase)
             : new HashSet<string>(StringComparer.OrdinalIgnoreCase) { key };
@@ -2093,7 +2170,9 @@
     private async Task OnDiscoveryWanSelectedAsync(string key)
     {
         _discoveryWanKey = key;
-        if (_selectedWanKeys.Contains(key)) { StateHasChanged(); return; }
+        if (!_lanScope && !_allScope && _selectedWanKeys.Contains(key)) { StateHasChanged(); return; }
+        _lanScope = false;
+        _allScope = false;
         _selectedWanKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { key };
         await ApplyWanSelectionAsync(persist: true);
     }
@@ -2114,7 +2193,7 @@
 
     private string WanScopeJson()
     {
-        var scope = !_multiWanUiVisible || _wanOptions.Count <= 1
+        var scope = !ScopeBarVisible
             ? null
             : (object)new
             {
@@ -2130,6 +2209,10 @@
                 // So the chart can leave the LAN category when the WANs now on screen have no LAN
                 // targets. Only the chart knows which category it is currently showing.
                 hasLan = HasTargetsInWanScope(MonitoringTargetType.Fabric),
+                // LAN is a scope of its own, not a WAN: the chart shows what is on this network and
+                // offers only the categories that can fill it.
+                lan = _lanScope,
+                all = _allScope,
             };
         return System.Text.Json.JsonSerializer.Serialize(scope);
     }
@@ -2190,6 +2273,11 @@
         _selectedWanKeys.RemoveWhere(k => !_wanOptions.Any(o => o.Key.Equals(k, StringComparison.OrdinalIgnoreCase)));
         if (_selectedWanKeys.Count == 0)
             _selectedWanKeys.Add(_primaryWanKey);
+        // The stored selection, now that there are options to validate it against. Here as well as
+        // at the mount because the mount runs once and can get there first: _monitoringReady does
+        // not wait on this load, so the restore would find nothing to restore against, decline to
+        // spend its one-shot, and never be asked again. Its own guard makes the second call free.
+        await RestoreWanSelectionAsync();
         // A link that arrived before this point resolved nothing and was waiting on it. Applying
         // it here rather than leaving it to the next mount is what makes a deep link land on its
         // WAN every time instead of most of the time.
@@ -2246,14 +2334,21 @@
         // the first round trip looked right, and every one after it read back the primary. The
         // narrowing is released and the stored set re-read when the charts remount; until then
         // there is nothing here worth adopting against.
-        if (_linkNarrowedWanSelection) return;
+        // Both: the flag is only set once the link has been applied, which can be after this runs.
+        if (_linkNarrowedWanSelection || LinkNarrowsWanFilter) return;
         try
         {
             var shared = await JS.InvokeAsync<string?>("localStorage.getItem", SharedWanScopeKey);
             var focus = string.IsNullOrEmpty(shared) ? _primaryWanKey : shared!.Trim().ToLowerInvariant();
-            if (!_wanOptions.Any(o => o.Key.Equals(focus, StringComparison.OrdinalIgnoreCase))
+            // LAN and All are scope decisions, not a WAN selection to reconcile - adopting a focus
+            // over either one throws away what the user picked. This ran straight after the restore
+            // read a stored LAN, so LAN was restored and overwritten on the same pass, every time.
+            if (_lanScope || _allScope
+                || !_wanOptions.Any(o => o.Key.Equals(focus, StringComparison.OrdinalIgnoreCase))
                 || _selectedWanKeys.Contains(focus))
                 return;
+            _lanScope = false;
+            _allScope = false;
             _selectedWanKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { focus };
             if (apply) await ApplyWanSelectionAsync(persist: true);
         }
@@ -2318,6 +2413,8 @@
         // options are loaded by here, so a WAN this site does not have will not resolve on a later
         // pass either. Leaving it unstamped would hold the deep-link gate open forever.
         _appliedLinkWanKey = LinkWanKey;
+        Logger.LogDebug("Link WAN: resolved {Wan} to [{Keys}] against [{Options}]",
+            WanParam, string.Join(",", keys), string.Join(",", _wanOptions.Select(o => o.Key)));
         if (keys.Count == 0) return;
         // Narrowing for as long as the link does. Never persisted, and released on the way back
         // in without one, so a saved All is what the tab has again next time.
@@ -2325,7 +2422,11 @@
         // Claims the restore as well, so the stored selection cannot be read over the top of the
         // link on a first load - and is never written, so the saved filter survives the visit.
         _wanSelectionRestored = true;
+        // A link naming WANs lands on those WANs, not on whatever scope was left over. Covering
+        // every one of them is the whole site, which is what All means.
+        _lanScope = false;
         _selectedWanKeys = new HashSet<string>(keys, StringComparer.OrdinalIgnoreCase);
+        _allScope = _wanOptions.Count > 1 && _wanOptions.All(w => _selectedWanKeys.Contains(w.Key));
         await ApplyWanSelectionAsync(persist: false);
     }
 
@@ -2355,11 +2456,25 @@
 
     private async Task RestoreWanSelectionAsync()
     {
-        if (_wanSelectionRestored || !_multiWanUiVisible || _wanOptions.Count <= 1) return;
+        if (_wanSelectionRestored || !ScopeBarVisible) return;
         _wanSelectionRestored = true;
         try
         {
+            var storedScope = await JS.InvokeAsync<string?>("localStorage.getItem", NpScopeKey);
             var stored = await JS.InvokeAsync<string?>("localStorage.getItem", NpWanSetKey);
+            // No scope stored is either a fresh install or one that predates the key. A WAN set
+            // already stored means the second, and moving that user onto LAN would take them off a
+            // choice they made; with nothing stored at all, LAN is the honest opening view.
+            // Not on a single-WAN site: there LAN hides the one WAN's targets, which is most of
+            // the list, so those open on everything until the user narrows it themselves.
+            _lanScope = string.IsNullOrEmpty(storedScope)
+                ? string.IsNullOrEmpty(stored) && _wanOptions.Count > 1
+                : string.Equals(storedScope, LanScopeToken, StringComparison.OrdinalIgnoreCase);
+            // And opens on All there: the option list seeds the one WAN as selected, so left alone
+            // the LAN rows would be filtered out of a view nobody had narrowed.
+            _allScope = string.IsNullOrEmpty(storedScope)
+                ? _wanOptions.Count == 1
+                : string.Equals(storedScope, AllScopeToken, StringComparison.OrdinalIgnoreCase);
             if (!string.IsNullOrEmpty(stored))
             {
                 var keys = stored.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -2379,7 +2494,8 @@
 
     /// <summary>The WAN a target's data describes: its stamped key, or the primary when unstamped.</summary>
     private string TargetWanKey(MonitoringTarget t) =>
-        string.IsNullOrEmpty(t.WanInterface) ? _primaryWanKey : t.WanInterface!.ToLowerInvariant();
+        NetworkOptimizer.Storage.Models.MonitoringTarget.IsUnpinned(t.WanInterface)
+            ? _primaryWanKey : t.WanInterface!.ToLowerInvariant();
     private System.Threading.Timer? _liveRefreshTimer;
     private System.Threading.Timer? _dataRefreshTimer;
     private DotNetObjectReference<Monitoring>? _mapDotNetRef;
@@ -3463,20 +3579,10 @@
     /// put it in comparison mode, one line pair per WAN.
     /// </summary>
     // ─── Cross-tab jumps: watch a moment, or analyze it ───
-
-    // The category tokens the chart module and its header buttons use. Named here because the
-    // jumps have to reason about two of them: LAN and Custom targets are not reached over any one
-    // WAN, so those views span every WAN rather than carrying a filter across.
-    private const string FabricCategory = "Fabric";
-    private const string AccessIspCategory = "AccessIsp";
-    private const string CustomCategory = "Custom";
-    private const string TransitCategory = "Transit";
-
-    /// <summary>
-    /// The <c>?at=</c> value meaning "it was live, not parked" - the analysis lands on a trailing
-    /// window instead of one frozen at the click.
-    /// </summary>
-    private const string LiveAtToken = "live";
+    // The category tokens and the live marker come from MonitoringLinks, via the using static at
+    // the top of this file. They were declared here as well, and the dashboard's copy of these
+    // tiles spelled them as bare literals - three spellings of the same strings, which is how the
+    // two Live surfaces drifted apart in the first place.
 
     /// <summary>
     /// Opens Latency and Packet Loss on what the Live tab is showing: the same instant, the
@@ -3487,14 +3593,12 @@
     /// </summary>
     private void JumpToAnalysis(string category)
     {
+        // The one thing that legitimately differs between the two Live surfaces: these tiles can be
+        // parked on an instant, so they carry it. The dashboard's cannot, and always say live.
         var at = _mapHistoricAt is { } parkedAt
             ? new DateTimeOffset(parkedAt.ToUniversalTime()).ToUnixTimeMilliseconds().ToString()
             : LiveAtToken;
-        // LAN targets are not reached over any one WAN, so that jump asks for all of them rather
-        // than narrowing the analysis to whichever WAN the tiles happened to be showing.
-        var wanQuery = LiveWan.QueryFragment(
-            category == FabricCategory ? Services.Monitoring.LiveWanScope.AllWansToken : null);
-        NavigationManager.NavigateTo($"/monitoring?tab=performance&category={category}&at={at}{wanQuery}");
+        NavigationManager.NavigateTo(Analysis(category, at, LiveWan));
     }
 
     private sealed record LatencyChartView(string AtIso, string Category);
@@ -3590,11 +3694,10 @@
                 .OrderBy(t => t.TargetType).ThenBy(t => t.Name).ToListAsync();
             _wanContexts = await db.WanContexts.AsNoTracking().OrderBy(c => c.Name).ToListAsync();
             await ResolveMultiWanVisibilityAsync();
-            if (_multiWanUiVisible)
-            {
-                await LoadWanOptionsAsync();
-                await LiveWan.LoadAsync();
-            }
+            // Always: the LAN/WAN scope bar needs the WAN even when there is only one of them.
+            // Comparison UI stays gated on _multiWanUiVisible, which one WAN never satisfies.
+            await LoadWanOptionsAsync();
+            if (_multiWanUiVisible) await LiveWan.LoadAsync();
             _allSfps = await db.MonitoredSfps.AsNoTracking().ToListAsync();
             _monitoredSfps = _allSfps.Where(s => s.IsMonitoredOnt).ToList();
 
@@ -4088,6 +4191,10 @@
     private void ClearLinkedWan()
     {
         if (string.IsNullOrWhiteSpace(WanParam)) return;
+        // Never before the link has been read. Loading the live scope self-selects a WAN and raises
+        // its own change, so on a cold load this threw the parameter away while it was still the
+        // only record of where the user asked to go.
+        if (LinkNarrowsWanFilter && _appliedLinkWanKey != LinkWanKey) return;
 
         var stripped = SiteContextService.RemoveQueryParam(NavigationManager.Uri, "wan");
         if (stripped == NavigationManager.Uri) return;
@@ -4704,7 +4811,7 @@
     /// </summary>
     private List<MonitoringTarget> TargetsForWan(MonitoringTargetType type, string wanKey, bool isPrimary) =>
         _targets.Where(t => t.TargetType == type && t.Enabled)
-            .Where(t => string.IsNullOrEmpty(t.WanInterface)
+            .Where(t => NetworkOptimizer.Storage.Models.MonitoringTarget.IsUnpinned(t.WanInterface)
                 ? isPrimary
                 : string.Equals(
                     NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!),
@@ -5394,8 +5501,12 @@
                     _preSelectAtMs = null;
                     _preSelectTrailing = false;
                 }
+                // Drains any scope that arrived while the import was still in flight - see the shim
+                // in ApplyWanSelectionAsync. Before postMount, so framing uses the right scope.
                 await JS.InvokeVoidAsync("eval",
-                    $"(async () => {{ const m = await import('{chartsUrl}'); window.__latencyCharts = m; await m.mount('latency-charts-container', {WanScopeJson()}, '{DefaultChartCategory()}'); {postMount} }})();");
+                    $"(async () => {{ const m = await import('{chartsUrl}'); window.__latencyCharts = m; await m.mount('latency-charts-container', {WanScopeJson()}, '{DefaultChartCategory()}'); "
+                    + "if (window.__netoptPendingWanScope !== undefined) { m.setWanScope(window.__netoptPendingWanScope); window.__netoptPendingWanScope = undefined; } "
+                    + $"{postMount} }})();");
                 // The link's WAN is applied above, so a deep-linked investigation held back at the
                 // top of this method can run now. Done here rather than left to the next render:
                 // the apply does not always raise one, and waiting for an unrelated render is the
@@ -5407,7 +5518,11 @@
         else if (_activeTab != "performance" && _latencyChartsMounted)
         {
             _latencyChartsMounted = false;
-            try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount();"); }
+            // Leaving ends the visit a link governed, so the next arrival gets to be honoured even
+            // when it names the same WAN. The stamp is once-PER-VISIT; left set across the leave it
+            // was once ever, and a second jump on the same WAN silently kept the scope it found.
+            _appliedLinkWanKey = null;
+            try { await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.unmount(); window.__netoptPendingWanScope = undefined;"); }
             catch { }
             // The flaky-LAN advisory is tied to the live chart, so clear it when the chart leaves.
             _lanFlakyCategoryActive = false;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2510,6 +2510,10 @@
     private long? _pendingAtMs;
     private string? _armedAtUri;
 
+    /// <summary>The URL whose ?investigate= has already run, so the parameter left in the address
+    /// bar cannot re-run the search on an unrelated URL change.</summary>
+    private string? _armedInvestigateUri;
+
     /// <summary>The instant a link asked for, while the timeline is still sitting on it.</summary>
     private long? _linkedInstantMs;
 
@@ -2796,10 +2800,15 @@
             _scrollToWanContextsPending = true;
         }
 
-        // Deep link from the ISP Health loss factors straight into investigation
-        if (_activeTab == "performance" && _pendingInvestigateParam == null
+        // Deep link from the ISP Health loss factors into investigation. Armed by the NAVIGATION
+        // that carried it, like the linked instant below: ?investigate= stays in the address bar
+        // while the investigation is on screen, so arming on every re-supply re-ran the search
+        // whenever anything else touched the URL - a drag-zoom drops ?at=/?wan= and did exactly
+        // that, reframing the chart over the range the user had just drawn.
+        if (_activeTab == "performance" && NavigationManager.Uri != _armedInvestigateUri
             && (InvestigateParam == "packet-loss" || InvestigateParam == "loaded-loss"))
         {
+            _armedInvestigateUri = NavigationManager.Uri;
             _pendingInvestigateParam = InvestigateParam;
         }
 
@@ -4200,8 +4209,10 @@
         if (stripped == NavigationManager.Uri) return;
         // The URL is about to change, which re-arms the linked instant unless the arm moves with it -
         // a WAN change would then seek them back to the link's moment. _pendingAtMs is deliberately
-        // left as it stands: this is not a statement about time.
+        // left as it stands: this is not a statement about time. The investigation arm moves too -
+        // the URL changed, the search did not.
         _armedAtUri = stripped;
+        if (_armedInvestigateUri != null) _armedInvestigateUri = stripped;
         NavigationManager.NavigateTo(stripped, forceLoad: false, replace: true);
     }
 
@@ -4217,8 +4228,10 @@
         if (stripped == current) return;
         // Armed against the new URL first, or being re-supplied under it would arm a fresh seek
         // and pull them straight back to where they just left. Set even when only the WAN was
-        // dropped, since the URL still changed and would otherwise re-arm the instant.
+        // dropped, since the URL still changed and would otherwise re-arm the instant. Same for the
+        // investigation: this call is how a drag-zoom reaches the URL.
         _armedAtUri = stripped;
+        if (_armedInvestigateUri != null) _armedInvestigateUri = stripped;
         if (!string.IsNullOrWhiteSpace(AtParam)) _pendingAtMs = null;
         NavigationManager.NavigateTo(stripped, forceLoad: false, replace: true);
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -705,6 +705,10 @@ else if (_diagResult != null && !string.IsNullOrEmpty(_diagResult.InterfaceError
                 agents.Add(new ProbeVantageAgent(
                     connection.AgentId,
                     agentNames.GetValueOrDefault(connection.AgentId, connection.AgentName),
+                    // TODO(#1106): use the durable per-agent overload
+                    // IsAgentOnGatewayAsync(slug, agentId, candidates) instead - this one has no
+                    // persisted verdict, so a console that has not answered yet mislabels the
+                    // vantage.
                     await OnGatewayDetector.MatchGatewayAddressAsync(SiteContext.Slug, connection.HostAddresses) != null,
                     bindings));
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3560,7 +3560,7 @@
                                                                     @if (_collectorAgentIds.TryGetValue(site.Slug, out var collectorId) && collectorId == agent.Id)
                                                                     {
                                                                         <span class="status-badge status-active"
-                                                                              data-tooltip="Polls this site's SNMP and probes its LAN and primary-WAN targets. Chosen automatically; another agent takes over if this one drops.">Collecting</span>
+                                                                              data-tooltip="Polls this site's SNMP and probes its LAN targets, plus any target on the default WAN path. Chosen automatically; another agent takes over if this one drops.">Collecting</span>
                                                                     }
                                                                     <span class="site-agent-status">
                                                                         @if (!agent.Enabled)

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3601,7 +3601,7 @@
                                                                 @if (_upgradeCommandAgentId == agent.Id)
                                                                 {
                                                                     <div class="agent-upgrade-cmd">
-                                                                        @if (AgentOnGateway(site.Id))
+                                                                        @if (AgentOnGateway(agent.Id))
                                                                         {
                                                                             <p class="form-help">On the UniFi gateway - enrollment is preserved, only the binary updates:</p>
                                                                             <CopyableCommand Text="@GatewayUpgradeCommand()" Tooltip="Copy the gateway upgrade command" />
@@ -4428,8 +4428,7 @@
                 await LoadSshViaAgentAsync(site);
                 await LoadAgentCoversSiteAsync(site);
                 await LoadClientSpeedTestTargetAsync(site);
-                _agentOnGateway[site.Id] = !site.IsDefault
-                    && await OnGatewayDetector.IsAgentOnGatewayAsync(site.Slug);
+                await LoadAgentsOnGatewayAsync(site);
                 _collectorAgentIds[site.Slug] = await ProbeSink.GetCollectorAgentIdAsync(site.Slug);
             }
         }
@@ -4546,7 +4545,7 @@
     // example when no agent has reported in.
     private string ClientSpeedTestPlaceholder(Site site)
     {
-        if (AgentOnGateway(site.Id))
+        if (SiteHasGatewayAgent(site.Id))
             return "none - the agent runs on the UniFi gateway; enter a separate box hosting the speed test";
         var lanIp = AgentsFor(site.Id)
             .Where(a => a.Enabled && !string.IsNullOrEmpty(a.LanIp) && TunnelRegistry.IsReachable(a))
@@ -4562,16 +4561,56 @@
             : "e.g. 192.168.1.50 or https://speed.example.com";
     }
 
-    // The site's agent runs on the UniFi gateway itself (per AgentOnGatewayDetector),
-    // loaded when the site's agent panel expands.
+    // Which agents run on the UniFi gateway itself, keyed by AGENT id and loaded when the site's
+    // agent panel expands. Per agent rather than per site because a site with several agents has
+    // one gateway and only one of them may be sitting on it, and because the site-level verdict
+    // (AgentOnGatewayDetector.IsAgentOnGatewayAsync) answers false for the default site by
+    // contract - a contract its speed-test consumers rely on, so this asks the per-address
+    // question instead and a main-site gateway agent is recognized as one.
     private readonly Dictionary<int, bool> _agentOnGateway = new();
 
     // Which agent currently collects for each site, keyed by slug. Derived rather than configured,
     // and asked of the same code the push path acts on so the page cannot claim otherwise.
     private readonly Dictionary<string, int?> _collectorAgentIds = new();
 
-    private bool AgentOnGateway(int siteId) =>
-        _agentOnGateway.TryGetValue(siteId, out var onGateway) && onGateway;
+    private bool AgentOnGateway(int agentId) =>
+        _agentOnGateway.TryGetValue(agentId, out var onGateway) && onGateway;
+
+    // Any of the site's agents on the gateway - for the questions that are about the SITE rather
+    // than one agent row.
+    // TODO(#1106): its one caller wants a narrower question than ANY. The placeholder mirrors what a
+    // blank override resolves to, and SiteSpeedTestTargetResolver resolves against ONE agent, so a
+    // site with a gateway agent and a real-box agent makes the two disagree. Secondary sites only:
+    // the main site does not render the field.
+    private bool SiteHasGatewayAgent(int siteId) =>
+        AgentsFor(siteId).Any(a => AgentOnGateway(a.Id));
+
+    /// <summary>
+    /// Resolves each of the site's agents against the site's gateway addresses. The live tunnel
+    /// reports every address its host holds, which is the reliable answer; an agent with no open
+    /// tunnel falls back to its last known LAN IP, since an outdated agent - exactly the one whose
+    /// upgrade command this drives - may well be the one that is down.
+    /// <para>
+    /// Never blocks on the site's UniFi Console. The addresses to compare against come from it, and
+    /// on an agent site it reconnects through the agent's own tunnel, so this panel routinely opens
+    /// ahead of it - but a site whose console is broken or unconfigured is exactly where an
+    /// operator goes to fix it, and it has to stay responsive. The detector answers from its
+    /// persisted verdict meanwhile.
+    /// </para>
+    /// </summary>
+    private async Task LoadAgentsOnGatewayAsync(Site site)
+    {
+        var connections = TunnelRegistry.GetForSite(site.Slug);
+        var resolved = await Task.WhenAll(AgentsFor(site.Id).Select(async agent =>
+        {
+            var candidates = connections.FirstOrDefault(c => c.AgentId == agent.Id)?.HostAddresses;
+            if (candidates is not { Count: > 0 })
+                candidates = string.IsNullOrEmpty(agent.LanIp) ? Array.Empty<string>() : new[] { agent.LanIp! };
+            return (agent.Id, OnGateway: await OnGatewayDetector.IsAgentOnGatewayAsync(site.Slug, agent.Id, candidates));
+        }));
+        foreach (var (agentId, onGateway) in resolved)
+            _agentOnGateway[agentId] = onGateway;
+    }
 
     private async Task LoadClientSpeedTestTargetAsync(Site site)
         => _clientSpeedTestTarget[site.Id] = (await SiteConfig.GetAsync(site.Slug)).ClientSpeedTestTarget;

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -1,5 +1,6 @@
-@using NetworkOptimizer.Storage.Models
+﻿@using NetworkOptimizer.Storage.Models
 @using Microsoft.EntityFrameworkCore
+@using NetworkOptimizer.Web.Components.Shared.Monitoring
 @inject MonitoringLiveStats LiveStats
 @inject SiteContextService SiteCtx
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ExecutorFactory
@@ -10,12 +11,16 @@
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
         <h2 class="card-title">Latency Targets</h2>
-        @if (_wanChoices.Count > 1)
+        @if (ShowScopeFilter)
         {
             <div class="time-range-selector wan-selector @(_wanChoices.Count > 3 ? "wan-selector-many" : "")" @onclick:stopPropagation>
+                <button class="time-btn @(LanScope || ShowingAll ? "active" : "")"
+                        @onclick="PickLanAsync" @onclick:stopPropagation>LAN</button>
                 @foreach (var w in _wanChoices)
                 {
-                    <button class="time-btn @(!AllSelected && SelectedWanKeys.Contains(w.Key) ? "active" : "")"
+                    @* All lights every pill: it shows every WAN, and on a single-WAN site the
+                       parent has no option list to fill the selection from. *@
+                    <button class="time-btn @(!LanScope && (ShowingAll || SelectedWanKeys.Contains(w.Key)) ? "active" : "")"
                             @onclick="() => PickWanAsync(w.Key)" @onclick:stopPropagation>
                         @{
                             var wp = NetworkOptimizer.UniFi.GatewayWanHelper.SplitWanLabel(
@@ -24,8 +29,26 @@
                         {<span class="wan-pill-token">@wp.WanToken</span>}
                     </button>
                 }
-                <button class="time-btn wan-all-btn @(AllSelected ? "active" : "")"
-                        @onclick="() => PickWanAsync(AllWansKey)" @onclick:stopPropagation>All</button>
+                @if (!ShowingAll)
+                {
+                    <button class="time-btn wan-all-btn"
+                            @onclick="() => PickWanAsync(AllWansKey)" @onclick:stopPropagation>All</button>
+                }
+                @if (ScopeIsNarrowed)
+                {
+                    <WanFilterResetButton OnReset="ResetScopeAsync" />
+                }
+            </div>
+            @* Narrows the rows the scope already chose. Hidden on mobile: the scope row alone
+               already wraps there, and the Type column still says what each row is. *@
+            <div class="time-range-selector lt-type-filter hide-mobile" @onclick:stopPropagation>
+                @foreach (var t in AvailableTypes())
+                {
+                    <button class="time-btn @(_typeFilter == t ? "active" : "")"
+                            @onclick="() => PickTypeAsync(t)" @onclick:stopPropagation>@TypeFilterLabel(t)</button>
+                }
+                <button class="time-btn @(_typeFilter == null ? "active" : "")"
+                        @onclick="() => PickTypeAsync(null)" @onclick:stopPropagation>All</button>
             </div>
         }
         <div style="display: flex; align-items: center; gap: 0.5rem;">
@@ -69,7 +92,7 @@
                         <th>Address</th>
                         @if (WanContexts.Count > 0)
                         {
-                            <th>WAN</th>
+                            <th>WAN / Path</th>
                         }
                         <th>Interval</th>
                         <th>Latest</th>
@@ -82,7 +105,15 @@
                     {
                         <tr>
                             <td colspan="@VisibleColumnCount" class="latency-targets-empty">
-                                No targets for this WAN.
+                                @* Names both things the reader narrowed by, since either one alone
+                                   leaves the other looking like the reason. *@
+                                @(LanScope
+                                    ? (_typeFilter != null
+                                        ? "No targets of this type on this network."
+                                        : "No targets on this network yet.")
+                                    : (_typeFilter != null
+                                        ? "No targets of this type for this WAN."
+                                        : "No targets for this WAN."))
                             </td>
                         </tr>
                     }
@@ -92,7 +123,7 @@
                         <tr id="latency-target-@t.Id" class="@(t.Enabled ? "" : "latency-target-paused")">
                             <td>
                                 <span class="status-badge @TargetTypeBadgeClass(t.TargetType)">
-                                    @t.TargetType.ToDisplayName()
+                                    @TargetTypeBadgeLabel(t.TargetType)
                                 </span>
                             </td>
                             <td>@t.Name</td>
@@ -103,7 +134,7 @@
                                     <SiteOperatorOnly>
                                         <select class="cadence-select"
                                             @onchange="(e) => UpdateWanContextAsync(t.Id, e)">
-                                        <option value="" selected="@(t.WanContextId == null)">@PrimaryWanLabel</option>
+                                        <option value="" selected="@(t.WanContextId == null)">Default path</option>
                                         @foreach (var wc in WanContexts)
                                         {
                                             <option value="@wc.Id" selected="@(t.WanContextId == wc.Id)">@wc.Name</option>
@@ -240,9 +271,9 @@
                     @if (WanContexts.Count > 0)
                     {
                         <div class="form-group">
-                            <label class="form-label">WAN</label>
+                            <label class="form-label">WAN / Path</label>
                             <select class="form-control" @bind="_newTargetWanContextId">
-                                <option value="">@PrimaryWanLabel</option>
+                                <option value="">Default path</option>
                                 @foreach (var wc in WanContexts)
                                 {
                                     <option value="@wc.Id">@wc.Name</option>
@@ -296,6 +327,10 @@
 </div>
 
 <style>
+    .lt-type-filter {
+        margin: 0 0.5rem;
+    }
+
     .lt-intro {
         display: flex;
         align-items: flex-start;
@@ -416,23 +451,105 @@
     /// rest of the tab reads and needs nothing else to remember it.
     /// </summary>
     /// <summary>
-    /// Whether the selection this card can act on is "everything". True when every WAN is selected,
-    /// and also when NONE of them is: the tab's WAN bar offers WANs this card has no pill for - one
-    /// with no context and so no targets of its own - and filtering a list to a WAN it cannot show
-    /// leaves an empty table with no lit pill to explain it. All is the honest reading of a
-    /// selection this list has nothing to say about.
+    /// Whether the scope is holding a COMPARISON, the only state a clear undoes. One WAN alone, or
+    /// the LAN alone, is the view the user switched to rather than a filter over it - see the same
+    /// rule on the tab's own WAN bar. All counts: it is every WAN at once, and it takes the place of
+    /// the All pill once that pill has nothing left to offer.
     /// </summary>
-    private bool AllSelected =>
-        _wanChoices.Count > 1
-        && (_wanChoices.All(w => SelectedWanKeys.Contains(w.Key))
-            || !_wanChoices.Any(w => SelectedWanKeys.Contains(w.Key)));
+    /// <para>
+    /// Never on a single-WAN site: there the All pill is on screen whenever anything is narrowed,
+    /// and it already restores the whole list - a clear beside it would be the same button twice.
+    /// </para>
+    private bool ScopeIsNarrowed =>
+        !SingleWan && (AllScope || (!LanScope && SelectedWanKeys.Count > 1));
+
+    /// <summary>Whether the site has one WAN, where LAN and WAN are the only real split.</summary>
+    private bool SingleWan => _wanChoices.Count == 1;
+
+    /// <summary>
+    /// Whether the list is showing everything: All outright, or nothing picked - which is where a
+    /// single-WAN site starts, and what VisibleTargets already treats as unfiltered. On a multi-WAN
+    /// site the parent always seeds a selection, so this is exactly AllScope there.
+    /// </summary>
+    private bool ShowingAll => AllScope || (!LanScope && SelectedWanKeys.Count == 0);
+
+    /// <summary>Back to one WAN - the primary, matching what the tab's own clear returns to.</summary>
+    private async Task ResetScopeAsync()
+    {
+        var primary = _wanChoices.FirstOrDefault(w => w.IsPrimary) ?? _wanChoices.FirstOrDefault();
+        if (primary != null) await PickWanAsync(primary.Key);
+    }
 
     private async Task PickWanAsync(string key)
     {
+        await HoldPositionAsync();
         // Filtering a list that is closed changes something the user cannot see, so open it.
         _collapsed = false;
         if (OnWanSelected.HasDelegate) await OnWanSelected.InvokeAsync(key);
     }
+
+    /// <summary>
+    /// Holds the card still across a filter change: the pills also pick the chart series above it,
+    /// and the statistics table there grows or shrinks by rows, sliding the pill out from under the
+    /// cursor. Not while collapsed - the click opens the card, and collapse-reveal.js scrolls that.
+    /// </summary>
+    private async Task HoldPositionAsync()
+    {
+        if (_collapsed) return;
+        await JS.InvokeVoidAsync("noHoldScroll", "latency-targets");
+    }
+
+    /// <summary>
+    /// Drops a type filter the new scope cannot show. Done here rather than in the pill handlers
+    /// because those run before the parent has changed the scope, so they would test the type
+    /// against the list it is leaving - a Fabric filter surviving into a WAN scope leaves the row
+    /// with nothing active and the table with nothing in it.
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        if (_typeFilter is MonitoringTargetType t && !AvailableTypes().Contains(t))
+            _typeFilter = null;
+    }
+
+    private async Task PickLanAsync()
+    {
+        await HoldPositionAsync();
+        _collapsed = false;
+        if (OnLanSelected.HasDelegate) await OnLanSelected.InvokeAsync();
+    }
+
+    private async Task PickTypeAsync(MonitoringTargetType? type)
+    {
+        await HoldPositionAsync();
+        _typeFilter = type;
+        _collapsed = false;
+    }
+
+    /// <summary>
+    /// The types the current scope can actually contain. The LAN holds this network's own devices
+    /// and the targets pointed at it; a WAN holds neither, because neither leaves by one.
+    /// </summary>
+    private IReadOnlyList<MonitoringTargetType> AvailableTypes() => LanScope
+        ? new[] { MonitoringTargetType.Fabric, MonitoringTargetType.Custom }
+        : AllScope
+            ? new[] { MonitoringTargetType.Fabric, MonitoringTargetType.AccessIsp, MonitoringTargetType.Transit,
+                MonitoringTargetType.InternetService, MonitoringTargetType.Custom }
+            : new[] { MonitoringTargetType.AccessIsp, MonitoringTargetType.Transit,
+                MonitoringTargetType.InternetService, MonitoringTargetType.Custom };
+
+    /// <summary>
+    /// The Type column's badge. Access ISP is shortened to the name the filter pill above it uses,
+    /// which is also the widest label the column has to carry.
+    /// </summary>
+    private static string TargetTypeBadgeLabel(MonitoringTargetType type) =>
+        type == MonitoringTargetType.AccessIsp ? "ISP" : type.ToDisplayName();
+
+    private static string TypeFilterLabel(MonitoringTargetType type) => type switch
+    {
+        MonitoringTargetType.AccessIsp => "ISP",
+        MonitoringTargetType.InternetService => "Internet",
+        _ => type.ToDisplayName(),
+    };
 
     /// <summary>
     /// The rows for the WANs on screen. A target with no WAN of its own belongs to the primary, the
@@ -443,10 +560,17 @@
 
     private IEnumerable<MonitoringTarget> VisibleTargets()
     {
-        var ordered = Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name);
-        if (_wanChoices.Count <= 1 || AllSelected || SelectedWanKeys.Count == 0) return ordered;
+        IEnumerable<MonitoringTarget> ordered = Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name);
+        if (_typeFilter is MonitoringTargetType wanted) ordered = ordered.Where(t => t.TargetType == wanted);
+        // The LAN is what sits on this network, whatever WAN a row happens to be stamped with, and
+        // a WAN is the opposite. Only All carries both.
+        if (LanScope)
+            return ordered.Where(NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal);
+        if (AllScope) return ordered;
+        if (_wanChoices.Count == 0 || SelectedWanKeys.Count == 0) return ordered;
+        ordered = ordered.Where(t => !NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal(t));
         var primaryKey = _wanChoices.FirstOrDefault(w => w.IsPrimary)?.Key;
-        return ordered.Where(t => string.IsNullOrEmpty(t.WanInterface)
+        return ordered.Where(t => NetworkOptimizer.Storage.Models.MonitoringTarget.IsUnpinned(t.WanInterface)
             ? primaryKey != null && SelectedWanKeys.Contains(primaryKey)
             : SelectedWanKeys.Any(k => string.Equals(
                 NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(k),
@@ -477,7 +601,13 @@
             if (choices.Any(c => string.Equals(c.Key, key, StringComparison.OrdinalIgnoreCase))) continue;
             choices.Add(new WanChoice(key, WanLabelFor(liveWans, key, ctx.Name), IsPrimary: false));
         }
-        _wanChoices = choices.Count > 1 ? choices : new List<WanChoice>();
+        // WAN order, not the order the vantages came back in - those are read by name, which put
+        // these pills out of sequence against every other WAN bar on the page.
+        //
+        // The single choice is KEPT. A site with one WAN still has a LAN worth separating from it,
+        // and dropping it left that site a LAN pill with nothing to sit beside.
+        _wanChoices = choices
+            .OrderBy(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(c.Key)).ToList();
     }
 
     private static string WanLabelFor(
@@ -514,6 +644,26 @@
     private int _newTargetPort = 443;
     private int _newTargetInterval = 10;
     private string _newTargetWanContextId = "";
+    private MonitoringTargetType? _typeFilter;
+
+    /// <summary>Scoped to this network rather than to a WAN; the WAN pills go unlit.</summary>
+    [Parameter] public bool LanScope { get; set; }
+
+    /// <summary>
+    /// Whether the page is on the explicit All scope. Not the same as every WAN happening to be
+    /// selected: All asks for the whole site and takes the LAN with it, a hand-built selection
+    /// asks for exactly the WANs in it.
+    /// </summary>
+    [Parameter] public bool AllScope { get; set; }
+    [Parameter] public EventCallback OnLanSelected { get; set; }
+
+    /// <summary>
+    /// The scope row shows once there is more than one WAN, or as soon as there is anything on the
+    /// LAN to separate out - a single-WAN site still benefits from telling the two apart.
+    /// </summary>
+    private bool ShowScopeFilter => _wanChoices.Count > 1
+        || Targets.Any(NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal);
+
     private bool _revealAddForm;
     private bool _ringAddForm;
     private string? _addTargetError;
@@ -600,6 +750,7 @@
     {
         _showAddTarget = true;
         _revealAddForm = true;
+        PreselectWanFromScope();
     }
 
     /// <summary>
@@ -613,6 +764,26 @@
         _showAddTarget = true;
         _revealAddForm = true;
         _ringAddForm = true;
+        PreselectWanFromScope();
+    }
+
+    /// <summary>
+    /// Opens the form on the WAN the list is already filtered to, when a vantage measures it.
+    /// Adding a target while looking at one WAN almost always means adding it to that WAN, and
+    /// leaving the field on the default path meant the new row vanished from the very view it was
+    /// added in. Only for a single WAN in scope: LAN and All are not one WAN, and a hand-built
+    /// selection of several does not name one either.
+    /// </summary>
+    private void PreselectWanFromScope()
+    {
+        _newTargetWanContextId = "";
+        if (LanScope || AllScope || SelectedWanKeys.Count != 1) return;
+
+        var key = NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(SelectedWanKeys.First());
+        var vantage = WanContexts.FirstOrDefault(c => !string.IsNullOrEmpty(c.WanInterface)
+            && string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!),
+                key, StringComparison.OrdinalIgnoreCase));
+        if (vantage != null) _newTargetWanContextId = vantage.Id.ToString();
     }
 
     protected override async Task OnParametersSetAsync() => await LoadWanChoicesAsync();

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -1,8 +1,9 @@
-@using NetworkOptimizer.Web.Components.Shared.Monitoring
+﻿@using NetworkOptimizer.Web.Components.Shared.Monitoring
 @using Microsoft.EntityFrameworkCore
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services
 @using NetworkOptimizer.Web.Services.Monitoring.IspHealth
+@using static NetworkOptimizer.Web.Services.Monitoring.MonitoringLinks
 @using NetworkOptimizer.Core.Enums
 @implements IDisposable
 @inject MonitoringLiveStats LiveStats
@@ -98,7 +99,7 @@ else
                 }
             </div>
             @{ var ispTarget = ScopedTargetStats(MonitoringTargetType.AccessIsp, meanAcrossTargets: false); }
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis("AccessIsp"))">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis(AccessIspCategory))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -114,7 +115,7 @@ else
                 }
                 <div class="stat-label">ISP RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis("AccessIsp"))">
+            <div class="monitoring-stat-card clickable-stat-card" @onclick="@(() => JumpToAnalysis(AccessIspCategory))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -131,7 +132,7 @@ else
                 <div class="stat-label">ISP Loss</div>
             </div>
             @{ var transitTarget = ScopedTargetStats(MonitoringTargetType.Transit, meanAcrossTargets: true); }
-            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis("Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis(TransitCategory))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -147,7 +148,7 @@ else
                 }
                 <div class="stat-label">Transit RTT</div>
             </div>
-            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis("Transit"))">
+            <div class="monitoring-stat-card clickable-stat-card stat-card-no-minheight" @onclick="@(() => JumpToAnalysis(TransitCategory))">
                 @if (LiveWan.IsComparing)
                 {
                     <div class="stat-value stat-value-stacked">
@@ -560,6 +561,11 @@ else
             // monitoring IS configured, the console is just unreachable. Live stats
             // come from the buffers/Influx, not this call; the console-down banner
             // explains any staleness instead.
+            // From the site's own records, not the console - the WAN pills and every link's ?wan=
+            // need it. Nested inside the console call below, an unreachable console left the tiles
+            // rendering with no WAN scope, so their links carried no WAN at all.
+            await LiveWan.LoadAsync();
+
             try
             {
                 var devices = await ConnectionService.GetDiscoveredDevicesAsync();
@@ -569,7 +575,6 @@ else
                         d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway);
                     _gatewayMac = gw?.Mac?.Replace("-", ":").ToLowerInvariant();
                     _gatewayWanIfNames = gw?.WanInterfaceNames ?? new();
-                    await LiveWan.LoadAsync();
                 }
                 _consoleUnreachable = false;
             }
@@ -696,8 +701,11 @@ else
     /// </summary>
     private void JumpToAnalysis(string category)
     {
-        NavigationManager.NavigateTo(
-            $"/monitoring?tab=performance&category={category}{LiveWan.QueryFragment()}");
+        // Always live: these tiles have no parked instant to carry, unlike the Monitoring tab's own,
+        // which pass the moment they are frozen at. Without the token the destination fell back to
+        // its saved window, so a click on a tile showing what is happening right now could land on
+        // some earlier stretch of the day.
+        NavigationManager.NavigateTo(Analysis(category, LiveAtToken, LiveWan));
     }
 
     private (double? rtt, double loss) GetBestTargetStats(MonitoringTargetType type)
@@ -734,7 +742,7 @@ else
     /// </summary>
     private List<MonitoringTarget> TargetsForWan(MonitoringTargetType type, string wanKey, bool isPrimary) =>
         _targets.Where(t => t.TargetType == type && t.Enabled)
-            .Where(t => string.IsNullOrEmpty(t.WanInterface)
+            .Where(t => NetworkOptimizer.Storage.Models.MonitoringTarget.IsUnpinned(t.WanInterface)
                 ? isPrimary
                 : string.Equals(
                     NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!),

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -773,7 +773,11 @@
             if (choices.Any(c => c.Key == key)) continue;
             choices.Add(new TracerWanChoice(key, LabelFor(key, ctx.Name), IsPrimary: false, Context: ctx));
         }
-        _wanChoices = choices.Count > 1 ? choices : new List<TracerWanChoice>();
+        // WAN order, not the order the vantages came back in - those are read by name, which put
+        // these pills out of sequence against every other WAN bar on the page.
+        _wanChoices = choices.Count > 1
+            ? choices.OrderBy(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(c.Key)).ToList()
+            : new List<TracerWanChoice>();
         _selectedTracerWanKey = primaryKey;
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -1,4 +1,4 @@
-@using Microsoft.AspNetCore.Authorization
+﻿@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.EntityFrameworkCore
 @using NetworkOptimizer.Storage.Models
@@ -15,6 +15,8 @@
 @inject AgentProbeResultSink ProbeSink
 @inject SiteAgentCoverage AgentCoverage
 @inject Microsoft.JSInterop.IJSRuntime JS
+@inject UniFiConnectionService Connection
+@inject ILogger<WanContextsCard> Log
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
@@ -131,7 +133,7 @@
                                        style="margin-left: 0.25rem;">Verify</a>
                                     <button class="btn btn-sm btn-danger"
                                         @onclick="() => DeleteContextAsync(wc.Id)"
-                                        data-tooltip="Remove this vantage (its targets move back to the primary WAN)"
+                                        data-tooltip="Remove this vantage (its targets move back to the default WAN path)"
                                         style="margin-left: 0.25rem;">
                                     Remove
                                 </button>
@@ -964,7 +966,7 @@
             }
             else
             {
-                db.WanContexts.Add(new WanContext
+                var created = new WanContext
                 {
                     Name = name,
                     Description = string.IsNullOrWhiteSpace(_newDescription) ? null : _newDescription.Trim(),
@@ -973,7 +975,10 @@
                     WanInterface = wanInterface,
                     InterfaceName = string.IsNullOrEmpty(interfaceName) ? null : interfaceName,
                     CreatedAt = DateTime.UtcNow,
-                });
+                };
+                db.WanContexts.Add(created);
+                await db.SaveChangesAsync();
+                await AdoptUnpinnedTargetsIfPrimaryAsync(db, created);
             }
             await db.SaveChangesAsync();
 
@@ -992,6 +997,155 @@
         }
     }
 
+    /// <summary>
+    /// Hands a new primary-WAN vantage the targets that were probing that WAN unpinned. They are
+    /// the same measurements; without this they stay in a bucket the vantage's own report cannot
+    /// see. Only where unpinned honestly meant this WAN - a failover site always, a load-balancing
+    /// one never, because there the probe took whichever WAN the balancer picked.
+    /// </summary>
+    private async Task AdoptUnpinnedTargetsIfPrimaryAsync(
+        NetworkOptimizer.Storage.Models.NetworkOptimizerDbContext db,
+        NetworkOptimizer.Storage.Models.WanContext vantage)
+    {
+        try
+        {
+            var primary = _wans.FirstOrDefault(w => w.IsPrimary)?.WanInterface;
+            if (!NetworkOptimizer.Web.Services.Monitoring.PrimaryWanVantageAdoption
+                    .MeasuresPrimaryWan(vantage, primary))
+            {
+                Log.LogDebug(
+                    "Vantage adoption: '{Name}' measures {Wan}, site primary is {Primary} - not adopting",
+                    vantage.Name, vantage.WanInterface, primary ?? "(unknown)");
+                return;
+            }
+
+            // SiteLoadBalances is null until a connected console has answered; unknown is not a
+            // yes, so nothing is adopted on a guess.
+            var loadBalances = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+                .AnyAsync(db.WanProfiles, p => p.SiteLoadBalances == true);
+            // The route names a MAC, so it says WHICH box is steered. It only justifies this
+            // vantage's targets when that box is the one this vantage probes from - a route
+            // pinning the server says nothing about an agent's probes, or the reverse.
+            // The route has to pin the box this vantage probes from AND the box that currently
+            // probes the unpinned targets. Either mismatch and the route is evidence about some
+            // other box's traffic, not about the readings being re-filed.
+            var routePin = loadBalances ? await RoutePinnedProbeAsync(vantage.WanInterface!) : null;
+            var collector = await ProbeSink.GetCollectorAgentIdAsync(SiteCtx.Slug);
+            var routePinsThisVantage = routePin != null
+                && routePin.AgentId == vantage.AgentId
+                && routePin.AgentId == collector;
+            if (!NetworkOptimizer.Web.Services.Monitoring.PrimaryWanVantageAdoption
+                    .ShouldAdopt(loadBalances, routePinsThisVantage))
+            {
+                Log.LogDebug(
+                    "Vantage adoption: '{Name}' measures the primary, but the site load balances and "
+                    + "no policy route pins its probes there (route found: {Found}, pins agent: {PinAgent}, "
+                    + "vantage agent: {VantageAgent}) - not adopting",
+                    vantage.Name, routePin != null,
+                    routePin?.AgentId?.ToString() ?? "(server/none)",
+                    vantage.AgentId?.ToString() ?? "(server)");
+                return;
+            }
+
+            // The card's per-vantage target count reflects the move as soon as the form closes,
+            // so the outcome is already on screen without a message for it.
+            var moved = await NetworkOptimizer.Web.Services.Monitoring.PrimaryWanVantageAdoption
+                .AdoptUnpinnedTargetsAsync(db, vantage);
+            Log.LogInformation(
+                "Vantage adoption: '{Name}' ({Wan}) took {Count} unpinned target(s); site {Mode}",
+                vantage.Name, vantage.WanInterface, moved,
+                loadBalances ? "load balances and a policy route pins them" : "fails over");
+        }
+        catch (Exception ex)
+        {
+            // Adoption is a convenience on top of a vantage that has already been saved; failing
+            // it must not fail the save the user asked for.
+            Log.LogWarning(ex, "Vantage adoption failed for '{Name}'; the vantage itself was saved", vantage.Name);
+        }
+    }
+
+    /// <summary>
+    /// Whether a policy route sends everything one of this site's probing boxes emits out the
+    /// given WAN. That is the only thing that makes an unpinned probe attributable on a
+    /// load-balancing site, where it otherwise took whichever WAN the balancer picked. Best
+    /// effort: any gap and the answer is no.
+    /// </summary>
+    private async Task<NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder.Plan?>
+        RoutePinnedProbeAsync(string wanInterface)
+    {
+        try
+        {
+            var api = Connection.Client;
+            if (api == null)
+            {
+                Log.LogDebug("Policy-route check: no console connection, so no route can be read");
+                return null;
+            }
+
+            var routes = await api.GetTrafficRoutesAsync();
+            if (routes.Count == 0)
+            {
+                Log.LogDebug("Policy-route check: the site has no traffic routes");
+                return null;
+            }
+
+            var hosts = ProbeHosts();
+            Log.LogDebug("Policy-route check: {Count} route(s) against {Hosts} probing box(es): {Addresses}",
+                routes.Count, hosts.Count,
+                string.Join(", ", hosts.Select(h => $"{h.LanIp ?? "(no address)"}=>{(h.AgentId?.ToString() ?? "server")}")));
+
+            var plan = NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder.Build(
+                routes,
+                await Connection.GetNetworksAsync(),
+                await api.GetClientsAsync(),
+                hosts);
+            Log.LogDebug("Policy-route check: {Result}",
+                plan == null
+                    ? "no enabled all-destinations route names any of them"
+                    : $"pinned to {plan.WanInterface} via agent {plan.AgentId?.ToString() ?? "server"}"
+                      + $", kill switch {(plan.KillSwitchEnabled ? "on" : "off")}");
+
+            // Last, because it is the only question here that can cost a console round trip: a
+            // gateway-resident agent binds its own probe source, so a route naming it is a
+            // coincidence rather than the steering this looks for.
+            if (plan != null && await OnGatewayDetector.IsIpOnGatewayAsync(SiteCtx.Slug, plan.MatchedLanIp))
+            {
+                Log.LogDebug("Policy-route check: {Ip} is the gateway itself, which binds its own probe source",
+                    plan.MatchedLanIp);
+                return null;
+            }
+
+            return plan != null && string.Equals(
+                NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(plan.WanInterface),
+                NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wanInterface),
+                StringComparison.OrdinalIgnoreCase)
+                ? plan
+                : null;
+        }
+        catch (Exception ex)
+        {
+            Log.LogDebug(ex, "Policy-route check failed; treating this vantage as unproven");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Every box that probes for this site: its connected agents, each on the address it announced,
+    /// and the server on its own. A route names a MAC, so enumerating the candidates is what lets
+    /// the match say WHICH box is steered rather than only that one is.
+    /// </summary>
+    private List<NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder.ProbeHost> ProbeHosts()
+    {
+        var hosts = TunnelRegistry.GetForSite(SiteCtx.Slug)
+            .Where(c => !string.IsNullOrWhiteSpace(c.LanIp))
+            .Select(c => new NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder
+                .ProbeHost(c.AgentId, c.LanIp))
+            .ToList();
+        hosts.Add(new NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder.ProbeHost(
+            null, NetworkOptimizer.Core.Helpers.NetworkUtilities.GetAllLocalIpAddresses().FirstOrDefault()));
+        return hosts;
+    }
+
     private async Task DeleteContextAsync(int contextId)
     {
         if (!_canConfigure) return;
@@ -1000,13 +1154,15 @@
             await using var db = CreateDb();
             var row = await db.WanContexts.FindAsync(contextId);
             if (row == null) return;
-            // The reference is loose (no FK): move the context's targets back to the primary
-            // WAN before removing it - BOTH keys, so no row stays stamped with a WAN nothing
-            // probes for it any more (see WanContextTargetStamping).
-            await NetworkOptimizer.Web.Services.Monitoring.WanContextTargetStamping
+            // The reference is loose (no FK): move the context's targets back to unpinned first,
+            // so no row keeps a WAN nothing probes for it (see WanContextTargetStamping).
+            var released = await NetworkOptimizer.Web.Services.Monitoring.WanContextTargetStamping
                 .ReleaseContextTargetsAsync(db, contextId);
             db.WanContexts.Remove(row);
             await db.SaveChangesAsync();
+            Log.LogInformation(
+                "Deleted vantage '{Name}' ({Wan}); {Count} target(s) went back to unpinned",
+                row.Name, row.WanInterface ?? "(no WAN)", released);
             await RepushProbeConfigAsync();
             await OnChanged.InvokeAsync();
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -701,6 +701,11 @@
             foreach (var connection in TunnelRegistry.GetForSite(SiteCtx.Slug))
             {
                 if (connection.SupportsSourceBind != true) continue;
+                // TODO(#1106): use the durable per-agent overload
+                // IsAgentOnGatewayAsync(slug, agentId, candidates) instead. This resolves live and
+                // has no persisted verdict, so a console that is not up yet - the norm on an agent
+                // site, where it reconnects through the agent's own tunnel - reads as "not on the
+                // gateway" and offers source-address binding where interface binding belongs.
                 if (await OnGatewayDetector.MatchGatewayAddressAsync(SiteCtx.Slug, connection.HostAddresses) != null)
                     byInterface.Add(connection.AgentId);
                 else

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
@@ -242,7 +242,7 @@ public static class MonitoringChartEndpoints
                     : NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wan!);
                 var wanIsPrimary = string.Equals(wanKey,
                     NetworkOptimizer.UniFi.GatewayWanHelper.DefaultWanKey, StringComparison.OrdinalIgnoreCase);
-                targets = targets.Where(t => string.IsNullOrEmpty(t.WanInterface)
+                targets = targets.Where(t => NetworkOptimizer.Storage.Models.MonitoringTarget.IsUnpinned(t.WanInterface)
                     ? wanIsPrimary
                     : string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!),
                         wanKey, StringComparison.OrdinalIgnoreCase))
@@ -381,7 +381,7 @@ public static class MonitoringChartEndpoints
                 .Where(t => t.TargetType == targetType && t.Enabled
                     && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
                 .OrderBy(t => t.Name)
-                .Select(t => new { t.TargetId, t.Name, t.AutoLabel, t.WanInterface, t.Address })
+                .Select(t => new { t.TargetId, t.Name, t.AutoLabel, t.WanInterface, t.Address, t.TargetType, t.IsLocal })
                 .ToListAsync(ct);
 
             if (targets.Count == 0)
@@ -400,10 +400,15 @@ public static class MonitoringChartEndpoints
                     // Role label ("gateway"/"switch"/"ap"/...) so the LAN flaky detector can
                     // identify the gateway target and mask out gateway-outage windows.
                     autoLabel = t.AutoLabel,
-                    // WAN ownership (null = unstamped = primary) and address, so the chart's WAN
-                    // filter can scope series client-side and pair the same host's per-WAN twins.
+                    // WAN ownership and address, so the chart's WAN filter can scope series
+                    // client-side and pair the same host's per-WAN twins.
                     wanInterface = t.WanInterface,
                     address = t.Address,
+                    // Whether this sits on the local network, decided server-side from the resolved
+                    // answer rather than by re-testing the address in JS - one rule, one place, and
+                    // a hostname can only be answered here.
+                    isLan = NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal(
+                        t.TargetType, t.Address, t.IsLocal, t.WanInterface),
                     rtt = pts.Select(p => new { time = p.Time.ToString("o"), value = p.RttAvgMs }),
                     loss = pts.Select(p => new { time = p.Time.ToString("o"), value = p.LossPercent }),
                 };

--- a/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentOnGatewayDetector.cs
@@ -46,6 +46,11 @@ public class AgentOnGatewayDetector
     // work without a system scope.
     private readonly ConcurrentDictionary<string, string> _agentIp = new();
     private readonly ConcurrentDictionary<string, Task> _refreshing = new();
+    // Per-agent verdicts and their in-flight refreshes, for the per-agent overload. Separate from
+    // the site-level pair above rather than replacing it: the two answer different questions and
+    // the site-level one keeps its own contract.
+    private readonly ConcurrentDictionary<(string Slug, int AgentId), (bool OnGateway, DateTime At)> _agentCache = new();
+    private readonly ConcurrentDictionary<(string Slug, int AgentId), Task> _agentRefreshing = new();
     // The site's gateway addresses from the last resolution, so the per-connection check below can
     // answer for an agent the site-level verdict never considered. Cached and refreshed on the same
     // TTL as the verdict itself; a site with 2+ agents has one gateway either way.
@@ -90,7 +95,7 @@ public class AgentOnGatewayDetector
         // invented false into the empty cache.
         if (!hasCached)
         {
-            var persisted = await LoadPersistedAsync(siteSlug);
+            var persisted = await LoadPersistedAsync(siteSlug, SystemSettingKeys.AgentOnGateway);
             if (persisted != null)
             {
                 _cache.TryAdd(siteSlug, (persisted.Value, DateTime.MinValue));
@@ -112,6 +117,110 @@ public class AgentOnGatewayDetector
         }
         return _cache.TryGetValue(siteSlug, out var fresh) && fresh.OnGateway;
     }
+
+    /// <summary>
+    /// Whether ONE agent runs on its site's gateway, given the addresses that agent is known by.
+    /// The per-agent counterpart of <see cref="IsAgentOnGatewayAsync(string, CancellationToken)"/>,
+    /// carrying the same durability: a persisted verdict seeds the answer before the console can be
+    /// asked, and a refresh that cannot reach the console keeps the last answer rather than
+    /// inventing a no.
+    /// <para>
+    /// That durability is the whole point. The addresses to compare against come from the site's
+    /// UniFi Console, which on an agent site reconnects through that agent's own tunnel - so a
+    /// caller asking right after a restart, an agent update, or a page switch would otherwise get a
+    /// silent no and show a gateway agent the wrong instructions. Callers must not block on the
+    /// console to avoid that: a site with a broken or unconfigured console is exactly where someone
+    /// goes to fix it, and it has to stay responsive.
+    /// </para>
+    /// <para>
+    /// Deliberately not gated on the site being non-default, unlike the site-level verdict whose
+    /// "false for the default site" contract its speed-test consumers rely on.
+    /// </para>
+    /// </summary>
+    public async Task<bool> IsAgentOnGatewayAsync(
+        string siteSlug, int agentId, IReadOnlyList<string> candidates, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(siteSlug))
+            return false;
+
+        var key = (siteSlug, agentId);
+        var hasCached = _agentCache.TryGetValue(key, out var cached);
+        if (hasCached && DateTime.UtcNow - cached.At < CacheTtl)
+            return cached.OnGateway;
+
+        // Seeded before the refresh starts, for the same reason the site-level path does it: a
+        // refresh that finds the console down must keep this answer rather than race a made-up
+        // false into an empty cache.
+        if (!hasCached)
+        {
+            var persisted = await LoadPersistedAsync(siteSlug, SystemSettingKeys.AgentOnGatewayFor(agentId));
+            if (persisted != null)
+            {
+                _agentCache.TryAdd(key, (persisted.Value, DateTime.MinValue));
+                hasCached = _agentCache.TryGetValue(key, out cached);
+            }
+        }
+
+        // Nothing to compare: an agent that has never reported an address. Never persisted, so a
+        // known verdict is kept and an unknown one stays unknown.
+        if (candidates.Count == 0)
+            return hasCached && cached.OnGateway;
+
+        // TODO(#1106): the FIRST resolve for an agent has no verdict to fall back on, so if the
+        // console cannot answer at that moment this returns a no and the caller renders it. It
+        // self-corrects on the next ask (the refresh persists), and in practice only a page parked
+        // through a server restart sees it, so it is low severity rather than none.
+        // Every agent enrolled before this key existed gets one pass through that window too: the
+        // site-level verdict persists under AgentOnGateway and nothing reads it back under the
+        // per-agent key. Backfilling it is not worth building - the site-level row does not record
+        // WHICH agent it was about, so it is only unambiguous on a single-agent site, and the main
+        // site (the one this overload exists for) never persisted a row at all.
+        var refresh = StartOrJoinAgentRefresh(siteSlug, agentId, candidates);
+        if (hasCached)
+            return cached.OnGateway;
+
+        try
+        {
+            await refresh.WaitAsync(ct);
+        }
+        catch (OperationCanceledException)
+        {
+            // Caller gave up (panel closed) - the refresh itself continues and fills the cache.
+        }
+        return _agentCache.TryGetValue(key, out var fresh) && fresh.OnGateway;
+    }
+
+    /// <summary>One in-flight refresh per agent; the result lands in the cache and is persisted.</summary>
+    private Task StartOrJoinAgentRefresh(string siteSlug, int agentId, IReadOnlyList<string> candidates) =>
+        _agentRefreshing.GetOrAdd((siteSlug, agentId), key => Task.Run(async () =>
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(RefreshTimeout);
+                var connection = _siteConnections.GetFor(key.Slug);
+                if (!connection.IsConnected || connection.Client == null)
+                {
+                    // Console not up (the norm on an agent site right after a restart, since it
+                    // reconnects through the agent's tunnel).
+                    if (_agentCache.TryGetValue(key, out var last))
+                        _agentCache[key] = (last.OnGateway, DateTime.UtcNow);
+                    return;
+                }
+
+                await ResolveGatewayIpsAsync(key.Slug, connection.Client, cts.Token);
+                var onGateway = await MatchGatewayAddressAsync(key.Slug, candidates, cts.Token) != null;
+                _agentCache[key] = (onGateway, DateTime.UtcNow);
+                await PersistAsync(key.Slug, SystemSettingKeys.AgentOnGatewayFor(key.AgentId), onGateway);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Agent-on-gateway detection failed for agent {AgentId} at site {Slug}", key.AgentId, key.Slug);
+            }
+            finally
+            {
+                _agentRefreshing.TryRemove(key, out _);
+            }
+        }));
 
     /// <summary>
     /// The address the site's agent reported at the last detection, or null if none has completed.
@@ -254,7 +363,7 @@ public class AgentOnGatewayDetector
         var onGateway = gatewayIps.Contains(agentIp!, StringComparer.OrdinalIgnoreCase);
         _cache[siteSlug] = (onGateway, DateTime.UtcNow);
         _agentIp[siteSlug] = agentIp!;
-        await PersistAsync(siteSlug, onGateway);
+        await PersistAsync(siteSlug, SystemSettingKeys.AgentOnGateway, onGateway);
     }
 
     /// <summary>
@@ -286,6 +395,12 @@ public class AgentOnGatewayDetector
             foreach (var port in device.PortTable ?? new())
                 AddHostIp(hostIps, port.Ip);
         }
+        // TODO(#1106): this takes ONE LAN address - ResolveGatewayLanIpAsync is FirstOrDefault()
+        // over the corporate networks - so a multi-VLAN gateway contributes its default LAN and
+        // nothing else (a real case: 2 of the 6 addresses the box holds). Harmless for an agent
+        // reporting local_ips, since one of those will hit, but an older single-address agent
+        // matches only if it happened to name one of the two. NetworkInfo.Gateway is already
+        // mapped for EVERY network in UniFiConnectionService / UniFiDiscovery and closes it.
         try
         {
             var lanIp = await Monitoring.SnmpDeviceRules.ResolveGatewayLanIpAsync(client, ct);
@@ -334,13 +449,13 @@ public class AgentOnGatewayDetector
             _cache[siteSlug] = (cached.OnGateway, DateTime.UtcNow);
     }
 
-    /// <summary>The persisted last verdict for a site, or null when never detected.</summary>
-    private async Task<bool?> LoadPersistedAsync(string siteSlug)
+    /// <summary>The persisted last verdict under the given key, or null when never detected.</summary>
+    private async Task<bool?> LoadPersistedAsync(string siteSlug, string settingKey)
     {
         try
         {
-            await using var db = _siteDbFactory.CreateForSite(siteSlug, isDefault: false);
-            var value = (await db.SystemSettings.FindAsync(SystemSettingKeys.AgentOnGateway))?.Value;
+            await using var db = _siteDbFactory.CreateForSite(siteSlug, IsDefaultSite(siteSlug));
+            var value = (await db.SystemSettings.FindAsync(settingKey))?.Value;
             return value == null ? null : value == "true";
         }
         catch (Exception ex)
@@ -350,18 +465,26 @@ public class AgentOnGatewayDetector
         }
     }
 
+    /// <summary>
+    /// The default site keeps its settings in the main database rather than a per-site one. The
+    /// site-level verdict never reaches here for it (it answers false and returns), but the
+    /// per-agent one does, and asking for a site database it does not have would write the verdict
+    /// somewhere nothing reads it back from.
+    /// </summary>
+    private static bool IsDefaultSite(string siteSlug) => siteSlug == SiteManagementService.DefaultSiteSlug;
+
     /// <summary>Persists a real (console-backed) verdict; writes only on change to spare the site DB.</summary>
-    private async Task PersistAsync(string siteSlug, bool onGateway)
+    private async Task PersistAsync(string siteSlug, string settingKey, bool onGateway)
     {
         try
         {
             var value = onGateway ? "true" : "false";
-            await using var db = _siteDbFactory.CreateForSite(siteSlug, isDefault: false);
-            var setting = await db.SystemSettings.FindAsync(SystemSettingKeys.AgentOnGateway);
+            await using var db = _siteDbFactory.CreateForSite(siteSlug, IsDefaultSite(siteSlug));
+            var setting = await db.SystemSettings.FindAsync(settingKey);
             if (setting == null)
                 db.SystemSettings.Add(new SystemSetting
                 {
-                    Key = SystemSettingKeys.AgentOnGateway,
+                    Key = settingKey,
                     Value = value
                 });
             else if (setting.Value != value)

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -460,16 +460,23 @@ public class AgentProbeResultSink
 
     /// <summary>
     /// Which agent currently collects for a site, for display. Same answer the push path acts on,
-    /// asked from one place so the page cannot disagree with what is actually happening. Null when
-    /// no agent is connected.
+    /// asked from one place so the page cannot disagree with what is actually happening.
+    /// <para>
+    /// Null when no agent is connected, and null on a default site whose agent does not cover
+    /// collection - there the agent is an ADDITIONAL vantage and this server does the collecting,
+    /// so naming an agent would claim a handover that never happened. The push path gates on the
+    /// same question before choosing an unassigned owner; this used to skip it and answer with
+    /// whichever agent happened to be connected.
+    /// </para>
     /// </summary>
     public async Task<int?> GetCollectorAgentIdAsync(string siteSlug, CancellationToken ct = default)
     {
         var connected = _tunnelRegistry.GetForSite(siteSlug).Select(c => c.AgentId).ToList();
         if (connected.Count == 0) return null;
+        var isDefault = siteSlug == SiteManagementService.DefaultSiteSlug;
+        if (isDefault && !await _agentCoverage.CoversAsync(siteSlug)) return null;
         try
         {
-            var isDefault = siteSlug == SiteManagementService.DefaultSiteSlug;
             await using var db = _siteDbFactory.CreateForSite(siteSlug, isDefault);
             var contexts = await db.WanContexts.AsNoTracking().ToListAsync(ct);
             var primaryWanKey = await ResolvePersistedPrimaryWanKeyAsync(db, ct);

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -368,6 +368,10 @@ public class AgentProbeResultSink
             // The MATCHED address, not the agent's own reported one: the site's target for the
             // gateway carries the address the console knows it by, which is not necessarily the
             // address the agent named itself with.
+            // TODO(#1106): this one needs the matched ADDRESS, not a yes/no, so the durable
+            // per-agent overload does not drop in - it would have to persist the address too.
+            // Same exposure as the others: no console, no match, and the gateway's own target is
+            // handed back to the agent that sits on it.
             var selfAddress = await _onGatewayDetector.MatchGatewayAddressAsync(
                 connection.SiteSlug, connection.HostAddresses, ct);
             var skippedSelf = 0;
@@ -514,6 +518,7 @@ public class AgentProbeResultSink
         if (unbound.Count == 0) return false;
 
         // Asked only when there is something to heal: it can await a console round trip.
+        // TODO(#1106): a yes/no, so the durable per-agent overload does drop in here.
         if (await _onGatewayDetector.MatchGatewayAddressAsync(
                 connection.SiteSlug, connection.HostAddresses, ct) == null)
             return false;

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1923,7 +1923,7 @@ public class LanFlowMapService
     /// <summary>True for names that aren't a real user identity: default port placeholders
     /// ("SFP+ 2") and generic WAN names ("WAN2", "Internet 2").</summary>
     private static bool IsPlaceholderWanName(string name)
-        => InterfaceLabelResolver.IsDefaultPortName(name) || DisplayFormatters.IsGenericWanName(name);
+        => GatewayWanHelper.IsPlaceholderWanName(name);
 
     private static void InterpolateInteriorPlacements(LanFlowMapSnapshot snapshot, NetworkTopology topology)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthModels.cs
@@ -696,8 +696,18 @@ public class AsnSeries
     public bool IsDestination { get; init; }
 }
 
-/// <summary>Load classification of one aggregate window.</summary>
-public record LoadWindow(bool IsIdle, bool IsLoadedDown, bool IsLoadedUp);
+/// <summary>
+/// Load classification of one aggregate window. The Classified* pair is the rates' verdict before
+/// isolated runs were demoted, read only as the opposite-direction barrier when matching samples to
+/// load: demotion clears the live flag on a speed test's shorter phase, and with it the marker that
+/// keeps the surviving phase from reaching across the handover.
+/// </summary>
+public record LoadWindow(
+    bool IsIdle,
+    bool IsLoadedDown,
+    bool IsLoadedUp,
+    bool ClassifiedLoadedDown = false,
+    bool ClassifiedLoadedUp = false);
 
 /// <summary>A WAN throughput point joined into load classification.</summary>
 public record ThroughputSample(DateTime Time, double? DownloadBps, double? UploadBps);

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthOptions.cs
@@ -260,6 +260,34 @@ public class IspHealthOptions
     /// <summary>Minimum loaded samples per direction for the loaded factors to score that direction.</summary>
     public int MinLoadedSamples { get; set; } = 5;
 
+    /// <summary>
+    /// Probes that must have SEEN loss before loaded loss reports a rate, when the pool covers fewer
+    /// than <see cref="LoadedLossMinEpisodes"/> episodes. <see cref="MinLoadedSamples"/> counts
+    /// samples, which are overwhelmingly zeros, so it passes on a single lossy probe.
+    /// </summary>
+    public int LoadedLossMinLossyProbes { get; set; } = 2;
+
+    /// <summary>Load episodes that let a single lossy probe stand: several dilute it, one does not.</summary>
+    public int LoadedLossMinEpisodes { get; set; } = 2;
+
+    /// <summary>
+    /// Nominal seconds a loss probe spends measuring - the standard burst is five pings a second
+    /// apart. Used as the floor for the interval a probe is matched on; the series' own cadence
+    /// wins when it is coarser.
+    /// </summary>
+    public int LoadedProbeSpanSeconds { get; set; } = 5;
+
+    /// <summary>Ceiling on a sample's span, so a very coarse series cannot claim minutes of load.</summary>
+    public int LoadedProbeSpanMaxSeconds { get; set; } = 120;
+
+    /// <summary>
+    /// How much of a sample's interval must have run under load before it counts for that direction
+    /// at all. Deliberately well under a half: a sample straddling a speed test's handover genuinely
+    /// measured both phases, and the aggregation has already lost which probe sat where, so it joins
+    /// both pools weighted by how much of it each phase covered rather than being assigned outright.
+    /// </summary>
+    public double LoadedOverlapMinFraction { get; set; } = 0.25;
+
     /// <summary>Aggregate window in minutes for chart series.</summary>
     public int AggregateWindowMinutes { get; set; } = 1;
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthScorer.cs
@@ -408,8 +408,8 @@ public class IspHealthScorer
         double? down = null, up = null;
         if (loadWindows.Count > 0)
         {
-            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp, upstream: false);
-            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown, upstream: true);
+            down = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedDown, w => w.ClassifiedLoadedUp, upstream: false);
+            up = LoadedLatencyDelta(inputs, loadWindows, w => w.IsLoadedUp, w => w.ClassifiedLoadedDown, upstream: true);
         }
 
         bool downFromSpeedTest = false, upFromSpeedTest = false;
@@ -578,7 +578,11 @@ public class IspHealthScorer
         var floor = _options.LoadedLatencyMinLoadWeight;
         var windowSeconds = Math.Max(1, _options.LoadWindowSeconds);
         var fullSeconds = Math.Max(windowSeconds, _options.LoadedLatencyFullCredibilitySustainedSeconds);
-        var episodeSeconds = SeriesStats.LoadEpisodeSeconds(loaded, windowSeconds);
+        // Runs measured at the RATE series' spacing. The loaded set is no longer dilated, and
+        // dilation was what accidentally bridged the gaps here: where the rates are aggregated
+        // coarser than a window, loaded keys are never adjacent, so every key read as its own
+        // episode and a long saturation scored the same credibility as a two-second burst.
+        var episodeSeconds = SeriesStats.LoadEpisodeSeconds(loaded, RateSampleSeconds(inputs));
 
         double DurationWeight(DateTime key) =>
             episodeSeconds.TryGetValue(key, out var seconds)
@@ -965,7 +969,8 @@ public class IspHealthScorer
         {
             Name = "Loaded Latency",
             Score = (int)Math.Round(scores.Average()),
-            Weight = _options.LoadedLatencyWeight,
+            // Same reasoning as Loaded Loss: one direction measured is half the question answered.
+            Weight = _options.LoadedLatencyWeight * (scores.Count / 2.0),
             ValueText = string.Join(", ", parts),
             Description = $"Latency increase under load vs +{FormatMsBand(profile.LoadedDeltaExcellentMs)} excellent and +{FormatMsBand(profile.LoadedDeltaAcceptableMs)} acceptable for {profile.DisplayName}.{source}"
         }, true);
@@ -985,10 +990,9 @@ public class IspHealthScorer
     /// Loaded-latency delta from ISP access hops only. Each access hop's loaded RTT
     /// samples are baseline-subtracted and pooled; the median of the pool (filtered
     /// > 0.5 ms) is the result. Pooling raw samples instead of per-target aggregates
-    /// is stable even with sparse loaded data (typical residential). Loaded windows are
-    /// dilated (see <see cref="DilateLoadedWindows"/>) so the ramp-in rise and drain tail of
-    /// an event - which fall in transition windows outside the strict rate threshold - are
-    /// captured rather than dropped.
+    /// is stable even with sparse loaded data (typical residential). Samples are matched by
+    /// interval overlap (see <see cref="LoadedCoverage"/>), which extends each loaded window by
+    /// the ramp and drain so an event's edges are captured rather than dropped.
     /// </summary>
     private double? LoadedLatencyDelta(
         IspHealthInputs inputs,
@@ -998,7 +1002,12 @@ public class IspHealthScorer
         bool upstream)
     {
         const double noiseFloor = 0.5;
-        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
+        // Same overlap matching as loaded loss - see LoadedCoverage. A misbinned probe is less
+        // damaging here (episodes are pooled and corroborated against the speed tests) but it is
+        // the same error, and the corroboration is a backstop rather than a reason to keep it.
+        var loaded = BuildLoadedKeySet(loadWindows, directionSelector);
+        bool OppositeLoaded(DateTime key) =>
+            loadWindows.TryGetValue(key, out var w) && oppositeSelector(w);
 
         var accessCohort = inputs.AccessHopSeries.Count > 0
             ? inputs.AccessHopSeries
@@ -1018,16 +1027,24 @@ public class IspHealthScorer
             .ToList();
 
         var perHop = new List<(DateTime Time, double Value, int Series)>();
+        // The loaded window each matched sample overlapped, so episode grouping and load weighting
+        // below read the window the probe measured instead of re-flooring its stamp.
+        var keyByTime = new Dictionary<DateTime, DateTime>();
         for (var h = 0; h < agreementCohort.Count; h++)
         {
             var hop = agreementCohort[h];
             var baseline = ComputeIdleBaseline(hop, loadWindows);
             if (baseline == null) continue;
 
-            var series = h;
-            perHop.AddRange(hop
-                .Where(s => s.RttAvgMs.HasValue && loaded.Contains(FloorToWindow(s.Time)))
-                .Select(s => (s.Time, s.RttAvgMs!.Value - baseline.Value, series)));
+            var span = SampleSpanSeconds(hop);
+            foreach (var s in hop)
+            {
+                if (!s.RttAvgMs.HasValue) continue;
+                var (coverage, key) = LoadedCoverage(s.Time, span, inputs, loaded, OppositeLoaded);
+                if (coverage <= 0 || coverage < _options.LoadedOverlapMinFraction) continue;
+                perHop.Add((s.Time, s.RttAvgMs.Value - baseline.Value, h));
+                keyByTime[s.Time] = key;
+            }
         }
 
         // Hops that reported at the same instant are collapsed to what they AGREED on before any
@@ -1046,10 +1063,11 @@ public class IspHealthScorer
         // seven seconds, so "the newest three windows" is the last twenty seconds and any brief
         // lull inside one bad evening would read as a line that was fixed. An episode is however
         // long the line actually stayed loaded, which is the unit a person means by "a load event".
-        var episodeStarts = SeriesStats.LoadEpisodeStarts(loaded, Math.Max(1, _options.LoadWindowSeconds));
+        var episodeStarts = SeriesStats.LoadEpisodeStarts(loaded.Keys, EpisodeGroupSeconds(inputs));
+        DateTime MatchedKey(DateTime t) => keyByTime.TryGetValue(t, out var k) ? k : FloorToWindow(t);
         var episodes = pooled
-            .Where(x => episodeStarts.ContainsKey(FloorToWindow(x.Time)))
-            .GroupBy(x => episodeStarts[FloorToWindow(x.Time)])
+            .Where(x => episodeStarts.ContainsKey(MatchedKey(x.Time)))
+            .GroupBy(x => episodeStarts[MatchedKey(x.Time)])
             .Select(g => (Time: g.Key, Value: EpisodeDelta(g.Select(x => x.Value).ToList(), noiseFloor)))
             .OrderByDescending(e => e.Time)
             .ToList();
@@ -1105,7 +1123,7 @@ public class IspHealthScorer
                 ?? double.NegativeInfinity;
         }
 
-        var loadWeight = BuildLoadWeighting(inputs, upstream, loaded);
+        var loadWeight = BuildLoadWeighting(inputs, upstream, loaded.Keys);
         var stale = _options.LoadedLatencyElevationStaleEpisodes;
         var elevatedEpisodes = episodes.Where(e => e.Value >= noiseFloor).ToList();
 
@@ -1182,8 +1200,10 @@ public class IspHealthScorer
             }, false);
         }
 
-        var downLoss = LoadedMeanLoss(inputs, lossPool, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp, upstream: false);
-        var upLoss = LoadedMeanLoss(inputs, lossPool, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown, upstream: true);
+        var downLoss = LoadedMeanLoss(inputs, lossPool, loadWindows, w => w.IsLoadedDown, w => w.ClassifiedLoadedUp,
+            upstream: false, direction: "down", out var downThin);
+        var upLoss = LoadedMeanLoss(inputs, lossPool, loadWindows, w => w.IsLoadedUp, w => w.ClassifiedLoadedDown,
+            upstream: true, direction: "up", out var upThin);
 
         var scores = new List<double>();
         if (downLoss.HasValue) scores.Add(ScoreLossBand(downLoss.Value, profile.LoadedLossDownLowPct, profile.LoadedLossDownHighPct));
@@ -1194,7 +1214,11 @@ public class IspHealthScorer
             {
                 Name = "Loaded Loss",
                 Weight = _options.LoadedLossWeight,
-                Description = "The line was never under sustained load during the window."
+                // Two different silences: nothing loaded the line, versus something did and a
+                // single probe caught a single drop.
+                Description = downThin || upThin
+                    ? "The line was under load too briefly to measure loss - a single dropped probe is not a rate."
+                    : "The line was never under sustained load during the window."
             }, false);
         }
 
@@ -1206,13 +1230,31 @@ public class IspHealthScorer
             upLoss.HasValue ? $"{FormatPct(upLoss.Value)} up" : "n/a up"
         };
 
+        // Name the band(s) the score was actually made against. The downstream band was cited
+        // unconditionally, so a report that only graded upstream quoted a range it never used -
+        // 1% to 2% against an upstream figure judged on 0.5% to 1.5%.
+        var bands = new List<string>();
+        if (downLoss.HasValue)
+            bands.Add($"{FormatPct(profile.LoadedLossDownLowPct)} to {FormatPct(profile.LoadedLossDownHighPct)} downstream");
+        if (upLoss.HasValue)
+            bands.Add($"{FormatPct(profile.LoadedLossUpLowPct)} to {FormatPct(profile.LoadedLossUpHighPct)} upstream");
+
+        // A direction that reported nothing reads "n/a" in the value, and until now the factor kept
+        // its full pull on the dimension while its score quietly became the surviving direction's
+        // alone. Absence of evidence should cost influence, not re-centre the answer: half the
+        // directions measured, half the weight, and BuildDimension renormalises the rest.
+        var thin = downThin ? "Downstream" : upThin ? "Upstream" : null;
+        var thinNote = thin == null
+            ? string.Empty
+            : $" {thin} is not graded - one dropped probe in a single load episode is not a rate.";
+
         return (new IspScoreFactor
         {
             Name = "Loaded Loss",
             Score = (int)Math.Round(scores.Average()),
-            Weight = _options.LoadedLossWeight,
+            Weight = _options.LoadedLossWeight * (scores.Count / 2.0),
             ValueText = string.Join(", ", parts),
-            Description = $"Packet loss while the line is under load vs the {FormatPct(profile.LoadedLossDownLowPct)} to {FormatPct(profile.LoadedLossDownHighPct)} downstream band for {profile.DisplayName}."
+            Description = $"Packet loss while the line is under load vs the {string.Join(" and ", bands)} band{(bands.Count > 1 ? "s" : "")} for {profile.DisplayName}.{thinNote}"
         }, true);
     }
 
@@ -1234,49 +1276,101 @@ public class IspHealthScorer
         Dictionary<DateTime, LoadWindow> loadWindows,
         Func<LoadWindow, bool> directionSelector,
         Func<LoadWindow, bool> oppositeSelector,
-        bool upstream)
+        bool upstream,
+        string direction,
+        out bool thinEvidence)
     {
-        var loaded = DilateLoadedWindows(loadWindows, directionSelector, oppositeSelector);
-        var samples = lossPool.SelectMany(series => series)
-            .Where(s => s.LossPercent.HasValue && !InOutage(s.Time)
-                && loaded.Contains(FloorToWindow(s.Time)))
-            .Select(s => (s.Time, Value: _gatewayFloor.Apply(s.LossPercent!.Value, s.Time)))
-            .ToList();
+        thinEvidence = false;
+        // Matched by OVERLAP against the seconds each loaded window describes, not by flooring the
+        // probe's end-stamp into a bucket. See LoadedCoverage.
+        var loaded = BuildLoadedKeySet(loadWindows, directionSelector);
+        bool OppositeLoaded(DateTime key) =>
+            loadWindows.TryGetValue(key, out var w) && oppositeSelector(w);
+
+        var samples = new List<(DateTime Time, double Value, DateTime Key, double Coverage)>();
+        foreach (var series in lossPool)
+        {
+            var span = SampleSpanSeconds(series);
+            foreach (var s in series)
+            {
+                if (!s.LossPercent.HasValue || InOutage(s.Time)) continue;
+                var (coverage, key) = LoadedCoverage(s.Time, span, inputs, loaded, OppositeLoaded);
+                // Zero coverage is checked on its own: at a minimum fraction of 0 a sample that
+                // touched no loaded window would otherwise join the pool weighing nothing, which the
+                // mean survives but the lossy-probe count behind the gate below does not.
+                if (coverage <= 0 || coverage < _options.LoadedOverlapMinFraction) continue;
+                samples.Add((s.Time, _gatewayFloor.Apply(s.LossPercent.Value, s.Time), key, coverage));
+            }
+        }
         var losses = samples.Select(s => s.Value).ToList();
-        // Loaded loss rests on however many samples happen to fall inside the loaded windows, and on
-        // a long window the rate series is aggregated far coarser than LoadWindowSeconds, so that set
-        // can be small enough for a few dark samples to set the whole figure. Log what it was built
-        // from - a mean over a handful of samples is a very different claim from one over thousands.
-        _logger?.LogDebug(
-            "ISP Health: loaded loss pool {Count} sample(s) from {Windows} loaded window key(s), {Dark} at/above 99% ({Mean}% mean)",
-            losses.Count, loaded.Count, losses.Count(l => l >= 99.0),
-            losses.Count > 0 ? losses.Average().ToString("0.##", CultureInfo.InvariantCulture) : "n/a");
-        if (losses.Count < _options.MinLoadedSamples) return null;
+
         // Same credibility rules as loaded latency: a sustained saturation says far more about
         // behavior under load than a two-second burst that may not even have been load, and recent
         // evidence outranks old evidence of the same kind. A weighted MEAN rather than a median,
         // because loss is a rate - most samples are zero even on a bad line, and a median over
         // them reports zero however bad the rest are.
-        var loadWeight = BuildLoadWeighting(inputs, upstream, loaded);
-        return SeriesStats.WeightedMean(samples
+        var loadWeight = BuildLoadWeighting(inputs, upstream, loaded.Keys);
+        // Weighted on the window the probe actually overlapped, not on its stamp: the stamp is what
+        // was pointing a bucket too late, and reading utilization off that bucket is what let a
+        // download-phase probe collect the upload phase's credibility.
+        var weighted = samples
             .Select(s => (s.Value,
-                SeriesStats.RecencyWeight(inputs.WindowEnd - s.Time, _options.LoadedLatencyRecencyHalfLifeHours)
-                    * loadWeight(s.Time)))
-            .ToList()) ?? losses.Average();
+                Weight: SeriesStats.RecencyWeight(inputs.WindowEnd - s.Time, _options.LoadedLatencyRecencyHalfLifeHours)
+                    * loadWeight(s.Key) * s.Coverage))
+            .ToList();
+        var weightedMean = SeriesStats.WeightedMean(weighted);
+
+        var lossy = losses.Count(l => l > 0);
+        // Counted at the RATE series' own spacing, not LoadWindowSeconds. On a long window the rates
+        // are aggregated coarser than the window, so loaded keys are never adjacent and one six-hour
+        // saturation counts as hundreds of episodes.
+        var episodes = SeriesStats
+            .LoadEpisodeStarts(loaded.Keys, EpisodeGroupSeconds(inputs))
+            .Values.Distinct().Count();
+        // Both means, because the reported one is the WEIGHTED one: the raw mean alone read 0.63%
+        // for a figure the panel showed as 2.1%. The heaviest sample's weight share explains that
+        // gap - it says when the credibility weighting handed one sample the whole answer.
+        if (_logger?.IsEnabled(LogLevel.Debug) == true)
+        {
+            var totalWeight = 0.0;
+            var topWeight = 0.0;
+            foreach (var (_, w) in weighted)
+            {
+                if (w <= 0) continue;
+                totalWeight += w;
+                if (w > topWeight) topWeight = w;
+            }
+            _logger.LogDebug(
+                "ISP Health: loaded loss {Direction} pool {Count} sample(s) from {Windows} loaded window key(s) over "
+                + "{Episodes} episode(s), {Lossy} with loss, {Dark} at/above 99%; {Mean}% raw mean -> {Weighted}% "
+                + "weighted, heaviest sample holds {Share}% of the weight",
+                direction, losses.Count, loaded.Keys.Count, episodes, lossy, losses.Count(l => l >= 99.0),
+                losses.Count > 0 ? losses.Average().ToString("0.##", CultureInfo.InvariantCulture) : "n/a",
+                weightedMean?.ToString("0.##", CultureInfo.InvariantCulture) ?? "n/a",
+                (totalWeight > 0 ? topWeight / totalWeight * 100 : 0).ToString("0.#", CultureInfo.InvariantCulture));
+        }
+
+        if (losses.Count < _options.MinLoadedSamples) return null;
+
+        // A rate needs more than one observation. A five-ping probe quantizes to 20% steps, so one
+        // dropped ping in one scheduled speed test can otherwise be the entire figure - and the
+        // weighting concentrates it rather than diluting it. Silent only when there IS uncorroborated
+        // loss; a pool with none still reports 0%, which is a real measurement.
+        if (lossy > 0 && lossy < _options.LoadedLossMinLossyProbes && episodes < _options.LoadedLossMinEpisodes)
+        {
+            _logger?.LogDebug(
+                "ISP Health: loaded loss {Direction} not graded - {Lossy} probe(s) with loss across {Episodes} "
+                + "load episode(s), needs {NeedLossy} probe(s) or {NeedEpisodes} episode(s)",
+                direction, lossy, episodes, _options.LoadedLossMinLossyProbes, _options.LoadedLossMinEpisodes);
+            thinEvidence = true;
+            return null;
+        }
+
+        return weightedMean ?? losses.Average();
     }
 
-    /// <summary>
-    /// Window keys that count as loaded in a direction for sample matching: the directly
-    /// loaded windows plus up to <see cref="IspHealthOptions.LoadedLeadSeconds"/> before and
-    /// <see cref="IspHealthOptions.LoadedTailSeconds"/> after each loaded run. The ramp fills
-    /// the queue before throughput crosses the loaded threshold and the drain (plus end-stamped
-    /// loss probes) trails it, so without dilation the edges of every event are dropped. Dilation
-    /// never crosses into a window loaded in the OPPOSITE direction, so a speed test's download
-    /// tail does not bleed into its upload phase. Idle classification is unaffected (this builds a
-    /// loaded set only), keeping the baseline a clean uncongested floor.
-    /// </summary>
     // Loaded window keys per direction for the current report. Both lists are filled on the first
-    // request from a single pass, since the dilation asks for them four times.
+    // request from a single pass, since matching asks for them four times.
     private List<DateTime>? _loadedDownKeys;
     private List<DateTime>? _loadedUpKeys;
 
@@ -1300,36 +1394,6 @@ public class IspHealthScorer
         return directionSelector(new LoadWindow(false, true, false)) ? _loadedDownKeys : _loadedUpKeys;
     }
 
-    private HashSet<DateTime> DilateLoadedWindows(
-        Dictionary<DateTime, LoadWindow> loadWindows,
-        Func<LoadWindow, bool> directionSelector,
-        Func<LoadWindow, bool> oppositeSelector)
-    {
-        var leadWindows = (int)Math.Ceiling((double)_options.LoadedLeadSeconds / _options.LoadWindowSeconds);
-        var tailWindows = (int)Math.Ceiling((double)_options.LoadedTailSeconds / _options.LoadWindowSeconds);
-
-        var loaded = new HashSet<DateTime>();
-        // Only the loaded keys matter, and there are a couple of dozen of them against six figures of
-        // windows on a long span. This runs four times - latency and loss, each direction - so the
-        // scan is cached per Score() call rather than repeated.
-        foreach (var key in LoadedKeysFor(loadWindows, directionSelector))
-        {
-            loaded.Add(key);
-            for (var i = 1; i <= leadWindows; i++)
-            {
-                var k = key.AddSeconds(-i * _options.LoadWindowSeconds);
-                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
-                loaded.Add(k);
-            }
-            for (var i = 1; i <= tailWindows; i++)
-            {
-                var k = key.AddSeconds(i * _options.LoadWindowSeconds);
-                if (loadWindows.TryGetValue(k, out var nw) && oppositeSelector(nw)) break;
-                loaded.Add(k);
-            }
-        }
-        return loaded;
-    }
 
     /// <summary>
     /// Grades one ASN (transit) or one ISP hop: a quality blend (stability, jitter,
@@ -2534,11 +2598,182 @@ public class IspHealthScorer
         var loss = false;
         if (loadWindows.Count > 0)
         {
-            var downLoss = LoadedMeanLoss(inputs, inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown, w => w.IsLoadedUp, upstream: false);
-            var upLoss = LoadedMeanLoss(inputs, inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp, w => w.IsLoadedDown, upstream: true);
+            var downLoss = LoadedMeanLoss(inputs, inputs.LossPoolSeries, loadWindows, w => w.IsLoadedDown,
+                w => w.ClassifiedLoadedUp, upstream: false, direction: "down", out _);
+            var upLoss = LoadedMeanLoss(inputs, inputs.LossPoolSeries, loadWindows, w => w.IsLoadedUp,
+                w => w.ClassifiedLoadedDown, upstream: true, direction: "up", out _);
             loss = downLoss > profile.LoadedLossDownHighPct || upLoss > profile.LoadedLossUpHighPct;
         }
         return (latency, loss);
+    }
+
+    // Cached for the current report: the four loaded-factor passes all want it, and the series runs
+    // to five figures.
+    private int? _rateSampleSeconds;
+
+    // The ORIGINAL aggregate stamp behind each loaded window key. FloorToWindow moves a stamp onto a
+    // .NET-epoch grid, which is offset from the Unix-epoch grid Influx aggregates on, so the key
+    // alone cannot say which seconds its rates describe. Overlap matching needs that.
+    private Dictionary<DateTime, DateTime>? _stampByKey;
+
+    private Dictionary<DateTime, DateTime> StampByKey(IspHealthInputs inputs)
+    {
+        if (_stampByKey != null) return _stampByKey;
+        _stampByKey = new Dictionary<DateTime, DateTime>();
+        foreach (var r in inputs.WanRates) _stampByKey[FloorToWindow(r.Time)] = r.Time;
+        return _stampByKey;
+    }
+
+    /// <summary>
+    /// How much of a probe's measurement interval ran while the line was loaded in this direction,
+    /// as a fraction of the probe's span.
+    /// <para>
+    /// A probe is stamped when its LAST ping returns, and Influx bins it by that stamp, so a probe
+    /// that finished a fraction of a second past a bucket boundary is filed under the next bucket
+    /// and inherits its character. On a back-to-back speed test that bucket is the other direction's
+    /// phase, so download-phase loss was landing on upload every time. Comparing the probe's own
+    /// interval against the seconds each rate window actually describes removes the whole class of
+    /// error, including the epoch-grid offset above.
+    /// </para>
+    /// </summary>
+    /// <returns>
+    /// The covered fraction, and the loaded window the probe overlapped MOST. Callers key episode
+    /// grouping and load weighting off that window rather than off the probe's own stamp, which is
+    /// the thing that was pointing at the wrong bucket in the first place.
+    /// </returns>
+    private (double Coverage, DateTime Key) LoadedCoverage(
+        DateTime probeEnd, double spanSeconds, IspHealthInputs inputs,
+        LoadedKeySet loaded, Func<DateTime, bool> oppositeLoaded)
+    {
+        var loadedKeys = loaded.Keys;
+        if (spanSeconds <= 0 || loadedKeys.Count == 0) return (0, default);
+
+        var stamps = StampByKey(inputs);
+        var width = RateSampleSeconds(inputs);
+        var step = Math.Max(1, _options.LoadWindowSeconds);
+        var probeStart = probeEnd.AddSeconds(-spanSeconds);
+        // Only the handful of windows that can reach the probe's interval, allowing for the lead and
+        // tail extensions and for a rate window wider than one key step. Both ends are FLOORED onto
+        // the key grid - the walk steps by whole windows, so an off-grid start never lands on a key.
+        var first = FloorToWindow(probeStart.AddSeconds(-(width + _options.LoadedTailSeconds + step)));
+        var last = FloorToWindow(probeEnd.AddSeconds(_options.LoadedLeadSeconds + step));
+
+        // Nearly every sample in a window is nowhere near a load event - four loaded keys against
+        // twelve thousand is a normal day - and walking the grid for each one is most of the cost of
+        // this factor. The loop can only count keys inside [Min, Max], so missing that range
+        // entirely is the same answer for two comparisons instead of a dozen lookups.
+        if (last < loaded.Min || first > loaded.Max) return (0, default);
+
+        var covered = 0.0;
+        var best = 0.0;
+        var bestKey = default(DateTime);
+        for (var key = first; key <= last; key = key.AddSeconds(step))
+        {
+            if (!loadedKeys.Contains(key) || !stamps.TryGetValue(key, out var stamp)) continue;
+
+            // The window's own seconds, then the physical ramp and drain either side. The extensions
+            // stop at a window the RATES called loaded the other way, so a download run's drain
+            // cannot reach across a handover and claim the upload phase's probes.
+            var from = stamp.AddSeconds(-width);
+            var to = stamp;
+            if (!oppositeLoaded(key.AddSeconds(-step))) from = from.AddSeconds(-_options.LoadedLeadSeconds);
+            if (!oppositeLoaded(key.AddSeconds(step))) to = to.AddSeconds(_options.LoadedTailSeconds);
+
+            var lo = from > probeStart ? from : probeStart;
+            var hi = to < probeEnd ? to : probeEnd;
+            if (hi <= lo) continue;
+
+            var overlap = (hi - lo).TotalSeconds;
+            covered += overlap;
+            if (overlap > best) { best = overlap; bestKey = key; }
+        }
+        return (Math.Min(1.0, covered / spanSeconds), bestKey);
+    }
+
+    /// <summary>
+    /// Gap that still counts as the same load episode. One window wider than the rate spacing:
+    /// flooring stamps onto the key grid makes the gap between consecutive loaded keys jitter either
+    /// side of the true spacing (56 or 63 s for a 60 s series), and an exact test splits an episode
+    /// on the wide ones. Grouping only - episode DURATION stays on the true spacing.
+    /// </summary>
+    private int EpisodeGroupSeconds(IspHealthInputs inputs) =>
+        RateSampleSeconds(inputs) + Math.Max(1, _options.LoadWindowSeconds);
+
+    /// <summary>A direction's loaded window keys with their extent, so a sample far from any load
+    /// event is rejected on two comparisons.</summary>
+    private sealed record LoadedKeySet(IReadOnlySet<DateTime> Keys, DateTime Min, DateTime Max);
+
+    private LoadedKeySet BuildLoadedKeySet(
+        Dictionary<DateTime, LoadWindow> loadWindows, Func<LoadWindow, bool> directionSelector)
+    {
+        var keys = LoadedKeysFor(loadWindows, directionSelector);
+        var set = new HashSet<DateTime>(keys);
+        if (keys.Count == 0) return new LoadedKeySet(set, DateTime.MaxValue, DateTime.MinValue);
+
+        var min = DateTime.MaxValue;
+        var max = DateTime.MinValue;
+        foreach (var k in keys)
+        {
+            if (k < min) min = k;
+            if (k > max) max = k;
+        }
+        return new LoadedKeySet(set, min, max);
+    }
+
+    // Span per series for the current report. Each series is asked twice, once per direction, and
+    // the median costs a sort of the whole series - five figures long on a long window.
+    private readonly Dictionary<object, double> _sampleSpanCache = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Seconds of line time one loss/latency sample speaks for.
+    /// <para>
+    /// These series arrive ALREADY aggregated: a sample stamped T is the mean of every probe that
+    /// completed in (T-A, T], and each of those spent a ping burst measuring before it completed, so
+    /// the sample covers (T-A-P, T]. Where inside that span the lossy probe actually sat is gone with
+    /// the aggregation - which is why attribution across a speed test's handover is PROPORTIONAL
+    /// rather than exclusive. Recovering the instant would mean reading the loss series unaggregated
+    /// inside the loaded windows.
+    /// </para>
+    /// </summary>
+    private double SampleSpanSeconds(IReadOnlyList<LatencySample> series)
+    {
+        if (_sampleSpanCache.TryGetValue(series, out var cached)) return cached;
+
+        var probe = (double)Math.Max(1, _options.LoadedProbeSpanSeconds);
+        if (series.Count < 2) return _sampleSpanCache[series] = probe;
+
+        var gaps = new List<double>(series.Count - 1);
+        for (var i = 1; i < series.Count; i++)
+        {
+            var gap = (series[i].Time - series[i - 1].Time).TotalSeconds;
+            if (gap > 0) gaps.Add(gap);
+        }
+        if (gaps.Count == 0) return _sampleSpanCache[series] = probe;
+        gaps.Sort();
+        var aggregate = SeriesStats.MedianSorted(gaps) ?? 0;
+        return _sampleSpanCache[series] =
+            Math.Clamp(aggregate + probe, probe, Math.Max(probe, _options.LoadedProbeSpanMaxSeconds));
+    }
+
+    /// <summary>Median spacing of the WAN rate series, floored at the load window.</summary>
+    private int RateSampleSeconds(IspHealthInputs inputs)
+    {
+        if (_rateSampleSeconds is { } cached) return cached;
+
+        var floor = Math.Max(1, _options.LoadWindowSeconds);
+        var rates = inputs.WanRates;
+        if (rates.Count < 2) return (_rateSampleSeconds = floor).Value;
+
+        var gaps = new List<double>(rates.Count - 1);
+        for (var i = 1; i < rates.Count; i++)
+        {
+            var gap = (rates[i].Time - rates[i - 1].Time).TotalSeconds;
+            if (gap > 0) gaps.Add(gap);
+        }
+        gaps.Sort();
+        var median = SeriesStats.MedianSorted(gaps);
+        _rateSampleSeconds = median is > 0 ? Math.Max(floor, (int)Math.Round(median.Value)) : floor;
+        return _rateSampleSeconds.Value;
     }
 
     private DateTime FloorToWindow(DateTime time) =>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/IspHealthService.cs
@@ -64,6 +64,12 @@ public class IspHealthService
     // Configured target window (hours), cached from MonitoringSettings on each auto-compute so the
     // dashboard tile and tab can read it without a DB hit. 0 until the first auto-compute runs.
     private volatile int _configuredWindowHours;
+    /// <summary>Connected agents, for naming the boxes a policy route might steer. Null in tests.</summary>
+    private readonly AgentTunnelRegistry? _tunnelRegistry;
+    /// <summary>Resolves which box actually probes the unassigned targets. Null in tests.</summary>
+    private readonly AgentProbeResultSink? _probeSink;
+    /// <summary>Tells a gateway-resident agent from one on the LAN. Null in tests.</summary>
+    private readonly AgentOnGatewayDetector? _onGatewayDetector;
 
     public IspHealthService(
         MonitoringInfluxRegistry influxRegistry,
@@ -72,9 +78,15 @@ public class IspHealthService
         SiteConnectionRegistry siteConnections,
         PhysicalLinkResolver physicalLinkResolver,
         ILogger<IspHealthService> logger,
+        AgentTunnelRegistry? tunnelRegistry = null,
+        AgentProbeResultSink? probeSink = null,
+        AgentOnGatewayDetector? onGatewayDetector = null,
         string siteSlug = SiteManagementService.DefaultSiteSlug,
         string? wanInterface = null)
     {
+        _tunnelRegistry = tunnelRegistry;
+        _probeSink = probeSink;
+        _onGatewayDetector = onGatewayDetector;
         _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
         _isDefault = _siteSlug == SiteManagementService.DefaultSiteSlug;
         _scopedWanKey = string.IsNullOrWhiteSpace(wanInterface)
@@ -1463,9 +1475,9 @@ public class IspHealthService
         List<MonitoringTarget> targets, string wanKey, bool includeUnassigned) =>
         // Keys normalized ("wan1" == "wan"): legacy installs stamped rows with the wan1 alias,
         // and an unnormalized comparison would silently drop them from their own report.
-        targets.Where(t => string.IsNullOrEmpty(t.WanInterface)
+        targets.Where(t => MonitoringTarget.IsUnpinned(t.WanInterface)
                 ? includeUnassigned
-                : string.Equals(GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface),
+                : string.Equals(GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!),
                     GatewayWanHelper.WanInterfaceKeyFromKey(wanKey), StringComparison.OrdinalIgnoreCase))
             .ToList();
 
@@ -2002,6 +2014,139 @@ public class IspHealthService
     }
 
     /// <summary>
+    /// Creates the vantage a policy route already justifies, and hands it the unpinned targets it
+    /// describes.
+    /// <para>
+    /// Load-balancing sites only. There an unpinned probe took whichever WAN the balancer picked,
+    /// so its readings belong to no WAN - unless the operator steered that box down one on the
+    /// gateway, which is an attribution that exists and only we were missing. The route names a
+    /// MAC, so the vantage binds to the box it actually pins rather than to a guess.
+    /// </para>
+    /// <para>
+    /// Short-circuits once a vantage covers the pinned WAN, which makes it idempotent: the first
+    /// run creates it and every later one finds it and stops. Best effort in every direction - any
+    /// gap and the targets stay unpinned, which is still the truthful answer here. Caller saves.
+    /// </para>
+    /// </summary>
+    private async Task CreateVantageForRoutedProbesAsync(
+        NetworkOptimizerDbContext db, IReadOnlyList<NetworkInfo> networks, CancellationToken ct)
+    {
+        try
+        {
+            // Belt and braces on top of the load-balance flag: a site with one WAN has nothing to
+            // balance across, so whatever that flag says, an unpinned probe there took the only
+            // WAN there is. Never let a mis-resolved flag mint a vantage on a single-WAN site.
+            var wanCount = networks.Count(n => n.IsWan && n.Enabled);
+            if (wanCount < 2)
+            {
+                _logger.LogDebug(
+                    "Routed-probe vantage: site has {Count} enabled WAN(s); nothing to attribute", wanCount);
+                return;
+            }
+
+            var unpinnedCount = await db.MonitoringTargets.CountAsync(
+                t => t.WanContextId == null
+                    && t.TargetType != MonitoringTargetType.Fabric
+                    && (t.WanInterface == null || t.WanInterface == MonitoringTarget.UnpinnedWan), ct);
+            if (unpinnedCount == 0) return;
+
+            var api = _connectionService.Client;
+            if (api == null) return;
+
+            var routes = await api.GetTrafficRoutesAsync(ct);
+            if (routes.Count == 0) return;
+
+            var hosts = ProbeHosts();
+            var plan = PinnedProbeContextBuilder.Build(
+                routes, networks, await api.GetClientsAsync(ct), hosts);
+            if (plan == null)
+            {
+                _logger.LogDebug(
+                    "Routed-probe vantage: {Count} unpinned target(s), but no all-destinations route "
+                    + "names any of this site's {Hosts} probing box(es)", unpinnedCount, hosts.Count);
+                return;
+            }
+
+            // The route has to pin the box that ACTUALLY probes these targets. A route steering the
+            // server says nothing about an agent's probes, and binding the vantage to the wrong box
+            // is worse than saying nothing: a target whose vantage names an agent that is not the
+            // one asking gets pushed to nobody, so it would stop being probed entirely.
+            var collector = _probeSink == null ? null : await _probeSink.GetCollectorAgentIdAsync(_siteSlug, ct);
+            if (plan.AgentId != collector)
+            {
+                _logger.LogDebug(
+                    "Routed-probe vantage: the route pins {Pinned}, but {Collector} probes the unpinned "
+                    + "targets - the route says nothing about those probes",
+                    plan.AgentId?.ToString() ?? "the server",
+                    collector?.ToString() ?? "the server");
+                return;
+            }
+
+            // Last, because it is the only question here that can cost a console round trip: a
+            // gateway-resident agent binds its probe source directly and needs no policy route, so
+            // a route appearing to name it is a coincidence rather than the steering we are after.
+            if (_onGatewayDetector != null
+                && await _onGatewayDetector.IsIpOnGatewayAsync(_siteSlug, plan.MatchedLanIp, ct))
+            {
+                _logger.LogDebug(
+                    "Routed-probe vantage: {Ip} is the gateway itself, which binds its own probe source - "
+                    + "no policy route needed or believed", plan.MatchedLanIp);
+                return;
+            }
+
+            // Already covered: nothing to create, and nothing to adopt that the existing vantage
+            // did not already take.
+            var existing = await db.WanContexts.FirstOrDefaultAsync(
+                c => c.WanInterface == plan.WanInterface, ct);
+            if (existing != null)
+            {
+                _logger.LogDebug(
+                    "Routed-probe vantage: '{Name}' already covers {Wan}; leaving it alone",
+                    existing.Name, plan.WanInterface);
+                return;
+            }
+
+            var vantage = new WanContext
+            {
+                Name = plan.ContextName,
+                Description = "Created automatically: a policy route sends this site's probes out this WAN.",
+                AgentId = plan.AgentId,
+                WanInterface = plan.WanInterface,
+                CreatedAt = DateTime.UtcNow,
+            };
+            db.WanContexts.Add(vantage);
+            await db.SaveChangesAsync(ct);
+
+            var moved = await PrimaryWanVantageAdoption.AdoptUnpinnedTargetsAsync(db, vantage, ct);
+            _logger.LogInformation(
+                "Routed-probe vantage: created '{Name}' for {Wan} (agent {Agent}, kill switch {Kill}) "
+                + "and gave it {Count} unpinned target(s)",
+                vantage.Name, plan.WanInterface, plan.AgentId?.ToString() ?? "server",
+                plan.KillSwitchEnabled ? "on" : "off", moved);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not check whether a policy route routes this site's probes");
+        }
+    }
+
+    /// <summary>
+    /// Every box that probes for this site: its connected agents on the addresses they announced,
+    /// and the server on its own. A route names a MAC, so the candidates are what let a match say
+    /// WHICH box is steered rather than only that one is.
+    /// </summary>
+    private List<PinnedProbeContextBuilder.ProbeHost> ProbeHosts()
+    {
+        var hosts = (_tunnelRegistry?.GetForSite(_siteSlug) ?? new List<AgentTunnelConnection>())
+            .Where(c => !string.IsNullOrWhiteSpace(c.LanIp))
+            .Select(c => new PinnedProbeContextBuilder.ProbeHost(c.AgentId, c.LanIp))
+            .ToList();
+        hosts.Add(new PinnedProbeContextBuilder.ProbeHost(
+            null, NetworkUtilities.GetAllLocalIpAddresses().FirstOrDefault()));
+        return hosts;
+    }
+
+    /// <summary>
     /// Stores this WAN's expected speeds so they outlive the console connection. One row per WAN
     /// group; a rename changes the display name, not the identity.
     /// </summary>
@@ -2066,6 +2211,13 @@ public class IspHealthService
                 }
                 row.IsPrimary = string.Equals(row.WanNetworkgroup, primaryGroup, StringComparison.OrdinalIgnoreCase);
                 row.SiteLoadBalances = loadBalances;
+
+                // Only where the attribution is genuinely lost. A failover site's unpinned probes
+                // already read as the primary, so there is nothing to recover and no vantage worth
+                // creating; a load-balancing site's took whichever WAN the balancer picked, and a
+                // policy route is the only thing that can say which.
+                if (loadBalances)
+                    await CreateVantageForRoutedProbesAsync(db, networks, ct);
             }
             await db.SaveChangesAsync(ct);
         }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/IspHealth/LoadClassifier.cs
@@ -71,7 +71,8 @@ public static class LoadClassifier
                 && peak.Down < options.IdleThresholdFraction * expectedDownBps.Value
                 && peak.Up < options.IdleThresholdFraction * expectedUpBps.Value;
 
-            result[key] = new LoadWindow(idle, loadedDown, loadedUp);
+            // Recorded twice: DemoteIsolated clears the live flags, never the classified pair.
+            result[key] = new LoadWindow(idle, loadedDown, loadedUp, loadedDown, loadedUp);
         }
 
         // Demote loaded windows that stand alone. A saturating transfer holds across consecutive

--- a/src/NetworkOptimizer.Web/Services/Monitoring/LocalTargetResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/LocalTargetResolver.cs
@@ -1,0 +1,138 @@
+﻿using System.Net;
+using System.Net.Sockets;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Settles whether a target sits on the local network, once, and writes the answer down.
+/// <para>
+/// A literal address answers itself. A hostname does not - "cloudkey.local" and
+/// "speedtest.example.net" are the same shape - so it is resolved to the address it actually
+/// reaches and judged on that. Kept because it almost never changes and because the alternative is
+/// a DNS lookup on every read of a column three different features consult.
+/// </para>
+/// </summary>
+public static class LocalTargetResolver
+{
+    /// <summary>How many unresolved targets one sweep will look up, so a site with a long list of
+    /// dead hostnames cannot spend a whole tick on DNS.</summary>
+    private const int SweepBatchSize = 25;
+
+    /// <summary>
+    /// Whether a target is on the local network.
+    /// <para>
+    /// The address is the last question asked, not the first. What a target IS, and which WAN it is
+    /// already filed under, both answer this outright - and an address cannot, because plenty of
+    /// upstream things wear a private one. A cable modem's first hop lives on 192.168.100.1 and a
+    /// CGNAT first mile on 100.64/10; neither is on this network, and both would read as local if
+    /// the address went first.
+    /// </para>
+    /// </summary>
+    public static bool IsLocal(MonitoringTarget target) =>
+        IsLocal(target.TargetType, target.Address, target.IsLocal, target.WanInterface);
+
+    /// <summary>
+    /// The same question from loose fields, for callers projecting columns rather than loading
+    /// entities.
+    /// </summary>
+    /// <param name="targetType">What the target is; only a Custom one is ambiguous.</param>
+    /// <param name="address">The configured address.</param>
+    /// <param name="isLocal">What that address resolved to, or null when nothing has settled it.</param>
+    /// <param name="wanInterface">The WAN it is filed under, if it is filed under one.</param>
+    public static bool IsLocal(
+        MonitoringTargetType targetType, string? address, bool? isLocal, string? wanInterface)
+    {
+        // The discovered gateway, switches and APs: local by what they are.
+        if (targetType == MonitoringTargetType.Fabric) return true;
+
+        // Carrying a WAN means something measured it over that WAN, which settles it.
+        if (!MonitoringTarget.IsUnpinned(wanInterface)) return false;
+
+        // Access ISP, Transit and Internet Service are upstream by classification - the first mile
+        // is not this network however its address reads. Custom is the only type that could be
+        // either, so it is the only one the address gets a say in.
+        if (targetType != MonitoringTargetType.Custom) return false;
+
+        return isLocal ?? NetworkUtilities.IsPrivateIpAddress(address ?? string.Empty);
+    }
+
+    /// <summary>
+    /// Resolves one address to a local/not-local answer and the address it answered on, or nulls
+    /// when DNS cannot say. Never throws: an unanswerable name leaves the target unresolved rather
+    /// than wrongly settled. The resolved IP comes back so callers can say WHY in a log - a wrong
+    /// verdict is almost always a surprising IP rather than a bad rule.
+    /// </summary>
+    /// <param name="address">The target's address, a literal or a hostname.</param>
+    /// <param name="logger">Optional, for reporting a lookup that failed outright.</param>
+    /// <param name="ct">Cancellation.</param>
+    public static async Task<(bool? IsLocal, string? ResolvedIp)> ResolveAsync(
+        string? address, ILogger? logger = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(address)) return (null, null);
+        var name = address.Trim();
+        try
+        {
+            // A literal answers itself; only a name needs asking.
+            var answers = IPAddress.TryParse(name, out var literal)
+                ? new[] { literal }
+                : await Dns.GetHostAddressesAsync(name, ct);
+
+            var chosen = NetworkUtilities.SelectUsableAddress(answers);
+            if (chosen is null)
+            {
+                logger?.LogDebug(
+                    "Local check: {Address} did not resolve to a usable address, so whether it is local "
+                    + "is still unknown", address);
+                return (null, null);
+            }
+
+            return (NetworkUtilities.IsPrivateIpAddress(chosen), chosen.ToString());
+        }
+        catch (Exception ex)
+        {
+            logger?.LogDebug(ex, "Local check: looking up {Address} failed; leaving it unresolved", address);
+            return (null, null);
+        }
+    }
+
+    /// <summary>
+    /// Resolves targets that have no answer yet. Returns how many were settled. Only touches nulls,
+    /// so it costs nothing once a site is resolved and needs no run-once bookkeeping. Caller saves.
+    /// </summary>
+    /// <param name="db">The site's database.</param>
+    /// <param name="ct">Cancellation.</param>
+    public static async Task<int> SweepUnresolvedAsync(
+        NetworkOptimizerDbContext db, ILogger? logger = null, CancellationToken ct = default)
+    {
+        // Only Custom rows: everything else is decided by what it is or by the WAN it carries, so
+        // resolving their addresses would spend DNS on an answer nothing reads.
+        var pending = await db.MonitoringTargets
+            .Where(t => t.IsLocal == null && t.TargetType == MonitoringTargetType.Custom)
+            .OrderBy(t => t.Id)
+            .Take(SweepBatchSize)
+            .ToListAsync(ct);
+        if (pending.Count == 0) return 0;
+
+        var settled = 0;
+        foreach (var target in pending)
+        {
+            if (ct.IsCancellationRequested) break;
+            var (answer, ip) = await ResolveAsync(target.Address, logger, ct);
+            if (answer == null) continue;
+            target.IsLocal = answer;
+            settled++;
+            // Per target, because this is the moment a target changes which side of the LAN/WAN
+            // line it falls on - and that decides where it appears, whether a vantage may adopt
+            // it, and whether a metered WAN may slow it. A count alone cannot answer "why is this
+            // one over there".
+            logger?.LogInformation(
+                "Local check: {Name} ({Address}) resolved to {Ip} - {Verdict}",
+                target.Name, target.Address, ip, answer.Value ? "on this network" : "reached over a WAN");
+        }
+        return settled;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Monitoring.Probes;
@@ -228,9 +228,9 @@ public class MonitoringAlertEvaluator
         // choice the page's own LAN jump makes. A stamped target names its WAN.
         if (target.TargetType == MonitoringTargetType.Fabric)
             return $"{url}&wan={LiveWanScope.AllWansToken}";
-        return string.IsNullOrEmpty(target.WanInterface)
+        return MonitoringTarget.IsUnpinned(target.WanInterface)
             ? url
-            : $"{url}&wan={Uri.EscapeDataString(target.WanInterface)}";
+            : $"{url}&wan={Uri.EscapeDataString(target.WanInterface!)}";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringLinks.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringLinks.cs
@@ -1,4 +1,4 @@
-namespace NetworkOptimizer.Web.Services.Monitoring;
+﻿namespace NetworkOptimizer.Web.Services.Monitoring;
 
 /// <summary>
 /// The links the Live surfaces build into the analysis views.
@@ -30,22 +30,24 @@ public static class MonitoringLinks
     /// LAN and Custom targets are not reached over any one WAN, so those views ask for all of them
     /// rather than narrowing to whichever WAN the tiles happened to be showing.
     /// </para>
+    /// <para>
+    /// The WAN fragment is asked of the scope rather than rebuilt here. This method once took the
+    /// selection apart and reassembled it, which drifted from the scope's own rule: it emitted a
+    /// filter whenever a key was selected, where the scope emits one only when the site has a
+    /// choice worth carrying. Two spellings of one rule is what this class exists to prevent, so
+    /// it does not get to keep a second copy of that one either.
+    /// </para>
     /// </summary>
     /// <param name="category">Chart category to open.</param>
     /// <param name="at">A Unix-ms instant, or <see cref="LiveAtToken"/>.</param>
-    /// <param name="selectedWanKeys">The WANs on screen. Empty on a single-WAN site.</param>
-    /// <param name="allSelected">Whether that selection is every WAN the site has.</param>
-    public static string Analysis(
-        string category, string at, IReadOnlyCollection<string> selectedWanKeys, bool allSelected)
+    /// <param name="wanScope">The WAN selection on screen, which writes its own query fragment.</param>
+    public static string Analysis(string category, string at, LiveWanScope wanScope)
     {
-        var wan = category is FabricCategory or CustomCategory || allSelected
+        var spansEveryWan = category is FabricCategory or CustomCategory
             ? LiveWanScope.AllWansToken
-            : string.Join(",", selectedWanKeys);
-
-        var wanQuery = selectedWanKeys.Count > 0 && wan.Length > 0
-            ? $"&wan={Uri.EscapeDataString(wan)}"
-            : "";
-        return $"/monitoring?tab=performance&category={category}&at={at}{wanQuery}";
+            : null;
+        return $"/monitoring?tab=performance&category={category}&at={at}"
+            + wanScope.QueryFragment(spansEveryWan);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringPathView.cs
@@ -89,7 +89,8 @@ public class MonitoringPathView
             .Where(t => t.TargetType == MonitoringTargetType.AccessIsp
                         && t.Enabled
                         && (t.WanInterface == resolvedWanInterface
-                            || (isPrimary && t.WanInterface == null)))
+                            || (isPrimary && (t.WanInterface == null
+                                || t.WanInterface == MonitoringTarget.UnpinnedWan))))
             .OrderBy(t => t.Id)
             .ToListAsync(ct);
 
@@ -131,7 +132,8 @@ public class MonitoringPathView
             var transitRows = await db.MonitoringTargets.AsNoTracking()
                 .Where(t => t.TargetType == MonitoringTargetType.Transit
                             && t.Enabled
-                            && (t.WanInterface == resolvedWanInterface || t.WanInterface == null))
+                            && (t.WanInterface == resolvedWanInterface || t.WanInterface == null
+                                || t.WanInterface == MonitoringTarget.UnpinnedWan))
                 .OrderBy(t => t.AsnNumber)
                 .ToListAsync(ct);
 
@@ -261,14 +263,14 @@ public class MonitoringPathView
                     var wanSpeed = wan.Speed is int s && s > 0 ? s : 0;
 
                     string? interfaceKey = null;
-                    string? friendlyName = null;
+                    string? portName = null;
                     int linkSpeed = wanSpeed;
 
                     if (wan.PortIdx.HasValue &&
                         portInfo.TryGetValue(wan.PortIdx.Value, out var pi))
                     {
                         interfaceKey = pi.networkName;
-                        friendlyName = pi.name;
+                        portName = pi.name;
                         if (linkSpeed == 0 && pi.speed > 0) linkSpeed = pi.speed;
                     }
 
@@ -276,19 +278,16 @@ public class MonitoringPathView
                     // same as uplinkIfname for non-VLAN connections).
                     var physicalIfname = wan.IfName;
 
-                    // For virtual WANs (GRE, etc.) without port_table entries,
-                    // resolve the friendly name from WAN network configs via
-                    // ethernet_overrides networkgroup or wan key convention.
-                    if (string.IsNullOrEmpty(friendlyName))
-                    {
-                        var lookupIfname = physicalIfname ?? uplinkIfname;
-                        string? networkGroup = null;
-                        if (!string.IsNullOrEmpty(lookupIfname) && ifnameToNetworkGroup.TryGetValue(lookupIfname, out var ng))
-                            networkGroup = ng;
-                        networkGroup ??= GatewayWanHelper.WanNetworkGroupFromKey(wan.Key);
-                        if (networkGroupToName.TryGetValue(networkGroup, out var configName))
-                            friendlyName = configName;
-                    }
+                    // The WAN network's own name, via ethernet_overrides networkgroup or the wan
+                    // key convention. Virtual WANs (GRE and the like) have no port_table entry, so
+                    // this is the only name they have; GatewayWanHelper decides which one wins.
+                    var lookupIfname = physicalIfname ?? uplinkIfname;
+                    string? networkGroup = null;
+                    if (!string.IsNullOrEmpty(lookupIfname) && ifnameToNetworkGroup.TryGetValue(lookupIfname, out var ng))
+                        networkGroup = ng;
+                    networkGroup ??= GatewayWanHelper.WanNetworkGroupFromKey(wan.Key);
+                    networkGroupToName.TryGetValue(networkGroup, out var configName);
+                    var friendlyName = GatewayWanHelper.ResolveWanName(configName, portName);
 
                     interfaceKey ??= GatewayWanHelper.WanInterfaceKeyFromKey(wan.Key);
 
@@ -299,7 +298,9 @@ public class MonitoringPathView
                         IsPrimary = false,
                         Up = wan.Up,
                         GatewayMac = gwMac,
-                        GatewayPortName = friendlyName,
+                        // The port, not the display name - unchanged from before the two were split:
+                        // the port's own name where there is one, the network's for a virtual WAN.
+                        GatewayPortName = portName ?? configName,
                         UplinkIfName = uplinkIfname,
                         PhysicalIfName = physicalIfname,
                         LinkSpeedMbps = linkSpeed > 0 ? linkSpeed : (int?)null,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PinnedProbeContextBuilder.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PinnedProbeContextBuilder.cs
@@ -1,0 +1,102 @@
+using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Which WAN a policy route pins a site's probing to, and which box that route names.
+/// <para>
+/// Only load-balancing sites need it. There an unpinned probe measures no single WAN, so its
+/// targets are unattributable - unless the operator has already steered the probing box down one
+/// WAN on the gateway. The route names a MAC, so it identifies the box as well as the WAN: the
+/// vantage it justifies is bound to whoever the route actually pins, never to a guess.
+/// </para>
+/// </summary>
+public static class PinnedProbeContextBuilder
+{
+    /// <summary>A box that probes for this site, and the LAN address the gateway knows it by.</summary>
+    /// <param name="AgentId">The agent, or null for the Network Optimizer server itself.</param>
+    /// <param name="LanIp">The address to look up in the client cache.</param>
+    public sealed record ProbeHost(int? AgentId, string? LanIp);
+
+    /// <summary>What a policy route pins, and which of this site's probing boxes it names.</summary>
+    /// <param name="WanInterface">Normalized WAN key the targets get stamped with.</param>
+    /// <param name="ContextName">Name for the vantage, taken from the WAN so it reads like the others.</param>
+    /// <param name="AgentId">
+    /// The agent whose probes the route steers, or null when it is the server's. This is what the
+    /// vantage binds to - a vantage naming no agent on an agent-collected site would have its
+    /// targets pushed to nobody.
+    /// </param>
+    /// <param name="KillSwitchEnabled">False means a failover re-routes while the stamp stays put.</param>
+    /// <param name="MatchedLanIp">
+    /// The address of the box the route named. Carried so a caller can run its one expensive
+    /// question - is this box the gateway itself? - against a single host, after the cheap
+    /// in-memory matching has already settled which one it is.
+    /// </param>
+    public sealed record Plan(
+        string WanInterface, string ContextName, int? AgentId, bool KillSwitchEnabled, string? MatchedLanIp);
+
+    /// <summary>
+    /// The vantage to create for whichever probing box a route pins, or null when none is pinned.
+    /// Pure, so the whole decision is testable without a console: callers fetch the routes,
+    /// clients and networks, and enumerate their probing boxes.
+    /// </summary>
+    /// <param name="routes">The site's traffic routes.</param>
+    /// <param name="networks">The site's networks, for turning a route's network id into a WAN.</param>
+    /// <param name="clients">The site's clients, for turning each box's address into a MAC.</param>
+    /// <param name="hosts">Every box that probes for this site - the server and any agents.</param>
+    public static Plan? Build(
+        IEnumerable<UniFiTrafficRouteResponse> routes,
+        IEnumerable<NetworkInfo> networks,
+        IEnumerable<UniFiClientResponse> clients,
+        IEnumerable<ProbeHost> hosts)
+    {
+        var routeList = routes as IList<UniFiTrafficRouteResponse> ?? routes.ToList();
+        var clientList = clients as IList<UniFiClientResponse> ?? clients.ToList();
+        var networkList = networks as IList<NetworkInfo> ?? networks.ToList();
+
+        foreach (var host in hosts)
+        {
+            var mac = MacForAddress(clientList, host.LanIp);
+            if (mac == null) continue;
+
+            var pin = TrafficRouteWanPinning.ResolvePin(routeList, mac);
+            if (pin == null) continue;
+
+            // The route names a network id; only a WAN one says anything. A route onto a LAN or a
+            // VPN network is a different feature entirely.
+            var network = networkList.FirstOrDefault(n =>
+                string.Equals(n.Id, pin.NetworkId, StringComparison.OrdinalIgnoreCase));
+            if (network == null || !network.IsWan || string.IsNullOrEmpty(network.WanNetworkgroup)) continue;
+
+            var key = GatewayWanHelper.WanInterfaceKeyFromKey(network.WanNetworkgroup);
+            var label = string.IsNullOrWhiteSpace(network.Name) ? key : network.Name;
+            return new Plan(key, label, host.AgentId, pin.KillSwitchEnabled, host.LanIp);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The MAC the client cache holds for an address. LastIp is deliberately not consulted: it is
+    /// stale by definition and would hand back whichever device used to hold the address.
+    /// </summary>
+    /// <param name="clients">The site's clients.</param>
+    /// <param name="ip">The address to look up.</param>
+    public static string? MacForAddress(IEnumerable<UniFiClientResponse> clients, string? ip)
+    {
+        if (string.IsNullOrWhiteSpace(ip)) return null;
+        var wanted = ip.Trim();
+        var matches = clients
+            .Where(c => !string.IsNullOrEmpty(c.Mac)
+                && (string.Equals(c.Ip, wanted, StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(c.FixedIp, wanted, StringComparison.OrdinalIgnoreCase)))
+            .Select(c => c.Mac)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        // Exactly one or nothing. Two devices claiming an address is a site problem, and picking
+        // one of them would pin the targets to whichever WAN the wrong box uses.
+        return matches.Count == 1 ? matches[0] : null;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/PrimaryWanVantageAdoption.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/PrimaryWanVantageAdoption.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Helpers;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Pulls a site's unpinned targets into the vantage that measures the primary WAN, the moment one
+/// exists.
+/// <para>
+/// An unpinned probe leaves by the box's own route, which on a failover site is the primary. Once
+/// a vantage measures that WAN, those targets belong to it - left out they sit in a bucket the
+/// vantage's own report cannot see, which is the opposite of what creating it was for. Their
+/// history follows: the Influx series is keyed on target id, which does not change, and the
+/// primary's WAN scope already ORs untagged points with its vantage's tag.
+/// </para>
+/// </summary>
+public static class PrimaryWanVantageAdoption
+{
+    /// <summary>
+    /// Whether an unpinned target can honestly be called this WAN's.
+    /// <para>
+    /// On a failover site, yes: unpinned means the primary except for the length of an outage. On
+    /// a load-balancing site it means no single WAN, and only a policy route pinning the probing
+    /// box makes it this one - which the caller resolves and passes as
+    /// <paramref name="routePinsProbesToPrimary"/>.
+    /// </para>
+    /// </summary>
+    public static bool ShouldAdopt(bool siteLoadBalances, bool routePinsProbesToPrimary) =>
+        !siteLoadBalances || routePinsProbesToPrimary;
+
+    /// <summary>
+    /// Moves every unpinned target that actually leaves by a WAN onto this vantage. Returns how
+    /// many moved. Caller saves.
+    /// <para>
+    /// LAN targets are left alone, and there are two kinds. Fabric is the discovered gateway,
+    /// switches and APs. The other is a hand-added target pointing at a private address - a
+    /// controller, a NAS, anything on the same network - which is every bit as much a LAN
+    /// measurement even though its type says Custom. Neither traverses a WAN, so filing them under
+    /// one would say their latency is that WAN's.
+    /// </para>
+    /// <para>
+    /// A LAN host named by hostname rather than address is not recognised here and will be
+    /// adopted; the address is all this has to go on.
+    /// </para>
+    /// </summary>
+    /// <param name="db">The site's database.</param>
+    /// <param name="vantage">The vantage measuring the primary WAN; must already have its Id.</param>
+    /// <param name="ct">Cancellation.</param>
+    public static async Task<int> AdoptUnpinnedTargetsAsync(
+        NetworkOptimizerDbContext db, WanContext vantage, CancellationToken ct = default)
+    {
+        if (vantage.Id == 0 || string.IsNullOrEmpty(vantage.WanInterface)) return 0;
+
+        // Two kinds of row belong to this vantage, and nothing on screen told them apart: one that
+        // names no WAN, and one the primary's own discovery already stamped with this WAN but
+        // never gave a vantage. Both read as "Default path" in the target list, because that
+        // control shows the CONTEXT; taking only the first left the other sitting there looking
+        // identical and untouched.
+        var vantageKey = GatewayWanHelper.WanInterfaceKeyFromKey(vantage.WanInterface!);
+        var unpinned = (await db.MonitoringTargets
+            .Where(t => t.WanContextId == null && t.TargetType != MonitoringTargetType.Fabric)
+            .ToListAsync(ct))
+            .Where(t => !IsLanTarget(t)
+                && (MonitoringTarget.IsUnpinned(t.WanInterface)
+                    || string.Equals(GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!),
+                        vantageKey, StringComparison.OrdinalIgnoreCase)))
+            .ToList();
+
+        foreach (var target in unpinned)
+            WanContextTargetStamping.ApplyAssignment(target, vantage.Id, vantage.WanInterface);
+
+        return unpinned.Count;
+    }
+
+    /// <summary>
+    /// Whether a target measures something on this network rather than out through a WAN. Answered
+    /// by <see cref="LocalTargetResolver"/>, which prefers what was resolved and settled for this
+    /// target over what its address happens to look like.
+    /// </summary>
+    public static bool IsLanTarget(MonitoringTarget target) => LocalTargetResolver.IsLocal(target);
+
+    /// <summary>
+    /// Whether this vantage measures the site's primary WAN, which is the only one whose unpinned
+    /// targets it can claim. Null when the primary is unknown, and an unknown primary claims
+    /// nothing.
+    /// </summary>
+    public static bool MeasuresPrimaryWan(WanContext vantage, string? primaryWanKey) =>
+        !string.IsNullOrEmpty(primaryWanKey)
+        && !string.IsNullOrEmpty(vantage.WanInterface)
+        && string.Equals(
+            GatewayWanHelper.WanInterfaceKeyFromKey(vantage.WanInterface!),
+            GatewayWanHelper.WanInterfaceKeyFromKey(primaryWanKey!),
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamRediscoveryService.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 
@@ -120,6 +120,22 @@ public class UpstreamRediscoveryService : BackgroundService
             : _siteDbFactory.CreateForSite(slug, isDefault: false);
         var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
         if (settings == null || !settings.Enabled) return;
+
+        // Settle any target whose address has not been resolved to a local/not-local answer yet.
+        // A batch at a time, nulls only, so it costs nothing once a site is settled.
+        try
+        {
+            var settled = await LocalTargetResolver.SweepUnresolvedAsync(db, _logger, ct);
+            if (settled > 0)
+            {
+                await db.SaveChangesAsync(ct);
+                _logger.LogDebug("Resolved {Count} target(s) as local or not for site {Slug}", settled, slug);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not resolve local targets for site {Slug} this tick", slug);
+        }
 
         // Keep Custom/Internet witness targets' ancestry filled and fresh every tick (hourly),
         // independent of the 7-day full re-discovery cadence below. They aren't part of the sweep,
@@ -625,7 +641,8 @@ public class UpstreamRediscoveryService : BackgroundService
                     || t.TargetType == MonitoringTargetType.Transit
                     || t.TargetType == MonitoringTargetType.InternetService)
                 && (t.DiscoveryMethod == DiscoveryMethod.UserProvided
-                    ? (t.WanInterface == wanInterface || t.WanInterface == null || t.WanInterface == "")
+                    ? (t.WanInterface == wanInterface || t.WanInterface == null || t.WanInterface == ""
+                        || t.WanInterface == MonitoringTarget.UnpinnedWan)
                     : t.WanInterface == wanInterface))
             .ToListAsync(ct);
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
@@ -2510,6 +2510,8 @@ public class UpstreamTracerService
         // context says who probes them. Setting them together is what closes the gap where a
         // context's targets had a context but no WAN, so no per-WAN reader could find them.
         var wanContextId = _binding?.WanContextId;
+        // Unpinned rows are the unbound run's alone - see OwnsTargetRow.
+        var isUnboundRun = _binding == null;
 
         // What this WAN's probing costs. Targets are created at the plan's cadence, and on a
         // metered WAN the ones already here are slowed to match - a link that has just been
@@ -2538,14 +2540,14 @@ public class UpstreamTracerService
         foreach (var hop in State.AccessHops.Where(h => h.Enabled))
         {
             _logger.LogDebug("Commit access hop: id={TargetId} label='{Label}' addr={Address}", hop.TargetId, hop.Label, hop.Address);
-            await UpsertTargetAsync(db, hop, wanInterface, wanContextId, ct, probePlan.PollIntervalSeconds);
+            await UpsertTargetAsync(db, hop, wanInterface, wanContextId, ct, probePlan.PollIntervalSeconds, isUnboundRun);
         }
         foreach (var hop in State.AccessHops.Where(h => !h.Enabled))
         {
             // With per-WAN twin rows an address can have several rows; pause only the one this
             // WAN owns (another WAN's row - and its measuring - is that WAN's to manage).
             var existing = (await db.MonitoringTargets.Where(t => t.Address == hop.Address).ToListAsync(ct))
-                .FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface));
+                .FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
             if (existing != null)
             {
                 existing.Enabled = false;
@@ -2558,7 +2560,7 @@ public class UpstreamTracerService
             _logger.LogDebug("Commit transit: id={TargetId} label='{Label}' addr={Address} method={Method}",
                 transit.TargetId, transit.Label, transit.HopAddress ?? transit.PathProxyTarget, transit.Method);
             await UpsertTransitTargetAsync(db, transit, wanInterface, wanContextId, ct,
-                pollIntervalSeconds: probePlan.PollIntervalSeconds);
+                pollIntervalSeconds: probePlan.PollIntervalSeconds, isUnboundRun: isUnboundRun);
         }
         foreach (var transit in State.TransitAsns.Where(t => !t.Enabled))
         {
@@ -2569,14 +2571,14 @@ public class UpstreamTracerService
             if (transit.Method == DiscoveryMethod.PathProxy)
             {
                 await UpsertTransitTargetAsync(db, transit, wanInterface, wanContextId, ct, enabled: false,
-                    pollIntervalSeconds: probePlan.PollIntervalSeconds);
+                    pollIntervalSeconds: probePlan.PollIntervalSeconds, isUnboundRun: isUnboundRun);
                 continue;
             }
             var addr = transit.HopAddress ?? transit.PathProxyTarget;
             if (string.IsNullOrEmpty(addr)) continue;
             // Same per-WAN row selection as the access-hop pause above.
             var existing = (await db.MonitoringTargets.Where(t => t.Address == addr).ToListAsync(ct))
-                .FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface));
+                .FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
             if (existing != null)
             {
                 existing.Enabled = false;
@@ -2653,15 +2655,19 @@ public class UpstreamTracerService
         // already slower than the plan, which is a deliberate choice of the operator's.
         if (probePlan.Rung > 0)
         {
-            var repaced = await db.MonitoringTargets
+            var candidates = await db.MonitoringTargets
                 .Where(t => t.TargetType != MonitoringTargetType.Fabric
                     && t.PollIntervalSeconds < probePlan.PollIntervalSeconds)
                 .ToListAsync(ct);
-            repaced = repaced.Where(t => OwnsTargetRow(t.WanInterface, wanInterface)).ToList();
+            var repaced = SelectTargetsToRepace(
+                candidates, probePlan.PollIntervalSeconds, wanInterface, isUnboundRun);
             foreach (var target in repaced) target.PollIntervalSeconds = probePlan.PollIntervalSeconds;
-            if (repaced.Count > 0)
-                _logger.LogInformation("Metered WAN {Wan}: slowed {Count} existing target(s) to {Interval}s",
-                    wanInterface, repaced.Count, probePlan.PollIntervalSeconds);
+            // Logged even at zero: the count is how an operator confirms this WAN reached only its
+            // own rows, which is the whole of the fix. Silence would look the same as not running.
+            _logger.LogInformation(
+                "Metered WAN {Wan} ({Unbound}): slowed {Count} of {Considered} faster target(s) to {Interval}s",
+                wanInterface, isUnboundRun ? "unbound run, owns unpinned rows" : "bound run, its own rows only",
+                repaced.Count, candidates.Count, probePlan.PollIntervalSeconds);
         }
 
         await db.SaveChangesAsync(ct);
@@ -2831,15 +2837,44 @@ public class UpstreamTracerService
             .FirstOrDefault();
     }
 
-    internal static bool OwnsTargetRow(string? rowWanInterface, string wanInterface)
-        => string.IsNullOrEmpty(rowWanInterface)
-           // Normalized ("wan1" == "wan"): legacy rows stamped with the wan1 alias are the SAME
-           // WAN as a "wan" run, not a rival - unnormalized, every re-run on such an install
-           // would twin its own targets.
-           || string.Equals(
-               NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(rowWanInterface),
-               NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wanInterface),
-               StringComparison.OrdinalIgnoreCase);
+    /// <summary>
+    /// The targets a metered WAN's commit slows: rows it owns that still probe faster than the
+    /// plan. Cadence is not indexed by WAN, so the read is site-wide and ownership is the only
+    /// thing keeping a metered WAN off other WANs' targets - and off LAN ones, which never touch
+    /// its data plan. Fabric never leaves the WAN; anything already slower is the operator's call.
+    /// </summary>
+    internal static List<MonitoringTarget> SelectTargetsToRepace(
+        IEnumerable<MonitoringTarget> candidates, int pollIntervalSeconds, string wanInterface, bool isUnboundRun) =>
+        candidates
+            .Where(t => t.TargetType != MonitoringTargetType.Fabric
+                && t.PollIntervalSeconds < pollIntervalSeconds
+                && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun))
+            .ToList();
+
+    /// <summary>
+    /// Whether a target row belongs to the WAN this discovery run is committing for. Reading an
+    /// unpinned row as "owned by whichever WAN is committing" let a metered secondary adopt the
+    /// site's hand-added targets and slow every one of them.
+    /// </summary>
+    /// <param name="rowWanInterface">The row's WAN, or unpinned.</param>
+    /// <param name="wanInterface">The WAN this run is committing for.</param>
+    /// <param name="isUnboundRun">
+    /// Whether this run has no <see cref="WanProbeBinding"/>, which is the only thing that owns
+    /// unpinned rows. Identity, not inference: a secondary is only ever traced through a context,
+    /// so a bound run is never the unpinned probes'. Deliberately avoids resolving a primary WAN
+    /// key, which no console-free path can know and which is not "wan" - any group holds the role.
+    /// </param>
+    internal static bool OwnsTargetRow(string? rowWanInterface, string wanInterface, bool isUnboundRun = true)
+    {
+        if (MonitoringTarget.IsUnpinned(rowWanInterface)) return isUnboundRun;
+        // Normalized ("wan1" == "wan"): legacy rows stamped with the wan1 alias are the SAME
+        // WAN as a "wan" run, not a rival - unnormalized, every re-run on such an install
+        // would twin its own targets.
+        return string.Equals(
+            NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(rowWanInterface!),
+            NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wanInterface),
+            StringComparison.OrdinalIgnoreCase);
+    }
 
     /// <summary>
     /// The WAN-qualified target id for this WAN's twin of a host another WAN's discovery already
@@ -2864,7 +2899,9 @@ public class UpstreamTracerService
     /// <param name="wanInterface">WAN this discovery ran against.</param>
     /// <param name="wanContextId">Context this run belongs to, or null for the primary run.</param>
     /// <param name="ct">Cancellation.</param>
-    internal static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, int? wanContextId, CancellationToken ct, int pollIntervalSeconds = MeteredProbePolicy.DefaultIntervalSeconds)
+    /// <param name="pollIntervalSeconds">Cadence new rows are created at.</param>
+    /// <param name="isUnboundRun">Whether this is the unbound (primary) run - see OwnsTargetRow.</param>
+    internal static async Task UpsertTargetAsync(NetworkOptimizerDbContext db, AccessHopCandidate hop, string wanInterface, int? wanContextId, CancellationToken ct, int pollIntervalSeconds = MeteredProbePolicy.DefaultIntervalSeconds, bool isUnboundRun = true)
     {
         // UniFi's WAN SLA probe targets (1.1.1.1 / 8.8.8.8) are public DNS resolvers, not
         // ISP first-mile infrastructure. They never belong as an Access ISP target; drop any
@@ -2886,9 +2923,9 @@ public class UpstreamTracerService
         var rows = await db.MonitoringTargets
             .Where(t => t.TargetId == hop.TargetId || t.TargetId == twinId || t.Address == hop.Address)
             .ToListAsync(ct);
-        var existing = rows.FirstOrDefault(t => t.TargetId == hop.TargetId && OwnsTargetRow(t.WanInterface, wanInterface))
+        var existing = rows.FirstOrDefault(t => t.TargetId == hop.TargetId && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun))
             ?? rows.FirstOrDefault(t => t.TargetId == twinId)
-            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface));
+            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
         var claimedByOtherWan = existing == null && rows.Count > 0;
         if (existing == null)
         {
@@ -2948,7 +2985,9 @@ public class UpstreamTracerService
     /// <param name="wanContextId">Context this run belongs to, or null for the primary run.</param>
     /// <param name="ct">Cancellation.</param>
     /// <param name="enabled">Whether the target is committed enabled (a declined path-end is saved paused).</param>
-    internal static async Task UpsertTransitTargetAsync(NetworkOptimizerDbContext db, TransitAsnCandidate transit, string wanInterface, int? wanContextId, CancellationToken ct, bool enabled = true, int pollIntervalSeconds = MeteredProbePolicy.DefaultIntervalSeconds)
+    /// <param name="pollIntervalSeconds">Cadence new rows are created at.</param>
+    /// <param name="isUnboundRun">Whether this is the unbound (primary) run - see OwnsTargetRow.</param>
+    internal static async Task UpsertTransitTargetAsync(NetworkOptimizerDbContext db, TransitAsnCandidate transit, string wanInterface, int? wanContextId, CancellationToken ct, bool enabled = true, int pollIntervalSeconds = MeteredProbePolicy.DefaultIntervalSeconds, bool isUnboundRun = true)
     {
         if (transit.Method == DiscoveryMethod.Unresolved || string.IsNullOrEmpty(transit.TargetId)) return;
 
@@ -2964,9 +3003,9 @@ public class UpstreamTracerService
             .Where(t => t.TargetId == transit.TargetId || t.TargetId == twinId
                 || (address != null && t.Address == address))
             .ToListAsync(ct);
-        var existing = rows.FirstOrDefault(t => t.TargetId == transit.TargetId && OwnsTargetRow(t.WanInterface, wanInterface))
+        var existing = rows.FirstOrDefault(t => t.TargetId == transit.TargetId && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun))
             ?? rows.FirstOrDefault(t => t.TargetId == twinId)
-            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface));
+            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
         var claimedByOtherWan = existing == null && rows.Count > 0;
         if (existing == null)
         {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanContextTargetStamping.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanContextTargetStamping.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using NetworkOptimizer.Storage;
 using NetworkOptimizer.Storage.Models;
 
 namespace NetworkOptimizer.Web.Services.Monitoring;
@@ -7,22 +6,37 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// <summary>
 /// Keeps <see cref="MonitoringTarget.WanContextId"/> (probe routing) and
 /// <see cref="MonitoringTarget.WanInterface"/> (which WAN the data describes - the key every
-/// per-WAN reader scopes on) moving together at runtime. The deploy-time backfill migration
-/// only fixed rows that existed then; every later assignment, context edit, and context
-/// deletion goes through here so the two keys can never drift apart again.
+/// per-WAN reader scopes on) moving together at runtime.
+/// <para>
+/// Targets bound to no WAN carry <see cref="MonitoringTarget.UnpinnedWan"/>, not NULL. An absent
+/// value got interpreted, and the readers disagreed: most took it for the primary, while the one
+/// governing discovery writes took it for "belongs to whatever WAN is asking" and let a metered
+/// secondary slow every hand-added target on the site.
+/// </para>
 /// </summary>
 public static class WanContextTargetStamping
 {
     /// <summary>
     /// The WanInterface a target should carry after a WAN-context (re)assignment: the context's
-    /// WAN, or null when the target moves back to the primary (an unstamped target IS a
-    /// primary-path measurement to every scoped reader).
+    /// WAN, or the site's primary when the target moves back off a context.
     /// </summary>
-    public static void ApplyAssignment(MonitoringTarget target, int? wanContextId, string? contextWanInterface)
+    /// <param name="target">The target being assigned.</param>
+    /// <param name="wanContextId">The context it moves to, or null to go back to unpinned.</param>
+    /// <param name="contextWanInterface">That context's WAN, ignored when moving off a context.</param>
+    public static void ApplyAssignment(
+        MonitoringTarget target, int? wanContextId, string? contextWanInterface)
     {
         target.WanContextId = wanContextId;
-        target.WanInterface = wanContextId == null ? null : contextWanInterface;
+        // A context naming no WAN (one exists on every pre-WAN-column install) says no more than
+        // no context does, so both land on unpinned.
+        target.WanInterface = wanContextId == null
+            ? MonitoringTarget.UnpinnedWan
+            : Pinned(contextWanInterface);
     }
+
+    /// <summary>The WAN key to store, or the unpinned marker when there is none.</summary>
+    private static string Pinned(string? wanInterface) =>
+        string.IsNullOrEmpty(wanInterface) ? MonitoringTarget.UnpinnedWan : wanInterface;
 
     /// <summary>
     /// Re-stamps every target assigned to a context after the context's WAN changed, so their
@@ -33,15 +47,17 @@ public static class WanContextTargetStamping
     {
         var targets = await db.MonitoringTargets.Where(t => t.WanContextId == wanContextId).ToListAsync(ct);
         foreach (var target in targets)
-            target.WanInterface = wanInterface;
+            target.WanInterface = Pinned(wanInterface);
         return targets.Count;
     }
 
     /// <summary>
-    /// Moves a deleted context's targets back to the primary: both keys cleared, because a row
-    /// keeping the dead context's WAN stamp would stay invisible to the primary report while no
-    /// context probes it any more. Caller saves.
+    /// Moves a deleted context's targets back to unpinned - nothing binds their probes any more,
+    /// and keeping the dead context's WAN would file them under one nothing probes. Caller saves.
     /// </summary>
+    /// <param name="db">The site's database.</param>
+    /// <param name="wanContextId">The context being deleted.</param>
+    /// <param name="ct">Cancellation.</param>
     public static async Task<int> ReleaseContextTargetsAsync(
         NetworkOptimizerDbContext db, int wanContextId, CancellationToken ct = default)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Globalization;
 using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Core.Enums;
@@ -143,7 +143,7 @@ public class WanOutageEvaluator
         await RefreshContextAsync(now, fresh, ct);
 
         var byWan = fresh
-            .GroupBy(t => string.IsNullOrEmpty(t.Target.WanInterface)
+            .GroupBy(t => MonitoringTarget.IsUnpinned(t.Target.WanInterface)
                 ? _context.PrimaryWanKey
                 : GatewayWanHelper.WanInterfaceKeyFromKey(t.Target.WanInterface!),
                 StringComparer.OrdinalIgnoreCase)

--- a/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringLiveStats.cs
@@ -1,4 +1,4 @@
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
@@ -398,7 +398,7 @@ public class MonitoringLiveStats
             ? GatewayWanHelper.DefaultWanKey
             : GatewayWanHelper.WanInterfaceKeyFromKey(wanInterface!);
         var primaryScope = isPrimary || string.IsNullOrEmpty(wanInterface);
-        targets = targets.Where(t => string.IsNullOrEmpty(t.WanInterface)
+        targets = targets.Where(t => MonitoringTarget.IsUnpinned(t.WanInterface)
             ? primaryScope
             : string.Equals(GatewayWanHelper.WanInterfaceKeyFromKey(t.WanInterface!), key,
                 StringComparison.OrdinalIgnoreCase))

--- a/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
@@ -1,4 +1,4 @@
-using System.Net;
+﻿using System.Net;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
@@ -53,6 +53,12 @@ public class MonitoringTargetService : IMonitoringTargetService
             throw new MonitoringTargetValidationException("Address must be a valid IP or hostname.");
 
         var (asnNumber, asnName) = await ResolveAsnAsync(spec.TargetType, address);
+        // Settled once, here, while the user is waiting anyway. A failure leaves it unresolved
+        // rather than guessed - the sweep will try again, and readers fall back meanwhile.
+        var (isLocal, resolvedIp) = await Monitoring.LocalTargetResolver.ResolveAsync(address, _logger, ct);
+        if (isLocal != null)
+            _logger.LogInformation("Local check: {Name} ({Address}) resolved to {Ip} - {Verdict}",
+                name, address, resolvedIp, isLocal.Value ? "on this network" : "reached over a WAN");
 
         // Manual Transit/Access ISP adds are user-provided upstream hops the tracer didn't
         // find. Tag them UserProvided so upstream change-detection treats them as curated
@@ -78,20 +84,23 @@ public class MonitoringTargetService : IMonitoringTargetService
             VantagePoint = "server",
             CreatedAt = DateTime.UtcNow,
             AsnNumber = asnNumber,
-            AsnName = asnName
+            AsnName = asnName,
+            IsLocal = isLocal
         };
 
-        // Same stamping the reassign path uses, so a target created against a WAN context carries
-        // both keys from its first poll: the context that routes the probe and the WAN the readings
-        // are filed under.
+        // Same stamping the reassign path uses, so a target carries both keys from its first poll:
+        // the context that routes the probe and the WAN the readings are filed under. Added against
+        // no context, it is unpinned and says so.
+        string? contextWanInterface = null;
         if (spec.WanContextId is int newContextId)
         {
             await using var contextDb = CreateDb();
             var context = await contextDb.WanContexts.FindAsync(new object?[] { newContextId }, ct);
             if (context == null)
                 throw new MonitoringTargetValidationException("That WAN context no longer exists.");
-            Monitoring.WanContextTargetStamping.ApplyAssignment(entity, newContextId, context.WanInterface);
+            contextWanInterface = context.WanInterface;
         }
+        Monitoring.WanContextTargetStamping.ApplyAssignment(entity, spec.WanContextId, contextWanInterface);
 
         await using (var db = CreateDb())
         {
@@ -177,7 +186,7 @@ public class MonitoringTargetService : IMonitoringTargetService
         // The context's WAN rides along with the assignment: WanContextId routes the probes and
         // WanInterface says which WAN the data describes, and every per-WAN reader scopes on the
         // latter - an assignment that moved only the routing would keep grading the data under
-        // the old WAN. Moving back to the primary clears both (see WanContextTargetStamping).
+        // the old WAN. Moving off a context makes it unpinned (see WanContextTargetStamping).
         string? contextWanInterface = null;
         if (wanContextId is int contextId)
         {

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -1,10 +1,10 @@
 using System.Text;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Sqm;
 using NetworkOptimizer.Sqm.Models;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Web.Services.Ssh;
 using SqmConfig = NetworkOptimizer.Sqm.Models.SqmConfiguration;
-using NetworkOptimizer.Core.Helpers;
 
 namespace NetworkOptimizer.Web.Services;
 
@@ -24,6 +24,15 @@ public class SqmDeploymentService : ISqmDeploymentService
     // Gateway paths
     private const string OnBootDir = "/data/on_boot.d";
     private const string SqmDir = "/data/sqm";
+
+    // The boot script installs its dependencies inline on a first deploy: it adds the
+    // Ookla packagecloud repo (which runs its own apt-get update and fetches a GPG key),
+    // then apt-get installs speedtest, bc and jq. On a cold apt cache or a slow WAN that
+    // runs well past the 30 second default, so give it room rather than tearing down a
+    // deployment that is still working. Re-deploys skip the whole block and finish fast.
+    // Five minutes is comfortably clear of a slow first install without leaving the page
+    // sitting on a boot script that has genuinely wedged.
+    private static readonly TimeSpan BootScriptTimeout = TimeSpan.FromMinutes(5);
 
     public SqmDeploymentService(
         ILogger<SqmDeploymentService> logger,
@@ -410,7 +419,8 @@ public class SqmDeploymentService : ISqmDeploymentService
             // Step 4: Run the boot script to set up everything
             steps.Add("Running boot script (installs deps, creates scripts, configures cron)...");
             var setupResult = await RunCommandAsync(
-                $"chmod +x {OnBootDir}/{bootScriptName} && {OnBootDir}/{bootScriptName}");
+                $"chmod +x {OnBootDir}/{bootScriptName} && {OnBootDir}/{bootScriptName}",
+                BootScriptTimeout);
 
             if (!setupResult.success)
             {

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -1,14 +1,13 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.AgentProtocol;
 using NetworkOptimizer.Alerts.Events;
-using NetworkOptimizer.Storage;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
 using NetworkOptimizer.Web.Services.Ssh;
 
@@ -382,30 +381,47 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
                 }
                 else
                 {
-                    // Fallback: if measured speed exceeds 125% of any single WAN's
-                    // configured speed, assume multiple WANs are bonded. The 25% margin
-                    // accounts for ISP overprovisioning and burst headroom.
-                    var maxSingleDown = wanNetworks!.Max(n => n.WanDownloadMbps ?? 0);
-                    var maxSingleUp = wanNetworks!.Max(n => n.WanUploadMbps ?? 0);
-                    const double fudgeFactor = 1.25;
-
-                    if (downloadMbps > maxSingleDown * fudgeFactor || uploadMbps > maxSingleUp * fudgeFactor)
+                    // Without the gateway there is no observation of where the traffic went, only
+                    // inference. What the site can still say for itself comes first.
+                    var (siteGroup, siteName) = await IdentifyWanFromSiteFactsAsync(cancellationToken);
+                    if (!string.IsNullOrEmpty(siteGroup))
                     {
-                        var groups = wanNetworks!
-                            .Select(n => n.WanNetworkgroup ?? "WAN")
-                            .Distinct().OrderBy(g => g);
-                        result.WanNetworkGroup = string.Join("+", groups);
-                        var names = wanNetworks!
-                            .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
-                            .Distinct().OrderBy(n => n);
-                        result.WanName = string.Join(" + ", names);
+                        result.WanNetworkGroup = siteGroup;
+                        result.WanName = siteName;
                     }
                     else
                     {
-                        var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
-                            finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
-                        result.WanNetworkGroup = wanGroup;
-                        result.WanName = wanName;
+                        // Fallback: if measured speed exceeds 125% of any single WAN's
+                        // configured speed, assume multiple WANs are bonded. The 25% margin
+                        // accounts for ISP overprovisioning and burst headroom.
+                        //
+                        // Only where bonding is possible at all. A failover site carries one test on
+                        // one WAN whatever the numbers say, and the ceiling this compares against is a
+                        // plan speed somebody typed in - left stale, every result looks impossible for
+                        // a single WAN and the test gets attributed to ALL of them at once.
+                        var maxSingleDown = wanNetworks!.Max(n => n.WanDownloadMbps ?? 0);
+                        var maxSingleUp = wanNetworks!.Max(n => n.WanUploadMbps ?? 0);
+                        const double fudgeFactor = 1.25;
+
+                        if (await SiteLoadBalancesAsync(cancellationToken)
+                            && (downloadMbps > maxSingleDown * fudgeFactor || uploadMbps > maxSingleUp * fudgeFactor))
+                        {
+                            var groups = wanNetworks!
+                                .Select(n => n.WanNetworkgroup ?? "WAN")
+                                .Distinct().OrderBy(g => g);
+                            result.WanNetworkGroup = string.Join("+", groups);
+                            var names = wanNetworks!
+                                .Select(n => !string.IsNullOrEmpty(n.Name) ? n.Name : n.WanNetworkgroup ?? "WAN")
+                                .Distinct().OrderBy(n => n);
+                            result.WanName = string.Join(" + ", names);
+                        }
+                        else
+                        {
+                            var (wanGroup, wanName) = await PathAnalyzer.IdentifyWanConnectionAsync(
+                                finalWanIp ?? "", downloadMbps, uploadMbps, cancellationToken);
+                            result.WanNetworkGroup = wanGroup;
+                            result.WanName = wanName;
+                        }
                     }
                 }
             }
@@ -441,6 +457,94 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         Success = false,
         ErrorMessage = errorMessage,
     };
+
+    /// <summary>
+    /// Whether the site spreads traffic across its WANs, from what a connected console last
+    /// recorded. Unknown is not a yes: a site nobody has resolved cannot be assumed to bond.
+    /// </summary>
+    private async Task<bool> SiteLoadBalancesAsync(CancellationToken ct)
+    {
+        try
+        {
+            using var scope = CreateSiteScope();
+            var siteDb = scope.ServiceProvider.GetRequiredService<SiteDbContextFactory>();
+            var siteCtx = scope.ServiceProvider.GetRequiredService<SiteContextService>();
+            await using var db = siteDb.CreateForSite(siteCtx.Slug, siteCtx.IsDefault);
+            return await EntityFrameworkQueryableExtensions.AnyAsync(db.WanProfiles, p => p.SiteLoadBalances == true, ct);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not read whether the site load balances; assuming it does not");
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Which WAN this test went out, from what the site knows about itself rather than from what
+    /// the numbers resemble.
+    /// <para>
+    /// Two answers, both about the box that actually ran the test - this server, or the site's
+    /// agent. A single vantage on that side names its WAN outright; several means several boxes,
+    /// and which one ran the test is not knowable from here. Failing that, a site that fails
+    /// over sends everything unpinned out its primary, which is true except for the length of an
+    /// outage. A load-balancing site gets neither, because there the WAN genuinely was whichever
+    /// the balancer picked and only the gateway could have seen it.
+    /// </para>
+    /// </summary>
+    private async Task<(string? Group, string? Name)> IdentifyWanFromSiteFactsAsync(CancellationToken ct)
+    {
+        try
+        {
+            var viaAgent = await _tunnelRouting.IsViaAgentAsync(SiteSlug);
+            using var scope = CreateSiteScope();
+            var siteDb = scope.ServiceProvider.GetRequiredService<SiteDbContextFactory>();
+            var siteCtx = scope.ServiceProvider.GetRequiredService<SiteContextService>();
+            await using var db = siteDb.CreateForSite(siteCtx.Slug, siteCtx.IsDefault);
+
+            // A vantage names the WAN its box probes over, which is the same box and the same
+            // path this test took. Scoped to whoever ran it: a vantage bound to an agent says
+            // nothing about a test this server ran, or the other way round. Only one candidate
+            // may answer - two agent-bound vantages are two boxes on two WANs, and we cannot
+            // tell from here which of them ran the test, so guessing would name a WAN at random.
+            var vantages = await EntityFrameworkQueryableExtensions.ToListAsync(
+                db.WanContexts.AsNoTracking().Where(c => c.WanInterface != null && c.WanInterface != ""), ct);
+            var candidates = vantages.Where(c => viaAgent ? c.AgentId != null : c.AgentId == null).ToList();
+            if (candidates.Count > 1)
+            {
+                Logger.LogDebug(
+                    "WAN attribution: {Count} vantages sit on the {Runner} side, so none of them identifies this test",
+                    candidates.Count, viaAgent ? "agent" : "server");
+            }
+            var owning = candidates.Count == 1 ? candidates[0] : null;
+            if (owning?.WanInterface is string vantageWan)
+            {
+                var group = GatewayWanHelper.WanNetworkGroupFromKey(vantageWan);
+                Logger.LogInformation(
+                    "WAN attribution: vantage '{Name}' covers the {Runner} that ran this test, so it went out {Group}",
+                    owning.Name, viaAgent ? "agent" : "server", group);
+                return (group, owning.Name);
+            }
+
+            if (await EntityFrameworkQueryableExtensions.AnyAsync(db.WanProfiles, p => p.SiteLoadBalances == true, ct))
+                return (null, null);
+
+            var primary = await EntityFrameworkQueryableExtensions.FirstOrDefaultAsync(
+                db.WanProfiles.AsNoTracking(), p => p.IsPrimary == true, ct);
+            if (primary?.WanNetworkgroup is string primaryGroup)
+            {
+                Logger.LogInformation(
+                    "WAN attribution: the site fails over, so an unpinned test left by the primary ({Group})",
+                    primaryGroup);
+                return (primaryGroup, primary.Name);
+            }
+            return (null, null);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Could not identify the WAN from the site's own records");
+            return (null, null);
+        }
+    }
 
     /// <summary>
     /// Use SSH route lookup on the gateway to determine which WAN interfaces

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1,4 +1,4 @@
-/* ============================================
+﻿/* ============================================
    Network Optimizer - Main Stylesheet
    Modern, dark-mode friendly design
    ============================================ */
@@ -550,9 +550,33 @@ h1:focus {
     }
 }
 
+.time-window-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+@media (max-width: 768px) {
+    .time-window-controls .time-btn[data-shift] {
+        padding: 0.5rem;
+    }
+}
+
 .wan-selector .wan-filter-reset {
     position: static;
     margin-left: 0.15rem;
+}
+
+.stats-name-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.stats-name-head .wan-filter-reset {
+    position: static;
+    padding: 0 0.15rem;
 }
 
 @media (max-width: 768px) {
@@ -572,16 +596,6 @@ h1:focus {
         margin: 0;
     }
 
-    #latency-charts-container .monitoring-chart-header {
-        position: relative;
-    }
-
-    #latency-charts-container .monitoring-chart-header > .monitoring-jump-btn {
-        position: absolute;
-        top: -0.2rem;
-        right: -0.2rem;
-        margin: 0;
-    }
 }
 
 .card-header-collapsible {
@@ -15684,8 +15698,22 @@ a.affected-client:hover {
     color: var(--text-primary);
 }
 
-.monitoring-chart-header > .monitoring-jump-btn {
-    padding-right: 0.1rem;
+#latency-charts-container .monitoring-chart-header {
+    position: relative;
+}
+
+#latency-charts-container .monitoring-chart-header > .monitoring-jump-btn {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    margin: 0;
+}
+
+@media (max-width: 768px) {
+    #latency-charts-container .monitoring-chart-header > .monitoring-jump-btn {
+        top: -0.2rem;
+        right: -0.2rem;
+    }
 }
 
 .live-view-jump-row {

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -1,10 +1,10 @@
-// Cellular modem signal time-series charts: RSRP, SNR, Signal Quality.
+﻿// Cellular modem signal time-series charts: RSRP, SNR, Signal Quality.
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -137,15 +137,22 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); });
 }
 
+// Draws exactly the modems that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per modem on each of the four charts, and every one of
+// those is a full redraw. Colors come from modemMeta, which holds each modem's palette slot from
+// the full list, so filtering never re-colors what stays on screen.
 function updateVisibility() {
-    modemMeta.forEach(m => {
-        const vis = visibility[m.id] !== false;
-        [rsrpChart, rsrqChart, snrChart, qualityChart].forEach(chart => {
-            if (!chart) return;
-            if (vis) chart.showSeries(m.label);
-            else chart.hideSeries(m.label);
-        });
-    });
+    const modems = (lastData?.modems || []).filter(m => visibility[m.id] !== false);
+    const seriesOf = (pick) => modems.map(m => ({
+        name: m.label,
+        color: modemMeta.find(x => x.id === m.id)?.color || PALETTE[0],
+        data: alignedPoints(m.data || [], pick),
+    }));
+    if (rsrpChart) rsrpChart.updateSeries(seriesOf(p => p.rsrp), false);
+    if (rsrqChart) rsrqChart.updateSeries(seriesOf(p => p.rsrq), false);
+    if (snrChart) snrChart.updateSeries(seriesOf(p => p.snr), false);
+    if (qualityChart) qualityChart.updateSeries(seriesOf(p => p.quality), false);
 }
 
 async function loadAndUpdate() {
@@ -155,42 +162,9 @@ async function loadAndUpdate() {
         id: m.id, label: m.label, color: PALETTE[i % PALETTE.length],
     }));
 
-    const rsrpSeries = [];
-    const rsrqSeries = [];
-    const snrSeries = [];
-    const qualitySeries = [];
-    data.modems.forEach((m, i) => {
-        const color = PALETTE[i % PALETTE.length];
-        const pts = m.data || [];
-        rsrpSeries.push({
-            name: m.label,
-            color,
-            data: alignedPoints(pts, p => p.rsrp),
-        });
-        rsrqSeries.push({
-            name: m.label,
-            color,
-            data: alignedPoints(pts, p => p.rsrq),
-        });
-        snrSeries.push({
-            name: m.label,
-            color,
-            data: alignedPoints(pts, p => p.snr),
-        });
-        qualitySeries.push({
-            name: m.label,
-            color,
-            data: alignedPoints(pts, p => p.quality),
-        });
-    });
-
-    if (rsrpChart) rsrpChart.updateSeries(rsrpSeries, false);
-    if (rsrqChart) rsrqChart.updateSeries(rsrqSeries, false);
-    if (snrChart) snrChart.updateSeries(snrSeries, false);
-    if (qualityChart) qualityChart.updateSeries(qualitySeries, false);
-
-    updateVisibility();
+    // Before updateVisibility, which draws from it.
     lastData = data;
+    updateVisibility();
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-filter.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-filter.js
@@ -16,6 +16,21 @@
  */
 const RESERVED_CLASS = 'wan-filter-badges-reserved';
 
+/**
+ * The standard clear-filter glyph: funnel with an X. Stroked, currentColor, 24 viewBox - the same
+ * idiom as the X icons already in the app, so it inherits hover colour for free.
+ *
+ * Exported because the stats tables draw the same control into a table header, where the measured
+ * placement below has nothing to measure. Sharing the markup is the point: one control on two
+ * surfaces must not become two drawings of it.
+ */
+export const FILTER_RESET_SVG =
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M3 5h14l-5.25 6.2V17l-3.5 1.75v-7.55z"/>'
+    + '<path d="m16.5 16.5 4.5 4.5m0-4.5-4.5 4.5"/>'
+    + '</svg>';
+
 /// Do the two rectangles share any area at all.
 function collides(btn, chips) {
     const b = btn.getBoundingClientRect();
@@ -83,14 +98,7 @@ export function renderFilterReset(container, isFiltered, onReset, label = 'Clear
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'wan-filter-reset';
-    // The standard clear-filter glyph: funnel with an X. Stroked, currentColor, 24 viewBox -
-    // the same idiom as the X icons already in the app, so it inherits hover colour for free.
-    btn.innerHTML =
-        '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
-        + 'stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
-        + '<path d="M3 5h14l-5.25 6.2V17l-3.5 1.75v-7.55z"/>'
-        + '<path d="m16.5 16.5 4.5 4.5m0-4.5-4.5 4.5"/>'
-        + '</svg>';
+    btn.innerHTML = FILTER_RESET_SVG;
     btn.setAttribute('aria-label', label);
     btn.setAttribute('data-tooltip', label);
     btn.addEventListener('click', (e) => {

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -1,3 +1,5 @@
+import { isFiltered, FILTER_RESET_SVG } from './chart-filter.js?v=5';
+
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 
@@ -59,6 +61,19 @@ export function renderStatsTable(el, container, opts) {
         return `<th data-sort-col="${i}"${classes ? ` class="${classes}"` : ''}>${col.header}${arrow}</th>`;
     }).join('');
 
+    // The clear sits in the name column's header, at its right edge. Only while something is
+    // actually filtered out: always-on would be a permanently dead button on the common case, the
+    // same rule the chip rows follow. Drawn inline rather than through renderFilterReset, whose
+    // placement is measured against chips this header does not have.
+    const showReset = !!filter && isFiltered(filter.visibility());
+    // Wording follows the caller: eight of these tables filter chart series, the port stats table
+    // filters device cards, and calling those series would name something that is not on screen.
+    const resetLabel = filter?.resetLabel ?? 'Clear series filter';
+    const nameHead = showReset
+        ? `<span class="stats-name-head">${nameHeader}<button type="button" class="wan-filter-reset"
+            aria-label="${escapeHtml(resetLabel)}" data-tooltip="${escapeHtml(resetLabel)}">${FILTER_RESET_SVG}</button></span>`
+        : nameHeader;
+
     const rowsHtml = sorted.map(r => {
         const filtered = r.visible === false;
         const cls = filtered ? ' class="stats-row-filtered"' : '';
@@ -77,7 +92,7 @@ export function renderStatsTable(el, container, opts) {
         <div class="table-responsive">
         <table class="data-table" style="font-size:0.8125rem">
             <thead><tr>
-                <th>${nameHeader}</th>
+                <th>${nameHead}</th>
                 ${headers}
             </tr></thead>
             <tbody>${rowsHtml}</tbody>
@@ -110,6 +125,14 @@ export function renderStatsTable(el, container, opts) {
     if (filter && !el._filterDelegated) {
         el._filterDelegated = true;
         el.addEventListener('click', (e) => {
+            // Ahead of the sort guard: the clear lives in a header cell, so a click on it is a
+            // click in a th, and it must not be read as a request to sort by that column.
+            if (e.target.closest('.wan-filter-reset')) {
+                e.stopPropagation();
+                filter.resetVisibility();
+                filter.onChanged(container);
+                return;
+            }
             if (e.target.closest('th[data-sort-col]')) return;
             const td = e.target.closest('[data-stat-id]');
             if (!td) return;
@@ -118,15 +141,26 @@ export function renderStatsTable(el, container, opts) {
             const key = filter.key;
             const vis = filter.visibility();
 
+            // A row may speak for more than itself - the same host measured over several WANs is
+            // one thing the user is watching, split across rows only because the WANs are being
+            // compared. groupOf says which ids move together; without it a row speaks for itself.
+            // Compared as strings throughout: the id comes off a data attribute, so it is always a
+            // string, while meta keys are whatever the caller holds (a numeric target id, here).
+            const ids = (filter.groupOf ? filter.groupOf(id) : [id]).map(String);
+            const inGroup = new Set(ids);
+            const groupVisible = ids.some(i => vis[i] !== false);
+
             if (e.ctrlKey || e.metaKey) {
-                vis[id] = vis[id] === false ? undefined : false;
+                ids.forEach(i => { vis[i] = groupVisible ? false : undefined; });
             } else {
                 const allVis = meta.every(m => vis[m[key]] !== false);
-                const onlyThis = vis[id] !== false
-                    && meta.filter(m => m[key] !== id).every(m => vis[m[key]] === false);
+                const onlyThis = groupVisible
+                    && meta.filter(m => !inGroup.has(String(m[key]))).every(m => vis[m[key]] === false);
                 if (onlyThis) { filter.resetVisibility(); }
-                else if (allVis) { meta.forEach(m => { vis[m[key]] = m[key] === id; }); }
-                else { vis[id] = vis[id] === false; }
+                else if (allVis) { meta.forEach(m => { vis[m[key]] = inGroup.has(String(m[key])); }); }
+                // Flip it: assigning the state back to itself leaves a hidden row hidden, so the
+                // click after a solo did nothing at all.
+                else { ids.forEach(i => { vis[i] = !groupVisible; }); }
             }
             filter.onChanged(container);
         });

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-tooltip.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-tooltip.js
@@ -1,4 +1,4 @@
-// Shared tooltip behaviour for the Monitoring time-series charts.
+﻿// Shared tooltip behaviour for the Monitoring time-series charts.
 //
 // Lived in device-health-charts.js and latency-charts.js as two copies of the same
 // function; the other five chart sets used the stock ApexCharts tooltip, which lists
@@ -33,7 +33,59 @@ const DOT_LAYER = 'netopt-hover-dots';
  * elements at all. Nulls are skipped, so a line with no reading at this instant has no dot
  * rather than one parked on the axis.
  */
-function paintHoverDots(w, dataPointIndex) {
+// The x the pointer is actually on. Taken from the hovered series when there is one, and from
+// the first series holding a point at that index otherwise, which is what a shared tooltip lands
+// on when it cannot name one.
+function hoveredXValue(w, dataPointIndex, seriesIndex) {
+    const direct = w.globals.seriesX[seriesIndex]?.[dataPointIndex];
+    if (direct != null && !isNaN(direct)) return direct;
+    for (const xs of w.globals.seriesX || []) {
+        const x = xs?.[dataPointIndex];
+        if (x != null && !isNaN(x)) return x;
+    }
+    return null;
+}
+
+// Where a series holds its point for a given x, or -1 when it has none near enough to be the
+// same moment. Series on this chart are separate targets polled at their own intervals, so the
+// same index means a different time in each of them - matching on the value is what keeps the
+// dots on one vertical line instead of scattering them along the axis.
+function indexAtX(xs, x) {
+    if (!xs || xs.length === 0 || x == null) return -1;
+    // Binary search: x is ascending, and this now runs for the rows as well as the dots, on every
+    // mousemove, over ranges that reach thousands of points per series.
+    let lo = 0, hi = xs.length - 1;
+    while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (xs[mid] < x) lo = mid + 1; else hi = mid;
+    }
+    let best = lo;
+    if (lo > 0 && Math.abs(xs[lo - 1] - x) <= Math.abs(xs[lo] - x)) best = lo - 1;
+    const bestGap = Math.abs(xs[best] - x);
+    // Half a step of this series' own spacing: close enough to be the same bucket, far enough
+    // out and the series simply has nothing here, which is worth showing as a missing dot
+    // rather than as a dot in the wrong place.
+    const span = xs.length > 1 ? Math.abs(xs[xs.length - 1] - xs[0]) / (xs.length - 1) : 0;
+    return bestGap <= Math.max(span / 2, 1) ? best : -1;
+}
+
+/**
+ * Which point each series holds at the hovered moment - ONE resolution, used for the dot and for
+ * the row alike.
+ *
+ * They were resolved separately, and disagreed the moment two series did not share timestamps: the
+ * dot was placed by matching the x value while the row read the array position, so a series polled
+ * on its own cadence drew its dot on a spike and printed the value it held at some other moment.
+ * The reader then had to hunt along the line for the x where the two happened to coincide.
+ */
+function hoveredIndices(w, dataPointIndex, seriesIndex) {
+    const hoveredX = hoveredXValue(w, dataPointIndex, seriesIndex);
+    const at = (w.globals.seriesX || []).map(xs =>
+        hoveredX == null ? dataPointIndex : indexAtX(xs, hoveredX));
+    return { hoveredX, at };
+}
+
+function paintHoverDots(w, at) {
     const inner = w.globals.dom.baseEl.querySelector('.apexcharts-inner');
     if (!inner) return;
 
@@ -63,7 +115,8 @@ function paintHoverDots(w, dataPointIndex) {
     const points = w.globals.pointsArray;
     for (let i = 0; i < points.length; i++) {
         if (w.globals.collapsedSeriesIndices?.indexOf(i) >= 0) continue;
-        const p = points[i]?.[dataPointIndex];
+        if (at[i] == null || at[i] < 0) continue;
+        const p = points[i]?.[at[i]];
         if (!p) continue;
         const [cx, cy] = p;
         if (cx == null || cy == null || isNaN(cx) || isNaN(cy)) continue;
@@ -79,8 +132,9 @@ function paintHoverDots(w, dataPointIndex) {
     }
 }
 
-export function valueSortedTooltip({ series, dataPointIndex, w }, options = {}) {
-    paintHoverDots(w, dataPointIndex);
+export function valueSortedTooltip({ series, seriesIndex, dataPointIndex, w }, options = {}) {
+    const { hoveredX, at } = hoveredIndices(w, dataPointIndex, seriesIndex);
+    paintHoverDots(w, at);
     const esc = s => String(s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
     // The axis formatter by default, since it is already right for the chart. An explicit one
     // is for charts whose axis deliberately omits a unit that the tooltip should still carry -
@@ -90,11 +144,16 @@ export function valueSortedTooltip({ series, dataPointIndex, w }, options = {}) 
     const fmtOpt = options.format ?? w.config.yaxis?.[0]?.labels?.formatter ?? (v => v);
     const fmtFor = i => Array.isArray(fmtOpt) ? (fmtOpt[i] ?? (v => v)) : fmtOpt;
     const rows = [];
-    let ts = null;
+    let ts = hoveredX;
     for (let i = 0; i < series.length; i++) {
-        const v = series[i]?.[dataPointIndex];
+        // The same index the dot uses. A series whose nearest reading is further off than half its
+        // own spacing has nothing to say at this moment, so it gets no row - the same silence it
+        // gets no dot for, rather than a number belonging to some other instant.
+        const j = at[i] ?? dataPointIndex;
+        if (j < 0) continue;
+        const v = series[i]?.[j];
         if (v == null) continue;
-        ts ??= w.globals.seriesX[i]?.[dataPointIndex];
+        ts ??= w.globals.seriesX[i]?.[j];
         rows.push({ name: w.globals.seriesNames[i], color: w.globals.colors[i % w.globals.colors.length], v, i });
     }
     // Sorted by value only where the series share a SCALE - several WANs' throughput on one axis,

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -1,10 +1,10 @@
-// Cable modem signal time-series charts: DS Power, DS SNR, US Power, Uncorrectable Errors.
+﻿// Cable modem signal time-series charts: DS Power, DS SNR, US Power, Uncorrectable Errors.
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
 const _esc = document.createElement('span');
@@ -146,26 +146,40 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); });
 }
 
+// Downstream, upstream and the two error counts each get their own color per modem, so the four
+// charts stay readable side by side. Indexed by the modem's place in the full list, so filtering
+// never re-colors a line.
+const COLOR_SETS = [
+    { ds: PALETTE[0], us: PALETTE[4], uncorr: PALETTE[2], corr: PALETTE[1] },
+    { ds: PALETTE[6], us: PALETTE[3], uncorr: PALETTE[12], corr: PALETTE[11] },
+    { ds: PALETTE[10], us: PALETTE[18], uncorr: PALETTE[19], corr: PALETTE[13] },
+];
+
+// Draws exactly the modems that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per modem per series, and each of those is a full
+// redraw. No single-modem short-circuit: this is the draw path now, not just the toggle path.
 function updateVisibility() {
-    if (deviceMeta.length <= 1) return;
-    deviceMeta.forEach(m => {
-        const vis = visibility[m.id] !== false;
-        [dsPowerChart, dsSnrChart, usPowerChart].forEach(chart => {
-            if (!chart) return;
-            try { if (vis) chart.showSeries(m.label); else chart.hideSeries(m.label); } catch (_) {}
-        });
-        if (errorsChart) {
-            try {
-                if (vis) {
-                    errorsChart.showSeries(m.label + ' Uncorrectable');
-                    errorsChart.showSeries(m.label + ' Correctable');
-                } else {
-                    errorsChart.hideSeries(m.label + ' Uncorrectable');
-                    errorsChart.hideSeries(m.label + ' Correctable');
-                }
-            } catch (_) {}
-        }
+    const all = lastData?.devices || [];
+    const devices = all.filter(d => visibility[d.id] !== false);
+    const dsPowerSeries = [];
+    const dsSnrSeries = [];
+    const usPowerSeries = [];
+    const errorsSeries = [];
+    devices.forEach(d => {
+        const c = COLOR_SETS[all.indexOf(d) % COLOR_SETS.length];
+        const pts = d.data || [];
+        dsPowerSeries.push({ name: d.label, color: c.ds, data: alignedPoints(pts, p => p.dsPower) });
+        dsSnrSeries.push({ name: d.label, color: c.ds, data: alignedPoints(pts, p => p.dsSnr) });
+        usPowerSeries.push({ name: d.label, color: c.us, data: alignedPoints(pts, p => p.usPower) });
+        errorsSeries.push(
+            { name: d.label + ' Uncorrectable', color: c.uncorr, data: alignedPoints(pts, p => p.uncorrDelta) },
+            { name: d.label + ' Correctable', color: c.corr, data: alignedPoints(pts, p => p.corrDelta) });
     });
+    if (dsPowerChart) dsPowerChart.updateSeries(dsPowerSeries, false);
+    if (dsSnrChart) dsSnrChart.updateSeries(dsSnrSeries, false);
+    if (usPowerChart) usPowerChart.updateSeries(usPowerSeries, false);
+    if (errorsChart) errorsChart.updateSeries(errorsSeries, false);
 }
 
 async function loadAndUpdate() {
@@ -175,52 +189,9 @@ async function loadAndUpdate() {
         id: d.id, label: d.label, color: PALETTE[i % PALETTE.length],
     }));
 
-    const dsPowerSeries = [];
-    const dsSnrSeries = [];
-    const usPowerSeries = [];
-    const errorsSeries = [];
-    const COLOR_SETS = [
-        { ds: PALETTE[0], us: PALETTE[4], uncorr: PALETTE[2], corr: PALETTE[1] },
-        { ds: PALETTE[6], us: PALETTE[3], uncorr: PALETTE[12], corr: PALETTE[11] },
-        { ds: PALETTE[10], us: PALETTE[18], uncorr: PALETTE[19], corr: PALETTE[13] },
-    ];
-    data.devices.forEach((d, i) => {
-        const c = COLOR_SETS[i % COLOR_SETS.length];
-        const pts = d.data || [];
-        dsPowerSeries.push({
-            name: d.label,
-            color: c.ds,
-            data: alignedPoints(pts, p => p.dsPower),
-        });
-        dsSnrSeries.push({
-            name: d.label,
-            color: c.ds,
-            data: alignedPoints(pts, p => p.dsSnr),
-        });
-        usPowerSeries.push({
-            name: d.label,
-            color: c.us,
-            data: alignedPoints(pts, p => p.usPower),
-        });
-        errorsSeries.push({
-            name: d.label + ' Uncorrectable',
-            color: c.uncorr,
-            data: alignedPoints(pts, p => p.uncorrDelta),
-        });
-        errorsSeries.push({
-            name: d.label + ' Correctable',
-            color: c.corr,
-            data: alignedPoints(pts, p => p.corrDelta),
-        });
-    });
-
-    if (dsPowerChart) dsPowerChart.updateSeries(dsPowerSeries, false);
-    if (dsSnrChart) dsSnrChart.updateSeries(dsSnrSeries, false);
-    if (usPowerChart) usPowerChart.updateSeries(usPowerSeries, false);
-    if (errorsChart) errorsChart.updateSeries(errorsSeries, false);
-
-    updateVisibility();
+    // Before updateVisibility, which draws from it.
     lastData = data;
+    updateVisibility();
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -1,10 +1,10 @@
-// TODO: Extract time-range controls (presets, shift arrows, custom range popover,
+﻿// TODO: Extract time-range controls (presets, shift arrows, custom range popover,
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 // A device answers SNMP but can still miss a single field on a poll - a temperature or
@@ -163,16 +163,33 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); });
 }
 
+// Draws exactly the devices that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per device on every chart, and each of those is a full
+// redraw - so one chip click cost a redraw per device it changed, on each of temp, CPU, memory and
+// every custom chart. Colors are hashed off the device name, so filtering never re-colors a line.
+function drawSeries() {
+    const devices = (lastData?.devices || []).filter(d => visibility[d.mac] !== false);
+    const makeSeries = (field) => devices.map(d => ({
+        name: d.name,
+        color: hashColor(d.name),
+        data: alignedPoints(d.data || [], p => p[field], 'time', GAP_BRIDGE_MS),
+    }));
+    if (tempChart) tempChart.updateSeries(makeSeries('temp'), false);
+    if (cpuChart) cpuChart.updateSeries(makeSeries('cpu'), false);
+    if (memChart) memChart.updateSeries(makeSeries('mem'), false);
+    for (const [field, chart] of Object.entries(customCharts)) {
+        if (!chart) continue;
+        chart.updateSeries(devices.map(d => ({
+            name: d.name,
+            color: hashColor(d.name),
+            data: (d.custom?.[field] || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
+        })), false);
+    }
+}
+
 function updateVisibility() {
-    deviceMeta.forEach(d => {
-        const vis = visibility[d.mac] !== false;
-        const allCharts = [tempChart, cpuChart, memChart, ...Object.values(customCharts)];
-        for (const chart of allCharts) {
-            if (!chart) continue;
-            if (vis) chart.showSeries(d.name);
-            else chart.hideSeries(d.name);
-        }
-    });
+    drawSeries();
     applyAnnotations();
 }
 
@@ -211,21 +228,13 @@ async function loadAndUpdate() {
     }));
     // Set before updateVisibility below, which is what draws the marks.
     lastEvents = data.events || [];
-    const makeSeries = (field) => data.devices.map(d => ({
-        name: d.name,
-        color: hashColor(d.name),
-        data: alignedPoints(d.data || [], p => p[field], 'time', GAP_BRIDGE_MS),
-    }));
-    if (tempChart) tempChart.updateSeries(makeSeries('temp'), false);
-    if (cpuChart) cpuChart.updateSeries(makeSeries('cpu'), false);
-    if (memChart) memChart.updateSeries(makeSeries('mem'), false);
-
     const newDefs = data.customFields || [];
     const container = document.getElementById(containerId);
+    // Before updateVisibility, which draws from it.
+    lastData = data;
     if (container) await syncCustomCharts(container, data.devices, newDefs);
 
     updateVisibility();
-    lastData = data;
     if (container) {
         renderBadges(container);
         renderStatsTable(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -1,10 +1,10 @@
-// ISP Health per-ASN RTT chart - pure JS ApexCharts fed by
+﻿// ISP Health per-ASN RTT chart - pure JS ApexCharts fed by
 // /api/monitoring/isp-health/asn-series. Fixed 24 h window; congestion events
 // render as shaded x-axis ranges, path shifts as annotation lines.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 
 const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
 const POLL_MS = 60000;
@@ -39,6 +39,9 @@ let badgesEl = null;
 const _escSpan = document.createElement('span');
 function escapeHtml(v) { _escSpan.textContent = v ?? ''; return _escSpan.innerHTML; }
 let lastEvents = [];
+// The full series set from the last poll, so a chip click can redraw the chart from it without
+// going back to the server.
+let lastSeries = [];
 
 function buildOpts() {
     return {
@@ -214,9 +217,9 @@ async function loadAndUpdate() {
 
         lastEvents = json.events || [];
         chart.updateOptions({ annotations: buildAnnotations(lastEvents) }, false, false);
-        // Preserve the user's drag-zoom; a series refresh while zoomed would snap back
-        // updateSeries resets per-series visibility, so re-apply after every refresh.
-        if (!isZoomed) { chart.updateSeries(series, false); applySeriesVisibility(); }
+        lastSeries = series;
+        // Preserve the user's drag-zoom; a series refresh while zoomed would snap back.
+        if (!isZoomed) applySeriesVisibility();
     } catch (e) {
         if (e.name !== 'AbortError') console.warn('isp-health chart load failed', e);
     }
@@ -224,12 +227,12 @@ async function loadAndUpdate() {
 
 function applySeriesVisibility() {
     if (!chart) return;
-    asnMeta.forEach(m => {
-        if (seriesVisibility[m.name] === false) chart.hideSeries(m.name);
-        else chart.showSeries(m.name);
-    });
+    // One update carrying just the series that should be drawn. This used to call
+    // hideSeries/showSeries per ASN, and each of those is a full redraw, so isolating one provider
+    // on a path with several cost a redraw for every chip it changed.
+    chart.updateSeries(lastSeries.filter(x => seriesVisibility[x.name] !== false), false);
 
-    // hideSeries/showSeries redraw against the default axis range, so a chip click threw away a
+    // Redrawing resets the axis range, so a chip click threw away a
     // drag-zoom - you would zoom into an event, isolate the provider you wanted to look at, and
     // land back on the whole window. Filtering and zooming are answers to the same question here,
     // so they have to survive each other. Re-applied rather than prevented, because the library

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -1,13 +1,13 @@
-// Latency & Packet Loss charts — pure JS ApexCharts, fed by /api/monitoring/chart-data.
+﻿// Latency & Packet Loss charts — pure JS ApexCharts, fed by /api/monitoring/chart-data.
 // Mounted from Blazor the same way as lan-flow-map.js.
 // TODO: Extract time-range controls (presets, shift arrows, custom range popover,
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 import { downloadColor, uploadColor } from './chart-colors.js?v=2';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
@@ -57,19 +57,62 @@ let wanScope = null;
 // Dash patterns by WAN order: primary solid, then visibly distinct patterns per extra WAN.
 const WAN_DASH_PATTERNS = [0, 6, 2, 9];
 
+// The server's marker for a target whose probe is pinned to no WAN. Null means the same thing on
+// rows written before the marker existed, so both are treated as unpinned here.
+const UNPINNED_WAN = 'unpinned';
+
 function effectiveWanKey(t) {
-    // Unstamped targets are primary-path measurements (same rule as the server side).
-    return (t.wanInterface || wanScope?.primaryKey || 'wan').toLowerCase();
+    // Unpinned targets are primary-path measurements (same rule as the server side). Checked
+    // rather than relying on a falsy value: the marker is a real string, so `||` alone would take
+    // it for a WAN key, match no selected pill, and drop every LAN target off the chart.
+    const wan = t.wanInterface && t.wanInterface.toLowerCase() !== UNPINNED_WAN ? t.wanInterface : null;
+    return (wan || wanScope?.primaryKey || 'wan').toLowerCase();
 }
 
 function wanComparisonActive() {
     return !!wanScope && wanScope.selected.length > 1;
 }
 
+// Which categories each scope can show anything in. LAN holds the fabric devices and the
+// hand-added targets that sit on this network; a single WAN holds neither, because neither leaves
+// by it. All is the union, so it offers everything.
+const CATEGORIES_BY_SCOPE = {
+    lan: ['Fabric', 'Custom'],
+    wan: ['AccessIsp', 'Transit', 'InternetService', 'Custom'],
+    all: ['Fabric', 'AccessIsp', 'Transit', 'InternetService', 'Custom'],
+};
+
+function scopeName() {
+    if (!wanScope) return 'all';
+    if (wanScope.lan) return 'lan';
+    return wanScope.all ? 'all' : 'wan';
+}
+
 function filterTargetsToWanScope(targets) {
     if (!wanScope) return targets;
+    // LAN is its own scope, not a WAN: it shows what is on this network and nothing else, and a
+    // single WAN shows the opposite. Only All carries both.
+    if (wanScope.lan) return targets.filter(t => t.isLan);
+    if (wanScope.all) return targets;
     const sel = new Set(wanScope.selected.map(k => k.toLowerCase()));
-    return targets.filter(t => sel.has(effectiveWanKey(t)));
+    return targets.filter(t => !t.isLan && sel.has(effectiveWanKey(t)));
+}
+
+// Shows only the categories the current scope can fill, and moves off one it cannot: the current
+// choice is kept whenever it survives the move - switching WAN while on Custom should stay on
+// Custom - and otherwise falls to the first that does.
+function applyCategoryAvailability() {
+    const container = document.getElementById(containerId);
+    if (!container) return currentCategory;
+    const allowed = CATEGORIES_BY_SCOPE[scopeName()] || CATEGORIES_BY_SCOPE.all;
+    container.querySelectorAll('[data-category]').forEach(b => {
+        b.style.display = allowed.includes(b.dataset.category) ? '' : 'none';
+    });
+    if (!allowed.includes(currentCategory)) currentCategory = allowed[0];
+    container.querySelectorAll('[data-category]').forEach(b => {
+        b.classList.toggle('active', b.dataset.category === currentCategory);
+    });
+    return currentCategory;
 }
 
 function wanDisplayName(t) {
@@ -239,13 +282,13 @@ function renderBadges(container) {
     const el = container.querySelector('.latency-filter-badges');
     if (el) el.dataset.tour = 'chart-series-filter';
     if (!el) return;
-    if (targetMeta.length <= 1) { el.innerHTML = ''; return; }
+    if (badgeGroups().length <= 1) { el.innerHTML = ''; return; }
 
-    el.innerHTML = targetMeta.map(t => {
-        const vis = visibility[t.id] !== false;
-        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-target="${t.id}">
-            <span class="wan-badge-dot" style="background-color: ${t.color}"></span>
-            <span>${escapeHtml(t.name)}</span>
+    el.innerHTML = badgeGroups().map(g => {
+        const vis = g.ids.some(id => visibility[id] !== false);
+        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-target="${escapeHtml(g.key)}">
+            <span class="wan-badge-dot" style="background-color: ${g.color}"></span>
+            <span>${escapeHtml(g.key)}</span>
         </button>`;
     }).join('');
 
@@ -254,21 +297,28 @@ function renderBadges(container) {
         el.addEventListener('click', (e) => {
             const btn = e.target.closest('button[data-target]');
             if (!btn) return;
-            const tid = btn.dataset.target;
+            const key = btn.dataset.target;
+            const groups = badgeGroups();
+            const group = groups.find(g => g.key === key);
+            if (!group) return;
+            const inGroup = new Set(group.ids);
+            const groupVisible = group.ids.some(id => visibility[id] !== false);
 
             if (e.ctrlKey || e.metaKey) {
-                visibility[tid] = visibility[tid] === false ? undefined : false;
+                group.ids.forEach(id => { visibility[id] = groupVisible ? false : undefined; });
             } else {
                 const allVis = targetMeta.every(t => visibility[t.id] !== false);
-                const onlyThis = visibility[tid] !== false
-                    && targetMeta.filter(t => t.id !== tid).every(t => visibility[t.id] === false);
+                const onlyThis = groupVisible
+                    && targetMeta.filter(t => !inGroup.has(t.id)).every(t => visibility[t.id] === false);
 
                 if (onlyThis) {
                     visibility = {};
                 } else if (allVis) {
-                    targetMeta.forEach(t => visibility[t.id] = t.id === tid);
+                    targetMeta.forEach(t => visibility[t.id] = inGroup.has(t.id));
                 } else {
-                    visibility[tid] = visibility[tid] === false;
+                    // Flip it: assigning the state back to itself leaves a hidden host hidden, so
+                    // the click after a solo did nothing at all.
+                    group.ids.forEach(id => { visibility[id] = !groupVisible; });
                 }
             }
 
@@ -287,18 +337,44 @@ function renderBadges(container) {
     });
 }
 
+// One entry per host, in the order its series first appear, carrying every series id that host
+// owns. Keyed on the raw name because that is what decides the colour - two rows sharing a colour
+// are the same host over different WANs, and the badge speaks for both.
+function badgeGroups() {
+    const byHost = new Map();
+    targetMeta.forEach(t => {
+        const key = t.hostName ?? t.name;
+        if (!byHost.has(key)) byHost.set(key, { key, color: t.color, ids: [] });
+        byHost.get(key).ids.push(t.id);
+    });
+    return [...byHost.values()];
+}
+
+// Draws exactly the series that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries once per series per chart, and each of those is a full
+// redraw - so going from everything to one host, or clearing back again, cost a redraw for every
+// series that changed while the clicks in between cost two. That is why the first selection and
+// the clear were the slow ones. Nothing here talks to the server; it is all redraw.
 function updateChartVisibility() {
     if (!rttChart || !lossChart) return;
-    targetMeta.forEach((t, i) => {
-        const vis = visibility[t.id] !== false;
-        if (vis) {
-            rttChart.showSeries(t.name);
-            lossChart.showSeries(t.name);
-        } else {
-            rttChart.hideSeries(t.name);
-            lossChart.hideSeries(t.name);
-        }
-    });
+    const shown = (lastFetchData?.targets || []).filter(t => visibility[t.targetId] !== false);
+
+    const seriesOf = key => shown.map(t => ({
+        name: wanDisplayName(t),
+        color: hashColor(t.name),
+        data: (t[key] || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
+    }));
+
+    rttChart.updateSeries(seriesOf('rtt'), false);
+    lossChart.updateSeries(seriesOf('loss'), false);
+
+    // Dashes are positional, so they have to be rebuilt against the series actually drawn. Twins
+    // of one host share its colour, so the pattern is the only thing telling their WANs apart.
+    const annotations = buildInvestigateAnnotations();
+    const opts = { annotations, stroke: { curve: 'smooth', width: 2, dashArray: shown.map(wanDashFor) } };
+    rttChart.updateOptions(opts, false, false);
+    lossChart.updateOptions(opts, false, false);
 }
 
 // Mean loss (%) over the visible window at or above which a LAN fabric target is treated as
@@ -337,7 +413,7 @@ function notifyLanFlakyHints(data) {
         const ref = window.__netoptLatencyRef;
         if (!ref) return;
         let ids = [];
-        if (currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
+        if (scopeName() === 'lan' && currentCategory === 'Fabric' && data && Array.isArray(data.targets)) {
             // Mask out timestamps whose loss rode an outage rather than one target's own flakiness,
             // so a switch isn't flagged for loss the gateway (or a shared upstream) caused. A
             // timestamp is an outage when EITHER holds:
@@ -394,32 +470,11 @@ async function loadAndUpdate() {
     targetMeta = scopedTargets.map(t => ({
         id: t.targetId,
         name: wanDisplayName(t),
+        hostName: t.name,
         color: hashColor(t.name),
-    }));
-
-    const rttSeries = scopedTargets.map(t => ({
-        name: wanDisplayName(t),
-        color: hashColor(t.name),
-        data: (t.rtt || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
-    }));
-
-    const lossSeries = scopedTargets.map(t => ({
-        name: wanDisplayName(t),
-        color: hashColor(t.name),
-        data: (t.loss || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 
     lastFetchData = { ...data, targets: scopedTargets };
-
-    const dashArray = scopedTargets.map(wanDashFor);
-    if (rttChart) rttChart.updateSeries(rttSeries, false);
-    if (lossChart) lossChart.updateSeries(lossSeries, false);
-
-    const annotations = buildInvestigateAnnotations();
-    if (rttChart) rttChart.updateOptions({ annotations, stroke: { curve: 'smooth', width: 2, dashArray } }, false, false);
-    // Same dashes as the RTT chart: twins of one host share its color, so the pattern is the only
-    // thing telling their WANs apart here too.
-    if (lossChart) lossChart.updateOptions({ annotations, stroke: { curve: 'smooth', width: 2, dashArray } }, false, false);
 
     updateChartVisibility();
 
@@ -499,6 +554,10 @@ function renderStatsTable(container, showAll) {
         ],
         filter: { meta: () => targetMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },
+            // The same host over two WANs is one series to the user - they are comparing the WANs,
+            // not choosing between them - so its rows toggle together, exactly as the chip above
+            // does. Outside a comparison every group holds one id and this changes nothing.
+            groupOf: (id) => badgeGroups().find(g => g.ids.some(i => String(i) === String(id)))?.ids ?? [id],
             onChanged: (c) => { updateChartVisibility(); renderBadges(c); renderStatsTable(c, true); } },
     });
 }
@@ -664,9 +723,7 @@ export async function mount(elId, initialWanScope, initialCategory) {
     // LAN targets. From here the module owns it: the buttons carry no server-rendered active class,
     // so a re-render of the header cannot put a stale one back while this still holds another.
     if (initialCategory) currentCategory = initialCategory;
-    container.querySelectorAll('[data-category]').forEach(b => {
-        b.classList.toggle('active', b.dataset.category === currentCategory);
-    });
+    applyCategoryAvailability();
 
     const rttEl = container.querySelector('.latency-rtt-chart');
     const lossEl = container.querySelector('.latency-loss-chart');
@@ -894,16 +951,12 @@ export function restoreState() {
 // Blazor pushes the WAN pill bar's state here. Passing null clears scoping entirely
 // (the gate is closed - single WAN, no contexts).
 export function setWanScope(scope) {
-    wanScope = scope && Array.isArray(scope.selected) && scope.selected.length > 0 ? scope : null;
+    // The LAN scope carries no WAN keys, so it must survive the empty-selected check that used to
+    // mean "no scoping at all".
+    wanScope = scope && (scope.lan || (Array.isArray(scope.selected) && scope.selected.length > 0))
+        ? scope : null;
     visibility = {};
-    // LAN targets belong to the site, not to a WAN, so a secondary WAN has none - staying on the
-    // LAN category there draws an empty chart. Only ever leave a category that has nothing to show;
-    // coming back to a WAN that does have LAN targets leaves the choice alone, because by then it
-    // may be the one the user made.
-    if (wanScope && wanScope.hasLan === false && currentCategory === 'Fabric') {
-        setCategory('AccessIsp');
-        return;
-    }
+    applyCategoryAvailability();
     loadAndUpdate();
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -1,10 +1,10 @@
-// External ONT signal time-series charts: RX/TX Power, Temperature, OLT RX Power.
+﻿// External ONT signal time-series charts: RX/TX Power, Temperature, OLT RX Power.
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#4269d0', '#efb118', '#ff725c', '#6cc5b0', '#3ca951', '#ff8ab7'];
@@ -18,7 +18,6 @@ let powerChart = null;
 let tempChart = null;
 // FEC/BIP error-delta chart; its section stays hidden unless some ONT reports the counters.
 let errorsChart = null;
-let errorsSeriesByDevice = {};
 let pollTimer = null;
 let currentRangeHours = 24;
 let windowOffset = 0;
@@ -173,28 +172,48 @@ function onMarkResize() {
     markResizeTimer = setTimeout(applyAnnotations, 200);
 }
 
-function updateVisibility() {
-    // Ahead of the single-ONT short-circuit below: the marks are drawn whether or not there is
-    // more than one series to show and hide.
-    applyAnnotations();
-    if (deviceMeta.length <= 1) return;
-    deviceMeta.forEach(m => {
-        const vis = visibility[m.id] !== false;
-        try {
-            if (powerChart) {
-                if (vis) { powerChart.showSeries(m.label + ' RX'); powerChart.showSeries(m.label + ' TX'); }
-                else { powerChart.hideSeries(m.label + ' RX'); powerChart.hideSeries(m.label + ' TX'); }
-            }
-            if (tempChart) {
-                if (vis) tempChart.showSeries(m.label);
-                else tempChart.hideSeries(m.label);
-            }
-            const es = errorsSeriesByDevice[m.id];
-            if (errorsChart && es) {
-                es.forEach(n => vis ? errorsChart.showSeries(n) : errorsChart.hideSeries(n));
-            }
-        } catch (_) {}
+// RX, TX and temperature each get their own color per ONT, so the three charts stay readable
+// side by side. Indexed by the ONT's place in the full list, so filtering never re-colors a line.
+const COLOR_SETS = [
+    { rx: PALETTE[0], tx: PALETTE[4], temp: PALETTE[1] },
+    { rx: PALETTE[6], tx: PALETTE[3], temp: PALETTE[11] },
+    { rx: PALETTE[10], tx: PALETTE[18], temp: PALETTE[13] },
+];
+
+// Draws exactly the ONTs that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per ONT per series, and each of those is a full redraw.
+function drawSeries() {
+    const all = lastData?.devices || [];
+    const devices = all.filter(d => visibility[d.id] !== false);
+    const powerSeries = [];
+    const tempSeries = [];
+    // Positional, so rebuilt against the ONTs actually drawn: RX solid, TX dashed.
+    const powerDash = [];
+    devices.forEach(d => {
+        const c = COLOR_SETS[all.indexOf(d) % COLOR_SETS.length];
+        const pts = d.data || [];
+        powerSeries.push({ name: d.label + ' RX', color: c.rx, data: alignedPoints(pts, p => p.rx) });
+        powerSeries.push({ name: d.label + ' TX', color: c.tx, data: alignedPoints(pts, p => p.tx) });
+        powerDash.push(0);
+        powerDash.push(5);
+        tempSeries.push({ name: d.label, color: c.temp, data: alignedPoints(pts, p => p.temp) });
     });
+    if (powerChart) {
+        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: powerDash } }, false, false);
+        powerChart.updateSeries(powerSeries, false);
+    }
+    if (tempChart) tempChart.updateSeries(tempSeries, false);
+}
+
+function updateVisibility() {
+    applyAnnotations();
+    // No single-ONT short-circuit: this is the draw path now, not just the toggle path, so the one
+    // ONT on a single-ONT site would never be plotted at all.
+    drawSeries();
+    // Fire-and-forget: it mounts the chart on first use. Kept off the synchronous path so a chart
+    // error can never break chip re-rendering.
+    updateErrorsChart().catch(() => {});
 }
 
 async function loadAndUpdate() {
@@ -206,45 +225,9 @@ async function loadAndUpdate() {
     // Set before updateVisibility below, which is what draws the marks.
     lastEvents = data.events || [];
 
-    const powerSeries = [];
-    const tempSeries = [];
-    const COLOR_SETS = [
-        { rx: PALETTE[0], tx: PALETTE[4], temp: PALETTE[1] },
-        { rx: PALETTE[6], tx: PALETTE[3], temp: PALETTE[11] },
-        { rx: PALETTE[10], tx: PALETTE[18], temp: PALETTE[13] },
-    ];
-    data.devices.forEach((d, i) => {
-        const c = COLOR_SETS[i % COLOR_SETS.length];
-        const pts = d.data || [];
-        powerSeries.push({
-            name: d.label + ' RX',
-            color: c.rx,
-            data: alignedPoints(pts, p => p.rx),
-        });
-        powerSeries.push({
-            name: d.label + ' TX',
-            color: c.tx,
-            data: alignedPoints(pts, p => p.tx),
-        });
-        tempSeries.push({
-            name: d.label,
-            color: c.temp,
-            data: alignedPoints(pts, p => p.temp),
-        });
-    });
-
-    const powerDash = [];
-    data.devices.forEach(() => { powerDash.push(0); powerDash.push(5); });
-    if (powerChart) {
-        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: powerDash } }, false, false);
-        powerChart.updateSeries(powerSeries, false);
-    }
-    if (tempChart) tempChart.updateSeries(tempSeries, false);
-    // Never let an errors-chart failure abort the rest of the refresh (badges, stats table).
-    try { await updateErrorsChart(data); } catch (_) {}
-
-    updateVisibility();
+    // Before updateVisibility, which draws from it.
     lastData = data;
+    updateVisibility();
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
@@ -271,31 +254,29 @@ async function ensureErrorsChartMounted() {
     applyAnnotations();
 }
 
-async function updateErrorsChart(data) {
+async function updateErrorsChart() {
     const container = document.getElementById(containerId);
     const section = container?.querySelector('.ont-errors-section');
     if (!section) return;
-    const withErrors = (data.devices || []).filter(d =>
+    const reporting = (lastData?.devices || []).filter(d =>
         (d.data || []).some(p => p.fec != null || p.bip != null));
-    if (!withErrors.length) {
+    // The section appears when ANY ONT reports errors, filtered or not - it is a property of the
+    // hardware, so it must not come and go as the chips are clicked. Only its series are filtered.
+    if (!reporting.length) {
         section.style.display = 'none';
-        errorsSeriesByDevice = {};
         return;
     }
     await ensureErrorsChartMounted();
     if (!errorsChart) return;
     section.style.display = '';
 
-    errorsSeriesByDevice = {};
+    const withErrors = reporting.filter(d => visibility[d.id] !== false);
     const series = [];
     withErrors.forEach(d => {
         const pts = d.data || [];
-        const s = [
+        series.push(
             { name: `${d.label} FEC`, data: alignedPoints(pts, p => p.fec) },
-            { name: `${d.label} BIP`, data: alignedPoints(pts, p => p.bip) },
-        ];
-        errorsSeriesByDevice[d.id] = s.map(x => x.name);
-        series.push(...s);
+            { name: `${d.label} BIP`, data: alignedPoints(pts, p => p.bip) });
     });
     errorsChart.updateSeries(series, false);
 }
@@ -574,7 +555,6 @@ export function unmount() {
     containerId = null;
     deviceMeta = [];
     visibility = {};
-    errorsSeriesByDevice = {};
     chartEls = {};
     lastData = null;
     lastEvents = [];

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -2,8 +2,8 @@
 // at the current map scrubber position (or live), renders them via the shared
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
-import { renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { renderFilterReset } from './chart-filter.js?v=4';
+import { renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { renderFilterReset } from './chart-filter.js?v=5';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }
@@ -338,6 +338,8 @@ function renderTableNow(showAll) {
             key: 'mac',
             visibility: () => visibility,
             resetVisibility: clearTabFilter,
+            // This one filters device cards, not chart series, so the clear says so.
+            resetLabel: 'Clear filter',
             // Hide filtered devices entirely (showAllRows=false), not grey them out,
             // matching the pill behaviour; re-enable via the pills.
             onChanged: () => { savePrefs(); renderBadges(); renderTableNow(false); },

--- a/src/NetworkOptimizer.Web/wwwroot/js/scrollRestoration.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/scrollRestoration.js
@@ -17,6 +17,11 @@
 
     // Called from C# before navigation
     window.scrollRestoration = {
+        // The box that actually scrolls the page, for anything else that needs to move or measure
+        // it. Exposed rather than duplicated: the window is NOT the scroller here, and code that
+        // assumes it is fails silently - window.scrollBy simply moves nothing.
+        container: getScrollContainer,
+
         savePosition: function(path) {
             const container = getScrollContainer();
             if (container) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -1,10 +1,10 @@
-// SFP DDM time-series charts: RX/TX power, temperature, voltage.
+﻿// SFP DDM time-series charts: RX/TX power, temperature, voltage.
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 import { createMarkLayer } from './chart-event-marks.js?v=1';
 
 const PALETTE = window.Apex?.colors || ['#7EB26D', '#EAB839', '#6ED0E0', '#EF843C', '#E24D42', '#1F78C1'];
@@ -194,18 +194,37 @@ function onMarkResize() {
     markResizeTimer = setTimeout(applyAnnotations, 200);
 }
 
-function updateVisibility() {
-    moduleMeta.forEach(m => {
-        const vis = visibility[m.id] !== false;
-        if (powerChart) {
-            if (vis) { powerChart.showSeries(`${m.label} RX`); powerChart.showSeries(`${m.label} TX`); }
-            else { powerChart.hideSeries(`${m.label} RX`); powerChart.hideSeries(`${m.label} TX`); }
-        }
-        if (tempChart) {
-            if (vis) tempChart.showSeries(m.label);
-            else tempChart.hideSeries(m.label);
-        }
+// Draws exactly the modules that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per module, and each of those is a full redraw - so a
+// chip click cost one redraw per module it changed, and going from everything to one cost as many
+// as there are modules. Colors come from moduleMeta, which holds each module's palette slot from
+// the full list, so filtering never re-colors what stays on screen.
+function drawSeries() {
+    const modules = (lastData?.modules || []).filter(m => visibility[m.id] !== false);
+    const powerSeries = [];
+    const tSeries = [];
+    // Dash patterns are positional, so they are rebuilt against the series actually drawn: RX
+    // solid, TX dashed, per module.
+    const powerDash = [];
+    modules.forEach(m => {
+        const color = moduleMeta.find(x => x.id === m.id)?.color || PALETTE[0];
+        const pts = m.data || [];
+        powerSeries.push({ name: `${m.label} RX`, color: color, data: alignedPoints(pts, p => p.rx) });
+        powerSeries.push({ name: `${m.label} TX`, color: color, data: alignedPoints(pts, p => p.tx) });
+        powerDash.push(0);
+        powerDash.push(5);
+        tSeries.push({ name: m.label, color: color, data: alignedPoints(pts, p => p.temp) });
     });
+    if (powerChart) {
+        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: powerDash } }, false, false);
+        powerChart.updateSeries(powerSeries, false);
+    }
+    if (tempChart) tempChart.updateSeries(tSeries, false);
+}
+
+function updateVisibility() {
+    drawSeries();
     applyAnnotations();
     // Fire-and-forget: rebuilds the PON charts/section for the selected modules. Kept
     // off the synchronous path so a chart error can never break chip re-rendering.
@@ -265,40 +284,12 @@ async function loadAndUpdate() {
     // Set before updateVisibility below, which is what draws the marks.
     lastEvents = data.events || [];
 
-    const powerSeries = [];
-    const tSeries = [];
-    data.modules.forEach((m, i) => {
-        const color = PALETTE[i % PALETTE.length];
-        const pts = m.data || [];
-        powerSeries.push({
-            name: `${m.label} RX`,
-            color: color,
-            data: alignedPoints(pts, p => p.rx),
-        });
-        powerSeries.push({
-            name: `${m.label} TX`,
-            color: color,
-            data: alignedPoints(pts, p => p.tx),
-        });
-        tSeries.push({
-            name: m.label,
-            color: color,
-            data: alignedPoints(pts, p => p.temp),
-        });
-    });
-
-    const powerDash = [];
-    data.modules.forEach(() => { powerDash.push(0); powerDash.push(5); });
-    if (powerChart) {
-        powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: powerDash } }, false, false);
-        powerChart.updateSeries(powerSeries, false);
-    }
-    if (tempChart) tempChart.updateSeries(tSeries, false);
     // Never let a PON chart failure abort the rest of the refresh (badges, stats table).
     try { await updatePonCharts(data); } catch (_) {}
 
-    updateVisibility();
+    // Before updateVisibility, which draws from it.
     lastData = data;
+    updateVisibility();
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/site-context.js
@@ -218,3 +218,49 @@ window.noScrollTo = function (id, block) {
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: block || 'start' });
 };
+
+// Holds an element at the same place on screen while something ABOVE it changes height, for a
+// control the user is about to press again. Filtering the Latency Targets bar re-picks the chart
+// series above it, and the statistics table that grows or shrinks with them drags the whole card -
+// pills included - out from under the cursor. What the user is looking at is the fixed point here,
+// not the scroll offset, so the page moves to keep the element still rather than the other way
+// round. Scroll-anchoring the browser does on its own stops at the first layout; the table settles
+// over several, once the new series have loaded, so this watches for a window.
+window.noHoldScroll = function (id, windowMs) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    // The page does not scroll the window. .page-content owns the scrollbar on desktop and
+    // .main-content does on mobile, so window.scrollBy moves nothing and does not error either -
+    // it just silently does nothing at all. scrollRestoration already resolves which of the two it
+    // is, so it is asked rather than the rule being written out a second time here.
+    var box = window.scrollRestoration && window.scrollRestoration.container
+        ? window.scrollRestoration.container()
+        : null;
+    var startTop = el.getBoundingClientRect().top;
+    var until = performance.now() + (windowMs || 1500);
+    var released = false;
+    function release() { released = true; }
+    // The user's own scroll wins outright - they have just moved the fixed point themselves. Only
+    // input events, never 'scroll', which our own compensation raises.
+    window.addEventListener('wheel', release, { passive: true });
+    window.addEventListener('touchmove', release, { passive: true });
+    window.addEventListener('keydown', release);
+    function tick(now) {
+        if (released || now >= until) {
+            window.removeEventListener('wheel', release);
+            window.removeEventListener('touchmove', release);
+            window.removeEventListener('keydown', release);
+            return;
+        }
+        var delta = el.getBoundingClientRect().top - startTop;
+        if (Math.abs(delta) >= 1) {
+            // scrollTop assignment rather than scrollBy: scroll-behavior: smooth is set on
+            // html/body, and an animated correction would still be running when the next frame
+            // measures, so each frame would chase the last one instead of settling.
+            if (box) box.scrollTop += delta;
+            else window.scrollBy({ top: delta, left: 0, behavior: 'instant' });
+        }
+        requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+};

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -1,11 +1,11 @@
-// Starlink terminal time-series charts: power draw, ping drop rate, obstruction,
+﻿// Starlink terminal time-series charts: power draw, ping drop rate, obstruction,
 // outage seconds, GPS satellites, alignment offset.
 // Same control pattern as cellular-charts.js and cm-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=4';
-import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=8';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=4';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=6';
+import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=10';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
 
 const PALETTE = window.Apex?.colors || ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
 const _esc = document.createElement('span');
@@ -33,19 +33,6 @@ let visibility = {};
 let visibilityObserver = null;
 let isInViewport = true;
 let lastData = null;
-
-// Paired charts carry an avg (solid) and max (dashed) series per terminal;
-// the suffixes let visibility toggling reach both.
-function chartsWithSuffixes() {
-    return [
-        { chart: powerChart, suffixes: [' (avg)', ' (max)'] },
-        { chart: dropChart, suffixes: [' (avg)', ' (max)'] },
-        { chart: obstructionChart, suffixes: [''] },
-        { chart: outageChart, suffixes: [''] },
-        { chart: gpsChart, suffixes: [''] },
-        { chart: alignmentChart, suffixes: [''] },
-    ];
-}
 
 function baseOpts(height, yTitle, yFormatter, extra) {
     return {
@@ -153,38 +140,25 @@ function renderBadges(container) {
     renderFilterReset(el, isFiltered(visibility), () => { visibility = {}; updateVisibility(); renderBadges(container); });
 }
 
-function updateVisibility() {
-    deviceMeta.forEach(m => {
-        const vis = visibility[m.id] !== false;
-        chartsWithSuffixes().forEach(({ chart, suffixes }) => {
-            if (!chart) return;
-            suffixes.forEach(suffix => {
-                if (vis) chart.showSeries(m.label + suffix);
-                else chart.hideSeries(m.label + suffix);
-            });
-        });
-    });
-}
-
 const pct = v => v != null ? v * 100 : null;
 
-async function loadAndUpdate() {
-    const data = await fetchData();
-    if (!data?.devices) return;
-    deviceMeta = data.devices.map((d, i) => ({
-        id: d.id, label: d.label, color: PALETTE[i % PALETTE.length],
-    }));
-
+// Draws exactly the terminals that should be on screen, in one update per chart.
+//
+// This used to call showSeries/hideSeries per terminal per series on all six charts, and each of
+// those is a full redraw. Colors come from deviceMeta, which holds each terminal's palette slot
+// from the full list, so filtering never re-colors what stays on screen.
+function updateVisibility() {
+    const devices = (lastData?.devices || []).filter(d => visibility[d.id] !== false);
+    const colorOf = d => deviceMeta.find(x => x.id === d.id)?.color || PALETTE[0];
     const powerSeries = [];
     const dropSeries = [];
     const obstructionSeries = [];
     const outageSeries = [];
     const gpsSeries = [];
     const alignmentSeries = [];
-    data.devices.forEach((d, i) => {
-        const color = PALETTE[i % PALETTE.length];
-        const pts = d.data || [];
-        const map = (sel) => alignedPoints(pts, sel);
+    devices.forEach(d => {
+        const color = colorOf(d);
+        const map = (sel) => alignedPoints(d.data || [], sel);
         powerSeries.push(
             { name: `${d.label} (avg)`, color, data: map(p => p.powerAvg) },
             { name: `${d.label} (max)`, color, data: map(p => p.powerMax) });
@@ -197,8 +171,9 @@ async function loadAndUpdate() {
         alignmentSeries.push({ name: d.label, color, data: map(p => p.alignment) });
     });
 
-    // Solid avg / dashed max per terminal on the paired charts
-    const pairedDash = data.devices.flatMap(() => [0, 5]);
+    // Solid avg / dashed max per terminal on the paired charts. Positional, so rebuilt against the
+    // terminals actually drawn.
+    const pairedDash = devices.flatMap(() => [0, 5]);
     if (powerChart) {
         powerChart.updateOptions({ stroke: { curve: 'smooth', width: 2, dashArray: pairedDash } }, false, false);
         powerChart.updateSeries(powerSeries, false);
@@ -211,9 +186,18 @@ async function loadAndUpdate() {
     if (outageChart) outageChart.updateSeries(outageSeries, false);
     if (gpsChart) gpsChart.updateSeries(gpsSeries, false);
     if (alignmentChart) alignmentChart.updateSeries(alignmentSeries, false);
+}
 
-    updateVisibility();
+async function loadAndUpdate() {
+    const data = await fetchData();
+    if (!data?.devices) return;
+    deviceMeta = data.devices.map((d, i) => ({
+        id: d.id, label: d.label, color: PALETTE[i % PALETTE.length],
+    }));
+
+    // Before updateVisibility, which draws from it.
     lastData = data;
+    updateVisibility();
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);

--- a/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/wan-live-chart.js
@@ -1,10 +1,10 @@
-// WAN live chart — real-time area+line chart showing download, upload, packet
+﻿// WAN live chart — real-time area+line chart showing download, upload, packet
 // loss, and mean ISP/transit RTT. Pre-loads history from InfluxDB, then polls
 // /api/monitoring/live-stats for real-time updates.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import * as flowData from './lan-flow-data.js?v=7';
-import { valueSortedTooltip } from './chart-tooltip.js?v=8';
+import { valueSortedTooltip } from './chart-tooltip.js?v=10';
 import { downloadColor, uploadColor } from './chart-colors.js?v=2';
 
 const HISTORY_MINUTES = 5;

--- a/tests/NetworkOptimizer.Core.Tests/SelectUsableAddressTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/SelectUsableAddressTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests;
+
+/// <summary>
+/// A name can resolve to more than one address, and not all of them are hosts. Picking the wrong
+/// one decides the wrong answer about where the thing lives.
+/// </summary>
+public class SelectUsableAddressTests
+{
+    private static IPAddress[] Ips(params string[] values) =>
+        values.Select(IPAddress.Parse).ToArray();
+
+    [Fact]
+    public void Discards_the_unspecified_answer_and_takes_the_real_one()
+    {
+        // A gateway whose name carries a good A record behind a junk AAAA - which is what a
+        // search-domain suffix that exists but answers nothing looks like.
+        NetworkUtilities.SelectUsableAddress(Ips("::", "192.168.1.1"))
+            .Should().Be(IPAddress.Parse("192.168.1.1"));
+    }
+
+    [Fact]
+    public void Discards_an_unspecified_v4_answer_in_favour_of_a_real_v6_one()
+    {
+        // Rejecting has to happen BEFORE preferring, or a junk A record outranks a good AAAA.
+        NetworkUtilities.SelectUsableAddress(Ips("0.0.0.0", "2001:db8::1"))
+            .Should().Be(IPAddress.Parse("2001:db8::1"));
+    }
+
+    [Fact]
+    public void Prefers_ipv4_when_both_are_real()
+    {
+        NetworkUtilities.SelectUsableAddress(Ips("2001:db8::1", "203.0.113.10"))
+            .Should().Be(IPAddress.Parse("203.0.113.10"));
+    }
+
+    [Fact]
+    public void Takes_ipv6_when_that_is_all_there_is()
+    {
+        NetworkUtilities.SelectUsableAddress(Ips("2001:db8::1"))
+            .Should().Be(IPAddress.Parse("2001:db8::1"));
+    }
+
+    [Fact]
+    public void Finds_nothing_when_no_answer_is_a_host()
+    {
+        NetworkUtilities.SelectUsableAddress(Ips("::", "0.0.0.0")).Should().BeNull();
+        NetworkUtilities.SelectUsableAddress(Array.Empty<IPAddress>()).Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Storage.Tests/LegacyWan1KeyNormalizationTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/LegacyWan1KeyNormalizationTests.cs
@@ -1,4 +1,5 @@
-using FluentAssertions;
+﻿using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -48,15 +49,21 @@ public class LegacyWan1KeyNormalizationTests : IDisposable
         return new NetworkOptimizerDbContext(options);
     }
 
-    private static MonitoringTarget Target(string targetId, string? wanInterface) => new()
-    {
-        TargetId = targetId,
-        Name = targetId,
-        Address = "203.0.113.10",
-        TargetType = MonitoringTargetType.AccessIsp,
-        ProbeMode = ProbeMode.Icmp,
-        WanInterface = wanInterface,
-    };
+    /// <summary>
+    /// Seeds through raw SQL rather than the entity - see the note in
+    /// WanContextTargetWanBackfillTests: an EF insert would use the current model and break on
+    /// every column added to MonitoringTargets after this migration.
+    /// </summary>
+    private static void SeedTarget(NetworkOptimizerDbContext context, string targetId, string? wanInterface) =>
+        context.Database.ExecuteSqlRaw(
+            "INSERT INTO MonitoringTargets (TargetId, Name, Address, TargetType, ProbeMode, "
+            + "WanInterface, VantagePoint, PollIntervalSeconds, PingCount, Enabled, AutoDiscovered, "
+            + "CreatedAt) VALUES (@id, @id, '203.0.113.10', 2, 0, @wan, 'server', 10, 5, 1, 0, "
+            + "datetime('now'))",
+            new SqliteParameter("@id", targetId),
+            new SqliteParameter("@wan", (object?)wanInterface ?? DBNull.Value));
+
+
 
     [Fact]
     public void Normalize_RenamesTheLegacySpellingEverywhereItIsStored()
@@ -66,7 +73,7 @@ public class LegacyWan1KeyNormalizationTests : IDisposable
             context.GetService<IMigrator>().Migrate(PreNormalizeMigration);
 
             context.WanDiscoveryContexts.Add(new WanDiscoveryContext { WanInterface = "wan1", AccessTechnology = AccessTechnology.Gpon });
-            context.MonitoringTargets.Add(Target("access-legacy", "wan1"));
+            SeedTarget(context, "access-legacy", "wan1");
             context.UpstreamDiscoveries.Add(new UpstreamDiscovery { HopIp = "192.0.2.30", HopNumber = 1, WanInterface = "wan1" });
             context.WanContexts.Add(new WanContext { Id = 1, Name = "legacy-context", WanInterface = "wan1", ProbeSourceIp = "198.51.100.9" });
             context.SaveChanges();
@@ -156,8 +163,8 @@ public class LegacyWan1KeyNormalizationTests : IDisposable
             context.GetService<IMigrator>().Migrate(PreNormalizeMigration);
 
             context.WanDiscoveryContexts.Add(new WanDiscoveryContext { WanInterface = "wan2" });
-            context.MonitoringTargets.Add(Target("access-wan2", "wan2"));
-            context.MonitoringTargets.Add(Target("access-unstamped", null));
+            SeedTarget(context, "access-wan2", "wan2");
+            SeedTarget(context, "access-unstamped", null);
             context.SaveChanges();
         }
 
@@ -167,7 +174,9 @@ public class LegacyWan1KeyNormalizationTests : IDisposable
 
             context.WanDiscoveryContexts.Single().WanInterface.Should().Be("wan2");
             context.MonitoringTargets.Single(t => t.TargetId == "access-wan2").WanInterface.Should().Be("wan2");
-            context.MonitoringTargets.Single(t => t.TargetId == "access-unstamped").WanInterface.Should().BeNull();
+            // Normalization leaves it alone; the later unpinned migration then names it.
+            context.MonitoringTargets.Single(t => t.TargetId == "access-unstamped").WanInterface
+                .Should().Be(MonitoringTarget.UnpinnedWan);
         }
     }
 

--- a/tests/NetworkOptimizer.Storage.Tests/WanContextTargetWanBackfillTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/WanContextTargetWanBackfillTests.cs
@@ -1,4 +1,5 @@
-using FluentAssertions;
+﻿using FluentAssertions;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -49,16 +50,25 @@ public class WanContextTargetWanBackfillTests : IDisposable
         return new NetworkOptimizerDbContext(options);
     }
 
-    private static MonitoringTarget Target(string targetId, string address, int? contextId, string? wanInterface) => new()
-    {
-        TargetId = targetId,
-        Name = targetId,
-        Address = address,
-        TargetType = MonitoringTargetType.Custom,
-        ProbeMode = ProbeMode.Icmp,
-        WanContextId = contextId,
-        WanInterface = wanInterface,
-    };
+    /// <summary>
+    /// Seeds through raw SQL rather than the entity, naming only the columns that exist at the
+    /// migration under test. Inserting via EF would use the CURRENT model, so every column added
+    /// to MonitoringTargets afterwards would break these - which is the opposite of what a
+    /// migration test should be sensitive to.
+    /// </summary>
+    private static void SeedTarget(NetworkOptimizerDbContext context, string targetId, string address,
+        int? contextId, string? wanInterface) =>
+        context.Database.ExecuteSqlRaw(
+            "INSERT INTO MonitoringTargets (TargetId, Name, Address, TargetType, ProbeMode, "
+            + "WanContextId, WanInterface, VantagePoint, PollIntervalSeconds, PingCount, Enabled, "
+            + "AutoDiscovered, CreatedAt) VALUES (@id, @id, @addr, 4, 0, @ctx, @wan, 'server', 10, 5, "
+            + "1, 0, datetime('now'))",
+            new SqliteParameter("@id", targetId),
+            new SqliteParameter("@addr", address),
+            new SqliteParameter("@ctx", (object?)contextId ?? DBNull.Value),
+            new SqliteParameter("@wan", (object?)wanInterface ?? DBNull.Value));
+
+
 
     [Fact]
     public void Backfill_GivesAContextsTargetsTheContextsWan()
@@ -70,8 +80,8 @@ public class WanContextTargetWanBackfillTests : IDisposable
             context.WanContexts.Add(new WanContext { Id = 1, Name = "backup-wan", WanInterface = "wan2", ProbeSourceIp = "198.51.100.7" });
             // Assigned to the context but never given a WAN, and assigned but stamped with the
             // primary's WAN by a discovery that predates per-WAN contexts.
-            context.MonitoringTargets.Add(Target("t-unstamped", "203.0.113.1", contextId: 1, wanInterface: null));
-            context.MonitoringTargets.Add(Target("t-wrong-wan", "203.0.113.2", contextId: 1, wanInterface: "wan"));
+            SeedTarget(context, "t-unstamped", "203.0.113.1", contextId: 1, wanInterface: null);
+            SeedTarget(context, "t-wrong-wan", "203.0.113.2", contextId: 1, wanInterface: "wan");
             context.SaveChanges();
         }
 
@@ -93,8 +103,8 @@ public class WanContextTargetWanBackfillTests : IDisposable
         {
             context.GetService<IMigrator>().Migrate(PreBackfillMigration);
 
-            context.MonitoringTargets.Add(Target("t-primary", "203.0.113.3", contextId: null, wanInterface: "wan"));
-            context.MonitoringTargets.Add(Target("t-manual", "203.0.113.4", contextId: null, wanInterface: null));
+            SeedTarget(context, "t-primary", "203.0.113.3", contextId: null, wanInterface: "wan");
+            SeedTarget(context, "t-manual", "203.0.113.4", contextId: null, wanInterface: null);
             context.SaveChanges();
         }
 
@@ -103,7 +113,9 @@ public class WanContextTargetWanBackfillTests : IDisposable
             MigrationSafety.MigrateWithFriendlyErrors(context);
 
             context.MonitoringTargets.Single(t => t.TargetId == "t-primary").WanInterface.Should().Be("wan");
-            context.MonitoringTargets.Single(t => t.TargetId == "t-manual").WanInterface.Should().BeNull();
+            // Still unreconciled, but no longer NULL: a later migration names the state.
+            context.MonitoringTargets.Single(t => t.TargetId == "t-manual").WanInterface
+                .Should().Be(MonitoringTarget.UnpinnedWan);
         }
     }
 
@@ -116,7 +128,7 @@ public class WanContextTargetWanBackfillTests : IDisposable
             context.GetService<IMigrator>().Migrate(PreBackfillMigration);
 
             context.WanContexts.Add(new WanContext { Id = 2, Name = "legacy", ProbeSourceIp = "198.51.100.8" });
-            context.MonitoringTargets.Add(Target("t-legacy", "203.0.113.5", contextId: 2, wanInterface: "wan"));
+            SeedTarget(context, "t-legacy", "203.0.113.5", contextId: 2, wanInterface: "wan");
             context.SaveChanges();
         }
 

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
@@ -177,4 +177,52 @@ public class GatewayWanHelperTests
         GatewayWanHelper.EnumerateWanInterfaces(Device("""{ "type": "ucg" }""")).Should().BeEmpty();
         GatewayWanHelper.EnumerateWanInterfaces(Device("""{ "wan1": "not-an-object" }""")).Should().BeEmpty();
     }
+
+    // The network's own name wins; the port answers only when the network name is stock and the
+    // port has actually been renamed.
+    [Theory]
+    [InlineData("Acme Fiber", "Port 5", "Acme Fiber")]
+    [InlineData("Acme Fiber", "Uplink", "Acme Fiber")]
+    [InlineData("Internet 2", "Uplink", "Uplink")]
+    [InlineData("Internet", "Uplink", "Uplink")]
+    [InlineData("WAN2", "Uplink", "Uplink")]
+    [InlineData(null, "Uplink", "Uplink")]
+    [InlineData("  Acme Fiber  ", "Port 5", "Acme Fiber")]
+    public void ResolveWanName_prefers_the_network_name(string? network, string? port, string expected)
+    {
+        GatewayWanHelper.ResolveWanName(network, port).Should().Be(expected);
+    }
+
+    // A port placeholder in the NETWORK slot is still a placeholder - checking only for a generic
+    // WAN name there let "SFP+ 2" through as though someone had chosen it.
+    [Theory]
+    [InlineData("SFP+ 2", "Acme Fiber", "Acme Fiber")]
+    [InlineData("Port 5", null, null)]
+    public void ResolveWanName_rejects_a_port_placeholder_in_either_slot(
+        string? network, string? port, string? expected)
+    {
+        GatewayWanHelper.ResolveWanName(network, port).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Internet 2", true)]
+    [InlineData("WAN3", true)]
+    [InlineData("SFP+ 2", true)]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("Acme Fiber", false)]
+    public void IsPlaceholderWanName_covers_both_kinds(string? name, bool expected)
+    {
+        GatewayWanHelper.IsPlaceholderWanName(name).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Internet 2", "Port 5")]
+    [InlineData("Internet 2", null)]
+    [InlineData(null, null)]
+    [InlineData("", "")]
+    public void ResolveWanName_is_null_when_neither_is_a_real_name(string? network, string? port)
+    {
+        GatewayWanHelper.ResolveWanName(network, port).Should().BeNull();
+    }
 }

--- a/tests/NetworkOptimizer.UniFi.Tests/TrafficRouteWanPinningTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/TrafficRouteWanPinningTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// On a load-balancing site an unpinned probe measures no single WAN, and a policy route is the
+/// one thing that can say otherwise. It only counts when it steers EVERY destination for the
+/// probing box - anything narrower says nothing about where a probe elsewhere leaves.
+/// </summary>
+public class TrafficRouteWanPinningTests
+{
+    private const string ProbeMac = "00:11:22:33:44:55";
+
+    private static UniFiTrafficRouteResponse Route(
+        string networkId, bool enabled = true, string target = "INTERNET",
+        string? mac = ProbeMac, string deviceType = "CLIENT", bool killSwitch = false) => new()
+        {
+            Id = networkId + "-route",
+            Description = "route",
+            Enabled = enabled,
+            MatchingTarget = target,
+            NetworkId = networkId,
+            KillSwitchEnabled = killSwitch,
+            TargetDevices = new List<UniFiTrafficRouteTargetDevice>
+            {
+                new() { ClientMac = mac, Type = deviceType }
+            }
+        };
+
+    [Fact]
+    public void Pins_the_wan_of_a_blanket_internet_route_naming_the_device()
+    {
+        var pin = TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id") }, ProbeMac);
+
+        pin.Should().NotBeNull();
+        pin!.NetworkId.Should().Be("wan-net-id");
+    }
+
+    [Fact]
+    public void Ignores_a_disabled_route()
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id", enabled: false) }, ProbeMac)
+            .Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("IP")]
+    [InlineData("DOMAIN")]
+    [InlineData("REGION")]
+    public void Ignores_a_route_that_steers_only_some_destinations(string target)
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id", target: target) }, ProbeMac)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Ignores_a_route_aimed_at_another_device()
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id", mac: "aa:bb:cc:dd:ee:ff") }, ProbeMac)
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Accepts_an_all_clients_route()
+    {
+        var pin = TrafficRouteWanPinning.ResolvePin(
+            new[] { Route("wan-net-id", mac: null, deviceType: "ALL_CLIENTS") }, ProbeMac);
+
+        pin!.NetworkId.Should().Be("wan-net-id");
+    }
+
+    [Fact]
+    public void Prefers_the_route_naming_the_device_over_a_blanket_all_clients_one()
+    {
+        var routes = new[]
+        {
+            Route("all-clients-net", mac: null, deviceType: "ALL_CLIENTS"),
+            Route("named-net"),
+        };
+
+        TrafficRouteWanPinning.ResolvePin(routes, ProbeMac)!.NetworkId.Should().Be("named-net");
+    }
+
+    [Theory]
+    [InlineData("00-11-22-33-44-55")]
+    [InlineData("001122 334455")]
+    public void Compares_macs_regardless_of_separator_or_case(string written)
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id", mac: written) }, ProbeMac)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Reports_the_kill_switch_so_callers_know_a_failover_will_not_re_route()
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("n", killSwitch: true) }, ProbeMac)!
+            .KillSwitchEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Finds_nothing_for_a_device_with_no_mac()
+    {
+        TrafficRouteWanPinning.ResolvePin(new[] { Route("wan-net-id") }, null).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The console hands back bools and numbers as strings whenever it feels like it, so the DTO
+    /// leans on the flexible converters rather than trusting the JSON types.
+    /// </summary>
+    [Fact]
+    public void Reads_string_encoded_bools_the_console_may_send()
+    {
+        const string json = """
+        [{"_id":"r1","description":"[TEST] Rig out DOCSIS","enabled":"true",
+          "matching_target":"INTERNET","network_id":"wan-net-id",
+          "kill_switch_enabled":"false",
+          "target_devices":[{"client_mac":"00:11:22:33:44:55","type":"CLIENT"}]}]
+        """;
+
+        var routes = JsonSerializer.Deserialize<List<UniFiTrafficRouteResponse>>(json)!;
+
+        routes[0].Enabled.Should().BeTrue();
+        routes[0].KillSwitchEnabled.Should().BeFalse();
+        TrafficRouteWanPinning.ResolvePin(routes, ProbeMac)!.NetworkId.Should().Be("wan-net-id");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/IspHealthScorerTests.cs
@@ -677,6 +677,158 @@ public class IspHealthScorerTests
         factor.Score.Should().Be(70);
     }
 
+    /// <summary>Loss pool holding one series that is clean except for lossy probes at the given times.</summary>
+    private static IspHealthInputs WithLossyProbesUnderDownLoad(params int[] minutesIntoDownLoad)
+    {
+        var inputs = BuildInputs();
+        var series = TestSeries.Flat(TestSeries.Start, Day, 1.5, 0.3, 0);
+        foreach (var m in minutesIntoDownLoad)
+        {
+            var at = LoadedDownStart.AddMinutes(m);
+            series = series.WithSegment(at, at.AddMinutes(1), 1.5, 0.3, 20);
+        }
+        inputs.LossPoolSeries.Clear();
+        inputs.LossPoolSeries.Add(series);
+        return inputs;
+    }
+
+    private static string LoadedLossValueText(IspHealthInputs inputs) =>
+        new IspHealthScorer(Options).Score(inputs, Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss").ValueText ?? "";
+
+    [Fact]
+    public void One_lossy_probe_in_one_load_episode_does_not_make_a_loaded_loss_rate()
+    {
+        // A five-ping probe quantizes to 20% steps, so a single dropped ping is the smallest thing
+        // the pool can see - and the credibility weighting concentrates it instead of diluting it.
+        LoadedLossValueText(WithLossyProbesUnderDownLoad(30)).Should().StartWith("n/a down");
+    }
+
+    [Fact]
+    public void A_second_lossy_probe_makes_it_a_rate()
+    {
+        LoadedLossValueText(WithLossyProbesUnderDownLoad(30, 90)).Should().NotStartWith("n/a down");
+    }
+
+    [Fact]
+    public void A_clean_loaded_pool_still_reports_zero_rather_than_going_quiet()
+    {
+        LoadedLossValueText(WithLossyProbesUnderDownLoad()).Should().StartWith("0% down");
+    }
+
+    [Fact]
+    public void A_direction_that_never_reported_costs_the_factor_half_its_weight()
+    {
+        // Absence of evidence should cost influence rather than re-centre the factor on whichever
+        // direction did report, which it kept full weight to do.
+        var both = new IspHealthScorer(Options).Score(WithLossyProbesUnderDownLoad(), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss");
+        both.Weight.Should().BeApproximately(Options.LoadedLossWeight, 1e-9);
+
+        var oneSided = WithLossyProbesUnderDownLoad();
+        // Strip the upload load so only downstream has a pool to grade.
+        for (var i = 0; i < oneSided.WanRates.Count; i++)
+        {
+            var r = oneSided.WanRates[i];
+            if (r.Time >= LoadedUpStart && r.Time < LoadedUpEnd)
+                oneSided.WanRates[i] = r with { UploadBps = 5_000_000 };
+        }
+
+        var factor = new IspHealthScorer(Options).Score(oneSided, Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss");
+        factor.ValueText.Should().EndWith("n/a up");
+        factor.Weight.Should().BeApproximately(Options.LoadedLossWeight / 2, 1e-9);
+    }
+
+    [Fact]
+    public void A_gated_direction_says_so_rather_than_reading_like_it_was_never_loaded()
+    {
+        var factor = new IspHealthScorer(Options).Score(WithLossyProbesUnderDownLoad(30), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss");
+
+        factor.ValueText.Should().StartWith("n/a down");
+        factor.Description.Should().EndWith(
+            "Downstream is not graded - one dropped probe in a single load episode is not a rate.");
+    }
+
+    [Fact]
+    public void Loaded_loss_names_the_bands_it_actually_scored_against()
+    {
+        var factor = new IspHealthScorer(Options).Score(WithLossyProbesUnderDownLoad(), Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss");
+
+        factor.ValueText.Should().Be("0% down, 0% up");
+        factor.Description.Should().Be(
+            "Packet loss while the line is under load vs the 1% to 2% downstream and 0.5% to 1.5% upstream bands for GPON.");
+    }
+
+    // ─── Speed-test shaped load: a short download phase handing straight over to an upload phase,
+    // which is what a scheduled WAN speed test looks like and where end-stamped probes were landing
+    // in the wrong phase. Rates every 7 s so each phase is its own run of loaded windows. ───
+
+    private const int Ws = 7;
+
+    /// <summary>Two back-to-back down-then-up saturations an hour apart, on a 1000/1000 plan.</summary>
+    private static List<ThroughputSample> SpeedTestShapedRates(DateTime start, int count, params DateTime[] tests)
+    {
+        var rates = new List<ThroughputSample>();
+        for (var i = 0; i < count; i++)
+        {
+            var t = start.AddSeconds(i * Ws);
+            double down = 2_000_000, up = 2_000_000;
+            foreach (var test in tests)
+            {
+                var into = (t - test).TotalSeconds;
+                if (into >= 0 && into < 3 * Ws) down = 900_000_000;
+                else if (into >= 3 * Ws && into < 6 * Ws) up = 900_000_000;
+            }
+            rates.Add(new ThroughputSample(t, down, up));
+        }
+        return rates;
+    }
+
+    [Fact]
+    public void A_probe_finishing_just_past_the_handover_belongs_to_the_phase_it_measured()
+    {
+        // The reported bug. Loss arrives ALREADY aggregated onto the same grid as the rates, so a
+        // probe that ran under the download saturation but completed just after the last download
+        // window closed is stamped on the FIRST UPLOAD window - and was scored as upload loss.
+        var start = TestSeries.Start;
+        var testA = start.AddMinutes(10);
+        var testB = start.AddMinutes(70);
+        var rates = SpeedTestShapedRates(start, 1200, testA, testB);
+
+        var lossy = new[] { testA, testB }.Select(t => t.AddSeconds(3 * Ws)).ToHashSet();
+        var probes = new List<LatencySample>();
+        for (var i = 0; i < 1200; i++)
+        {
+            var t = start.AddSeconds(i * Ws);
+            probes.Add(new LatencySample(t, 2.0, 2.3, 0.3, lossy.Contains(t) ? 20 : 0));
+        }
+
+        var inputs = new IspHealthInputs
+        {
+            WindowStart = start,
+            WindowEnd = start.AddSeconds(1200 * Ws),
+            FirstHopSeries = probes,
+            AccessHopSeries = new List<List<LatencySample>> { probes },
+            LossPoolSeries = new List<List<LatencySample>> { probes },
+            WanRates = rates,
+            ExpectedDownloadMbps = 1000,
+            ExpectedUploadMbps = 1000,
+            ExpectedSpeedSource = "UniFi Network",
+            WanSpeedTests = new List<SpeedTestSample> { new(testA, 980, 980) }
+        };
+
+        var value = new IspHealthScorer(Options).Score(inputs, Gpon)
+            .AccessDimension.Factors.Single(f => f.Name == "Loaded Loss").ValueText ?? "";
+
+        // The sample straddles the handover and the aggregation has lost which probe sat where, so
+        // both phases carry it - but download must no longer read a flat zero while upload owns all
+        // of it, which is what the end-stamp binning produced.
+        value.Should().NotStartWith("0% down", "the probes ran under the download saturation");
+    }
+
     [Fact]
     public void Renormalizes_when_expected_speeds_missing()
     {

--- a/tests/NetworkOptimizer.Web.Tests/IspHealth/LoadClassifierTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/IspHealth/LoadClassifierTests.cs
@@ -104,6 +104,26 @@ public class LoadClassifierTests
     }
 
     [Fact]
+    public void Demotion_clears_the_live_flag_but_never_the_classified_one()
+    {
+        // Dilation's opposite-direction barrier reads the classified pair, so a demoted phase still
+        // stops the surviving phase from dilating into it.
+        var ws = Options.LoadWindowSeconds;
+        var rates = new List<ThroughputSample>
+        {
+            new(TestSeries.Start, 10_000_000, 1_000_000),
+            new(TestSeries.Start.AddSeconds(ws), 900_000_000, 2_000_000),
+            new(TestSeries.Start.AddSeconds(ws * 2), 10_000_000, 1_000_000)
+        };
+
+        var windows = LoadClassifier.Classify(rates, expectedDownloadMbps: 1000, expectedUploadMbps: 100, Options);
+
+        var demoted = windows[windows.Keys.OrderBy(k => k).ToList()[1]];
+        demoted.IsLoadedDown.Should().BeFalse();
+        demoted.ClassifiedLoadedDown.Should().BeTrue();
+    }
+
+    [Fact]
     public void Lone_loaded_window_between_idle_ones_does_not_count_as_load()
     {
         // This used to register as loaded. It no longer does, because it is indistinguishable from a

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/LocalTargetResolverTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/LocalTargetResolverTests.cs
@@ -1,0 +1,118 @@
+﻿using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Whether a target is on this network decides where it appears, whether a vantage may adopt it,
+/// and whether a metered WAN may slow it - so a wrong answer is worse than no answer.
+/// </summary>
+public class LocalTargetResolverTests
+{
+    private static MonitoringTarget Target(string address, bool? isLocal = null,
+        MonitoringTargetType type = MonitoringTargetType.Custom, string? wan = null) => new()
+        {
+            TargetId = "t",
+            Name = "t",
+            Address = address,
+            TargetType = type,
+            IsLocal = isLocal,
+            WanInterface = wan,
+        };
+
+    /// <summary>
+    /// Plenty of upstream things wear a private address - a cable modem's first hop on
+    /// 192.168.100.1, a CGNAT first mile on 100.64/10 - so what a target IS has to be asked before
+    /// where it appears to live.
+    /// </summary>
+    [Theory]
+    [InlineData(MonitoringTargetType.AccessIsp)]
+    [InlineData(MonitoringTargetType.Transit)]
+    [InlineData(MonitoringTargetType.InternetService)]
+    [InlineData(MonitoringTargetType.Wan)]
+    public void Upstream_types_are_never_local_however_their_address_reads(MonitoringTargetType type)
+    {
+        LocalTargetResolver.IsLocal(Target("192.168.100.1", type: type)).Should().BeFalse();
+        LocalTargetResolver.IsLocal(Target("192.168.100.1", isLocal: true, type: type)).Should().BeFalse();
+    }
+
+    /// <summary>A target filed under a WAN was measured over that WAN, whatever its address says.</summary>
+    [Fact]
+    public void A_wan_stamped_target_is_never_local()
+    {
+        LocalTargetResolver.IsLocal(Target("192.168.42.5", wan: "wan2")).Should().BeFalse();
+        LocalTargetResolver.IsLocal(Target("192.168.42.5", isLocal: true, wan: "wan2")).Should().BeFalse();
+    }
+
+    [Fact]
+    public void An_unpinned_custom_target_still_goes_by_its_address()
+    {
+        LocalTargetResolver.IsLocal(Target("192.168.42.5", wan: MonitoringTarget.UnpinnedWan)).Should().BeTrue();
+        LocalTargetResolver.IsLocal(Target("203.0.113.10", wan: MonitoringTarget.UnpinnedWan)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Fabric_is_local_whatever_address_it_wears()
+    {
+        LocalTargetResolver.IsLocal(Target("203.0.113.10", isLocal: false, type: MonitoringTargetType.Fabric))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Prefers_the_resolved_answer_over_the_address()
+    {
+        // A name that resolved onto this network, and one that resolved off it. Neither could be
+        // told from the other by looking at the text.
+        LocalTargetResolver.IsLocal(Target("cloudkey.example", isLocal: true)).Should().BeTrue();
+        LocalTargetResolver.IsLocal(Target("speedtest.example", isLocal: false)).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("192.168.1.5", true)]
+    [InlineData("10.0.0.9", true)]
+    [InlineData("172.20.4.1", true)]
+    [InlineData("203.0.113.10", false)]
+    [InlineData("cloudkey.example", false)]
+    public void Falls_back_to_the_address_when_nothing_has_resolved_it(string address, bool expected)
+    {
+        // A literal answers itself; a name cannot, and reads as not-local until DNS says otherwise.
+        LocalTargetResolver.IsLocal(Target(address)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("192.168.1.5", true)]
+    [InlineData("127.0.0.1", true)]
+    [InlineData("203.0.113.10", false)]
+    public async Task Resolves_a_literal_without_asking_dns(string address, bool expected)
+    {
+        var (isLocal, ip) = await LocalTargetResolver.ResolveAsync(address);
+
+        isLocal.Should().Be(expected);
+        ip.Should().Be(address);
+    }
+
+    /// <summary>
+    /// A search domain that exists but answers nothing hands back the unspecified address. It
+    /// parses as an address and is not any host, so settling on it would file a LAN device as
+    /// reached over a WAN. Which of several answers gets picked is NetworkUtilities'
+    /// SelectUsableAddress; this only pins that an unusable one never settles anything.
+    /// </summary>
+    [Theory]
+    [InlineData("::")]
+    [InlineData("0.0.0.0")]
+    public async Task Refuses_to_settle_on_an_unspecified_address(string address)
+    {
+        var (isLocal, _) = await LocalTargetResolver.ResolveAsync(address);
+
+        isLocal.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Leaves_an_empty_address_unresolved()
+    {
+        (await LocalTargetResolver.ResolveAsync("")).IsLocal.Should().BeNull();
+        (await LocalTargetResolver.ResolveAsync(null)).IsLocal.Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/PerWanDiscoveryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/PerWanDiscoveryTests.cs
@@ -1,7 +1,6 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
-using NetworkOptimizer.Storage;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Monitoring;
@@ -199,8 +198,13 @@ public class PerWanDiscoveryTests
             .Should().Be("access-198.51.100.1@wan2");
     }
 
+    /// <summary>
+    /// A bound run does not take over an unpinned row - it twins, exactly as it would for a row
+    /// stamped with another WAN. Adopting instead is what let a metered secondary claim the site's
+    /// hand-added targets wholesale.
+    /// </summary>
     [Fact]
-    public async Task ContextRun_AdoptsARowThatHasNoWanYet()
+    public async Task ContextRun_TwinsRatherThanAdoptingThePrimarysUnstampedRow()
     {
         await using var db = NewDb();
         db.MonitoringTargets.Add(new MonitoringTarget
@@ -212,16 +216,46 @@ public class PerWanDiscoveryTests
         });
         await db.SaveChangesAsync();
 
-        await UpstreamTracerService.UpsertTargetAsync(db, Hop("198.51.100.1"), "wan2", wanContextId: 4, default);
+        await UpstreamTracerService.UpsertTargetAsync(
+            db, Hop("198.51.100.1"), "wan2", wanContextId: 4, default, isUnboundRun: false);
+        await db.SaveChangesAsync();
+
+        var primaryRow = await db.MonitoringTargets.SingleAsync(t => t.TargetId == "access-198.51.100.1");
+        primaryRow.WanInterface.Should().BeNull();
+        primaryRow.WanContextId.Should().BeNull();
+
+        var twin = await db.MonitoringTargets.SingleAsync(t => t.TargetId == "access-198.51.100.1@wan2");
+        twin.WanInterface.Should().Be("wan2");
+        twin.WanContextId.Should().Be(4);
+    }
+
+    /// <summary>
+    /// The unbound run still adopts an unpinned row rather than twinning: the single-WAN upgrade
+    /// path, where re-running discovery must not leave two rows per hop.
+    /// </summary>
+    [Fact]
+    public async Task PrimaryRun_AdoptsARowThatHasNoWanYet()
+    {
+        await using var db = NewDb();
+        db.MonitoringTargets.Add(new MonitoringTarget
+        {
+            TargetId = "access-198.51.100.1",
+            Name = "First hop",
+            Address = "198.51.100.1",
+            TargetType = MonitoringTargetType.AccessIsp,
+        });
+        await db.SaveChangesAsync();
+
+        await UpstreamTracerService.UpsertTargetAsync(
+            db, Hop("198.51.100.1"), "wan", wanContextId: null, default, isUnboundRun: true);
         await db.SaveChangesAsync();
 
         var target = await db.MonitoringTargets.SingleAsync();
-        target.WanInterface.Should().Be("wan2");
-        target.WanContextId.Should().Be(4);
+        target.WanInterface.Should().Be("wan");
     }
 
     [Theory]
-    [InlineData(null, "wan", true)]      // never stamped - adoptable, which is every legacy row
+    [InlineData(null, "wan", true)]      // never stamped - the primary's, and this IS the primary
     [InlineData("", "wan", true)]
     [InlineData("wan", "wan", true)]
     [InlineData("WAN", "wan", true)]     // the WAN key's case is not a different WAN
@@ -230,6 +264,68 @@ public class PerWanDiscoveryTests
     {
         UpstreamTracerService.OwnsTargetRow(rowWan, runWan).Should().Be(expected);
     }
+
+    /// <summary>Unpinned rows belong to the unbound run alone, whatever WAN is committing.</summary>
+    [Theory]
+    [InlineData(null, "wan3", false, false)]   // a bound (context) run never owns an unstamped row
+    [InlineData(null, "wan", false, false)]    // not even when its WAN is the conventional first one
+    [InlineData(null, "wan", true, true)]      // the unbound run - the primary's - does
+    [InlineData(null, "wan3", true, true)]     // on a WAN3-primary site too: no key is consulted
+    [InlineData("wan", "wan3", false, false)]  // an explicit stamp is judged on its own terms
+    [InlineData("wan3", "wan3", false, true)]
+    [InlineData("wan1", "wan", false, true)]   // the wan1 alias is the same WAN
+    public void OwnsTargetRow_GivesUnstampedRowsToTheUnboundRunAlone(
+        string? rowWan, string runWan, bool isUnboundRun, bool expected)
+    {
+        UpstreamTracerService.OwnsTargetRow(rowWan, runWan, isUnboundRun).Should().Be(expected);
+    }
+
+    /// <summary>The reported bug: a metered secondary commits and slows only its own rows.</summary>
+    [Fact]
+    public void SelectTargetsToRepace_LeavesEveryWanButTheMeteredOneAlone()
+    {
+        var targets = new List<MonitoringTarget>
+        {
+            Target("ISP speedtest", MonitoringTargetType.AccessIsp, wan: null, interval: 10),
+            Target("LAN controller", MonitoringTargetType.Custom, wan: null, interval: 10),
+            Target("Transit handoff", MonitoringTargetType.Transit, wan: "wan", interval: 15),
+            Target("Satellite first hop", MonitoringTargetType.AccessIsp, wan: "wan2", interval: 15),
+            Target("Cellular first hop", MonitoringTargetType.AccessIsp, wan: "wan3", interval: 10),
+            Target("Gateway", MonitoringTargetType.Fabric, wan: "wan3", interval: 5),
+            Target("Already slow", MonitoringTargetType.Custom, wan: "wan3", interval: 120),
+        };
+
+        var repaced = UpstreamTracerService.SelectTargetsToRepace(
+            targets, pollIntervalSeconds: 60, wanInterface: "wan3", isUnboundRun: false);
+
+        repaced.Select(t => t.Name).Should().BeEquivalentTo("Cellular first hop");
+    }
+
+    /// <summary>Single-WAN: the unbound run's unpinned rows are its own, and slowing them is the point.</summary>
+    [Fact]
+    public void SelectTargetsToRepace_StillSlowsUnstampedRowsWhenThePrimaryIsTheMeteredWan()
+    {
+        var targets = new List<MonitoringTarget>
+        {
+            Target("Public resolver", MonitoringTargetType.InternetService, wan: null, interval: 10),
+            Target("First hop", MonitoringTargetType.AccessIsp, wan: "wan", interval: 10),
+        };
+
+        var repaced = UpstreamTracerService.SelectTargetsToRepace(
+            targets, pollIntervalSeconds: 60, wanInterface: "wan", isUnboundRun: true);
+
+        repaced.Select(t => t.Name).Should().BeEquivalentTo("Public resolver", "First hop");
+    }
+
+    private static MonitoringTarget Target(string name, MonitoringTargetType type, string? wan, int interval) => new()
+    {
+        TargetId = $"custom-{name.Replace(' ', '-')}",
+        Name = name,
+        Address = "192.0.2.1",
+        TargetType = type,
+        WanInterface = wan,
+        PollIntervalSeconds = interval
+    };
 
     [Fact]
     public void ContextsDueForDiscovery_SkipsAContextThatHasNoWanYet()

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/PinnedProbeContextBuilderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/PinnedProbeContextBuilderTests.cs
@@ -1,0 +1,113 @@
+﻿using FluentAssertions;
+using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// A policy route names a MAC, so it identifies the probing box as well as the WAN. That matters:
+/// a vantage bound to the wrong box - or to none at all on an agent-collected site - has its
+/// targets pushed to nobody.
+/// </summary>
+public class PinnedProbeContextBuilderTests
+{
+    private const string ServerMac = "aa:bb:cc:00:00:01";
+    private const string AgentMac = "aa:bb:cc:00:00:02";
+
+    private static UniFiTrafficRouteResponse RouteFor(string mac, string networkId) => new()
+    {
+        Id = "r-" + mac,
+        Enabled = true,
+        MatchingTarget = "INTERNET",
+        NetworkId = networkId,
+        TargetDevices = new List<UniFiTrafficRouteTargetDevice>
+        {
+            new() { ClientMac = mac, Type = "CLIENT" }
+        }
+    };
+
+    private static List<UniFiClientResponse> Clients() => new()
+    {
+        new() { Mac = ServerMac, Ip = "192.0.2.10" },
+        new() { Mac = AgentMac, Ip = "192.0.2.20" },
+    };
+
+    private static List<NetworkInfo> Networks() => new()
+    {
+        new() { Id = "net-wan2", Name = "Cable", Purpose = "wan", WanNetworkgroup = "WAN2", Enabled = true },
+        new() { Id = "net-lan", Name = "Default", Purpose = "corporate", Enabled = true },
+    };
+
+    [Fact]
+    public void Names_the_agent_whose_probes_the_route_steers()
+    {
+        var plan = PinnedProbeContextBuilder.Build(
+            new[] { RouteFor(AgentMac, "net-wan2") }, Networks(), Clients(),
+            new[]
+            {
+                new PinnedProbeContextBuilder.ProbeHost(7, "192.0.2.20"),
+                new PinnedProbeContextBuilder.ProbeHost(null, "192.0.2.10"),
+            });
+
+        plan.Should().NotBeNull();
+        plan!.AgentId.Should().Be(7);
+        plan.MatchedLanIp.Should().Be("192.0.2.20");
+        plan.WanInterface.Should().Be("wan2");
+        plan.ContextName.Should().Be("Cable");
+    }
+
+    [Fact]
+    public void Names_the_server_with_a_null_agent_when_the_route_pins_it()
+    {
+        var plan = PinnedProbeContextBuilder.Build(
+            new[] { RouteFor(ServerMac, "net-wan2") }, Networks(), Clients(),
+            new[]
+            {
+                new PinnedProbeContextBuilder.ProbeHost(7, "192.0.2.20"),
+                new PinnedProbeContextBuilder.ProbeHost(null, "192.0.2.10"),
+            });
+
+        plan!.AgentId.Should().BeNull();
+        plan.MatchedLanIp.Should().Be("192.0.2.10");
+    }
+
+    [Fact]
+    public void Declines_a_route_onto_a_network_that_is_not_a_wan()
+    {
+        PinnedProbeContextBuilder.Build(
+            new[] { RouteFor(ServerMac, "net-lan") }, Networks(), Clients(),
+            new[] { new PinnedProbeContextBuilder.ProbeHost(null, "192.0.2.10") })
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Declines_when_no_probing_box_is_a_known_client()
+    {
+        PinnedProbeContextBuilder.Build(
+            new[] { RouteFor(ServerMac, "net-wan2") }, Networks(), Clients(),
+            new[] { new PinnedProbeContextBuilder.ProbeHost(null, "198.51.100.99") })
+            .Should().BeNull();
+    }
+
+    [Fact]
+    public void Declines_when_two_devices_claim_the_same_address()
+    {
+        var clients = Clients();
+        clients.Add(new UniFiClientResponse { Mac = "aa:bb:cc:00:00:03", Ip = "192.0.2.10" });
+
+        PinnedProbeContextBuilder.MacForAddress(clients, "192.0.2.10").Should().BeNull();
+    }
+
+    [Fact]
+    public void Ignores_a_stale_last_ip_when_matching()
+    {
+        var clients = new List<UniFiClientResponse>
+        {
+            new() { Mac = ServerMac, Ip = "192.0.2.55", LastIp = "192.0.2.10" }
+        };
+
+        PinnedProbeContextBuilder.MacForAddress(clients, "192.0.2.10").Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/PrimaryWanVantageAdoptionTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/PrimaryWanVantageAdoptionTests.cs
@@ -1,0 +1,136 @@
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Unpinned targets probe the WAN the box leaves by. Once a vantage measures that WAN they belong
+/// to it, or they sit in a bucket its own report cannot see. Only where unpinned honestly meant
+/// that WAN, which is every failover site and no load-balancing one without a route to prove it.
+/// </summary>
+public class PrimaryWanVantageAdoptionTests
+{
+    private static NetworkOptimizerDbContext NewDb() =>
+        new(new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+
+    private static MonitoringTarget Target(string id, string? wan, int? contextId = null,
+        MonitoringTargetType type = MonitoringTargetType.Custom) => new()
+        {
+            TargetId = id,
+            Name = id,
+            Address = "203.0.113.10",
+            TargetType = type,
+            WanInterface = wan,
+            WanContextId = contextId
+        };
+
+    [Theory]
+    [InlineData(false, false, true)]   // failover: unpinned meant the primary
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]     // load balancing, but a route pins the box
+    [InlineData(true, false, false)]   // load balancing with nothing to prove it
+    public void ShouldAdopt_only_where_unpinned_honestly_meant_this_wan(
+        bool loadBalances, bool routePins, bool expected)
+    {
+        PrimaryWanVantageAdoption.ShouldAdopt(loadBalances, routePins).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("wan", "wan", true)]
+    [InlineData("wan1", "wan", true)]   // the legacy alias is the same WAN
+    [InlineData("wan3", "wan3", true)]  // a WAN3-primary site: no key is privileged
+    [InlineData("wan2", "wan", false)]
+    [InlineData("wan", null, false)]    // unknown primary claims nothing
+    public void MeasuresPrimaryWan_compares_normalized_keys(
+        string vantageWan, string? primaryKey, bool expected)
+    {
+        var vantage = new WanContext { Id = 1, Name = "v", WanInterface = vantageWan };
+
+        PrimaryWanVantageAdoption.MeasuresPrimaryWan(vantage, primaryKey).Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task Adopts_unpinned_targets_and_leaves_everything_else()
+    {
+        await using var db = NewDb();
+        var vantage = new WanContext { Id = 7, Name = "Fiber", WanInterface = "wan" };
+        db.MonitoringTargets.AddRange(
+            Target("legacy-null", null),
+            Target("unpinned", MonitoringTarget.UnpinnedWan),
+            Target("gateway", MonitoringTarget.UnpinnedWan, type: MonitoringTargetType.Fabric),
+            Target("other-wan", "wan3"),
+            // Stamped by the primary's own discovery but never given a vantage: reads as
+            // "Default path" in the list exactly like an unpinned row, so it belongs here too.
+            Target("primary-stamped", "wan"),
+            Target("already-assigned", MonitoringTarget.UnpinnedWan, contextId: 9));
+        await db.SaveChangesAsync();
+
+        (await PrimaryWanVantageAdoption.AdoptUnpinnedTargetsAsync(db, vantage)).Should().Be(3);
+        await db.SaveChangesAsync();
+
+        var byId = await db.MonitoringTargets.ToDictionaryAsync(t => t.TargetId);
+        byId["primary-stamped"].WanContextId.Should().Be(7);
+        byId["legacy-null"].WanContextId.Should().Be(7);
+        byId["legacy-null"].WanInterface.Should().Be("wan");
+        byId["unpinned"].WanContextId.Should().Be(7);
+
+        // Fabric never leaves the LAN, so no WAN describes it.
+        byId["gateway"].WanContextId.Should().BeNull();
+        byId["gateway"].WanInterface.Should().Be(MonitoringTarget.UnpinnedWan);
+        byId["other-wan"].WanInterface.Should().Be("wan3");
+        byId["other-wan"].WanContextId.Should().BeNull();
+        byId["already-assigned"].WanContextId.Should().Be(9);
+    }
+
+    /// <summary>
+    /// A hand-added target on a private address is a LAN measurement whatever its type says, so a
+    /// WAN vantage must not claim it - its latency never crossed that WAN.
+    /// </summary>
+    [Fact]
+    public async Task Leaves_custom_targets_that_point_at_the_lan()
+    {
+        await using var db = NewDb();
+        var vantage = new WanContext { Id = 7, Name = "Fiber", WanInterface = "wan" };
+        db.MonitoringTargets.AddRange(
+            Lan("controller", "192.168.42.5"),
+            Lan("nas", "10.0.0.9"),
+            Lan("private-172", "172.20.1.4"),
+            Target("public-vps", MonitoringTarget.UnpinnedWan));
+        await db.SaveChangesAsync();
+
+        (await PrimaryWanVantageAdoption.AdoptUnpinnedTargetsAsync(db, vantage)).Should().Be(1);
+        await db.SaveChangesAsync();
+
+        var byId = await db.MonitoringTargets.ToDictionaryAsync(t => t.TargetId);
+        byId["public-vps"].WanContextId.Should().Be(7);
+        byId["controller"].WanContextId.Should().BeNull();
+        byId["nas"].WanContextId.Should().BeNull();
+        byId["private-172"].WanContextId.Should().BeNull();
+    }
+
+    private static MonitoringTarget Lan(string id, string address) => new()
+    {
+        TargetId = id,
+        Name = id,
+        Address = address,
+        TargetType = MonitoringTargetType.Custom,
+        WanInterface = MonitoringTarget.UnpinnedWan
+    };
+
+    [Fact]
+    public async Task Adopts_nothing_for_a_vantage_that_was_never_saved()
+    {
+        await using var db = NewDb();
+        db.MonitoringTargets.Add(Target("unpinned", MonitoringTarget.UnpinnedWan));
+        await db.SaveChangesAsync();
+
+        var unsaved = new WanContext { Name = "Fiber", WanInterface = "wan" };
+
+        (await PrimaryWanVantageAdoption.AdoptUnpinnedTargetsAsync(db, unsaved)).Should().Be(0);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanContextTargetStampingTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanContextTargetStampingTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -133,7 +133,7 @@ public class WanContextTargetStampingTests : IDisposable
 
         var row = await ReadAsync(targetId);
         row.WanContextId.Should().BeNull();
-        row.WanInterface.Should().BeNull();
+        row.WanInterface.Should().Be(MonitoringTarget.UnpinnedWan);
     }
 
     [Fact]
@@ -147,14 +147,14 @@ public class WanContextTargetStampingTests : IDisposable
 
         var row = await ReadAsync(targetId);
         row.WanContextId.Should().Be(contextId);
-        row.WanInterface.Should().BeNull();
+        row.WanInterface.Should().Be(MonitoringTarget.UnpinnedWan);
     }
 
     [Fact]
     public async Task A_single_wan_target_that_was_never_assigned_stays_untouched()
     {
-        // Every row on a single-WAN install: no context to move to, nothing to stamp, and the
-        // no-change path must not write an audit event either.
+        // A no-op assignment must write NOTHING - not the stamp, not an audit event. Seeded
+        // directly rather than through the migration, so the WAN stays exactly as seeded.
         var targetId = await SeedTargetAsync("custom-hop");
 
         (await Targets().SetWanContextAsync(targetId, null)).Should().BeTrue();
@@ -191,7 +191,7 @@ public class WanContextTargetStampingTests : IDisposable
         var lte = await SeedContextAsync("lte", "wan3");
         await SeedTargetAsync("hop-a", backup, "wan2");
         await SeedTargetAsync("hop-b", lte, "wan3");
-        await SeedTargetAsync("hop-primary");
+        await SeedTargetAsync("hop-primary", contextId: null, wanInterface: "wan");
 
         await using (var db = Db())
         {
@@ -202,7 +202,7 @@ public class WanContextTargetStampingTests : IDisposable
         await using var read = Db();
         (await read.MonitoringTargets.SingleAsync(t => t.TargetId == "hop-a")).WanInterface.Should().Be("wan4");
         (await read.MonitoringTargets.SingleAsync(t => t.TargetId == "hop-b")).WanInterface.Should().Be("wan3");
-        (await read.MonitoringTargets.SingleAsync(t => t.TargetId == "hop-primary")).WanInterface.Should().BeNull();
+        (await read.MonitoringTargets.SingleAsync(t => t.TargetId == "hop-primary")).WanInterface.Should().Be("wan");
     }
 
     // ─── Path 3: deleting a context ───
@@ -222,7 +222,7 @@ public class WanContextTargetStampingTests : IDisposable
         await using var read = Db();
         var row = await read.MonitoringTargets.SingleAsync();
         row.WanContextId.Should().BeNull();
-        row.WanInterface.Should().BeNull();
+        row.WanInterface.Should().Be(MonitoringTarget.UnpinnedWan);
     }
 
     [Fact]
@@ -243,7 +243,7 @@ public class WanContextTargetStampingTests : IDisposable
     // ─── The rule itself ───
 
     [Fact]
-    public void ApplyAssignment_carries_the_contexts_wan_and_clears_it_on_the_way_back()
+    public void ApplyAssignment_carries_the_contexts_wan_and_marks_it_unpinned_on_the_way_back()
     {
         var target = new MonitoringTarget { TargetId = "t", Name = "t", Address = "203.0.113.10" };
 
@@ -251,9 +251,24 @@ public class WanContextTargetStampingTests : IDisposable
         target.WanContextId.Should().Be(7);
         target.WanInterface.Should().Be("wan2");
 
-        // The context's WAN is irrelevant on the way back to the primary: both keys clear.
+        // The context id clears, but the WAN does not go blank: unpinned is a claim, and on a
+        // load-balancing site it is the only true one.
         WanContextTargetStamping.ApplyAssignment(target, null, "wan2");
         target.WanContextId.Should().BeNull();
-        target.WanInterface.Should().BeNull();
+        target.WanInterface.Should().Be(MonitoringTarget.UnpinnedWan);
+        MonitoringTarget.IsUnpinned(target.WanInterface).Should().BeTrue();
+    }
+
+    /// <summary>Rows predating the marker carry NULL and must read the same, or they vanish from every per-WAN view.</summary>
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", true)]
+    [InlineData("unpinned", true)]
+    [InlineData("UNPINNED", true)]
+    [InlineData("wan", false)]
+    [InlineData("wan2", false)]
+    public void IsUnpinned_reads_the_legacy_null_and_the_sentinel_the_same_way(string? value, bool expected)
+    {
+        MonitoringTarget.IsUnpinned(value).Should().Be(expected);
     }
 }


### PR DESCRIPTION
Scoring accuracy in **ISP Health**, per-WAN target ownership on multi-WAN sites, the upgrade instructions a gateway-resident agent is offered, and Adaptive SQM's first deploy.

## Monitoring

### ISP Health

- **Loaded Loss attributes loss to the phase that caused it** - A probe is stamped when its last ping returns, so one finishing a fraction of a second past a measurement bucket was filed under the next bucket and took on its character. During a scheduled WAN speed test that next bucket is the upload phase, so loss measured while the line was saturated downloading was scored as upload loss, on every test. **Loaded Loss** and **Loaded Latency** now match samples by overlapping their measurement interval against the seconds each loaded window describes. A sample straddling a speed test's handover counts toward both directions, weighted by how much of it each phase covered.

- **Loaded Loss needs more than one dropped probe before it reports a rate** - A five-ping probe reports loss in 20% steps, so a single lost ping could set the entire figure on a line whose only load that day was two scheduled speed tests. A direction now needs a second lossy probe, or a second load episode, before it grades, and says so when it is withheld. A pool that saw no loss still reports 0%.

- **A half-measured loaded factor carries half the weight** - A direction that reported nothing read "n/a" while the factor kept its full pull on the Access Layer score, quietly becoming the surviving direction's alone. **Loaded Loss** and **Loaded Latency** now scale their weight by how many directions were measured.

- **Loaded Loss names the band it was graded against** - The card cited the downstream band unconditionally, so a report that only graded upstream quoted a range it had never used.

### Network Performance

- **A metered WAN no longer slows every other WAN's targets** - Declaring a WAN metered drops its targets to the plan's cadence. The ownership test behind that read a target with no WAN assignment as belonging to whichever WAN was committing, so on a multi-WAN site a metered secondary adopted every hand-added target on the site and slowed all of them, down to LAN targets whose traffic never touches that data plan. A migration repairs rows already rewritten.

- **Latency Targets: a probe that is not bound to a WAN now says so** - The absent value had to be interpreted and the readers disagreed, most taking it for the primary and the one governing discovery writes taking it for "whichever WAN is asking". The state is named instead. It is deliberately not "the primary": a probe leaving by the box's own route measures the primary on a failover site and no single WAN on one that load balances. **Add Target** and the per-target dropdown now read **Not pinned to a WAN** rather than carrying the primary's name.

- **Multi-WAN Monitoring - Vantages: a new primary-WAN vantage adopts the unpinned targets it now measures** - Left out, they sit in a bucket that vantage's report cannot see. Only where unpinned honestly meant that WAN: a failover site always qualifies, a load-balancing one only when a policy route pins the probing box down a single WAN. History follows the targets, and deleting the vantage returns them.

- **Zooming the chart stays inside an investigation** - Selecting a time range while investigating **Packet Loss Events** or **Loaded Loss Events** discarded the range and jumped back to the found event.

## Multi-Site

- **An agent on the UniFi gateway gets the gateway update instructions** - A main-site agent running on the gateway was handed the bare-metal, Docker and Proxmox LXC commands, none of which apply to it. Detection is now asked per agent rather than per site, and survives a console that is not reachable by falling back to the last known answer - an outdated agent is exactly the one whose upgrade command this drives, and it may well be the one that is down.

## Adaptive SQM

- **A first deploy gets time to install its dependencies** - The boot script installs its dependencies inline before it does anything else, and inherited a 30 second SSH default. On a cold apt cache or a slow WAN that ran out, and the deploy tore down a deployment that was still working while reporting the boot script had failed. Re-deploys skip the block entirely, which is why this only ever bit the first attempt.
