### PR TITLE
v2.6.2

### DIFF
--- a/docker/openspeedtest/Dockerfile
+++ b/docker/openspeedtest/Dockerfile
@@ -1,7 +1,9 @@
 # Ozark Connect Speed Test - based on OpenSpeedTest
 # Built from local customized source instead of upstream image
-# Pin to nginx 1.26 to match OpenSpeedTest (1.29+ has caching behavior changes)
-FROM nginx:1.26-alpine
+# Track the 1.30 stable line; the floating minor tag picks up patch releases.
+# Revisit when 1.30 goes legacy - a pinned EOL branch stops getting base-image
+# rebuilds, so the whole Alpine layer goes stale with it.
+FROM nginx:1.30-alpine
 
 # Copy our customized OpenSpeedTest files
 COPY src/OpenSpeedTest/ /usr/share/nginx/html/

--- a/scripts/install-macos-native.sh
+++ b/scripts/install-macos-native.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Install Network Optimizer natively on macOS
-# Usage: ./scripts/install-macos-native.sh
+# Usage: ./scripts/install-macos-native.sh [--upgrade-nginx]
 #
 # This script:
 # 1. Installs prerequisites via Homebrew
@@ -8,8 +8,28 @@
 # 3. Signs binaries for macOS
 # 4. Sets up OpenSpeedTest with nginx for browser-based speed testing
 # 5. Creates launchd service for auto-start
+#
+# Options:
+#   --upgrade-nginx  Also upgrade Homebrew's nginx. Off by default - see the note
+#                    at the brew step for why this is opt-in.
 
 set -e
+
+UPGRADE_NGINX=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --upgrade-nginx) UPGRADE_NGINX=true; shift ;;
+        -h|--help)
+            echo "Usage: ./scripts/install-macos-native.sh [--upgrade-nginx]"
+            echo ""
+            echo "  --upgrade-nginx  Also upgrade Homebrew's nginx. Off by default: that"
+            echo "                   nginx may serve other sites on this Mac, and"
+            echo "                   upgrading it restarts them."
+            exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
 
 # Refuse to run as root - everything installs to $HOME, root is never needed
 if [ "$(id -u)" = "0" ]; then
@@ -203,7 +223,19 @@ fi
 eval "$($BREW_PREFIX/bin/brew shellenv)"
 
 echo "Installing required packages..."
-brew install sshpass iperf3 nginx go 2>/dev/null || true
+brew install sshpass iperf3 go 2>/dev/null || true
+
+# nginx is deliberately not on the line above: brew install UPGRADES an outdated
+# formula, and Homebrew's nginx is shared - it may be fronting a reverse proxy or
+# other sites on this Mac, which an upgrade then restarts. Install it when missing,
+# move it only when asked. Build tools (go, dotnet) stay on the upgrade-always path.
+if ! brew list --formula nginx >/dev/null 2>&1; then
+    echo "Installing nginx..."
+    brew install nginx 2>/dev/null || true
+elif [ "$UPGRADE_NGINX" = true ]; then
+    echo "Upgrading nginx (--upgrade-nginx)..."
+    brew upgrade nginx 2>/dev/null || true
+fi
 
 # Check for .NET SDK
 if ! command -v dotnet &> /dev/null; then
@@ -217,10 +249,16 @@ else
     brew upgrade dotnet 2>/dev/null || true
 fi
 
-# Verify .NET version
+# Verify .NET version. The floor is read from the csproj, never written here: a
+# literal goes stale the moment the target framework moves, and then lets an SDK
+# too old to build the app pass the check.
+REQUIRED_DOTNET=$(sed -n 's|.*<TargetFramework>net\([0-9][0-9]*\)\.[0-9][0-9]*</TargetFramework>.*|\1|p' \
+    "$REPO_ROOT/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj" | head -1)
+REQUIRED_DOTNET="${REQUIRED_DOTNET:-10}"
+
 DOTNET_VERSION=$(dotnet --version 2>/dev/null | cut -d. -f1)
-if [ "$DOTNET_VERSION" -lt 8 ]; then
-    echo "Warning: .NET $DOTNET_VERSION detected. Network Optimizer requires .NET 8 or later."
+if [ -n "$DOTNET_VERSION" ] && [ "$DOTNET_VERSION" -lt "$REQUIRED_DOTNET" ]; then
+    echo "Warning: .NET $DOTNET_VERSION detected. Network Optimizer requires .NET $REQUIRED_DOTNET or later."
     echo "Updating .NET SDK..."
     brew upgrade dotnet || brew install dotnet
 fi
@@ -631,3 +669,20 @@ echo "  Stop:    launchctl unload ~/Library/LaunchAgents/$LAUNCH_AGENT_FILE"
 echo "  Start:   launchctl load ~/Library/LaunchAgents/$LAUNCH_AGENT_FILE"
 echo "  Logs:    tail -f $INSTALL_DIR/logs/stdout.log"
 echo ""
+
+# Reported, not acted on: see the note at the brew step. Self-suppresses after an
+# --upgrade-nginx run, since nginx is then current.
+NGINX_OUTDATED="$(brew outdated --verbose nginx 2>/dev/null || true)"
+if [ -n "$NGINX_OUTDATED" ]; then
+    echo "=== nginx update available ==="
+    echo ""
+    echo "  $NGINX_OUTDATED"
+    echo ""
+    echo "The speed test runs on Homebrew's nginx, which this installer leaves alone -"
+    echo "it may also be fronting a reverse proxy or other sites on this Mac, and an"
+    echo "upgrade restarts them. When you are ready:"
+    echo "  brew upgrade nginx"
+    echo ""
+    echo "Or re-run this installer with --upgrade-nginx to do both in one pass."
+    echo ""
+fi

--- a/src/NetworkOptimizer.Installer/SpeedTest/Download-Nginx.ps1
+++ b/src/NetworkOptimizer.Installer/SpeedTest/Download-Nginx.ps1
@@ -3,7 +3,7 @@
 
 param(
     [string]$OutputDir = "$PSScriptRoot\nginx",
-    [string]$Version = "1.26.2"  # Match Docker version for consistency
+    [string]$Version = "1.30.4"  # Match the Docker 1.30 stable line
 )
 
 $ErrorActionPreference = "Stop"

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -476,12 +476,14 @@
             </div>
             <div class="expand-wrapper @(!_investigateCollapsed && _investigateStateLoaded ? "expanded" : "")" style="@(!_investigateStateLoaded ? "display:none" : "")">
             <div class="expand-content">
-            <div class="card-body" style="display: flex; gap: 0.75rem; flex-wrap: wrap; align-items: center;">
+            <div class="card-body">
+                <div class="investigate-actions">
+                <div class="investigate-actions-row">
                 @if (_lossNavActive)
                 {
                     <button class="btn btn-sm btn-secondary loss-nav-arrow" @onclick="LossNavBack" disabled="@_investigatingLoss"
                             data-tooltip="Previous loss event">&#x25C0;</button>
-                    <button class="btn btn-primary" @onclick="LossNavDeactivate"
+                    <button class="btn btn-primary investigate-btn" @onclick="LossNavDeactivate"
                             data-tooltip="Exit @(_lossNavLoadedOnly ? "loaded" : "packet") loss investigation">
                         @(_lossNavLoadedOnly ? "Loaded Loss Events" : "Packet Loss Events")
                     </button>
@@ -490,21 +492,23 @@
                 }
                 else
                 {
-                    <button class="btn btn-secondary" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
+                    <button class="btn btn-secondary investigate-btn" @onclick="InvestigatePacketLoss" disabled="@_investigatingLoss"
                             data-tooltip="Find the most recent packet loss event across ISP, Transit, and Internet targets and jump to it on the chart">
                         @if (_investigatingLoss && !_lossNavLoadedOnly) { <span class="spinner-sm"></span> }
                         else { <span>Packet Loss Events</span> }
                     </button>
-                    <button class="btn btn-secondary" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
+                    <button class="btn btn-secondary investigate-btn" @onclick="InvestigateLoadedLoss" disabled="@_investigatingLoss"
                             data-tooltip="Find the most recent loss event that happened while the WAN was under load - the SQM/bufferbloat signal">
                         @if (_investigatingLoss && _lossNavLoadedOnly) { <span class="spinner-sm"></span> }
                         else { <span>Loaded Loss Events</span> }
                     </button>
                 }
+                </div>
                 @if (!string.IsNullOrEmpty(_lossInvestigateResult))
                 {
-                    <span class="page-description" style="align-self: center;">@_lossInvestigateResult</span>
+                    <span class="page-description investigate-result">@_lossInvestigateResult</span>
                 }
+                </div>
             </div>
             </div>
             </div>
@@ -5038,7 +5042,33 @@
     }
 
     private Task InvestigatePacketLoss() => NavigateToLossEvent(null, null, loadedOnly: false);
-    private Task InvestigateLoadedLoss() => NavigateToLossEvent(null, null, loadedOnly: true);
+
+    /// <summary>
+    /// Loaded loss is a WAN's own signal - graded against that WAN's plan speeds and read off its
+    /// counters - so the LAN scope has nothing to answer with, and any event found would land on a
+    /// chart holding none of its targets. Move to the first WAN, then investigate.
+    /// </summary>
+    private async Task InvestigateLoadedLoss()
+    {
+        var firstWan = _wanOptions.FirstOrDefault()?.Key;
+        if (_lanScope && firstWan != null)
+        {
+            // Claim the spinner before the scope round-trip, so the button is disabled for the
+            // whole action rather than only the query at the end of it.
+            _investigatingLoss = true;
+            _lossNavLoadedOnly = true;
+            StateHasChanged();
+            _lanScope = false;
+            _allScope = false;
+            _selectedWanKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { firstWan };
+            // Released here rather than left to the investigation's own finally: a scope change
+            // that threw would strand both buttons disabled for the life of the circuit. The
+            // investigation re-claims it before its first await, so nothing renders in between.
+            try { await ApplyWanSelectionAsync(persist: true); }
+            finally { _investigatingLoss = false; }
+        }
+        await NavigateToLossEvent(null, null, loadedOnly: true);
+    }
     // Step to the previous/next distinct event by querying strictly outside the current
     // event's bounds, so a multi-minute burst is one stop rather than one stop per minute.
     // The 1-minute aggregateWindow buckets are stamped at their STOP edge, so the bucket at
@@ -5128,7 +5158,13 @@
                     await JS.InvokeVoidAsync("eval", "window.__latencyCharts?.restoreState();");
                     return;
                 }
-                _lossInvestigateResult = after.HasValue ? "No newer events" : "No older events";
+                // Older/newer only answer a step. A first search that finds nothing has no event to
+                // be on either side of, so it reports the empty window it actually searched.
+                _lossInvestigateResult =
+                    after.HasValue ? "No newer events"
+                    : before.HasValue ? "No older events"
+                    : loadedOnly ? "No loaded loss events in the last 30 days"
+                    : "No packet loss events in the last 30 days";
                 return;
             }
             var category = result.TargetType switch

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3676,9 +3676,12 @@
                                                                 <input type="checkbox" checked="@AgentCoversSite(site.Id)"
                                                                        disabled="@(!AgentsFor(site.Id).Any())"
                                                                        @onchange="e => ToggleAgentCoversSite(site, (bool)e.Value!)" />
-                                                                An agent collects for this site - probes, path discovery and SNMP run
-                                                                there instead of on this server. Turn on if this server is off-site, or
-                                                                you want a separate agent.
+                                                                An agent collects for this site - @(_siteHasMultipleWans
+                                                                    ? "default path discovery and probes, and SNMP"
+                                                                    : "probes, path discovery and SNMP") run there instead of on this
+                                                                server. Turn on if this server is off-site, or you want a separate
+                                                                agent.@if (_siteHasMultipleWans)
+                                                                {<text> Agent(s) can still probe for Multi-WAN monitoring with this off.</text>}
                                                             </label>
                                                             @if (AgentCoversSite(site.Id))
                                                             {
@@ -3917,6 +3920,13 @@
     private bool _showMultiWanHint;
 
     /// <summary>
+    /// Whether this site has more than one WAN, from the same read the hint above uses. Unlike the
+    /// hint it is not dismissible and does not care whether a vantage exists yet - it only decides
+    /// whether copy that mentions Multi-WAN monitoring has an audience.
+    /// </summary>
+    private bool _siteHasMultipleWans;
+
+    /// <summary>
     /// Names the site in the card so a reader with several rows in the table knows which one to
     /// open. A whole phrase rather than a name dropped into a template, because the name is already
     /// a noun: "the Main Site site's Configuration" is what a template produces, and people do call
@@ -3933,7 +3943,8 @@
         try
         {
             var wans = await PathView.GetWansAsync();
-            if (wans.Count <= 1) return;
+            _siteHasMultipleWans = wans.Count > 1;
+            if (!_siteHasMultipleWans) return;
 
             // Agent-bound, not merely present. A vantage with no agent behind it is the state this
             // card exists to get someone out of: they created one, nothing probes it, and the reason

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -51,7 +51,7 @@
                         @onclick="() => PickTypeAsync(null)" @onclick:stopPropagation>All</button>
             </div>
         }
-        <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <div class="card-header-badges">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@VisibleTargets().Count(t => t.Enabled) active</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/MonitoringInterfacesCard.razor
@@ -19,7 +19,7 @@
         <div class="card-title-group">
             <h2 class="card-title">Monitoring Interfaces</h2>
         </div>
-        <div class="card-header-right">
+        <div class="card-header-badges">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
@@ -11,7 +11,7 @@
 <div class="card">
     <div class="card-header card-header-collapsible monitoring-chart-header" @onclick="ToggleCollapse">
         <h2 class="card-title">Optical (SFP / ONT)</h2>
-        <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <div class="card-header-badges">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@AllSfps.Count(s => s.IsMonitoredOnt) monitored</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SnmpDeviceStatusCard.razor
@@ -18,7 +18,7 @@
         <div class="card-title-group">
             <h2 class="card-title">SNMP Devices <span class="card-title-suffix">and Custom OIDs</span></h2>
         </div>
-        <div class="card-header-right">
+        <div class="card-header-badges">
             <span class="status-badge status-active" @onclick:stopPropagation="true">@SummaryLabel()</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -37,7 +37,7 @@
                 }
             </div>
         }
-        <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <div class="card-header-badges">
             <span class="status-badge @StateBadgeClass(_state.Step)" @onclick:stopPropagation="true">@StateLabel(_state.Step)</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -288,9 +288,8 @@
                     @if (SelectedAgentCanBindInterface)
                     {
                         <p>
-                            This agent runs on the gateway, so its probes can go out the WAN's own
-                            interface. Selecting a WAN fills this in. A gateway agent has to bind it:
-                            routing policy does not govern the gateway's own traffic.
+                            This agent runs on the gateway, so its probes leave by the WAN's own
+                            interface. The interface comes from the WAN you select.
                         </p>
                     }
                     else if (!string.IsNullOrEmpty(_newAgentId))

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -265,7 +265,9 @@
                             out the WAN instead.
                         </p>
                     }
-                    @if (!SelectedAgentCanBindSource)
+                    @* Three states, not two: nothing picked, an agent binding an address, and a
+                       gateway agent - whose interface binding the paragraph below covers. *@
+                    @if (string.IsNullOrEmpty(_newAgentId))
                     {
                         <p>
                             Give a source IP for local probing (the gateway must policy-route it out this
@@ -273,7 +275,7 @@
                             targets are probed only by that agent.
                         </p>
                     }
-                    else
+                    else if (SelectedAgentCanBindSource)
                     {
                         <p>
                             This agent binds this address for the WAN's probes. The address needs its own

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -67,8 +67,7 @@
                             The easiest way to monitor your other WANs is to deploy the agent on your
                             UniFi gateway. It reaches each WAN by that WAN's own interface, so there is
                             no routing policy to build. Set one up in
-                            <a href="/settings?tab=multisite#multi-site">Settings - Multi-Site</a>,
-                            under <strong>On a UniFi gateway</strong>.
+                            <a href="/settings?tab=multisite#multi-site">Settings - Multi-Site</a>.
                         </p>
                     </div>
                     <button class="btn btn-sm btn-tertiary" @onclick="DismissGatewayAgentHintAsync">Dismiss</button>
@@ -262,8 +261,7 @@
                             WAN: an agent on the UniFi gateway reaches every WAN by its own interface,
                             with no source address to pick and no routing policy to build. The install
                             command is in <a href="/settings?tab=multisite#multi-site">Settings -
-                            Multi-Site</a> - <strong>Set up agent</strong>, under <strong>On a UniFi
-                            gateway</strong>. Everything below relies on the gateway routing the probe
+                            Multi-Site</a>. Everything below relies on the gateway routing the probe
                             out the WAN instead.
                         </p>
                     }

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -21,8 +21,8 @@
 
 <div class="card">
     <div class="card-header card-header-collapsible" @onclick="ToggleCollapse">
-        <h2 class="card-title">Multi-WAN Monitoring - Vantages</h2>
-        <div style="display: flex; align-items: center; gap: 0.5rem;">
+        <h2 class="card-title">Multi-WAN<span class="hide-mobile"> Monitoring</span> - Vantages</h2>
+        <div class="card-header-badges">
             @if (WanContexts.Count > 0)
             {
                 <span class="status-badge status-active" @onclick:stopPropagation="true">@WanContexts.Count configured</span>

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -16,6 +16,7 @@
 @inject SiteAgentCoverage AgentCoverage
 @inject Microsoft.JSInterop.IJSRuntime JS
 @inject UniFiConnectionService Connection
+@inject UiHintService UiHints
 @inject ILogger<WanContextsCard> Log
 
 <div class="card">
@@ -53,6 +54,26 @@
                 fails over they follow the backup, and the latency and loss are still recorded
                 under @_primaryWanLabel.
             </p>
+        }
+
+        @if (ShowGatewayAgentHint)
+        {
+            @* Site Admin only: it asks for an install a Viewer or Operator cannot perform. *@
+            <SiteAdminOnly>
+                <div class="alert alert-info multi-wan-hint">
+                    <div class="multi-wan-hint-body">
+                        <span class="banner-icon banner-icon-info">i</span>
+                        <p>
+                            The easiest way to monitor your other WANs is to deploy the agent on your
+                            UniFi gateway. It reaches each WAN by that WAN's own interface, so there is
+                            no routing policy to build. Set one up in
+                            <a href="/settings?tab=multisite#site-agent-setup">Settings - Multi-Site</a>,
+                            under <strong>On a UniFi gateway</strong>.
+                        </p>
+                    </div>
+                    <button class="btn btn-sm btn-tertiary" @onclick="DismissGatewayAgentHintAsync">Dismiss</button>
+                </div>
+            </SiteAdminOnly>
         }
 
         @if (WanContexts.Count == 0)
@@ -234,6 +255,18 @@
                 }
                 <div class="info-box wc-help">
                     <p class="wc-help-title">Help</p>
+                    @if (NoGatewayAgentAvailable)
+                    {
+                        <p>
+                            No agent on the gateway yet. That is the shortest path to probing another
+                            WAN: an agent on the UniFi gateway reaches every WAN by its own interface,
+                            with no source address to pick and no routing policy to build. The install
+                            command is in <a href="/settings?tab=multisite#site-agent-setup">Settings -
+                            Multi-Site</a> - <strong>Set up agent</strong>, under <strong>On a UniFi
+                            gateway</strong>. Everything below relies on the gateway routing the probe
+                            out the WAN instead.
+                        </p>
+                    }
                     @if (!SelectedAgentCanBindSource)
                     {
                         <p>
@@ -250,6 +283,8 @@
                             a second address on an existing NIC won't route differently.
                         </p>
                     }
+                    @* A gateway agent leaves by the WAN's own interface and needs no route; anything
+                       binding an ADDRESS does, source-binding agents included. *@
                     @if (SelectedAgentCanBindInterface)
                     {
                         <p>
@@ -258,7 +293,7 @@
                             routing policy does not govern the gateway's own traffic.
                         </p>
                     }
-                    @if ((!string.IsNullOrWhiteSpace(_newSourceIp) && !SelectedAgentCanBindSource) || SelectedAgentNeedsPolicyRoute)
+                    else if (!string.IsNullOrEmpty(_newAgentId))
                     {
                         <p>
                             This agent reaches @WanLabelFor(_newWanInterface) only if the gateway routes it there. In UniFi
@@ -268,6 +303,16 @@
                             interface and MAC of its own - an LXC has one already, a VM or Docker
                             container can be given one - not a second address on a host that's already
                             on the network.
+                        </p>
+                    }
+                    else if (!string.IsNullOrWhiteSpace(_newSourceIp))
+                    {
+                        <p>
+                            This server reaches @WanLabelFor(_newWanInterface) only if the gateway routes it there. In
+                            UniFi Network, go to Settings - Policy Table and add a Policy-Based Route
+                            with this WAN as the interface, this server as the source, and Any as the
+                            destination. The source is matched by MAC, so the address has to sit on a
+                            NIC of its own - not a second address on the NIC this server already uses.
                         </p>
                     }
                 </div>
@@ -422,6 +467,22 @@
     private HashSet<int> _sourceBindAgents = new();
     private HashSet<int> _connectedAgents = new();
     private Dictionary<int, int> _targetCounts = new();
+    private bool _gatewayAgentHintAllowed;
+
+    /// <summary>
+    /// Whether none of this site's connected agents runs on the gateway, so the shortest route to
+    /// monitoring another WAN - install one there - is still open. Drives both the dismissible card
+    /// and the Help call-out, so the two can never say opposite things.
+    /// </summary>
+    private bool NoGatewayAgentAvailable => _bindCapableAgents.Count == 0;
+
+    /// <summary>
+    /// The standing recommendation, shown only where it is still news: more than one WAN, no
+    /// gateway agent, and the user has not dismissed it. Shares the Settings key, so dismissing it
+    /// in either place retires it in both - it is one message in two placements.
+    /// </summary>
+    private bool ShowGatewayAgentHint =>
+        _gatewayAgentHintAllowed && NoGatewayAgentAvailable && _wans.Count > 1;
 
     private bool SelectedAgentCanBindInterface =>
         int.TryParse(_newAgentId, out var agentId) && _bindCapableAgents.Contains(agentId);
@@ -434,12 +495,6 @@
     private bool SelectedAgentCanBindSource =>
         int.TryParse(_newAgentId, out var agentId) && _sourceBindAgents.Contains(agentId);
 
-    /// <summary>
-    /// Whether the selected agent binds nothing of its own, so the WHOLE box has to be routed out
-    /// the WAN for its probes to go anywhere near it. True for an agent that cannot bind at all -
-    /// an older binary - which is the setup that silently measures the primary WAN and files the
-    /// results under another one if the route is never built.
-    /// </summary>
     /// <summary>
     /// Whether THIS server still probes this site's paths, which is what a vantage with no agent
     /// depends on: the server is the thing binding the address. False for every secondary site, and
@@ -480,9 +535,6 @@
         && NetworkOptimizer.Core.Helpers.VersionUtilities.IsOlderThan(
             selected.LastVersion, NetworkOptimizer.Web.Services.AppVersionInfo.LatestAgentVersion);
 
-    private bool SelectedAgentNeedsPolicyRoute =>
-        !string.IsNullOrEmpty(_newAgentId) && !SelectedAgentCanBindInterface && !SelectedAgentCanBindSource;
-
     // WAN contexts are per-site data: route through the current site's database.
     private NetworkOptimizerDbContext CreateDb() => SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
 
@@ -501,6 +553,17 @@
         await LoadWansAsync();
         LoadConnectedAgents();
         await LoadBindCapableAgentsAsync();
+        _gatewayAgentHintAllowed = await UiHints.ShouldShowAsync(UiHintKeys.MultiWanVantageSetup);
+    }
+
+    /// <summary>
+    /// Retires the recommendation for this user, here and on Settings - Multi-Site, which share the
+    /// key.
+    /// </summary>
+    private async Task DismissGatewayAgentHintAsync()
+    {
+        _gatewayAgentHintAllowed = false;
+        await UiHints.DismissAsync(UiHintKeys.MultiWanVantageSetup);
     }
 
     private void LoadConnectedAgents()

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -67,7 +67,7 @@
                             The easiest way to monitor your other WANs is to deploy the agent on your
                             UniFi gateway. It reaches each WAN by that WAN's own interface, so there is
                             no routing policy to build. Set one up in
-                            <a href="/settings?tab=multisite#site-agent-setup">Settings - Multi-Site</a>,
+                            <a href="/settings?tab=multisite#multi-site">Settings - Multi-Site</a>,
                             under <strong>On a UniFi gateway</strong>.
                         </p>
                     </div>
@@ -261,7 +261,7 @@
                             No agent on the gateway yet. That is the shortest path to probing another
                             WAN: an agent on the UniFi gateway reaches every WAN by its own interface,
                             with no source address to pick and no routing policy to build. The install
-                            command is in <a href="/settings?tab=multisite#site-agent-setup">Settings -
+                            command is in <a href="/settings?tab=multisite#multi-site">Settings -
                             Multi-Site</a> - <strong>Set up agent</strong>, under <strong>On a UniFi
                             gateway</strong>. Everything below relies on the gateway routing the probe
                             out the WAN instead.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
@@ -1742,14 +1742,25 @@ public class UpstreamTracerService
         var allExisting = await reconcileDb.MonitoringTargets
             .AsNoTracking()
             .ToListAsync(ct);
-        var existingByAddress = new Dictionary<string, MonitoringTarget>(StringComparer.OrdinalIgnoreCase);
-        foreach (var t in allExisting.Where(t => !string.IsNullOrEmpty(t.Address)))
-            existingByAddress.TryAdd(t.Address, t);
+        // Deliberately NOT scoped to this run's WAN. A twin is the same host reached over another
+        // WAN, and the chart pairs twins by NAME to draw them in one color - so inheriting the name
+        // across WANs is what keeps that pairing, and the checkbox carries a decision the user has
+        // already made about the host. Never narrow this to the running WAN.
+        //
+        // Grouped, not first-wins: one address can hold several rows probed different ways, and the
+        // review has to reconcile against the one the commit will actually match - a row checking
+        // this host another way is a different target, so pre-checking and renaming the candidate
+        // after it would describe a merge that never happens.
+        var existingByAddress = allExisting
+            .Where(t => !string.IsNullOrEmpty(t.Address))
+            .GroupBy(t => t.Address, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
         foreach (var c in candidates)
         {
             var addr = c.HopAddress ?? c.PathProxyTarget;
             if (string.IsNullOrEmpty(addr)) continue;
-            if (existingByAddress.TryGetValue(addr, out var existing))
+            if (existingByAddress.TryGetValue(addr, out var rows)
+                && rows.FirstOrDefault(t => c.RespondedTo == null || t.ProbeMode == c.RespondedTo) is { } existing)
             {
                 c.Enabled = existing.Enabled;
                 c.PreservedFromExisting = true;
@@ -1759,7 +1770,8 @@ public class UpstreamTracerService
         }
         foreach (var hop in State.AccessHops)
         {
-            if (existingByAddress.TryGetValue(hop.Address, out var existing))
+            if (existingByAddress.TryGetValue(hop.Address, out var rows)
+                && rows.FirstOrDefault(t => t.ProbeMode == hop.RespondedTo) is { } existing)
             {
                 hop.Enabled = existing.Enabled;
                 if (!string.IsNullOrEmpty(existing.Name))
@@ -2925,7 +2937,11 @@ public class UpstreamTracerService
             .ToListAsync(ct);
         var existing = rows.FirstOrDefault(t => t.TargetId == hop.TargetId && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun))
             ?? rows.FirstOrDefault(t => t.TargetId == twinId)
-            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
+            // Matched on address alone, so the probe has to agree too: a row checking this host a
+            // different way measures a different thing, and merging the two rewrites one probe's
+            // history as the other's.
+            ?? rows.FirstOrDefault(t => t.ProbeMode == hop.RespondedTo
+                && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
         var claimedByOtherWan = existing == null && rows.Count > 0;
         if (existing == null)
         {
@@ -3005,7 +3021,10 @@ public class UpstreamTracerService
             .ToListAsync(ct);
         var existing = rows.FirstOrDefault(t => t.TargetId == transit.TargetId && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun))
             ?? rows.FirstOrDefault(t => t.TargetId == twinId)
-            ?? rows.FirstOrDefault(t => OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
+            // Same probe agreement as UpsertTargetAsync's address-only match. A trace that never
+            // established what it answered on has nothing to disagree with, so it still adopts.
+            ?? rows.FirstOrDefault(t => (transit.RespondedTo == null || t.ProbeMode == transit.RespondedTo)
+                && OwnsTargetRow(t.WanInterface, wanInterface, isUnboundRun));
         var claimedByOtherWan = existing == null && rows.Count > 0;
         if (existing == null)
         {

--- a/src/NetworkOptimizer.Web/Services/UiHintService.cs
+++ b/src/NetworkOptimizer.Web/Services/UiHintService.cs
@@ -151,6 +151,9 @@ public static class UiHintKeys
     /// Where to go to start monitoring a second WAN, shown on Settings - Multi-Site to a site that
     /// has more than one WAN and no vantage for any of them. Dismissed rather than counted down:
     /// it is a card on the page, not a passing tooltip.
+    ///
+    /// Shared with the Multi-WAN Monitoring - Vantages card, which makes the same recommendation to
+    /// a site with no gateway agent. One message in two placements, so one dismissal retires both.
     /// </summary>
     public const string MultiWanVantageSetup = "multi-wan-vantage-setup";
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2311,6 +2311,10 @@ a.stat-card-link:active {
     gap: 0.5rem;
 }
 
+.card-header-badges .issue-type-chevron {
+    margin-left: 0.25rem;
+}
+
 /* Buttons - Three colors only: primary (blue), secondary (grey), danger (red) */
 .btn {
     display: inline-flex;
@@ -2351,9 +2355,31 @@ a.btn-sm {
     line-height: 28px;
 }
 
+.investigate-actions {
+    width: fit-content;
+    max-width: 100%;
+}
+
+.investigate-actions-row {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.investigate-result {
+    display: block;
+    margin-top: 0.75rem;
+    text-align: center;
+}
+
 @media (max-width: 768px) {
     .loss-nav-arrow {
         min-width: 4rem;
+    }
+
+    .investigate-btn {
+        font-size: 0.8rem;
     }
 }
 
@@ -3949,7 +3975,8 @@ select.form-control {
         position: relative;
     }
 
-    .card-header .issue-type-chevron {
+    .card-header .issue-type-chevron,
+    .data-table .issue-type-chevron {
         position: static;
         transform: none;
     }
@@ -3957,6 +3984,16 @@ select.form-control {
     .card-header-collapsible .card-header-right {
         width: 100%;
         justify-content: space-between;
+    }
+
+    .card-header-collapsible > .card-title,
+    .card-header-collapsible > .card-title-group {
+        flex: 1 1 0;
+    }
+
+    .card-header-collapsible > .time-range-selector {
+        order: 1;
+        flex-basis: 100%;
     }
 
     /* Filter tabs mobile - wrap below title, compact sizing */

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/PerWanDiscoveryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/PerWanDiscoveryTests.cs
@@ -254,6 +254,107 @@ public class PerWanDiscoveryTests
         target.WanInterface.Should().Be("wan");
     }
 
+    /// <summary>
+    /// A hand-added target on a discovered host is the tracer's to manage - that is the point of
+    /// adding one - so the address-only match adopts it exactly as it always has.
+    /// </summary>
+    [Fact]
+    public async Task Run_AdoptsAHandAddedTargetProbedTheSameWay()
+    {
+        await using var db = NewDb();
+        db.MonitoringTargets.Add(new MonitoringTarget
+        {
+            TargetId = "custom-a9e6bd59",
+            Name = "My first hop",
+            Address = "198.51.100.1",
+            TargetType = MonitoringTargetType.Custom,
+            ProbeMode = ProbeMode.Icmp,
+            AutoDiscovered = false,
+        });
+        await db.SaveChangesAsync();
+
+        await UpstreamTracerService.UpsertTargetAsync(
+            db, Hop("198.51.100.1"), "wan", wanContextId: null, default, isUnboundRun: true);
+        await db.SaveChangesAsync();
+
+        var target = await db.MonitoringTargets.SingleAsync();
+        target.TargetId.Should().Be("custom-a9e6bd59");
+        target.WanInterface.Should().Be("wan");
+        target.Name.Should().Be("First hop");
+    }
+
+    /// <summary>
+    /// ...but only one probed the same way. A TCP check and an ICMP reply on one address are
+    /// different measurements, so merging them would rewrite one probe's history as the other's -
+    /// and rewrite the row itself, since the adopting run sets the name and the mode.
+    /// </summary>
+    [Fact]
+    public async Task Run_LeavesATargetProbedADifferentWayAlone()
+    {
+        await using var db = NewDb();
+        db.MonitoringTargets.Add(new MonitoringTarget
+        {
+            TargetId = "custom-a9e6bd59",
+            Name = "Example ISP (HTTPS)",
+            Address = "198.51.100.1",
+            TargetType = MonitoringTargetType.Custom,
+            ProbeMode = ProbeMode.Tcp,
+            Port = 443,
+            AutoDiscovered = false,
+        });
+        await db.SaveChangesAsync();
+
+        await UpstreamTracerService.UpsertTargetAsync(
+            db, Hop("198.51.100.1"), "wan", wanContextId: null, default, isUnboundRun: true);
+        await db.SaveChangesAsync();
+
+        var handAdded = await db.MonitoringTargets.SingleAsync(t => t.TargetId == "custom-a9e6bd59");
+        handAdded.Name.Should().Be("Example ISP (HTTPS)");
+        handAdded.ProbeMode.Should().Be(ProbeMode.Tcp);
+        handAdded.Port.Should().Be(443);
+        handAdded.WanInterface.Should().BeNull();
+
+        var discovered = await db.MonitoringTargets.SingleAsync(t => t.AutoDiscovered);
+        discovered.Address.Should().Be("198.51.100.1");
+        discovered.ProbeMode.Should().Be(ProbeMode.Icmp);
+        discovered.WanInterface.Should().Be("wan");
+    }
+
+    /// <summary>
+    /// The transit/path-end writer agrees with the access one - this is the pairing that absorbed a
+    /// hand-added HTTPS check into a WAN context's freshly discovered Cloudflare target.
+    /// </summary>
+    [Fact]
+    public async Task ContextRun_LeavesATransitTargetProbedADifferentWayAlone()
+    {
+        await using var db = NewDb();
+        db.MonitoringTargets.Add(new MonitoringTarget
+        {
+            TargetId = "custom-a9e6bd59",
+            Name = "Example Transit (HTTPS)",
+            Address = "203.0.113.9",
+            TargetType = MonitoringTargetType.Custom,
+            ProbeMode = ProbeMode.Tcp,
+            Port = 443,
+            AutoDiscovered = false,
+        });
+        await db.SaveChangesAsync();
+
+        await UpstreamTracerService.UpsertTransitTargetAsync(
+            db, Transit("203.0.113.9"), "wan4", wanContextId: 3, default, isUnboundRun: false);
+        await db.SaveChangesAsync();
+
+        var handAdded = await db.MonitoringTargets.SingleAsync(t => t.TargetId == "custom-a9e6bd59");
+        handAdded.Name.Should().Be("Example Transit (HTTPS)");
+        handAdded.ProbeMode.Should().Be(ProbeMode.Tcp);
+        handAdded.WanInterface.Should().BeNull();
+        handAdded.WanContextId.Should().BeNull();
+
+        var discovered = await db.MonitoringTargets.SingleAsync(t => t.AutoDiscovered);
+        discovered.WanInterface.Should().Be("wan4");
+        discovered.WanContextId.Should().Be(3);
+    }
+
     [Theory]
     [InlineData(null, "wan", true)]      // never stamped - the primary's, and this IS the primary
     [InlineData("", "wan", true)]


### PR DESCRIPTION
Release roll-up for v2.6.2.

## Multi-WAN Monitoring - Vantages

Recommends the agent on the UniFi gateway as the straightforward way to monitor a second WAN, and links to where it is set up. The Help box now addresses the prober actually in use: a gateway agent is not offered bindings it does not use, server-probed sites lose deployment advice for something already deployed, and the policy-based route paragraph reaches the LAN agent that needs it instead of being suppressed for it.

## Monitoring

Collapsible card headers keep their status badge on the title line with the caret at the card's right edge on mobile, across Network Performance, SFP Stats and Setup. The SNMP device row caret stays in its cell.

**Investigate** - Loaded Loss Events moves the scope off LAN before running, since loaded loss is a WAN's own signal; a first search that finds nothing reports the window it searched rather than "No older events"; the result line is centered under its buttons.

**Upstream Path Discovery** - the address-only match now requires the probe mode to agree, so a discovered host no longer merges into a hand-added target probed a different way. The review reconciliation matches the same way, so it describes what the commit will do.

## Speed Test

Bundled nginx moves off the EOL 1.26 branch to the 1.30 stable line, in both the container image and the Windows installer. The container pin had stopped receiving rebuilds, which froze the entire Alpine base layer, and the same Dockerfile builds the external WAN speed test servers users put on public addresses.

## macOS Install

The installer no longer upgrades Homebrew's nginx as a side effect, since it may front other sites on that Mac. It installs when missing, moves it only with `--upgrade-nginx`, and reports an available update otherwise. The .NET floor is read from the csproj rather than a literal.