### PR TITLE
Monitoring - CM Stats: Vodafone Station (ARRIS TG3442DE) support, and a dev build fix

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1625,6 +1625,7 @@
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
                                 <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="technicolor-cga">Technicolor CGA Series (HTTP)</option>
+                                <option value="vodafone-station">Vodafone Station (ARRIS TG3442DE)</option>
                                 <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
@@ -6986,6 +6987,7 @@
         "motorola-hnap" => "Motorola (HNAP)",
         "xfinity-gateway" => "Xfinity Gateway (HTTP)",
         "technicolor-cga" => "Technicolor CGA Series (HTTP)",
+        "vodafone-station" => "Vodafone Station (ARRIS TG3442DE)",
         _ => provider,
     };
 
@@ -6996,6 +6998,7 @@
         "motorola-hnap" => "N/A (uses /HNAP1/)",
         "xfinity-gateway" => "/network_setup.jst",
         "technicolor-cga" => "/api/v1/sta_docsis_status",
+        "vodafone-station" => "/php/status_docsis_data.php",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -352,6 +352,7 @@ builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>()
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
 builder.Services.AddSingleton<ICableModemProvider, TechnicolorCgaProvider>();
+builder.Services.AddSingleton<ICableModemProvider, VodafoneStationProvider>();
 builder.Services.AddSiteScopedRegistry<ModemMonitorRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ModemMonitorRegistry>());
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -42,30 +43,31 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         try
         {
             var stats = await TryPollAsync(context, cancellationToken);
-            if (stats != null)
-            {
-                _logger.LogDebug(
-                    "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
-                    context.Name, stats.DeviceModel,
-                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-            }
+            if (stats == null)
+                return PollResult<CableModemStats>.Failed(
+                    $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
 
-            return stats;
+            _logger.LogDebug(
+                "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DeviceModel,
+                stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return PollResult<CableModemStats>.Ok(stats);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -73,7 +75,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         {
             _sessions.TryRemove(context.Id, out _);
             _logger.LogWarning(ex, "Error polling Technicolor CGA {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 
@@ -102,7 +104,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -581,7 +581,11 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         return 0;
     }
 
-    private static string AesCcmEncryptHex(byte[] key, byte[] nonce, byte[] plaintext, string associatedData)
+    /// <summary>
+    /// Encrypt to the layout the modem expects: ciphertext followed by the authentication tag,
+    /// as one lowercase hex string.
+    /// </summary>
+    internal static string AesCcmEncryptHex(byte[] key, byte[] nonce, byte[] plaintext, string associatedData)
     {
         var ciphertext = new byte[plaintext.Length];
         var tag = new byte[TagLengthBytes];
@@ -592,7 +596,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         return Convert.ToHexStringLower(ciphertext) + Convert.ToHexStringLower(tag);
     }
 
-    private static string? AesCcmDecryptText(byte[] key, byte[] nonce, string encryptedHex, string associatedData)
+    internal static string? AesCcmDecryptText(byte[] key, byte[] nonce, string encryptedHex, string associatedData)
     {
         if (!TryParseHex(encryptedHex, out var blob) || blob.Length <= TagLengthBytes)
             return null;
@@ -642,11 +646,13 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
     internal static string? ExtractJsVar(string html, string name)
     {
         var escaped = Regex.Escape(name);
+        // The bare-assignment form must not match a longer identifier ending in this name; the
+        // firmware's own pages are full of js_-prefixed variables that would otherwise win.
         string[] patterns =
         [
             $"""(?:var|let|const)\s+{escaped}\s*=\s*['"]([^'"]+)['"]""",
             $"""window\.{escaped}\s*=\s*['"]([^'"]+)['"]""",
-            $"""{escaped}\s*=\s*['"]([^'"]+)['"]""",
+            $"""(?<![\w$.]){escaped}\s*=\s*['"]([^'"]+)['"]""",
         ];
 
         foreach (var pattern in patterns)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -1,0 +1,730 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for the ARRIS TG3442DE cable gateway, sold as the
+/// "Vodafone Station" in Germany. Authenticates with AES-CCM encrypted
+/// credentials and scrapes DOCSIS channel data from JS arrays embedded in
+/// /php/status_docsis_data.php.
+/// </summary>
+public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisposable
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "vodafone-station";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Vodafone Station (ARRIS TG3442DE)";
+
+    private const string DefaultDocsisPath = "/php/status_docsis_data.php";
+    private const string LoginPath = "/php/ajaxSet_Password.php";
+    private const string SessionPath = "/php/ajaxSet_Session.php";
+    private const string LogoutPath = "/php/logout.php";
+    private const string DeviceStatusPath = "/php/status_status_data.php";
+    private const string CredentialScriptPath = "/base_95x.js";
+
+    private const string LoginAad = "loginPassword";
+    private const string NonceAad = "nonce";
+    private const int PbkdfIterations = 1000;
+    private const int KeyLengthBytes = 16;
+    private const int TagLengthBytes = 16;
+    private const int CsrfNonceLength = 32;
+    private const int TimeoutSeconds = 15;
+
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly ILogger<VodafoneStationProvider> _logger;
+    private readonly ConcurrentDictionary<int, TgSession> _sessions = new();
+
+    public VodafoneStationProvider(ILogger<VodafoneStationProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                _logger.LogDebug(
+                    "Vodafone Station {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                    context.Name, stats.DeviceModel,
+                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+            }
+
+            return stats;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogWarning(ex, "Error polling Vodafone Station {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return (false, "Password is required for the Vodafone Station web interface");
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                return (true, $"Connected to {stats.DeviceModel} - " +
+                    $"{stats.DownstreamChannels.Count} downstream, {stats.UpstreamChannels.Count} upstream channels detected");
+            }
+
+            return (false, "Could not read DOCSIS data from the Vodafone Station. Check host, password, " +
+                "and that no other admin session is signed in.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    private async Task<CableModemStats?> TryPollAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return null;
+
+        var session = await EnsureSessionAsync(context, cancellationToken);
+        if (session == null)
+            return null;
+
+        var html = await TryFetchDocsisAsync(session, context, cancellationToken);
+        if (html == null)
+        {
+            // The modem allows a single active admin session, so another sign-in silently
+            // invalidates ours. Re-authenticate once before giving up.
+            await InvalidateSessionAsync(context, cancellationToken);
+            session = await LoginAsync(context, cancellationToken);
+            if (session == null)
+                return null;
+
+            html = await TryFetchDocsisAsync(session, context, cancellationToken);
+            if (html == null)
+                return null;
+        }
+
+        return ParseDocsis(html, context, session.DeviceModel);
+    }
+
+    private async Task<TgSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGetValue(context.Id, out var cached))
+            return cached;
+
+        return await LoginAsync(context, cancellationToken);
+    }
+
+    private async Task<TgSession?> LoginAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
+
+        var cookies = new CookieContainer();
+        using var client = CreateClient(cookies, baseUrl, csrfNonce: null);
+
+        var loginPage = await client.GetStringAsync(baseUrl + "/", cancellationToken);
+
+        var sessionId = ExtractJsVar(loginPage, "currentSessionId");
+        var ivHex = ExtractJsVar(loginPage, "myIv");
+        var saltHex = ExtractJsVar(loginPage, "mySalt");
+
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(ivHex) || string.IsNullOrEmpty(saltHex))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: login page is missing session variables (sessionId={HasSession}, myIv={HasIv}, mySalt={HasSalt})",
+                context.Name, !string.IsNullOrEmpty(sessionId), !string.IsNullOrEmpty(ivHex), !string.IsNullOrEmpty(saltHex));
+            return null;
+        }
+
+        if (!TryParseHex(saltHex, out var salt) || !TryParseHex(ivHex, out var iv))
+        {
+            _logger.LogWarning("Vodafone Station {Name}: mySalt/myIv are not valid hex", context.Name);
+            return null;
+        }
+
+        if (!IsSupportedNonceSize(iv.Length))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: myIv is {Length} bytes, which AES-CCM does not accept as a nonce",
+                context.Name, iv.Length);
+            return null;
+        }
+
+        var key = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password), salt, PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes);
+
+        var credentials = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["Password"] = password,
+            ["Nonce"] = sessionId,
+        });
+
+        var encryptData = AesCcmEncryptHex(key, iv, Encoding.UTF8.GetBytes(credentials), LoginAad);
+
+        var loginBody = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["EncryptData"] = encryptData,
+            ["Name"] = username,
+            ["AuthData"] = LoginAad,
+        });
+
+        using var loginContent = new StringContent(loginBody, Encoding.UTF8, "application/json");
+        using var loginResponse = await client.PostAsync(baseUrl + LoginPath, loginContent, cancellationToken);
+        if (!loginResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: login POST returned {Status}", context.Name, loginResponse.StatusCode);
+            return null;
+        }
+
+        var loginJson = await loginResponse.Content.ReadAsStringAsync(cancellationToken);
+        using var parsed = TryParseJson(loginJson);
+        if (parsed == null)
+        {
+            _logger.LogWarning("Vodafone Station {Name}: login response was not JSON", context.Name);
+            return null;
+        }
+
+        var status = GetJsonString(parsed.RootElement, "p_status") ?? "";
+        if (status.Equals("Lockout", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: account locked out after repeated failed sign-ins. Wait a few minutes or reboot the modem.",
+                context.Name);
+            return null;
+        }
+
+        if (status.Equals("Fail", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Vodafone Station {Name}: authentication failed (incorrect password)", context.Name);
+            return null;
+        }
+
+        var encryptedNonce = GetJsonString(parsed.RootElement, "encryptData")
+            ?? GetJsonString(parsed.RootElement, "EncryptData");
+
+        string csrfNonce;
+        if (!string.IsNullOrEmpty(encryptedNonce))
+        {
+            var decrypted = AesCcmDecryptText(key, iv, encryptedNonce, NonceAad);
+            if (string.IsNullOrEmpty(decrypted))
+            {
+                _logger.LogWarning("Vodafone Station {Name}: could not decrypt the CSRF nonce", context.Name);
+                return null;
+            }
+
+            csrfNonce = decrypted.Length > CsrfNonceLength ? decrypted[..CsrfNonceLength] : decrypted;
+        }
+        else
+        {
+            csrfNonce = GetJsonString(parsed.RootElement, "nonce") ?? sessionId;
+        }
+
+        var session = new TgSession(csrfNonce, cookies, "ARRIS TG3442DE (Vodafone Station)");
+
+        // Later requests need the nonce header, so build a fresh client for the remaining setup.
+        using var authedClient = CreateClient(cookies, baseUrl, csrfNonce);
+
+        // Some firmware only marks the session live once this is posted; failure is not fatal.
+        try
+        {
+            using var sessionResponse = await authedClient.PostAsync(baseUrl + SessionPath, content: null, cancellationToken);
+            _logger.LogDebug(
+                "Vodafone Station {Name}: session init returned {Status}", context.Name, sessionResponse.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: session init failed", context.Name);
+        }
+
+        await ApplyCredentialCookieAsync(authedClient, cookies, baseUrl, context, cancellationToken);
+
+        session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
+        _sessions[context.Id] = session;
+
+        _logger.LogDebug("Vodafone Station {Name}: authenticated (p_status={Status})", context.Name, status);
+        return session;
+    }
+
+    /// <summary>
+    /// Fetch the DOCSIS page, returning null when the session is no longer accepted so the
+    /// caller can re-authenticate. A page without the channel arrays means the modem served
+    /// the login page instead, which is the unauthenticated response rather than an error.
+    /// </summary>
+    private async Task<string?> TryFetchDocsisAsync(
+        TgSession session,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var path = string.IsNullOrWhiteSpace(context.StatusPagePath) ? DefaultDocsisPath : context.StatusPagePath;
+
+        using var client = CreateClient(session.Cookies, baseUrl, session.CsrfNonce);
+
+        try
+        {
+            using var response = await client.GetAsync(baseUrl + path, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "Vodafone Station {Name}: DOCSIS page returned {Status}", context.Name, response.StatusCode);
+                return null;
+            }
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            return DownstreamArrayRegex().IsMatch(html) || UpstreamArrayRegex().IsMatch(html) ? html : null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: DOCSIS page request failed", context.Name);
+            return null;
+        }
+    }
+
+    private async Task InvalidateSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (!_sessions.TryRemove(context.Id, out var session))
+            return;
+
+        var baseUrl = BuildBaseUrl(context);
+        using var client = CreateClient(session.Cookies, baseUrl, session.CsrfNonce);
+
+        try
+        {
+            using var response = await client.PostAsync(baseUrl + LogoutPath, content: null, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: logout failed", context.Name);
+        }
+    }
+
+    /// <summary>
+    /// The firmware expects a "credential" cookie that the browser's login script sets from
+    /// base_95x.js. Data requests are rejected without it on some builds.
+    /// </summary>
+    private async Task ApplyCredentialCookieAsync(
+        HttpClient client,
+        CookieContainer cookies,
+        string baseUrl,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var script = await client.GetStringAsync(baseUrl + CredentialScriptPath, cancellationToken);
+            var match = CredentialCookieRegex().Match(script);
+            if (!match.Success)
+            {
+                _logger.LogDebug("Vodafone Station {Name}: no credential cookie in base_95x.js", context.Name);
+                return;
+            }
+
+            cookies.Add(new Uri(baseUrl), new Cookie("credential", match.Groups[1].Value, "/"));
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: could not read base_95x.js", context.Name);
+        }
+    }
+
+    private static async Task<string> ReadDeviceModelAsync(
+        HttpClient client,
+        string baseUrl,
+        string fallback,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var status = await client.GetStringAsync(baseUrl + DeviceStatusPath, cancellationToken);
+            var hardware = ExtractJsVar(status, "js_HWTypeVersion");
+            if (string.IsNullOrWhiteSpace(hardware))
+                return fallback;
+
+            return hardware.StartsWith("ARRIS", StringComparison.OrdinalIgnoreCase) ? hardware : $"ARRIS {hardware}";
+        }
+        catch (HttpRequestException)
+        {
+            return fallback;
+        }
+    }
+
+    internal static CableModemStats ParseDocsis(string html, CmPollContext context, string deviceModel)
+    {
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
+            DeviceName = context.Name,
+            DeviceModel = deviceModel,
+        };
+
+        foreach (var channel in EnumerateChannels(html, DownstreamArrayRegex()))
+        {
+            var type = GetChannelString(channel, "ChannelType");
+            var modulation = GetChannelString(channel, "Modulation");
+            if (string.IsNullOrWhiteSpace(modulation) && type.Contains("OFDM", StringComparison.OrdinalIgnoreCase))
+                modulation = type;
+
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetChannelNumber(channel, "ChannelID"),
+                LockStatus = NormalizeLockStatus(GetChannelString(channel, "LockStatus")),
+                Modulation = modulation,
+                Frequency = ParseFrequencyHz(GetChannelString(channel, "Frequency")),
+                Power = ParsePowerDbmv(GetChannelString(channel, "PowerLevel")),
+                Snr = ParseLevel(GetChannelString(channel, "SNRLevel")),
+                // Codeword counters are absent on the firmware this was built against, so these
+                // stay 0 there; the alternate spellings cover builds that do publish them.
+                Correctables = (long)GetChannelNumber(channel, "CorrectableCodewords", "Correcteds", "CorrErr"),
+                Uncorrectables = (long)GetChannelNumber(channel, "UncorrectableCodewords", "Uncorrectables", "UncorrErr"),
+            });
+        }
+
+        foreach (var channel in EnumerateChannels(html, UpstreamArrayRegex()))
+        {
+            var type = GetChannelString(channel, "ChannelType");
+            if (string.IsNullOrWhiteSpace(type))
+                type = GetChannelString(channel, "Modulation");
+
+            stats.UpstreamChannels.Add(new UsChannel
+            {
+                ChannelId = (int)GetChannelNumber(channel, "ChannelID"),
+                LockStatus = NormalizeLockStatus(GetChannelString(channel, "LockStatus")),
+                ChannelType = type,
+                Frequency = ParseFrequencyHz(GetChannelString(channel, "Frequency")),
+                Power = ParsePowerDbmv(GetChannelString(channel, "PowerLevel")),
+                SymbolRate = (long)GetChannelNumber(channel, "SymbolRate"),
+            });
+        }
+
+        return stats;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateChannels(string html, Regex arrayRegex)
+    {
+        var match = arrayRegex.Match(html);
+        if (!match.Success)
+            yield break;
+
+        JsonDocument? document;
+        try
+        {
+            document = JsonDocument.Parse(match.Groups[1].Value);
+        }
+        catch (JsonException)
+        {
+            yield break;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind == JsonValueKind.Object)
+                    yield return element.Clone();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The TG reports "ACTIVE" where the rest of the app expects DOCSIS "Locked"; without this
+    /// mapping every locked-channel aggregate reads zero.
+    /// </summary>
+    internal static string NormalizeLockStatus(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Equals("ACTIVE", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("Locked", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Locked";
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Parse the TG frequency field to Hz. OFDM/OFDMA channels report a "start~end" band, which
+    /// becomes its center. Values below 1 MHz are taken as MHz, which is how narrower firmware
+    /// builds report the same field.
+    /// </summary>
+    internal static long ParseFrequencyHz(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return 0;
+
+        var separator = value.IndexOf('~');
+        if (separator >= 0)
+        {
+            var start = ParseLevel(value[..separator]);
+            var end = ParseLevel(value[(separator + 1)..]);
+            if (start == null || end == null)
+                return 0;
+
+            return ToHz((start.Value + end.Value) / 2);
+        }
+
+        var single = ParseLevel(value);
+        return single == null ? 0 : ToHz(single.Value);
+    }
+
+    private static long ToHz(double value)
+    {
+        if (value <= 0)
+            return 0;
+
+        return value >= 1_000_000 ? (long)value : (long)(value * 1_000_000);
+    }
+
+    /// <summary>
+    /// Parse the TG power field, which pairs both units as "-1.2 dBmV/1158.8 dBuV".
+    /// </summary>
+    internal static double? ParsePowerDbmv(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var separator = value.IndexOf('/');
+        if (separator >= 0)
+            value = value[..separator];
+
+        return ParseLevel(value);
+    }
+
+    /// <summary>
+    /// Parse a leading number from a value that may carry a unit suffix ("41.8 dB").
+    /// </summary>
+    internal static double? ParseLevel(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var end = 0;
+        while (end < value.Length && (char.IsAsciiDigit(value[end]) || value[end] is '-' or '+' or '.'))
+            end++;
+
+        var numeric = value[..end];
+        return double.TryParse(numeric, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string GetChannelString(JsonElement channel, string name)
+    {
+        if (!channel.TryGetProperty(name, out var value))
+            return "";
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Number => value.GetRawText(),
+            _ => "",
+        };
+    }
+
+    private static double GetChannelNumber(JsonElement channel, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            var raw = GetChannelString(channel, name);
+            if (raw.Length == 0)
+                continue;
+
+            var parsed = ParseLevel(raw);
+            if (parsed.HasValue)
+                return parsed.Value;
+        }
+
+        return 0;
+    }
+
+    private static string AesCcmEncryptHex(byte[] key, byte[] nonce, byte[] plaintext, string associatedData)
+    {
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[TagLengthBytes];
+
+        using var ccm = new AesCcm(key);
+        ccm.Encrypt(nonce, plaintext, ciphertext, tag, Encoding.ASCII.GetBytes(associatedData));
+
+        return Convert.ToHexStringLower(ciphertext) + Convert.ToHexStringLower(tag);
+    }
+
+    private static string? AesCcmDecryptText(byte[] key, byte[] nonce, string encryptedHex, string associatedData)
+    {
+        if (!TryParseHex(encryptedHex, out var blob) || blob.Length <= TagLengthBytes)
+            return null;
+
+        var ciphertext = blob.AsSpan(0, blob.Length - TagLengthBytes);
+        var tag = blob.AsSpan(blob.Length - TagLengthBytes);
+        var plaintext = new byte[ciphertext.Length];
+
+        try
+        {
+            using var ccm = new AesCcm(key);
+            ccm.Decrypt(nonce, ciphertext, tag, plaintext, Encoding.ASCII.GetBytes(associatedData));
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+
+        return Encoding.UTF8.GetString(plaintext);
+    }
+
+    private static bool IsSupportedNonceSize(int length)
+    {
+        var sizes = AesCcm.NonceByteSizes;
+        if (length < sizes.MinSize || length > sizes.MaxSize)
+            return false;
+
+        return sizes.SkipSize == 0
+            ? length == sizes.MinSize
+            : (length - sizes.MinSize) % sizes.SkipSize == 0;
+    }
+
+    private static bool TryParseHex(string value, out byte[] bytes)
+    {
+        try
+        {
+            bytes = Convert.FromHexString(value.Trim());
+            return true;
+        }
+        catch (FormatException)
+        {
+            bytes = [];
+            return false;
+        }
+    }
+
+    internal static string? ExtractJsVar(string html, string name)
+    {
+        var escaped = Regex.Escape(name);
+        string[] patterns =
+        [
+            $"""(?:var|let|const)\s+{escaped}\s*=\s*['"]([^'"]+)['"]""",
+            $"""window\.{escaped}\s*=\s*['"]([^'"]+)['"]""",
+            $"""{escaped}\s*=\s*['"]([^'"]+)['"]""",
+        ];
+
+        foreach (var pattern in patterns)
+        {
+            var match = Regex.Match(html, pattern, RegexOptions.None, RegexTimeout);
+            if (match.Success)
+                return match.Groups[1].Value;
+        }
+
+        return null;
+    }
+
+    private static HttpClient CreateClient(CookieContainer cookies, string baseUrl, string? csrfNonce)
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = cookies,
+            UseCookies = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            DefaultRequestHeaders =
+            {
+                { "User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
+                { "X-Requested-With", "XMLHttpRequest" },
+                { "Origin", baseUrl },
+                { "Referer", baseUrl + "/" },
+            },
+        };
+
+        if (!string.IsNullOrEmpty(csrfNonce))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("csrfNonce", csrfNonce);
+
+        return client;
+    }
+
+    private static string BuildBaseUrl(CmPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var scheme = port == 443 ? "https" : "http";
+        var suffix = port is 80 or 443 ? "" : $":{port}";
+        return $"{scheme}://{context.Host}{suffix}";
+    }
+
+    private static JsonDocument? TryParseJson(string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetJsonString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    public void Dispose()
+    {
+        _sessions.Clear();
+    }
+
+    [GeneratedRegex(@"json_dsData\s*=\s*(\[.+?\])\s*;", RegexOptions.Singleline)]
+    private static partial Regex DownstreamArrayRegex();
+
+    [GeneratedRegex(@"json_usData\s*=\s*(\[.+?\])\s*;", RegexOptions.Singleline)]
+    private static partial Regex UpstreamArrayRegex();
+
+    [GeneratedRegex("""createCookie\(\s*["']credential["']\s*,\s*["'](.+?)["']""")]
+    private static partial Regex CredentialCookieRegex();
+
+    private sealed record TgSession(string CsrfNonce, CookieContainer Cookies, string DeviceModel);
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -51,30 +52,31 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         try
         {
             var stats = await TryPollAsync(context, cancellationToken);
-            if (stats != null)
-            {
-                _logger.LogDebug(
-                    "Vodafone Station {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
-                    context.Name, stats.DeviceModel,
-                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-            }
+            if (stats == null)
+                return PollResult<CableModemStats>.Failed(
+                    $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
 
-            return stats;
+            _logger.LogDebug(
+                "Vodafone Station {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DeviceModel,
+                stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return PollResult<CableModemStats>.Ok(stats);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -82,7 +84,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         {
             _sessions.TryRemove(context.Id, out _);
             _logger.LogWarning(ex, "Error polling Vodafone Station {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 
@@ -111,7 +113,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using FluentAssertions;
 using NetworkOptimizer.Monitoring.Providers;
 using NetworkOptimizer.Web.Services.CableModemProviders;
@@ -145,6 +146,61 @@ public class VodafoneStationProviderTests
     public void ExtractJsVar_ReturnsNullWhenMissing()
     {
         VodafoneStationProvider.ExtractJsVar("var somethingElse = 'x';", "myIv").Should().BeNull();
+    }
+
+    // The firmware's pages are full of js_-prefixed variables, so a bare assignment must not be
+    // read off a longer identifier that merely ends with the name being looked up.
+    [Fact]
+    public void ExtractJsVar_IgnoresLongerIdentifiersEndingInTheName()
+    {
+        var page = "var js_mySalt = 'deadbeefdeadbeef';\nmySalt = 'cafebabecafebabe';\n";
+
+        VodafoneStationProvider.ExtractJsVar(page, "mySalt").Should().Be("cafebabecafebabe");
+    }
+
+    // The modem expects ciphertext followed by the 16-byte authentication tag as one hex string.
+    // The reverse order still looks like a valid payload and is rejected only by the device.
+    [Fact]
+    public void AesCcmEncryptHex_AppendsTagAndRoundTrips()
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+        const string payload = """{"Password":"secret","Nonce":"session"}""";
+
+        var encrypted = VodafoneStationProvider.AesCcmEncryptHex(
+            key, nonce, Encoding.UTF8.GetBytes(payload), "loginPassword");
+
+        encrypted.Should().HaveLength((Encoding.UTF8.GetByteCount(payload) + 16) * 2);
+        encrypted.Should().MatchRegex("^[0-9a-f]+$");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword")
+            .Should().Be(payload);
+    }
+
+    // The credentials and the returned CSRF nonce are sealed under different associated data, so
+    // mixing the two up has to fail closed.
+    [Fact]
+    public void AesCcmDecryptText_ReturnsNullOnAssociatedDataMismatch()
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+
+        var encrypted = VodafoneStationProvider.AesCcmEncryptHex(
+            key, nonce, Encoding.UTF8.GetBytes("token"), "nonce");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-hex")]
+    [InlineData("00112233")]
+    public void AesCcmDecryptText_ReturnsNullOnMalformedInput(string encrypted)
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword").Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
@@ -1,0 +1,198 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class VodafoneStationProviderTests
+{
+    private static CmPollContext Context() => new()
+    {
+        Id = 1,
+        Name = "Cable Modem",
+        Host = "192.0.2.10",
+        Port = 80,
+    };
+
+    // Shape of /php/status_docsis_data.php: the channel arrays are JS variables embedded in the
+    // page, not a JSON body.
+    private const string DocsisPage = """
+        <html><body><script type="text/javascript">
+        var json_dsData = [
+          {"__id":"1","ChannelID":"9","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":"602000000","PowerLevel":"-1.2 dBmV/1158.8 dBuV","SNRLevel":"41.8 dB"},
+          {"__id":"2","ChannelID":"10","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":"610000000","PowerLevel":"0.8 dBmV/1160.8 dBuV","SNRLevel":"40.2 dB"},
+          {"__id":"3","ChannelID":"33","LockStatus":"ACTIVE","ChannelType":"OFDM","Modulation":"","Frequency":"151000000~299000000","PowerLevel":"2.4 dBmV/1162.4 dBuV","SNRLevel":"43.0 dB"}
+        ];
+        var json_usData = [
+          {"__id":"1","ChannelID":"1","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"64QAM","Frequency":"51000000","PowerLevel":"43.3 dBmV","SymbolRate":"5120000"},
+          {"__id":"2","ChannelID":"5","LockStatus":"ACTIVE","ChannelType":"OFDMA","Modulation":"","Frequency":"29000000~45000000","PowerLevel":"44.0 dBmV","SymbolRate":"0"}
+        ];
+        </script></body></html>
+        """;
+
+    [Fact]
+    public void ParseDocsis_ParsesDownstreamChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(9);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("256QAM");
+        first.Frequency.Should().Be(602_000_000);
+        first.Power.Should().Be(-1.2);
+        first.Snr.Should().Be(41.8);
+    }
+
+    [Fact]
+    public void ParseDocsis_ParsesUpstreamChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var first = stats.UpstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.ChannelType.Should().Be("SC-QAM");
+        first.Frequency.Should().Be(51_000_000);
+        first.Power.Should().Be(43.3);
+        first.SymbolRate.Should().Be(5_120_000);
+    }
+
+    // OFDM/OFDMA channels report a band rather than a carrier, so the channel takes its center.
+    [Fact]
+    public void ParseDocsis_UsesBandCenterForOfdmChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        var ofdm = stats.DownstreamChannels[2];
+        ofdm.Frequency.Should().Be(225_000_000);
+        ofdm.Modulation.Should().Be("OFDM");
+
+        var ofdma = stats.UpstreamChannels[1];
+        ofdma.Frequency.Should().Be(37_000_000);
+        ofdma.ChannelType.Should().Be("OFDMA");
+    }
+
+    // The TG reports "ACTIVE" where every aggregate on CableModemStats counts "Locked". Without
+    // the mapping the channels still parse but each aggregate silently reads zero or null.
+    [Fact]
+    public void ParseDocsis_MapsActiveToLockedSoAggregatesPopulate()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately(0.667, 0.001);
+        stats.DownstreamSnrAvgDb.Should().BeApproximately(41.667, 0.001);
+        stats.UpstreamPowerAvgDbmv.Should().BeApproximately(43.65, 0.001);
+    }
+
+    [Theory]
+    [InlineData("ACTIVE", "Locked")]
+    [InlineData("Locked", "Locked")]
+    [InlineData("locked", "Locked")]
+    [InlineData("NOT_LOCKED", "NOT_LOCKED")]
+    [InlineData("", "")]
+    public void NormalizeLockStatus_MapsFirmwareValues(string raw, string expected)
+    {
+        VodafoneStationProvider.NormalizeLockStatus(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("602000000", 602_000_000)]
+    [InlineData("151000000~299000000", 225_000_000)]
+    [InlineData("602", 602_000_000)]
+    [InlineData("", 0)]
+    [InlineData("not-a-number", 0)]
+    public void ParseFrequencyHz_HandlesFirmwareFormats(string raw, long expected)
+    {
+        VodafoneStationProvider.ParseFrequencyHz(raw).Should().Be(expected);
+    }
+
+    // The TG pairs both units in one field; only the dBmV half is meaningful to us.
+    [Theory]
+    [InlineData("-1.2 dBmV/1158.8 dBuV", -1.2)]
+    [InlineData("43.3 dBmV", 43.3)]
+    [InlineData("0.0 dBmV/1160.0 dBuV", 0.0)]
+    public void ParsePowerDbmv_TakesTheDbmvHalf(string raw, double expected)
+    {
+        VodafoneStationProvider.ParsePowerDbmv(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParsePowerDbmv_ReturnsNullWhenAbsent()
+    {
+        VodafoneStationProvider.ParsePowerDbmv("").Should().BeNull();
+        VodafoneStationProvider.ParsePowerDbmv("n/a").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("var myIv = 'a1b2c3d4e5f60718';", "myIv", "a1b2c3d4e5f60718")]
+    [InlineData("let mySalt = \"0011223344556677\";", "mySalt", "0011223344556677")]
+    [InlineData("window.currentSessionId = 'abc123';", "currentSessionId", "abc123")]
+    [InlineData("currentSessionId = 'bare9876';", "currentSessionId", "bare9876")]
+    public void ExtractJsVar_ReadsDeclarationForms(string script, string name, string expected)
+    {
+        VodafoneStationProvider.ExtractJsVar(script, name).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ExtractJsVar_ReturnsNullWhenMissing()
+    {
+        VodafoneStationProvider.ExtractJsVar("var somethingElse = 'x';", "myIv").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDocsis_ReturnsEmptyChannelsWhenArraysAbsent()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis("<html><body>Login</body></html>", Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+        stats.UpstreamChannels.Should().BeEmpty();
+        stats.DeviceModel.Should().Be("ARRIS TG3442DE");
+    }
+
+    [Fact]
+    public void ParseDocsis_SkipsMalformedChannelArray()
+    {
+        var page = "var json_dsData = [ {\"ChannelID\": ; ];";
+
+        var stats = VodafoneStationProvider.ParseDocsis(page, Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+    }
+
+    // Numeric fields arrive quoted on some builds and bare on others.
+    [Fact]
+    public void ParseDocsis_AcceptsUnquotedNumericFields()
+    {
+        var page = """
+            var json_dsData = [
+              {"ChannelID":9,"LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":602000000,"PowerLevel":"-1.2 dBmV/1158.8 dBuV","SNRLevel":41.8}
+            ];
+            """;
+
+        var stats = VodafoneStationProvider.ParseDocsis(page, Context(), "ARRIS TG3442DE");
+
+        var channel = stats.DownstreamChannels.Should().ContainSingle().Subject;
+        channel.ChannelId.Should().Be(9);
+        channel.Frequency.Should().Be(602_000_000);
+        channel.Snr.Should().Be(41.8);
+    }
+
+    [Fact]
+    public void ParseDocsis_CarriesDeviceIdentityFromContext()
+    {
+        var context = Context() with { ConfiguredHost = "198.51.100.5" };
+
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, context, "ARRIS TG3442DE");
+
+        stats.DeviceHost.Should().Be("198.51.100.5");
+        stats.DeviceName.Should().Be("Cable Modem");
+    }
+}


### PR DESCRIPTION
Adds the ARRIS TG3442DE, sold as the "Vodafone Station" in Germany, to the cable modems Network Optimizer can monitor. Requested in #1087.

**This also repairs the `dev` build.** #1127 changed `ICableModemProvider.PollAsync` to return `PollResult<CableModemStats>` so a failed poll carries the reason the user sees. The Technicolor provider in #1134 was branched before that landed and merged after it; the two never touched the same lines, so the merge was clean and `dev` stopped compiling. Both providers are moved onto the new contract here.

## Monitoring - CM Stats

- **Vodafone Station (ARRIS TG3442DE)** - Pick it under **Provider** when adding a cable modem in Settings, and its downstream and upstream channels report alongside every other supported modem: per-channel frequency, power, SNR, modulation, lock state, and the locked-channel counts and averages that drive the charts and alerts.

This modem does not hand its channel data over easily. Signing in means deriving a key with PBKDF2-HMAC-SHA256 from a salt the login page carries, sealing the credentials with AES-CCM, and reading back a CSRF nonce that is itself encrypted; the DOCSIS figures then have to be lifted out of JavaScript arrays embedded in the status page rather than read from an API. It also permits only one admin session at a time, so a poll that gets turned away re-authenticates once on its own instead of going dark until someone notices.

The flow is ported from the MIT-licensed DOCSight driver (`itsDNNS/docsight`), which is proven against firmware `01.05.063.13.EURO.PC20`; the reporter runs `01.05.063.15.EURO.PC20`.

Two departures from that reference, both needed to make the data land correctly here:

- It ignores lock status. This modem says `ACTIVE` where DOCSIS says `Locked`, and every aggregate counts the latter, so the channels would have parsed while the locked counts and the power and SNR averages sat empty. Cross-checked against two other TG3442DE projects, which both accept either spelling.
- It reports frequencies in MHz. Ours are Hz, so OFDM and OFDMA bands keep their center frequency in Hz.

Codeword counters are not published by this firmware, so correctables and uncorrectables read zero on this modem. The parser picks them up if a build does publish them.

## Fixes

- **Cable modem polls report why they failed** - Both the Vodafone Station and the Technicolor CGA Series now say what went wrong instead of returning nothing, so a rejected password and an unreachable modem read differently in the stats panel and the Settings test. Transport failures are described the same way as every other provider, and an HTTP timeout is reported rather than rethrown.

Thanks @njoerd114 for the request, the reference, and the firmware detail.
