### PR TITLE
Monitoring - CM Stats: Technicolor CGA Series support

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1615,10 +1615,11 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Provider</label>
                             <select class="form-control" @bind="_editingCm.Provider">
-                                <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
+                                <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
+                                <option value="technicolor-cga">Technicolor CGA Series (HTTP)</option>
                                 <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
@@ -6965,6 +6966,7 @@
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",
         "xfinity-gateway" => "Xfinity Gateway (HTTP)",
+        "technicolor-cga" => "Technicolor CGA Series (HTTP)",
         _ => provider,
     };
 
@@ -6974,6 +6976,7 @@
         "arris-surfboard-hnap" => "N/A (uses /HNAP1/)",
         "motorola-hnap" => "N/A (uses /HNAP1/)",
         "xfinity-gateway" => "/network_setup.jst",
+        "technicolor-cga" => "/api/v1/sta_docsis_status",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -351,6 +351,7 @@ builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHttpProvider>()
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
+builder.Services.AddSingleton<ICableModemProvider, TechnicolorCgaProvider>();
 builder.Services.AddSiteScopedRegistry<ModemMonitorRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ModemMonitorRegistry>());
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -1,0 +1,570 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for Technicolor CGA-series gateways (CGA437A, CGA4322DE,
+/// CGA6444VF and relatives) shipped by cable ISPs including VOO and Vodafone.
+/// These expose a JSON API behind the single-page web UI, guarded by a
+/// double-PBKDF2 login and a CSRF token.
+/// </summary>
+public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "technicolor-cga";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Technicolor CGA Series (HTTP)";
+
+    private const string DefaultDocsisPath = "/api/v1/sta_docsis_status";
+    private const string LoginPath = "/api/v1/session/login";
+    private const string MenuPath = "/api/v1/session/menu";
+    private const string DeviceInfoPath = "/api/v1/sta_device_info";
+
+    private const string SaltRequestPassword = "seeksalthash";
+    private const int PbkdfIterations = 1000;
+    private const int KeyLengthBytes = 16;
+    private const int TimeoutSeconds = 15;
+
+    private readonly ILogger<TechnicolorCgaProvider> _logger;
+    private readonly ConcurrentDictionary<int, CgaSession> _sessions = new();
+
+    public TechnicolorCgaProvider(ILogger<TechnicolorCgaProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                _logger.LogDebug(
+                    "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                    context.Name, stats.DeviceModel,
+                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+            }
+
+            return stats;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogWarning(ex, "Error polling Technicolor CGA {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return (false, "Password is required for the Technicolor web interface");
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                return (true, $"Connected to {stats.DeviceModel} - " +
+                    $"{stats.DownstreamChannels.Count} downstream, {stats.UpstreamChannels.Count} upstream channels detected");
+            }
+
+            return (false, "Could not read DOCSIS data from the Technicolor gateway. Check host, username, and password. " +
+                "Some ISPs use a device-specific account name rather than admin.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    private async Task<CableModemStats?> TryPollAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return null;
+
+        var session = await EnsureSessionAsync(context, cancellationToken);
+        if (session == null)
+            return null;
+
+        var payload = await TryFetchDocsisAsync(session, context, cancellationToken);
+        if (payload == null)
+        {
+            // A token only stays valid for one signed-in session, so anything else signing in
+            // invalidates ours. Re-authenticate once before giving up.
+            _sessions.TryRemove(context.Id, out _);
+            session = await LoginAsync(context, cancellationToken);
+            if (session == null)
+                return null;
+
+            payload = await TryFetchDocsisAsync(session, context, cancellationToken);
+            if (payload == null)
+                return null;
+        }
+
+        using (payload)
+        {
+            return ParseDocsis(payload.RootElement, context, session.DeviceModel);
+        }
+    }
+
+    private async Task<CgaSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGetValue(context.Id, out var cached))
+            return cached;
+
+        return await LoginAsync(context, cancellationToken);
+    }
+
+    private async Task<CgaSession?> LoginAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
+
+        var cookies = new CookieContainer();
+        // The firmware expects this cookie before the first API call.
+        cookies.Add(new Uri(baseUrl), new Cookie("cwd", "No", "/"));
+
+        using var client = CreateClient(cookies, baseUrl, token: null);
+
+        // Requesting the salts with logout=true also clears any session left behind by a
+        // previous poll, which the firmware would otherwise refuse to replace.
+        using var saltResponse = await PostFormAsync(
+            client, baseUrl + LoginPath, username, SaltRequestPassword, cancellationToken);
+
+        if (saltResponse == null)
+            return null;
+
+        var salt = GetJsonString(saltResponse.RootElement, "salt");
+        var saltWebUi = GetJsonString(saltResponse.RootElement, "saltwebui");
+        saltResponse.Dispose();
+
+        if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(saltWebUi))
+        {
+            _logger.LogWarning(
+                "Technicolor CGA {Name}: login did not return salt/saltwebui. The device may not use the CGA JSON API.",
+                context.Name);
+            return null;
+        }
+
+        // Both rounds salt with the ASCII text of the value, and the first round's output is
+        // fed in as its lowercase hex string rather than as raw bytes.
+        var firstHash = Convert.ToHexStringLower(Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt),
+            PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes));
+
+        var secondHash = Convert.ToHexStringLower(Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(firstHash), Encoding.UTF8.GetBytes(saltWebUi),
+            PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes));
+
+        using var loginResponse = await PostFormAsync(
+            client, baseUrl + LoginPath, username, secondHash, cancellationToken);
+
+        if (loginResponse == null)
+            return null;
+
+        var error = GetJsonString(loginResponse.RootElement, "error");
+        if (!string.IsNullOrEmpty(error) && !error.Equals("ok", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Technicolor CGA {Name}: login rejected ({Error})", context.Name, error);
+            return null;
+        }
+
+        var token = GetJsonString(loginResponse.RootElement, "token") ?? "";
+        var session = new CgaSession(token, cookies, "Technicolor CGA");
+
+        using var authedClient = CreateClient(cookies, baseUrl, token);
+
+        // Some firmware only arms the session once the menu has been requested.
+        try
+        {
+            using var menuResponse = await authedClient.GetAsync(baseUrl + MenuPath, cancellationToken);
+            _logger.LogDebug("Technicolor CGA {Name}: menu init returned {Status}", context.Name, menuResponse.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA {Name}: menu init failed", context.Name);
+        }
+
+        session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
+        _sessions[context.Id] = session;
+
+        _logger.LogDebug("Technicolor CGA {Name}: authenticated", context.Name);
+        return session;
+    }
+
+    private async Task<JsonDocument?> PostFormAsync(
+        HttpClient client,
+        string url,
+        string username,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["username"] = username,
+            ["password"] = password,
+            ["logout"] = "true",
+        });
+
+        try
+        {
+            using var response = await client.PostAsync(url, content, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Technicolor CGA login POST returned {Status}", response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TryParseJson(body);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA login POST failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetch the DOCSIS payload, returning null when the session is no longer accepted so the
+    /// caller can re-authenticate.
+    /// </summary>
+    private async Task<JsonDocument?> TryFetchDocsisAsync(
+        CgaSession session,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var path = string.IsNullOrWhiteSpace(context.StatusPagePath) ? DefaultDocsisPath : context.StatusPagePath;
+
+        using var client = CreateClient(session.Cookies, baseUrl, session.Token);
+
+        // The web UI cache-busts every read; without it some firmware serves a stale payload.
+        var separator = path.Contains('?') ? '&' : '?';
+        var url = $"{baseUrl}{path}{separator}_={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture)}";
+
+        try
+        {
+            using var response = await client.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "Technicolor CGA {Name}: DOCSIS request returned {Status}", context.Name, response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var document = TryParseJson(body);
+            if (document == null)
+                return null;
+
+            var error = GetJsonString(document.RootElement, "error");
+            if (!string.IsNullOrEmpty(error) && !error.Equals("ok", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug("Technicolor CGA {Name}: DOCSIS request returned error {Error}", context.Name, error);
+                document.Dispose();
+                return null;
+            }
+
+            return document;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA {Name}: DOCSIS request failed", context.Name);
+            return null;
+        }
+    }
+
+    private static async Task<string> ReadDeviceModelAsync(
+        HttpClient client,
+        string baseUrl,
+        string fallback,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var body = await client.GetStringAsync(baseUrl + DeviceInfoPath, cancellationToken);
+            using var document = TryParseJson(body);
+            if (document == null)
+                return fallback;
+
+            var root = document.RootElement.TryGetProperty("data", out var data) ? data : document.RootElement;
+            var model = GetJsonString(root, "modelName") ?? GetJsonString(root, "model");
+            if (string.IsNullOrWhiteSpace(model))
+                return fallback;
+
+            return model.StartsWith("Technicolor", StringComparison.OrdinalIgnoreCase) ? model : $"Technicolor {model}";
+        }
+        catch (HttpRequestException)
+        {
+            return fallback;
+        }
+    }
+
+    internal static CableModemStats ParseDocsis(JsonElement root, CmPollContext context, string deviceModel)
+    {
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
+            DeviceName = context.Name,
+            DeviceModel = deviceModel,
+        };
+
+        // Channel arrays live under "data" on current firmware and at the root on older builds.
+        var data = root.TryGetProperty("data", out var wrapped) ? wrapped : root;
+
+        foreach (var channel in EnumerateArray(data, "downstream"))
+        {
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetNumber(channel, "channelid"),
+                LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+                Modulation = GetString(channel, "FFT", "Modulation"),
+                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
+                Power = ParseLevel(GetString(channel, "power")),
+                Snr = ParseSnr(GetString(channel, "SNR")),
+                Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
+                Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
+            });
+        }
+
+        foreach (var channel in EnumerateArray(data, "ofdm_downstream"))
+        {
+            var modulation = GetString(channel, "FFT_ofdm", "FFT");
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetNumber(channel, "channelid_ofdm", "channelid"),
+                LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+                Modulation = string.IsNullOrWhiteSpace(modulation) ? "OFDM" : modulation,
+                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency_ofdm", "CentralFrequency")),
+                Power = ParseLevel(GetString(channel, "power_ofdm", "power")),
+                Snr = ParseSnr(GetString(channel, "SNR_ofdm", "SNR")),
+                Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
+                Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
+            });
+        }
+
+        foreach (var channel in EnumerateArray(data, "upstream"))
+        {
+            stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: null));
+        }
+
+        foreach (var channel in EnumerateArray(data, "ofdma_upstream"))
+        {
+            stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: "OFDMA"));
+        }
+
+        return stats;
+    }
+
+    private static UsChannel BuildUpstream(JsonElement channel, string? defaultType)
+    {
+        var type = GetString(channel, "ChannelType");
+        if (string.IsNullOrWhiteSpace(type))
+            type = defaultType ?? GetString(channel, "FFT", "Modulation");
+
+        return new UsChannel
+        {
+            ChannelId = (int)GetNumber(channel, "channelidup", "channelid"),
+            LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+            ChannelType = type,
+            Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
+            Power = ParseLevel(GetString(channel, "power")),
+            SymbolRate = (long)GetNumber(channel, "SymbolRate", "symbolrate"),
+        };
+    }
+
+    private static IEnumerable<JsonElement> EnumerateArray(JsonElement parent, string name)
+    {
+        if (parent.ValueKind != JsonValueKind.Object ||
+            !parent.TryGetProperty(name, out var array) ||
+            array.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var element in array.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+                yield return element;
+        }
+    }
+
+    /// <summary>
+    /// The API reports lock state with its own vocabulary; the rest of the app counts DOCSIS
+    /// "Locked", so anything meaning locked has to arrive as that exact word.
+    /// </summary>
+    internal static string NormalizeLockStatus(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return "";
+
+        return value.ToLowerInvariant() switch
+        {
+            "locked" or "active" or "yes" or "true" or "1" => "Locked",
+            _ => value,
+        };
+    }
+
+    /// <summary>
+    /// Parse a frequency to Hz. Values below 1 MHz are taken as MHz, which is how some builds
+    /// report the same field.
+    /// </summary>
+    internal static long ParseFrequencyHz(string raw)
+    {
+        var value = ParseLevel(raw);
+        if (value is null or <= 0)
+            return 0;
+
+        return value.Value >= 1_000_000 ? (long)value.Value : (long)(value.Value * 1_000_000);
+    }
+
+    /// <summary>
+    /// Parse SNR/MER, which some firmware reports as a negative MSE.
+    /// </summary>
+    internal static double? ParseSnr(string raw)
+    {
+        var value = ParseLevel(raw);
+        return value.HasValue ? Math.Abs(value.Value) : null;
+    }
+
+    /// <summary>
+    /// Parse a leading number from a value that may carry a unit suffix ("1.1 dBmV").
+    /// </summary>
+    internal static double? ParseLevel(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var end = 0;
+        while (end < value.Length && (char.IsAsciiDigit(value[end]) || value[end] is '-' or '+' or '.'))
+            end++;
+
+        return double.TryParse(value[..end], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string GetString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!element.TryGetProperty(name, out var value))
+                continue;
+
+            var text = value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString() ?? "",
+                JsonValueKind.Number => value.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => "",
+            };
+
+            if (text.Length > 0)
+                return text;
+        }
+
+        return "";
+    }
+
+    private static double GetNumber(JsonElement element, params string[] names)
+        => ParseLevel(GetString(element, names)) ?? 0;
+
+    private static HttpClient CreateClient(CookieContainer cookies, string baseUrl, string? token)
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = cookies,
+            UseCookies = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+
+        // The firmware checks User-Agent, X-Requested-With, and Referer on every request,
+        // including the session initialization that follows login.
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            DefaultRequestHeaders =
+            {
+                { "User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
+                { "X-Requested-With", "XMLHttpRequest" },
+                { "Referer", baseUrl + "/" },
+            },
+        };
+
+        if (!string.IsNullOrEmpty(token))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("X-CSRF-TOKEN", token);
+
+        return client;
+    }
+
+    private static string BuildBaseUrl(CmPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var scheme = port == 443 ? "https" : "http";
+        var suffix = port is 80 or 443 ? "" : $":{port}";
+        return $"{scheme}://{context.Host}{suffix}";
+    }
+
+    private static JsonDocument? TryParseJson(string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetJsonString(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    public void Dispose()
+    {
+        _sessions.Clear();
+    }
+
+    private sealed record CgaSession(string Token, CookieContainer Cookies, string DeviceModel);
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
 
@@ -167,7 +166,6 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
 
         var salt = GetJsonString(saltResponse.RootElement, "salt");
         var saltWebUi = GetJsonString(saltResponse.RootElement, "saltwebui");
-        saltResponse.Dispose();
 
         if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(saltWebUi))
         {

--- a/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class TechnicolorCgaProviderTests
+{
+    private static CmPollContext Context() => new()
+    {
+        Id = 1,
+        Name = "Cable Modem",
+        Host = "192.0.2.10",
+        Port = 80,
+    };
+
+    // Shape of /api/v1/sta_docsis_status: SC-QAM and OFDM channels arrive in separate arrays
+    // under "data", each with its own field naming.
+    private const string DocsisPayload = """
+        {
+          "error": "ok",
+          "data": {
+            "downstream": [
+              {"channelid":"1","locked":"Locked","ChannelType":"SC-QAM","FFT":"256QAM","CentralFrequency":"602000000","power":"1.7","SNR":"37.0"},
+              {"channelid":"2","locked":"Locked","ChannelType":"SC-QAM","FFT":"256QAM","CentralFrequency":"610000000","power":"1.4","SNR":"37.0"}
+            ],
+            "ofdm_downstream": [
+              {"channelid_ofdm":"162","locked":"Locked","FFT_ofdm":"","CentralFrequency_ofdm":"225000000","power_ofdm":"5.8","SNR_ofdm":"41.0"}
+            ],
+            "upstream": [
+              {"channelidup":"1","locked":"Locked","ChannelType":"SC-QAM","FFT":"32QAM","CentralFrequency":"51000000","power":"43.3","SymbolRate":"5120000"}
+            ],
+            "ofdma_upstream": [
+              {"channelidup":"9","locked":"Locked","ChannelType":"","FFT":"","CentralFrequency":"37000000","power":"44.0"}
+            ]
+          }
+        }
+        """;
+
+    private static JsonElement Payload(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void ParseDocsis_ParsesScQamDownstream()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("256QAM");
+        first.Frequency.Should().Be(602_000_000);
+        first.Power.Should().Be(1.7);
+        first.Snr.Should().Be(37.0);
+    }
+
+    // OFDM channels use suffixed field names and are appended to the same downstream list.
+    [Fact]
+    public void ParseDocsis_ParsesOfdmDownstreamWithSuffixedFields()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var ofdm = stats.DownstreamChannels[2];
+        ofdm.ChannelId.Should().Be(162);
+        ofdm.Modulation.Should().Be("OFDM");
+        ofdm.Frequency.Should().Be(225_000_000);
+        ofdm.Power.Should().Be(5.8);
+        ofdm.Snr.Should().Be(41.0);
+    }
+
+    [Fact]
+    public void ParseDocsis_ParsesUpstreamChannels()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var scqam = stats.UpstreamChannels[0];
+        scqam.ChannelId.Should().Be(1);
+        scqam.ChannelType.Should().Be("SC-QAM");
+        scqam.Frequency.Should().Be(51_000_000);
+        scqam.Power.Should().Be(43.3);
+        scqam.SymbolRate.Should().Be(5_120_000);
+
+        // OFDMA channels carry no channel type of their own.
+        stats.UpstreamChannels[1].ChannelType.Should().Be("OFDMA");
+    }
+
+    // Every aggregate on CableModemStats counts "Locked", so the lock vocabulary has to be
+    // normalized or the channels parse while all the aggregates read zero or null.
+    [Fact]
+    public void ParseDocsis_PopulatesAggregates()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately(2.967, 0.001);
+        stats.DownstreamSnrAvgDb.Should().BeApproximately(38.333, 0.001);
+        stats.UpstreamPowerAvgDbmv.Should().BeApproximately(43.65, 0.001);
+    }
+
+    [Theory]
+    [InlineData("Locked", "Locked")]
+    [InlineData("locked", "Locked")]
+    [InlineData("ACTIVE", "Locked")]
+    [InlineData("YES", "Locked")]
+    [InlineData("1", "Locked")]
+    [InlineData("true", "Locked")]
+    [InlineData("Not Locked", "Not Locked")]
+    [InlineData("", "")]
+    public void NormalizeLockStatus_MapsFirmwareValues(string raw, string expected)
+    {
+        TechnicolorCgaProvider.NormalizeLockStatus(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("602000000", 602_000_000)]
+    [InlineData("602", 602_000_000)]
+    [InlineData("", 0)]
+    [InlineData("n/a", 0)]
+    public void ParseFrequencyHz_HandlesFirmwareFormats(string raw, long expected)
+    {
+        TechnicolorCgaProvider.ParseFrequencyHz(raw).Should().Be(expected);
+    }
+
+    // Some builds report MER as a negative MSE.
+    [Theory]
+    [InlineData("37.0", 37.0)]
+    [InlineData("-37.0", 37.0)]
+    public void ParseSnr_NormalizesSign(string raw, double expected)
+    {
+        TechnicolorCgaProvider.ParseSnr(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseSnr_ReturnsNullWhenAbsent()
+    {
+        TechnicolorCgaProvider.ParseSnr("").Should().BeNull();
+    }
+
+    // Older builds return the channel arrays at the root rather than under "data".
+    [Fact]
+    public void ParseDocsis_AcceptsUnwrappedPayload()
+    {
+        var payload = """
+            {"downstream":[{"channelid":"1","locked":"Locked","FFT":"256QAM","CentralFrequency":"602000000","power":"1.7","SNR":"37.0"}]}
+            """;
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(payload), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().ContainSingle();
+        stats.DownstreamChannels[0].Frequency.Should().Be(602_000_000);
+    }
+
+    // Numeric fields arrive quoted on some builds and bare on others.
+    [Fact]
+    public void ParseDocsis_AcceptsUnquotedNumericFields()
+    {
+        var payload = """
+            {"data":{"downstream":[{"channelid":1,"locked":"Locked","FFT":"256QAM","CentralFrequency":602000000,"power":1.7,"SNR":37.0}]}}
+            """;
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(payload), Context(), "Technicolor CGA");
+
+        var channel = stats.DownstreamChannels.Should().ContainSingle().Subject;
+        channel.ChannelId.Should().Be(1);
+        channel.Frequency.Should().Be(602_000_000);
+        channel.Power.Should().Be(1.7);
+        channel.Snr.Should().Be(37.0);
+    }
+
+    [Fact]
+    public void ParseDocsis_ReturnsEmptyChannelsWhenArraysAbsent()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload("""{"error":"ok","data":{}}"""), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+        stats.UpstreamChannels.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseDocsis_CarriesDeviceIdentityFromContext()
+    {
+        var context = Context() with { ConfiguredHost = "198.51.100.5" };
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), context, "Technicolor CGA437A");
+
+        stats.DeviceHost.Should().Be("198.51.100.5");
+        stats.DeviceName.Should().Be("Cable Modem");
+        stats.DeviceModel.Should().Be("Technicolor CGA437A");
+    }
+}


### PR DESCRIPTION
Adds Technicolor CGA-series cable gateways to the modems Network Optimizer can monitor. Requested in #1124.

## Monitoring - CM Stats

- **Technicolor CGA Series** - Pick it under **Provider** when adding a cable modem in Settings, and its downstream and upstream channels report alongside every other supported modem: per-channel frequency, power, SNR, modulation, symbol rate, lock state, and the locked-channel counts and averages that drive the charts and alerts.

These gateways render their DOCSIS tables from a JSON API behind a single-page web UI, reachable only after a two-round PBKDF2 sign-in and with a CSRF token attached to every read. The provider does that handshake, then polls the same endpoint the web UI does. SC-QAM, OFDM, and OFDMA channels each arrive in their own array under their own field names, and all three are read.

The flow is ported from the CGA path of the MIT-licensed DOCSight driver (`itsDNNS/docsight`).

Lock status is normalized to DOCSIS `Locked` because every aggregate counts that exact word; the reference driver drops the field, which would have left the locked counts and the power and SNR averages empty while the channels themselves parsed fine. Symbol rate is carried through for the same reason, and frequencies are kept in Hz to match the rest of the app.

Username stays configurable rather than assuming `admin`, since ISPs shipping these set their own account name.

**This has not yet been confirmed against the reporter's device.** The CGA API is the best-matching published reference for a Technicolor of this generation, but no trace from that unit has been provided, so the parser deliberately tolerates both the wrapped and unwrapped payload shapes and both quoted and bare numerics. If the reporter's channels come back with no lock state, that field's name is the first thing to check.

Also sorts the **Provider** list alphabetically, which was in no order at all.

Thanks @srialmaster for the request and the interface capture.
