### PR TITLE
Monitoring: latency target lifecycle, poll failures that say why, and two new cable modem providers

### DIFF
--- a/src/NetworkOptimizer.Monitoring/Providers/ICableModemProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/ICableModemProvider.cs
@@ -23,10 +23,12 @@ public interface ICableModemProvider
 
     /// <summary>
     /// Poll the cable modem and return its current stats.
-    /// Implementations should log internally and return null on transport
-    /// or parsing failure; throwing is reserved for programming errors.
+    /// Implementations should log internally and report transport or parsing failure
+    /// through <see cref="PollResult{TStats}.Failed"/>; throwing is reserved for
+    /// programming errors. Every failure carries a reason: it is what the Settings test
+    /// and the stats panel show.
     /// </summary>
-    Task<CableModemStats?> PollAsync(
+    Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default);
 

--- a/src/NetworkOptimizer.Monitoring/Providers/ICellularModemProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/ICellularModemProvider.cs
@@ -23,13 +23,14 @@ public interface ICellularModemProvider
 
     /// <summary>
     /// Poll the modem and return its current stats.
-    /// Implementations should log internally and return null on transport
-    /// or parsing failure; throwing is reserved for programming errors.
+    /// Implementations should log internally and report transport or parsing failure through
+    /// <see cref="PollResult<CellularModemStats>.Failed"/>; throwing is reserved for programming errors.
+    /// Every failure carries a reason: it is what the Settings test and the Dashboard card show.
     /// </summary>
     /// <param name="context">Provider-agnostic poll context.</param>
     /// <param name="cancellationToken">Optional cancellation.</param>
-    /// <returns>Stats on success, null on failure.</returns>
-    Task<CellularModemStats?> PollAsync(
+    /// <returns>Stats on success, or the reason the poll produced none.</returns>
+    Task<PollResult<CellularModemStats>> PollAsync(
         ModemPollContext context,
         CancellationToken cancellationToken = default);
 

--- a/src/NetworkOptimizer.Monitoring/Providers/IOntProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/IOntProvider.cs
@@ -23,10 +23,12 @@ public interface IOntProvider
 
     /// <summary>
     /// Poll the ONT and return its current stats.
-    /// Implementations should log internally and return null on transport
-    /// or parsing failure; throwing is reserved for programming errors.
+    /// Implementations should log internally and report transport or parsing failure
+    /// through <see cref="PollResult{TStats}.Failed"/>; throwing is reserved for
+    /// programming errors. Every failure carries a reason: it is what the Settings test
+    /// and the stats panel show.
     /// </summary>
-    Task<OntStats?> PollAsync(
+    Task<PollResult<OntStats>> PollAsync(
         OntPollContext context,
         CancellationToken cancellationToken = default);
 

--- a/src/NetworkOptimizer.Monitoring/Providers/IStarlinkProvider.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/IStarlinkProvider.cs
@@ -23,10 +23,12 @@ public interface IStarlinkProvider
 
     /// <summary>
     /// Poll the terminal and return its current stats.
-    /// Implementations should log internally and return null on transport
-    /// or parsing failure; throwing is reserved for programming errors.
+    /// Implementations should log internally and report transport or parsing failure
+    /// through <see cref="PollResult{TStats}.Failed"/>; throwing is reserved for
+    /// programming errors. Every failure carries a reason: it is what the Settings test
+    /// and the stats panel show.
     /// </summary>
-    Task<StarlinkStats?> PollAsync(
+    Task<PollResult<StarlinkStats>> PollAsync(
         StarlinkPollContext context,
         CancellationToken cancellationToken = default);
 

--- a/src/NetworkOptimizer.Monitoring/Providers/PollResult.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/PollResult.cs
@@ -1,0 +1,30 @@
+namespace NetworkOptimizer.Monitoring.Providers;
+
+/// <summary>
+/// The outcome of a provider poll: the stats, or the reason there are none.
+/// <para>
+/// A bare null told the caller only that nothing came back, which is what the UI then had to
+/// say. The reason travels with the failure so a rejected password and an unreachable device
+/// read differently to the person looking at them.
+/// </para>
+/// </summary>
+/// <typeparam name="TStats">The stats type the provider family returns.</typeparam>
+public sealed record PollResult<TStats> where TStats : class
+{
+    /// <summary>The polled stats, or null when the poll failed.</summary>
+    public TStats? Stats { get; init; }
+
+    /// <summary>
+    /// One short user-facing line saying why there are no stats. Null on success.
+    /// </summary>
+    public string? FailureReason { get; init; }
+
+    /// <summary>Whether the poll produced stats.</summary>
+    public bool Success => Stats != null;
+
+    /// <summary>A successful poll.</summary>
+    public static PollResult<TStats> Ok(TStats stats) => new() { Stats = stats };
+
+    /// <summary>A failed poll, with the reason to show the user.</summary>
+    public static PollResult<TStats> Failed(string reason) => new() { FailureReason = reason };
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260809220613_AddMonitoringTargetRetirement.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260809220613_AddMonitoringTargetRetirement.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260809220613_AddMonitoringTargetRetirement")]
+    partial class AddMonitoringTargetRetirement
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -1912,12 +1915,6 @@ namespace NetworkOptimizer.Storage.Migrations
 
                     b.Property<bool>("Enabled")
                         .HasColumnType("INTEGER");
-
-                    b.Property<bool?>("EnabledBeforeRetire")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<DateTime?>("HiddenAt")
-                        .HasColumnType("TEXT");
 
                     b.Property<bool?>("IsLocal")
                         .HasColumnType("INTEGER");

--- a/src/NetworkOptimizer.Storage/Migrations/20260809220613_AddMonitoringTargetRetirement.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260809220613_AddMonitoringTargetRetirement.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringTargetRetirement : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "RetiredAt",
+                table: "MonitoringTargets",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "RetiredReason",
+                table: "MonitoringTargets",
+                type: "TEXT",
+                maxLength: 200,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RetiredAt",
+                table: "MonitoringTargets");
+
+            migrationBuilder.DropColumn(
+                name: "RetiredReason",
+                table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260810000103_AddMonitoringTargetHidden.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260810000103_AddMonitoringTargetHidden.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260810000103_AddMonitoringTargetHidden")]
+    partial class AddMonitoringTargetHidden
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
@@ -1911,9 +1914,6 @@ namespace NetworkOptimizer.Storage.Migrations
                         .HasColumnType("INTEGER");
 
                     b.Property<bool>("Enabled")
-                        .HasColumnType("INTEGER");
-
-                    b.Property<bool?>("EnabledBeforeRetire")
                         .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("HiddenAt")

--- a/src/NetworkOptimizer.Storage/Migrations/20260810000103_AddMonitoringTargetHidden.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260810000103_AddMonitoringTargetHidden.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringTargetHidden : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "HiddenAt",
+                table: "MonitoringTargets",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HiddenAt",
+                table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260811124906_AddMonitoringTargetEnabledBeforeRetire.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260811124906_AddMonitoringTargetEnabledBeforeRetire.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811124906_AddMonitoringTargetEnabledBeforeRetire")]
+    partial class AddMonitoringTargetEnabledBeforeRetire
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260811124906_AddMonitoringTargetEnabledBeforeRetire.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260811124906_AddMonitoringTargetEnabledBeforeRetire.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMonitoringTargetEnabledBeforeRetire : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EnabledBeforeRetire",
+                table: "MonitoringTargets",
+                type: "INTEGER",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EnabledBeforeRetire",
+                table: "MonitoringTargets");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
+++ b/src/NetworkOptimizer.Storage/Models/MonitoringTarget.cs
@@ -146,6 +146,50 @@ public class MonitoringTarget
     /// </summary>
     public DateTime? LanFlakyHintDismissedAt { get; set; }
 
+    /// <summary>
+    /// When this target stopped describing anything real - its device left the UniFi device list,
+    /// or moved to a different address and a replacement target took over.
+    /// <para>
+    /// Retired is not paused. A paused target is a live target the user chose not to probe, and
+    /// resuming it is the obvious thing to offer; resuming a retired one would probe an address
+    /// nothing answers on. The row survives because its measurements are filed under its TargetId
+    /// and deleting it would orphan them - so readers exclude it, they do not remove it.
+    /// </para>
+    /// </summary>
+    public DateTime? RetiredAt { get; set; }
+
+    /// <summary>Why it was retired, in one line, for the badge tooltip. Null when it is live.</summary>
+    [MaxLength(200)]
+    public string? RetiredReason { get; set; }
+
+    /// <summary>
+    /// What <see cref="Enabled"/> was before retirement cleared it, so revival can put it back.
+    /// <para>
+    /// Retiring has to clear Enabled: a dozen readers treat that column as "is this row live" and
+    /// would otherwise start counting retired rows as active. But Enabled is also where a user's
+    /// pause lives, and overwriting it without keeping the old value silently un-paused a target
+    /// whose device left and came back. Null means never retired.
+    /// </para>
+    /// </summary>
+    public bool? EnabledBeforeRetire { get; set; }
+
+    /// <summary>Whether this target still describes something real.</summary>
+    public bool IsRetired => RetiredAt != null;
+
+    /// <summary>
+    /// When the user took this target off the Latency Targets list.
+    /// <para>
+    /// Hiding is a list filter and nothing more. The row is the only thing mapping a TargetId to a
+    /// name, an address and a device, so readers rendering history must still resolve a hidden one
+    /// - filter it where the list is drawn, never where a series is named, or hiding becomes
+    /// deleting by another route.
+    /// </para>
+    /// </summary>
+    public DateTime? HiddenAt { get; set; }
+
+    /// <summary>Whether the user has taken this target off the list.</summary>
+    public bool IsHidden => HiddenAt != null;
+
     public DateTime? LastVerified { get; set; }
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -3542,11 +3542,18 @@
         </div>
     </div>;
 
-    private void ReviewUpstreamDiscovery()
+    /// <summary>
+    /// Open the discovery the banner is about. That is always the primary WAN's: a secondary WAN
+    /// commits as it discovers (RunWanContextDiscoveriesAsync) and never raises a review, so only
+    /// the primary can be waiting on one. Without the switch this opened whatever WAN the pill bar
+    /// was filtered to, which is a different WAN's trace than the one being announced.
+    /// </summary>
+    private async Task ReviewUpstreamDiscovery()
     {
         _forceExpandUpstream = true;
         _scrollToDiscoveryPending = true;
         SetActiveTab("performance");
+        if (_multiWanUiVisible) await OnDiscoveryWanSelectedAsync(_primaryWanKey);
     }
 
     private async Task DismissUpstreamReviewAsync()
@@ -4438,7 +4445,7 @@
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var fabricMacs = _targets
-            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
+            .Where(t => t.TargetType == MonitoringTargetType.Fabric && !t.IsRetired && !string.IsNullOrEmpty(t.DeviceMac))
             .Select(t => t.DeviceMac!)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             // Three ways to answer, in order of how much the site can currently tell us:
@@ -4458,7 +4465,7 @@
         if (fabricMacs.Count == 0 && fabricTypes.Count == 0)
         {
             fabricMacs = _targets
-                .Where(t => t.TargetType == MonitoringTargetType.Fabric && !string.IsNullOrEmpty(t.DeviceMac))
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && !t.IsRetired && !string.IsNullOrEmpty(t.DeviceMac))
                 .Select(t => t.DeviceMac!)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringDevice.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringDevice.razor
@@ -263,6 +263,7 @@
             await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
             var fabric = await db.MonitoringTargets
                 .Where(t => t.TargetType == MonitoringTargetType.Fabric
+                            && t.RetiredAt == null
                             && t.DeviceMac != null && t.DeviceMac.ToLower() == NormalizeMac(Mac))
                 .Select(t => new { t.Name, t.TargetId })
                 .FirstOrDefaultAsync();

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1620,10 +1620,11 @@
                         <div class="form-group" style="flex: 2;">
                             <label class="form-label">Provider</label>
                             <select class="form-control" @bind="_editingCm.Provider">
-                                <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="arris-surfboard">ARRIS Surfboard (HTTP)</option>
                                 <option value="arris-surfboard-hnap">ARRIS Surfboard S33/S34 (HNAP)</option>
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
+                                <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
+                                <option value="technicolor-cga">Technicolor CGA Series (HTTP)</option>
                                 <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
@@ -6984,6 +6985,7 @@
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",
         "xfinity-gateway" => "Xfinity Gateway (HTTP)",
+        "technicolor-cga" => "Technicolor CGA Series (HTTP)",
         _ => provider,
     };
 
@@ -6993,6 +6995,7 @@
         "arris-surfboard-hnap" => "N/A (uses /HNAP1/)",
         "motorola-hnap" => "N/A (uses /HNAP1/)",
         "xfinity-gateway" => "/network_setup.jst",
+        "technicolor-cga" => "/api/v1/sta_docsis_status",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1385,10 +1385,13 @@
                             <div class="form-group" style="flex: 2;">
                                 <label class="form-label">Host / IP</label>
                                 <input type="text" class="form-control" @bind="editingModem.Host" placeholder="192.168.1.100" />
-                                <small class="form-help">
-                                    Can you only reach the management page of this device when directly connected?
-                                    <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
-                                </small>
+                                @if (!IsUniFiSshModem(editingModem.Provider))
+                                {
+                                    <small class="form-help">
+                                        Can you only reach the management page of this device when directly connected?
+                                        <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
+                                    </small>
+                                }
                             </div>
                             <div class="form-group" style="flex: 1;">
                                 <label class="form-label">Polling Interval (sec)</label>
@@ -1453,10 +1456,11 @@
                             {
                                 <div class="alert alert-@probeResultClass" style="margin-top: 0.5rem;">
                                     @probeResult
-                                    @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host))
+                                    @if (LooksUnreachable(probeResult) && !string.IsNullOrWhiteSpace(editingModem.Host)
+                                        && !IsUniFiSshModem(editingModem.Provider))
                                     {
                                         <div class="mi-funnel">
-                                            Can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
+                                            Still can't reach it? <a href="@MonitoringInterfaceLink(editingModem.Host, "wmodem")">Set up a monitoring interface →</a>
                                         </div>
                                     }
                                 </div>
@@ -1495,10 +1499,11 @@
             {
                 <div class="alert alert-@modemMessageClass" style="margin-top: 1rem;">
                     @modemMessage
-                    @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost))
+                    @if (LooksUnreachable(modemMessage) && !string.IsNullOrWhiteSpace(_modemTestedHost)
+                        && !IsUniFiSshModem(_modemTestedProvider))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost, "wmodem")">Set up a monitoring interface →</a>
+                            Still can't reach it? <a href="@MonitoringInterfaceLink(_modemTestedHost, "wmodem")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1699,7 +1704,7 @@
                     @if (LooksUnreachable(_cmTestResult) && !string.IsNullOrWhiteSpace(_cmTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost, "cm")">Set up a monitoring interface →</a>
+                            Still can't reach it? <a href="@MonitoringInterfaceLink(_cmTestedHost, "cm")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -1936,7 +1941,7 @@
                     @if (LooksUnreachable(_ontTestResult) && !string.IsNullOrWhiteSpace(_ontTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost, "ont")">Set up a monitoring interface →</a>
+                            Still can't reach it? <a href="@MonitoringInterfaceLink(_ontTestedHost, "ont")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -2118,7 +2123,7 @@
                     @if (LooksUnreachable(_starlinkTestResult) && !string.IsNullOrWhiteSpace(_starlinkTestedHost))
                     {
                         <div class="mi-funnel">
-                            Can't reach it? <a href="@MonitoringInterfaceLink(_starlinkTestedHost, "starlink")">Set up a monitoring interface →</a>
+                            Still can't reach it? <a href="@MonitoringInterfaceLink(_starlinkTestedHost, "starlink")">Set up a monitoring interface →</a>
                         </div>
                     }
                 </div>
@@ -4711,6 +4716,7 @@
     private string modemMessage = "";
     private string modemMessageClass = "";
     private string? _modemTestedHost;
+    private string? _modemTestedProvider;
     private List<DiscoveredModem> discoveredModems = new();
     private bool loadingDiscoveredModems = false;
     private bool modemFormExpanded = false;
@@ -4754,13 +4760,25 @@
     /// behind the WAN. Auth (401) or parse failures mean the device IS reachable, so we
     /// don't funnel those toward a monitoring interface.
     /// </summary>
+    /// <summary>
+    /// A UniFi modem is polled over SSH using the shared device credentials, on the console's own
+    /// device network - there is no separate management page to route to, so the monitoring
+    /// interface funnel has nothing to offer and only adds a wrong turn. Empty counts as UniFi:
+    /// it is the default provider for rows that predate the column.
+    /// </summary>
+    private static bool IsUniFiSshModem(string? provider) =>
+        string.IsNullOrWhiteSpace(provider)
+        || provider.Equals("qmicli", StringComparison.OrdinalIgnoreCase);
+
     private static bool LooksUnreachable(string? message)
     {
         if (string.IsNullOrEmpty(message)) return false;
         var m = message.ToLowerInvariant();
         return m.Contains("timeout") || m.Contains("timed out") || m.Contains("canceled") || m.Contains("cancelled")
             || m.Contains("refused") || m.Contains("no route") || m.Contains("unreachable")
-            || m.Contains("no such host") || m.Contains("actively refused") || m.Contains("connection attempt failed");
+            || m.Contains("no such host") || m.Contains("actively refused") || m.Contains("connection attempt failed")
+            // The summaries word these without the framework's vocabulary, so match how they read.
+            || m.Contains("did not answer") || m.Contains("could not reach") || m.Contains("could not be resolved");
     }
     private int? _ontTestingId;
     private int? _ontTogglingId;
@@ -6770,6 +6788,7 @@
         // save path would keep.
         modem.Host = NetworkUtilities.ExtractHostFromUrl(modem.Host);
         _modemTestedHost = modem.Host;
+        _modemTestedProvider = modem.Provider;
         modemMessage = $"Polling {modem.Name}...";
         modemMessageClass = "info";
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1625,6 +1625,7 @@
                                 <option value="motorola-hnap">Motorola MB8611, MB8600 (HNAP)</option>
                                 <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="technicolor-cga">Technicolor CGA Series (HTTP)</option>
+                                <option value="vodafone-station">Vodafone Station (ARRIS TG3442DE)</option>
                                 <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
@@ -6986,6 +6987,7 @@
         "motorola-hnap" => "Motorola (HNAP)",
         "xfinity-gateway" => "Xfinity Gateway (HTTP)",
         "technicolor-cga" => "Technicolor CGA Series (HTTP)",
+        "vodafone-station" => "Vodafone Station (ARRIS TG3442DE)",
         _ => provider,
     };
 
@@ -6996,6 +6998,7 @@
         "motorola-hnap" => "N/A (uses /HNAP1/)",
         "xfinity-gateway" => "/network_setup.jst",
         "technicolor-cga" => "/api/v1/sta_docsis_status",
+        "vodafone-station" => "/php/status_docsis_data.php",
         _ => "/DocsisStatus.htm",
     };
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -62,6 +62,11 @@
             </div>
         </div>
 
+        @if (!string.IsNullOrEmpty(pollError))
+        {
+            <div class="poll-error">@pollError</div>
+        }
+
         <div class="sqm-actions">
             @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
             <span data-tooltip="@(CurrentEnabled ? null : "Monitoring is disabled for this device. Enable it in Cellular Modem Settings.")" @onclick:stopPropagation>
@@ -266,6 +271,11 @@
                     </div>
                 }
             </div>
+        }
+
+        @if (!string.IsNullOrEmpty(pollError))
+        {
+            <div class="poll-error">@pollError</div>
         }
 
         <div class="sqm-actions">
@@ -549,7 +559,11 @@
                         // Just fetch cached stats for current modem - don't force a poll
                         var modem = configuredModems[currentModemIndex];
                         var newStats = await ModemService.GetCachedStatsAsync(modem.Id);
-                        if (newStats != null) modemStats = newStats;
+                        if (newStats != null)
+                        {
+                            modemStats = newStats;
+                            pollError = null;
+                        }
                     }
                     StateHasChanged();
                 }
@@ -559,6 +573,9 @@
             TimeSpan.FromSeconds(10),
             TimeSpan.FromSeconds(10));
     }
+
+    /// <summary>Why the last poll produced nothing, shown on the card until one succeeds.</summary>
+    private string? pollError;
 
     private async Task LoadStats()
     {
@@ -585,7 +602,8 @@
                 else
                 {
                     // No cached stats - do initial poll
-                    var (success, _) = await ModemService.PollModemAsync(modem);
+                    var (success, message) = await ModemService.PollModemAsync(modem);
+                    pollError = success ? null : message;
                     if (success)
                     {
                         modemStats = await ModemService.GetCachedStatsAsync(modem.Id);
@@ -616,7 +634,8 @@
             if (configuredModems.Count > 0 && currentModemIndex < configuredModems.Count)
             {
                 var modem = configuredModems[currentModemIndex];
-                var (success, _) = await ModemService.PollModemAsync(modem);
+                var (success, message) = await ModemService.PollModemAsync(modem);
+                pollError = success ? null : message;
                 if (success)
                 {
                     modemStats = await ModemService.GetCachedStatsAsync(modem.Id);
@@ -712,12 +731,14 @@
             var modem = configuredModems[currentModemIndex];
             var cached = await ModemService.GetCachedStatsAsync(modem.Id);
             modemStats = cached;
+            pollError = null;
             StateHasChanged();
 
             if (cached == null)
             {
                 // No cached stats - try polling, but don't block paging
-                var (success, _) = await ModemService.PollModemAsync(modem);
+                var (success, message) = await ModemService.PollModemAsync(modem);
+                pollError = success ? null : message;
                 if (success)
                 {
                     modemStats = await ModemService.GetCachedStatsAsync(modem.Id);

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -54,6 +54,11 @@
             </div>
         </div>
 
+        @if (!string.IsNullOrEmpty(_pollError))
+        {
+            <div class="poll-error">@_pollError</div>
+        }
+
         <div class="sqm-actions">
             @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
             <span data-tooltip="@(CurrentEnabled ? null : "Monitoring is disabled for this device. Enable it in CM Settings.")" @onclick:stopPropagation>
@@ -74,6 +79,11 @@
             <p class="status-message">
                 Monitor your cable modem's downstream power, SNR, upstream power, and FEC error rates. Supports Netgear, ARRIS Surfboard, Motorola, and Xfinity modems.
             </p>
+            @if (!string.IsNullOrEmpty(_pollError))
+            {
+                <div class="poll-error">@_pollError</div>
+            }
+
             <div class="sqm-actions">
                 <SiteAdminOnly><a href="/settings#cable-modem" class="btn btn-primary" @onclick:stopPropagation>Configure CM</a></SiteAdminOnly>
             </div>
@@ -145,6 +155,11 @@
             </div>
         </div>
 
+        @if (!string.IsNullOrEmpty(_pollError))
+        {
+            <div class="poll-error">@_pollError</div>
+        }
+
         <div class="sqm-actions">
             @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
             <span data-tooltip="@(CurrentEnabled ? null : "Monitoring is disabled for this device. Enable it in CM Settings.")" @onclick:stopPropagation>
@@ -174,6 +189,9 @@
     private CableModemStats? _stats;
     private int _currentIndex;
     private bool _isLoading = true;
+    /// <summary>Why the last poll produced nothing, shown on the card until one succeeds.</summary>
+    private string? _pollError;
+
     private bool _isRefreshing;
     private System.Threading.Timer? _refreshTimer;
 
@@ -217,7 +235,8 @@
         if (_configs.Count == 0 || !CurrentEnabled) return;
         _isRefreshing = true;
         StateHasChanged();
-        await CmService.PollCmAsync(_configs[_currentIndex].Id);
+        var (ok, message) = await CmService.PollCmAsync(_configs[_currentIndex].Id);
+        _pollError = ok ? null : message;
         await LoadStatsAsync();
         _isRefreshing = false;
         StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -52,7 +52,7 @@
             </div>
         }
         <div class="card-header-badges">
-            <span class="status-badge status-active" @onclick:stopPropagation="true">@VisibleTargets().Count(t => t.Enabled) active</span>
+            <span class="status-badge status-active" @onclick:stopPropagation="true">@VisibleTargets().Count(t => t.Enabled && !t.IsRetired) active</span>
             <span class="issue-type-chevron">@(_collapsed ? "▼" : "▲")</span>
         </div>
     </div>
@@ -67,6 +67,13 @@
             </p>
             <div class="lt-actions">
                 <a href="@RunProbeUrl" class="btn btn-sm btn-secondary">Run Probe</a>
+                @if (HiddenCount > 0)
+                {
+                    <button class="btn btn-sm btn-secondary" @onclick="ToggleShowHidden"
+                            data-tooltip="Removed targets are kept so their measurements stay readable.">
+                        @(_showHidden ? "Hide removed" : $"Show removed ({HiddenCount})")
+                    </button>
+                }
                 <SiteOperatorOnly>
                     <button class="btn btn-sm btn-primary" @onclick="ShowAddTargetFromTop">
                         + Add Target
@@ -99,6 +106,10 @@
                         <th>Interval</th>
                         <th>Latest</th>
                         <th>Last verified</th>
+                        @* Two action columns, not one: a retired row has no Pause, and with both
+                           buttons sharing a cell its Remove slid left out of line with every other
+                           Remove. Separate cells put the table's own column alignment to work. *@
+                        <th></th>
                         <th></th>
                     </tr>
                 </thead>
@@ -189,7 +200,15 @@
                                 </SiteOperatorOnly>
                             </td>
                             <td>
-                                @if (!t.Enabled)
+                                @if (t.IsHidden)
+                                {
+                                    <span class="text-muted" data-tooltip="@HiddenTooltip">removed</span>
+                                }
+                                else if (t.IsRetired)
+                                {
+                                    <span class="text-muted" data-tooltip="@RetiredTooltip(t)">retired</span>
+                                }
+                                else if (!t.Enabled)
                                 {
                                     <span class="text-muted">paused</span>
                                 }
@@ -221,22 +240,40 @@
                                 else
                                 { <span class="text-muted">never</span> }
                             </td>
-                            <td style="white-space: nowrap;">
-                                <SiteOperatorOnly>
-                                    <button class="btn btn-sm btn-secondary"
-                                        @onclick="() => SetTargetEnabledAsync(t.Id, !t.Enabled)"
-                                        title="@(t.Enabled ? "Pause probing" : "Resume probing")">
-                                    @(t.Enabled ? "Pause" : "Resume")
-                                </button>
-                                </SiteOperatorOnly>
-                                <SiteAdminOnly>
-                                    <button class="btn btn-sm btn-danger"
-                                        @onclick="() => DeleteTargetAsync(t.Id)"
-                                        title="Remove this target"
-                                        style="margin-left: 0.25rem;">
-                                    Remove
-                                </button>
-                                </SiteAdminOnly>
+                            <td class="lt-action-cell lt-action-cell-first">
+                                @if (t.IsHidden)
+                                {
+                                    <SiteAdminOnly>
+                                        <button class="btn btn-sm btn-secondary"
+                                            @onclick="() => RestoreTargetAsync(t.Id)"
+                                            data-tooltip="Put this target back on the list and resume probing it">
+                                        Restore
+                                    </button>
+                                    </SiteAdminOnly>
+                                }
+                                else if (!t.IsRetired)
+                                {
+                                    @* A retired target's address answers to nothing, so there is no probing to resume. *@
+                                    <SiteOperatorOnly>
+                                        <button class="btn btn-sm btn-secondary"
+                                            @onclick="() => SetTargetEnabledAsync(t.Id, !t.Enabled)"
+                                            data-tooltip="@(t.Enabled ? "Pause probing" : "Resume probing")">
+                                        @(t.Enabled ? "Pause" : "Resume")
+                                    </button>
+                                    </SiteOperatorOnly>
+                                }
+                            </td>
+                            <td class="lt-action-cell lt-action-cell-last">
+                                @if (!t.IsHidden)
+                                {
+                                    <SiteAdminOnly>
+                                        <button class="btn btn-sm btn-danger"
+                                            @onclick="() => DeleteTargetAsync(t.Id)"
+                                            data-tooltip="@RemoveTooltip(t)">
+                                        Remove
+                                    </button>
+                                    </SiteAdminOnly>
+                                }
                             </td>
                         </tr>
                     }
@@ -247,10 +284,9 @@
                     <p class="alert alert-danger">@_targetError</p>
                 }
             </div>
-            <p class="page-description" style="margin-top: 0.5rem;">
-                Removing a fabric or upstream-discovered WAN target will trigger it to be re-created
-                on the next agent cycle. Use <strong>Pause</strong> instead to stop
-                probing without losing the row's history.
+            <p class="page-description page-description-footnote">
+                <strong>Pause</strong> stops probing a target. <strong>Remove</strong> hides it as
+                well, but keeps everything it measured so <strong>Restore</strong> can bring it back.
             </p>
         }
 
@@ -360,6 +396,20 @@
         margin: 0 0.5rem;
     }
 
+    .data-table td.lt-action-cell {
+        white-space: nowrap;
+    }
+
+    .data-table td.lt-action-cell-first {
+        text-align: right;
+        padding-right: 0.5rem;
+    }
+
+    .data-table td.lt-action-cell-last {
+        text-align: left;
+        padding-left: 0;
+    }
+
     .lt-intro {
         display: flex;
         align-items: flex-start;
@@ -422,6 +472,14 @@
         .lt-intro {
             flex-direction: column;
             gap: 0.5rem;
+        }
+
+        .lt-intro .section-description {
+            margin-bottom: 0.5rem;
+        }
+
+        .lt-intro .lt-actions {
+            margin-bottom: 1rem;
         }
 
         .lt-form-grid {
@@ -567,6 +625,32 @@
                 MonitoringTargetType.InternetService, MonitoringTargetType.Custom };
 
     /// <summary>
+    /// How many removed targets pressing Show removed would actually reveal - narrowed the same
+    /// way the list is, so the count can never promise rows the current scope would filter out.
+    /// </summary>
+    private int HiddenCount => InScope(Targets.Where(t => t.IsHidden)).Count();
+
+    /// <summary>
+    /// Remove keeps a probed target's row so its series stays named, and only really deletes one
+    /// that never ran. The button says which it will do, because the two are not the same promise.
+    /// </summary>
+    private static string RemoveTooltip(MonitoringTarget t) => t.LastVerified != null
+        ? "Take this target off the list. Its measurements are kept, so nothing it recorded is orphaned."
+        : "Delete this target. It has never been probed, so there is nothing to keep.";
+
+    private const string HiddenTooltip =
+        "Removed from the list. Its measurements are kept so charts can still name them.";
+
+    /// <summary>
+    /// Why a target was retired, and what it still offers: the measurements stay readable, which
+    /// is the reason the row is here rather than gone.
+    /// </summary>
+    private static string RetiredTooltip(MonitoringTarget t) =>
+        string.IsNullOrWhiteSpace(t.RetiredReason)
+            ? "No longer probed. Its measurements are kept."
+            : $"{t.RetiredReason}. No longer probed; its measurements are kept.";
+
+    /// <summary>
     /// The Type column's badge. Access ISP is shortened to the name the filter pill above it uses,
     /// which is also the widest label the column has to carry.
     /// </summary>
@@ -597,7 +681,7 @@
         .ThenBy(c => c.Name, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Columns in the table, so an empty-state row spans all of them.</summary>
-    private int VisibleColumnCount => WanContexts.Count > 0 ? 8 : 7;
+    private int VisibleColumnCount => WanContexts.Count > 0 ? 9 : 8;
 
     /// <summary>
     /// What actually probes the listed targets, for the card's own description of itself. A target
@@ -702,9 +786,17 @@
         ? $"/network-tools?from={Uri.EscapeDataString(vantage)}"
         : "/network-tools";
 
-    private IEnumerable<MonitoringTarget> VisibleTargets()
+    private IEnumerable<MonitoringTarget> VisibleTargets() =>
+        InScope(_showHidden ? Targets : Targets.Where(t => !t.IsHidden));
+
+    /// <summary>
+    /// The type and LAN/WAN narrowing the card is currently showing, applied to whatever set is
+    /// handed in. Shared with <see cref="HiddenCount"/> so the Show removed button counts what
+    /// pressing it would actually reveal.
+    /// </summary>
+    private IEnumerable<MonitoringTarget> InScope(IEnumerable<MonitoringTarget> targets)
     {
-        IEnumerable<MonitoringTarget> ordered = Targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name);
+        IEnumerable<MonitoringTarget> ordered = targets.OrderBy(t => t.TargetType).ThenBy(t => t.Name);
         if (_typeFilter is MonitoringTargetType wanted) ordered = ordered.Where(t => t.TargetType == wanted);
         // The LAN is what sits on this network, whatever WAN a row happens to be stamped with, and
         // a WAN is the opposite. Only All carries both.
@@ -779,6 +871,10 @@
     private bool CanAddTargets => SiteCtx.IsDefault || ExecutorFactory.ServerVantageIsAgent;
 
     private bool _collapsed = true;
+
+    /// <summary>Reveals removed targets. Deliberately not persisted: it is a look at what was taken
+    /// off the list, not a preference, and a sticky one would leave the list permanently fuller.</summary>
+    private bool _showHidden;
     private bool _showAddTarget;
     private bool _addingTarget;
     private string _newTargetName = "";
@@ -892,6 +988,18 @@
     private async Task DeleteTargetAsync(int targetId)
     {
         await MutateAsync(() => TargetService.DeleteAsync(targetId));
+    }
+
+    private async Task RestoreTargetAsync(int targetId)
+    {
+        await MutateAsync(() => TargetService.SetHiddenAsync(targetId, false));
+    }
+
+    private async Task ToggleShowHidden()
+    {
+        await HoldPositionAsync();
+        _showHidden = !_showHidden;
+        _collapsed = false;
     }
 
     private async Task UpdateIntervalAsync(int targetId, ChangeEventArgs e)

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -106,6 +106,11 @@ else if (IsShowingExternal && _externalOntStats != null)
         </div>
     </div>
 
+    @if (!string.IsNullOrEmpty(_pollError))
+    {
+        <div class="poll-error ont-poll-error">@_pollError</div>
+    }
+
     <div class="sqm-actions">
         @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
         <span data-tooltip="@(CurrentExternalEnabled ? null : "Monitoring is disabled for this device. Enable it in ONT Settings.")" @onclick:stopPropagation>
@@ -160,6 +165,11 @@ else if (IsShowingExternal)
         </div>
     </div>
 
+    @if (!string.IsNullOrEmpty(_pollError))
+    {
+        <div class="poll-error ont-poll-error">@_pollError</div>
+    }
+
     <div class="sqm-actions">
         @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
         <span data-tooltip="@(CurrentExternalEnabled ? null : "Monitoring is disabled for this device. Enable it in ONT Settings.")" @onclick:stopPropagation>
@@ -185,6 +195,11 @@ else if (TotalCount == 0)
             <b>Standalone ONT?</b> Configure external polling for AT&amp;T gateways, Realtek
             ONT sticks, and other devices in Settings.
         </p>
+        @if (!string.IsNullOrEmpty(_pollError))
+        {
+            <div class="poll-error ont-poll-error">@_pollError</div>
+        }
+
         <div class="sqm-actions">
             <a href="@SfpMonitoringUrl" class="btn btn-secondary" @onclick:stopPropagation>SFP Monitoring</a>
             <SiteAdminOnly><a href="/settings#ont-monitoring" class="btn btn-primary" @onclick:stopPropagation>Configure ONT</a></SiteAdminOnly>
@@ -339,12 +354,21 @@ else
         </div>
     </div>
 
+    @if (!string.IsNullOrEmpty(_pollError))
+    {
+        <div class="poll-error ont-poll-error">@_pollError</div>
+    }
+
     <div class="sqm-actions">
         <a href="@SfpMonitoringUrl" class="btn btn-primary" @onclick:stopPropagation>SFP Monitoring</a>
     </div>
 }
 
 <style>
+    .ont-poll-error {
+        padding-top: 0.5rem;
+    }
+
     .metric-value.ont-model-value {
         font-size: 0.95rem;
     }
@@ -373,6 +397,9 @@ else
     private int _currentIndex = 0;
     private System.Threading.Timer? _refreshTimer;
     private OntStats? _externalOntStats;
+    /// <summary>Why the last poll produced nothing, shown on the card until one succeeds.</summary>
+    private string? _pollError;
+
     private bool _isRefreshing;
 
     private int TotalCount => _monitoredOnts.Count + _externalOnts.Count;
@@ -426,7 +453,7 @@ else
                 .OrderBy(s => s.DeviceMac).ThenBy(s => s.PortName)
                 .ToListAsync();
             _fabricTargets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == MonitoringTargetType.Fabric)
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.RetiredAt == null)
                 .ToListAsync();
             _externalOnts = await ExternalOntService.GetStandaloneConfigsAsync();
             if (_currentIndex >= TotalCount) _currentIndex = 0;
@@ -499,7 +526,8 @@ else
         StateHasChanged();
         try
         {
-            await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
+            var (_, failureReason) = await ExternalOntService.PollOntAsync(_externalOnts[extIdx].Id);
+            _pollError = failureReason;
             await RefreshExternalStatsAsync();
         }
         finally

--- a/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SfpModulesCard.razor
@@ -332,6 +332,7 @@ else
         var normalized = deviceMac.Replace("-", ":").ToLowerInvariant();
         var target = Targets.FirstOrDefault(t =>
             t.TargetType == MonitoringTargetType.Fabric
+            && !t.IsRetired
             && !string.IsNullOrEmpty(t.DeviceMac)
             && t.DeviceMac.Replace("-", ":").ToLowerInvariant() == normalized);
         return !string.IsNullOrEmpty(target?.Name) ? target.Name : deviceMac;
@@ -345,6 +346,7 @@ else
             return ip;
         var target = Targets.FirstOrDefault(t =>
             t.TargetType == MonitoringTargetType.Fabric
+            && !t.IsRetired
             && !string.IsNullOrEmpty(t.DeviceMac)
             && t.DeviceMac.Replace("-", ":").ToLowerInvariant() == normalized);
         return target?.Address ?? "255.255.255.255";

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -20,6 +20,11 @@
                 <span class="status-label">No Data</span>
             </div>
             <p class="status-message">No Starlink terminal configured.</p>
+            @if (!string.IsNullOrEmpty(_pollError))
+            {
+                <div class="poll-error">@_pollError</div>
+            }
+
             <div class="sqm-actions">
                 <SiteAdminOnly><a href="/settings#starlink" class="btn btn-primary" @onclick:stopPropagation>Configure Starlink</a></SiteAdminOnly>
             </div>
@@ -132,6 +137,11 @@
             }
         }
 
+        @if (!string.IsNullOrEmpty(_pollError))
+        {
+            <div class="poll-error">@_pollError</div>
+        }
+
         <div class="sqm-actions">
             @* Tooltip lives on the wrapper: a disabled button has pointer-events none and never fires the hover *@
             <span data-tooltip="@(CurrentEnabled ? null : "Monitoring is disabled for this device. Enable it in Starlink Settings.")" @onclick:stopPropagation>
@@ -156,6 +166,10 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
+    }
+
+    .starlink-stats-panel .sqm-actions {
+        margin-top: 0.5rem;
     }
 
     .starlink-header-right {
@@ -285,6 +299,9 @@
     private StarlinkStats? stats;
     private StarlinkObstructionMap? obstructionMap;
     private bool isLoading = true;
+    /// <summary>Why the last poll produced nothing, shown on the card until one succeeds.</summary>
+    private string? _pollError;
+
     private bool isRefreshing = false;
     private bool hasConfiguredTerminals = false;
     private List<NetworkOptimizer.Storage.Models.StarlinkConfiguration> configuredTerminals = new();
@@ -404,7 +421,8 @@
             if (configuredTerminals.Count > 0 && currentIndex < configuredTerminals.Count)
             {
                 var terminal = configuredTerminals[currentIndex];
-                await StarlinkService.PollStarlinkAsync(terminal.Id);
+                var (ok, message) = await StarlinkService.PollStarlinkAsync(terminal.Id);
+                _pollError = ok ? null : message;
                 stats = await StarlinkService.GetCachedStatsAsync(terminal.Id);
                 obstructionMap = await StarlinkService.GetCachedObstructionMapAsync(terminal.Id);
             }

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -42,7 +42,7 @@ public static class DeviceHealthChartEndpoints
 
             await using var db = siteDbFactory.CreateForSite(siteContext.Slug, siteContext.IsDefault);
             var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == MonitoringTargetType.Fabric)
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.RetiredAt == null)
                 .OrderBy(t => t.Name)
                 .Select(t => new { t.TargetId, t.Name, t.DeviceMac })
                 .ToListAsync(ct);

--- a/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/MonitoringChartEndpoints.cs
@@ -350,8 +350,10 @@ public static class MonitoringChartEndpoints
             int? rangeHours,
             DateTime? from,
             DateTime? to,
+            bool? includeInactive,
             CancellationToken ct) =>
         {
+            var showInactive = includeInactive == true;
             var targetType = category switch
             {
                 "AccessIsp" => MonitoringTargetType.AccessIsp,
@@ -377,15 +379,50 @@ public static class MonitoringChartEndpoints
             // the target_type tag (indexed, ~10ms) instead of contains() on
             // target_id set (full scan, ~400ms+).
             await using var db = siteDbFactory.CreateForSite(siteContext.Slug, siteContext.IsDefault);
-            var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == targetType && t.Enabled
+            var all = await db.MonitoringTargets.AsNoTracking()
+                .Where(t => t.TargetType == targetType
                     && (t.AsnNumber == null || !WellKnownAsns.NonTransitInfrastructure.Contains(t.AsnNumber.Value)))
                 .OrderBy(t => t.Name)
-                .Select(t => new { t.TargetId, t.Name, t.AutoLabel, t.WanInterface, t.Address, t.TargetType, t.IsLocal })
+                .Select(t => new
+                {
+                    t.TargetId,
+                    t.Name,
+                    t.AutoLabel,
+                    t.WanInterface,
+                    t.Address,
+                    t.TargetType,
+                    t.IsLocal,
+                    t.Enabled,
+                    t.DeviceMac
+                })
                 .ToListAsync(ct);
 
+            var liveDeviceMacs = all
+                .Where(t => t.Enabled && !string.IsNullOrEmpty(t.DeviceMac))
+                .Select(t => t.DeviceMac!)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            // Not every stopped series has finished. A device still probed under some other address
+            // is writing one history, and its earlier stretches are part of it - drop them and a
+            // switch of many months looks like it appeared the day its IP changed. Only a device
+            // with nothing still probing it is done, and only that belongs behind the toggle.
+            //
+            // Deliberately blind to Removed. Taking a row off the Latency Targets list is tidying
+            // that list; it says nothing about whether the device's history is worth reading, and
+            // conflating the two would make a bit of housekeeping erase the chart.
+            bool StillMonitored(string? deviceMac) =>
+                !string.IsNullOrEmpty(deviceMac) && liveDeviceMacs.Contains(deviceMac);
+
+            var targets = all
+                .Where(t => t.Enabled || showInactive || StillMonitored(t.DeviceMac))
+                .ToList();
+
+            // What the toggle would actually reveal, so it is offered only when that is something.
+            // A series already on the chart does not count towards it.
+            var inactiveCount = all.Count(t => !t.Enabled && !StillMonitored(t.DeviceMac));
+
             if (targets.Count == 0)
-                return Results.Ok(new { targets = Array.Empty<object>() });
+                return Results.Ok(new { targets = Array.Empty<object>(), inactiveCount });
 
             var data = await influx.QueryLatencyByTargetTypeAsync(targetType, queryFrom, queryTo, ct: ct);
 
@@ -409,12 +446,15 @@ public static class MonitoringChartEndpoints
                     // a hostname can only be answered here.
                     isLan = NetworkOptimizer.Web.Services.Monitoring.LocalTargetResolver.IsLocal(
                         t.TargetType, t.Address, t.IsLocal, t.WanInterface),
+                    // Nothing is probing this one, so its line has ended rather than paused for
+                    // rendering purposes. The chart draws it dashed and says so on the chip.
+                    inactive = !t.Enabled,
                     rtt = pts.Select(p => new { time = p.Time.ToString("o"), value = p.RttAvgMs }),
                     loss = pts.Select(p => new { time = p.Time.ToString("o"), value = p.LossPercent }),
                 };
             });
 
-            return Results.Ok(new { targets = result });
+            return Results.Ok(new { targets = result, inactiveCount });
         });
 
         group.MapGet("/api/monitoring/wan-rate-chart", async (

--- a/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/PortStatsEndpoints.cs
@@ -71,7 +71,7 @@ public static class PortStatsEndpoints
             // Device display name + type ("ap" / "switch" / "gateway") from the fabric
             // monitoring targets, matching how the device health chart resolves names.
             var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.DeviceMac != null)
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.RetiredAt == null && t.DeviceMac != null)
                 .Select(t => new { t.DeviceMac, t.Name, t.AutoLabel })
                 .ToListAsync(ct);
             var targetByMac = targets

--- a/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/SfpChartEndpoints.cs
@@ -53,7 +53,7 @@ public static class SfpChartEndpoints
             var ponData = await influx.QuerySfpPonByModulesAsync(modules, queryFrom, queryTo, ct: ct);
 
             var targets = await db.MonitoringTargets.AsNoTracking()
-                .Where(t => t.TargetType == MonitoringTargetType.Fabric)
+                .Where(t => t.TargetType == MonitoringTargetType.Fabric && t.RetiredAt == null)
                 .Select(t => new { t.DeviceMac, t.Name })
                 .ToListAsync(ct);
             var nameMap = targets

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -351,6 +351,7 @@ builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHttpProvider>()
 builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
+builder.Services.AddSingleton<ICableModemProvider, TechnicolorCgaProvider>();
 builder.Services.AddSiteScopedRegistry<ModemMonitorRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ModemMonitorRegistry>());
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -352,6 +352,7 @@ builder.Services.AddSingleton<ICableModemProvider, ArrisSurfboardHnapProvider>()
 builder.Services.AddSingleton<ICableModemProvider, MotorolaHnapProvider>();
 builder.Services.AddSingleton<ICableModemProvider, XfinityGatewayProvider>();
 builder.Services.AddSingleton<ICableModemProvider, TechnicolorCgaProvider>();
+builder.Services.AddSingleton<ICableModemProvider, VodafoneStationProvider>();
 builder.Services.AddSiteScopedRegistry<ModemMonitorRegistry>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<ModemMonitorRegistry>());
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -299,9 +299,11 @@ public class AgentProbeResultSink
                 return;
             }
 
+            // Retired targets are withheld for the same reason the server does not probe them:
+            // their address describes nothing, so an agent probing one only records a false loss.
             var targets = await db.MonitoringTargets
                 .AsNoTracking()
-                .Where(t => t.Enabled)
+                .Where(t => t.Enabled && t.RetiredAt == null)
                 .ToListAsync(ct);
             // Before anything reads a context's binding, give one back to any context that lost the
             // chance to have one. Runs here because this is the push that follows an agent's hello,

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 using NetworkOptimizer.Storage.Interfaces;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
@@ -102,16 +103,23 @@ public sealed class CableModemMonitorService : ICableModemService, IDisposable
     /// <summary>
     /// Manually trigger a poll for a specific cable modem.
     /// </summary>
-    public async Task PollCmAsync(int cmId)
+    public async Task<(bool success, string message)> PollCmAsync(int cmId)
     {
         var config = await GetConfigAsync(cmId);
         if (config == null)
         {
             _logger.LogWarning("PollCmAsync called for unknown CM config {Id}", cmId);
-            return;
+            return (false, "That cable modem is no longer configured.");
         }
 
         await PollSingleAsync(config);
+
+        // Read back rather than plumbing the reason out of the poll: the poll has just written
+        // it to LastError, and the timer loop that shares this path wants no return value.
+        var after = await GetConfigAsync(cmId);
+        return string.IsNullOrEmpty(after?.LastError)
+            ? (true, "Polled successfully.")
+            : (false, after!.LastError!);
     }
 
     /// <summary>
@@ -256,7 +264,8 @@ public sealed class CableModemMonitorService : ICableModemService, IDisposable
 
         try
         {
-            var stats = await provider.PollAsync(context);
+            var result = await provider.PollAsync(context);
+            var stats = result.Stats;
 
             if (stats != null)
             {
@@ -268,13 +277,14 @@ public sealed class CableModemMonitorService : ICableModemService, IDisposable
             }
             else
             {
-                await UpdateConfigErrorAsync(config.Id, "Poll returned no data");
+                await UpdateConfigErrorAsync(
+                    config.Id, result.FailureReason ?? "The modem returned no data.");
             }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling cable modem {Name} ({Id})", config.Name, config.Id);
-            await UpdateConfigErrorAsync(config.Id, ex.Message);
+            await UpdateConfigErrorAsync(config.Id, HttpFailureSummary.Describe(ex, config.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -44,30 +45,31 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("ARRIS Surfboard HNAP poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         try
         {
             var stats = await TryHnapAsync(context, cancellationToken);
-            if (stats != null)
-            {
-                _logger.LogDebug(
-                    "ARRIS Surfboard HNAP {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
-                    context.Name, stats.DeviceModel,
-                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-            }
+            if (stats == null)
+                return PollResult<CableModemStats>.Failed(
+                    $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
 
-            return stats;
+            _logger.LogDebug(
+                "ARRIS Surfboard HNAP {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DeviceModel,
+                stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return PollResult<CableModemStats>.Ok(stats);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -75,7 +77,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         {
             _sessions.TryRemove(context.Id, out _);
             _logger.LogWarning(ex, "Error polling ARRIS Surfboard HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -100,7 +102,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
@@ -6,6 +6,7 @@ using HtmlAgilityPack;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -40,14 +41,14 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("ARRIS Surfboard poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -63,7 +64,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
 
                 // Logout to free the session
                 await LogoutAsync(context, cancellationToken);
-                return stats;
+                return PollResult<CableModemStats>.Ok(stats);
             }
 
             // Fall back to SB6183 (HTTP, no auth)
@@ -74,21 +75,21 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
                 _logger.LogDebug(
                     "ARRIS SB6183 {Name} polled: {DsCount} DS channels, {UsCount} US channels",
                     context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-                return stats;
+                return PollResult<CableModemStats>.Ok(stats);
             }
 
             _logger.LogWarning("ARRIS Surfboard {Name} at {Host}: both SB8200 and SB6183 fetch failed",
                 context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling ARRIS Surfboard {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -121,7 +122,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -66,14 +67,14 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         if (_loginBackoffUntil.TryGetValue(context.Id, out var backoffUntil))
@@ -83,7 +84,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
                 _logger.LogDebug(
                     "Motorola HNAP {Name}: skipping poll until {Until:HH:mm:ss} UTC after login failure",
                     context.Name, backoffUntil);
-                return null;
+                return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             _loginBackoffUntil.TryRemove(context.Id, out _);
@@ -97,7 +98,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             if (sessionInfo == null)
             {
                 _logger.LogWarning("Motorola HNAP {Name} at {Host}: login failed", context.Name, context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var (session, baseUrl) = sessionInfo.Value;
@@ -114,7 +115,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             {
                 _sessions.TryRemove(context.Id, out _);
                 _logger.LogWarning("Motorola HNAP {Name} at {Host}: GetMultipleHNAPs failed", context.Name, context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var stats = ParseResponse(response, context);
@@ -123,7 +124,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
                 "Motorola HNAP {Name} polled: {DsCount} DS channels, {UsCount} US channels",
                 context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
 
-            return stats;
+            return PollResult<CableModemStats>.Ok(stats);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -133,7 +134,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         {
             _sessions.TryRemove(context.Id, out _);
             _logger.LogWarning(ex, "Error polling Motorola HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -179,7 +180,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -110,14 +111,14 @@ public sealed class NetgearCmProvider : ICableModemProvider
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Netgear CM poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         for (int attempt = 1; attempt <= MaxRetries; attempt++)
@@ -138,16 +139,16 @@ public sealed class NetgearCmProvider : ICableModemProvider
                         await Task.Delay(RetryDelay, cancellationToken);
                         continue;
                     }
-                    return null;
+                    return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
                 }
 
                 var stats = ParseDocsisStatus(html, context);
                 _logger.LogDebug(
                     "Netgear CM {Name} polled: {DsCount} DS channels, {UsCount} US channels",
                     context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-                return stats;
+                return PollResult<CableModemStats>.Ok(stats);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }
@@ -161,11 +162,14 @@ public sealed class NetgearCmProvider : ICableModemProvider
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Error polling Netgear CM {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
             }
         }
 
-        return null;
+        // Every retry is spent. The last attempt's own catch returns before this,
+        // so reaching here means each one came back empty rather than throwing.
+        return PollResult<CableModemStats>.Failed(
+            $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
     }
 
     /// <inheritdoc/>
@@ -201,7 +205,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -42,30 +43,31 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         try
         {
             var stats = await TryPollAsync(context, cancellationToken);
-            if (stats != null)
-            {
-                _logger.LogDebug(
-                    "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
-                    context.Name, stats.DeviceModel,
-                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-            }
+            if (stats == null)
+                return PollResult<CableModemStats>.Failed(
+                    $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
 
-            return stats;
+            _logger.LogDebug(
+                "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DeviceModel,
+                stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return PollResult<CableModemStats>.Ok(stats);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw;
         }
@@ -73,7 +75,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         {
             _sessions.TryRemove(context.Id, out _);
             _logger.LogWarning(ex, "Error polling Technicolor CGA {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 
@@ -102,7 +104,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -1,0 +1,568 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for Technicolor CGA-series gateways (CGA437A, CGA4322DE,
+/// CGA6444VF and relatives) shipped by cable ISPs including VOO and Vodafone.
+/// These expose a JSON API behind the single-page web UI, guarded by a
+/// double-PBKDF2 login and a CSRF token.
+/// </summary>
+public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "technicolor-cga";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Technicolor CGA Series (HTTP)";
+
+    private const string DefaultDocsisPath = "/api/v1/sta_docsis_status";
+    private const string LoginPath = "/api/v1/session/login";
+    private const string MenuPath = "/api/v1/session/menu";
+    private const string DeviceInfoPath = "/api/v1/sta_device_info";
+
+    private const string SaltRequestPassword = "seeksalthash";
+    private const int PbkdfIterations = 1000;
+    private const int KeyLengthBytes = 16;
+    private const int TimeoutSeconds = 15;
+
+    private readonly ILogger<TechnicolorCgaProvider> _logger;
+    private readonly ConcurrentDictionary<int, CgaSession> _sessions = new();
+
+    public TechnicolorCgaProvider(ILogger<TechnicolorCgaProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CableModemStats?> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
+            return null;
+        }
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                _logger.LogDebug(
+                    "Technicolor CGA {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                    context.Name, stats.DeviceModel,
+                    stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+            }
+
+            return stats;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogWarning(ex, "Error polling Technicolor CGA {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
+            return null;
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return (false, "Password is required for the Technicolor web interface");
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                return (true, $"Connected to {stats.DeviceModel} - " +
+                    $"{stats.DownstreamChannels.Count} downstream, {stats.UpstreamChannels.Count} upstream channels detected");
+            }
+
+            return (false, "Could not read DOCSIS data from the Technicolor gateway. Check host, username, and password. " +
+                "Some ISPs use a device-specific account name rather than admin.");
+        }
+        catch (Exception ex)
+        {
+            return (false, $"Connection failed: {ex.Message}");
+        }
+    }
+
+    private async Task<CableModemStats?> TryPollAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return null;
+
+        var session = await EnsureSessionAsync(context, cancellationToken);
+        if (session == null)
+            return null;
+
+        var payload = await TryFetchDocsisAsync(session, context, cancellationToken);
+        if (payload == null)
+        {
+            // A token only stays valid for one signed-in session, so anything else signing in
+            // invalidates ours. Re-authenticate once before giving up.
+            _sessions.TryRemove(context.Id, out _);
+            session = await LoginAsync(context, cancellationToken);
+            if (session == null)
+                return null;
+
+            payload = await TryFetchDocsisAsync(session, context, cancellationToken);
+            if (payload == null)
+                return null;
+        }
+
+        using (payload)
+        {
+            return ParseDocsis(payload.RootElement, context, session.DeviceModel);
+        }
+    }
+
+    private async Task<CgaSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGetValue(context.Id, out var cached))
+            return cached;
+
+        return await LoginAsync(context, cancellationToken);
+    }
+
+    private async Task<CgaSession?> LoginAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
+
+        var cookies = new CookieContainer();
+        // The firmware expects this cookie before the first API call.
+        cookies.Add(new Uri(baseUrl), new Cookie("cwd", "No", "/"));
+
+        using var client = CreateClient(cookies, baseUrl, token: null);
+
+        // Requesting the salts with logout=true also clears any session left behind by a
+        // previous poll, which the firmware would otherwise refuse to replace.
+        using var saltResponse = await PostFormAsync(
+            client, baseUrl + LoginPath, username, SaltRequestPassword, cancellationToken);
+
+        if (saltResponse == null)
+            return null;
+
+        var salt = GetJsonString(saltResponse.RootElement, "salt");
+        var saltWebUi = GetJsonString(saltResponse.RootElement, "saltwebui");
+
+        if (string.IsNullOrEmpty(salt) || string.IsNullOrEmpty(saltWebUi))
+        {
+            _logger.LogWarning(
+                "Technicolor CGA {Name}: login did not return salt/saltwebui. The device may not use the CGA JSON API.",
+                context.Name);
+            return null;
+        }
+
+        // Both rounds salt with the ASCII text of the value, and the first round's output is
+        // fed in as its lowercase hex string rather than as raw bytes.
+        var firstHash = Convert.ToHexStringLower(Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password), Encoding.UTF8.GetBytes(salt),
+            PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes));
+
+        var secondHash = Convert.ToHexStringLower(Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(firstHash), Encoding.UTF8.GetBytes(saltWebUi),
+            PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes));
+
+        using var loginResponse = await PostFormAsync(
+            client, baseUrl + LoginPath, username, secondHash, cancellationToken);
+
+        if (loginResponse == null)
+            return null;
+
+        var error = GetJsonString(loginResponse.RootElement, "error");
+        if (!string.IsNullOrEmpty(error) && !error.Equals("ok", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Technicolor CGA {Name}: login rejected ({Error})", context.Name, error);
+            return null;
+        }
+
+        var token = GetJsonString(loginResponse.RootElement, "token") ?? "";
+        var session = new CgaSession(token, cookies, "Technicolor CGA");
+
+        using var authedClient = CreateClient(cookies, baseUrl, token);
+
+        // Some firmware only arms the session once the menu has been requested.
+        try
+        {
+            using var menuResponse = await authedClient.GetAsync(baseUrl + MenuPath, cancellationToken);
+            _logger.LogDebug("Technicolor CGA {Name}: menu init returned {Status}", context.Name, menuResponse.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA {Name}: menu init failed", context.Name);
+        }
+
+        session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
+        _sessions[context.Id] = session;
+
+        _logger.LogDebug("Technicolor CGA {Name}: authenticated", context.Name);
+        return session;
+    }
+
+    private async Task<JsonDocument?> PostFormAsync(
+        HttpClient client,
+        string url,
+        string username,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["username"] = username,
+            ["password"] = password,
+            ["logout"] = "true",
+        });
+
+        try
+        {
+            using var response = await client.PostAsync(url, content, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Technicolor CGA login POST returned {Status}", response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            return TryParseJson(body);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA login POST failed");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Fetch the DOCSIS payload, returning null when the session is no longer accepted so the
+    /// caller can re-authenticate.
+    /// </summary>
+    private async Task<JsonDocument?> TryFetchDocsisAsync(
+        CgaSession session,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var path = string.IsNullOrWhiteSpace(context.StatusPagePath) ? DefaultDocsisPath : context.StatusPagePath;
+
+        using var client = CreateClient(session.Cookies, baseUrl, session.Token);
+
+        // The web UI cache-busts every read; without it some firmware serves a stale payload.
+        var separator = path.Contains('?') ? '&' : '?';
+        var url = $"{baseUrl}{path}{separator}_={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture)}";
+
+        try
+        {
+            using var response = await client.GetAsync(url, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "Technicolor CGA {Name}: DOCSIS request returned {Status}", context.Name, response.StatusCode);
+                return null;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var document = TryParseJson(body);
+            if (document == null)
+                return null;
+
+            var error = GetJsonString(document.RootElement, "error");
+            if (!string.IsNullOrEmpty(error) && !error.Equals("ok", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogDebug("Technicolor CGA {Name}: DOCSIS request returned error {Error}", context.Name, error);
+                document.Dispose();
+                return null;
+            }
+
+            return document;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Technicolor CGA {Name}: DOCSIS request failed", context.Name);
+            return null;
+        }
+    }
+
+    private static async Task<string> ReadDeviceModelAsync(
+        HttpClient client,
+        string baseUrl,
+        string fallback,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var body = await client.GetStringAsync(baseUrl + DeviceInfoPath, cancellationToken);
+            using var document = TryParseJson(body);
+            if (document == null)
+                return fallback;
+
+            var root = document.RootElement.TryGetProperty("data", out var data) ? data : document.RootElement;
+            var model = GetJsonString(root, "modelName") ?? GetJsonString(root, "model");
+            if (string.IsNullOrWhiteSpace(model))
+                return fallback;
+
+            return model.StartsWith("Technicolor", StringComparison.OrdinalIgnoreCase) ? model : $"Technicolor {model}";
+        }
+        catch (HttpRequestException)
+        {
+            return fallback;
+        }
+    }
+
+    internal static CableModemStats ParseDocsis(JsonElement root, CmPollContext context, string deviceModel)
+    {
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
+            DeviceName = context.Name,
+            DeviceModel = deviceModel,
+        };
+
+        // Channel arrays live under "data" on current firmware and at the root on older builds.
+        var data = root.TryGetProperty("data", out var wrapped) ? wrapped : root;
+
+        foreach (var channel in EnumerateArray(data, "downstream"))
+        {
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetNumber(channel, "channelid"),
+                LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+                Modulation = GetString(channel, "FFT", "Modulation"),
+                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
+                Power = ParseLevel(GetString(channel, "power")),
+                Snr = ParseSnr(GetString(channel, "SNR")),
+                Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
+                Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
+            });
+        }
+
+        foreach (var channel in EnumerateArray(data, "ofdm_downstream"))
+        {
+            var modulation = GetString(channel, "FFT_ofdm", "FFT");
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetNumber(channel, "channelid_ofdm", "channelid"),
+                LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+                Modulation = string.IsNullOrWhiteSpace(modulation) ? "OFDM" : modulation,
+                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency_ofdm", "CentralFrequency")),
+                Power = ParseLevel(GetString(channel, "power_ofdm", "power")),
+                Snr = ParseSnr(GetString(channel, "SNR_ofdm", "SNR")),
+                Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
+                Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
+            });
+        }
+
+        foreach (var channel in EnumerateArray(data, "upstream"))
+        {
+            stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: null));
+        }
+
+        foreach (var channel in EnumerateArray(data, "ofdma_upstream"))
+        {
+            stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: "OFDMA"));
+        }
+
+        return stats;
+    }
+
+    private static UsChannel BuildUpstream(JsonElement channel, string? defaultType)
+    {
+        var type = GetString(channel, "ChannelType");
+        if (string.IsNullOrWhiteSpace(type))
+            type = defaultType ?? GetString(channel, "FFT", "Modulation");
+
+        return new UsChannel
+        {
+            ChannelId = (int)GetNumber(channel, "channelidup", "channelid"),
+            LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
+            ChannelType = type,
+            Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
+            Power = ParseLevel(GetString(channel, "power")),
+            SymbolRate = (long)GetNumber(channel, "SymbolRate", "symbolrate"),
+        };
+    }
+
+    private static IEnumerable<JsonElement> EnumerateArray(JsonElement parent, string name)
+    {
+        if (parent.ValueKind != JsonValueKind.Object ||
+            !parent.TryGetProperty(name, out var array) ||
+            array.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (var element in array.EnumerateArray())
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+                yield return element;
+        }
+    }
+
+    /// <summary>
+    /// The API reports lock state with its own vocabulary; the rest of the app counts DOCSIS
+    /// "Locked", so anything meaning locked has to arrive as that exact word.
+    /// </summary>
+    internal static string NormalizeLockStatus(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return "";
+
+        return value.ToLowerInvariant() switch
+        {
+            "locked" or "active" or "yes" or "true" or "1" => "Locked",
+            _ => value,
+        };
+    }
+
+    /// <summary>
+    /// Parse a frequency to Hz. Values below 1 MHz are taken as MHz, which is how some builds
+    /// report the same field.
+    /// </summary>
+    internal static long ParseFrequencyHz(string raw)
+    {
+        var value = ParseLevel(raw);
+        if (value is null or <= 0)
+            return 0;
+
+        return value.Value >= 1_000_000 ? (long)value.Value : (long)(value.Value * 1_000_000);
+    }
+
+    /// <summary>
+    /// Parse SNR/MER, which some firmware reports as a negative MSE.
+    /// </summary>
+    internal static double? ParseSnr(string raw)
+    {
+        var value = ParseLevel(raw);
+        return value.HasValue ? Math.Abs(value.Value) : null;
+    }
+
+    /// <summary>
+    /// Parse a leading number from a value that may carry a unit suffix ("1.1 dBmV").
+    /// </summary>
+    internal static double? ParseLevel(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var end = 0;
+        while (end < value.Length && (char.IsAsciiDigit(value[end]) || value[end] is '-' or '+' or '.'))
+            end++;
+
+        return double.TryParse(value[..end], NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string GetString(JsonElement element, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!element.TryGetProperty(name, out var value))
+                continue;
+
+            var text = value.ValueKind switch
+            {
+                JsonValueKind.String => value.GetString() ?? "",
+                JsonValueKind.Number => value.GetRawText(),
+                JsonValueKind.True => "true",
+                JsonValueKind.False => "false",
+                _ => "",
+            };
+
+            if (text.Length > 0)
+                return text;
+        }
+
+        return "";
+    }
+
+    private static double GetNumber(JsonElement element, params string[] names)
+        => ParseLevel(GetString(element, names)) ?? 0;
+
+    private static HttpClient CreateClient(CookieContainer cookies, string baseUrl, string? token)
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = cookies,
+            UseCookies = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+
+        // The firmware checks User-Agent, X-Requested-With, and Referer on every request,
+        // including the session initialization that follows login.
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            DefaultRequestHeaders =
+            {
+                { "User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
+                { "X-Requested-With", "XMLHttpRequest" },
+                { "Referer", baseUrl + "/" },
+            },
+        };
+
+        if (!string.IsNullOrEmpty(token))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("X-CSRF-TOKEN", token);
+
+        return client;
+    }
+
+    private static string BuildBaseUrl(CmPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var scheme = port == 443 ? "https" : "http";
+        var suffix = port is 80 or 443 ? "" : $":{port}";
+        return $"{scheme}://{context.Host}{suffix}";
+    }
+
+    private static JsonDocument? TryParseJson(string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetJsonString(JsonElement element, string name)
+        => element.ValueKind == JsonValueKind.Object &&
+           element.TryGetProperty(name, out var value) &&
+           value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    public void Dispose()
+    {
+        _sessions.Clear();
+    }
+
+    private sealed record CgaSession(string Token, CookieContainer Cookies, string DeviceModel);
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -1,0 +1,738 @@
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Monitoring.Models;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
+
+namespace NetworkOptimizer.Web.Services.CableModemProviders;
+
+/// <summary>
+/// Cable modem provider for the ARRIS TG3442DE cable gateway, sold as the
+/// "Vodafone Station" in Germany. Authenticates with AES-CCM encrypted
+/// credentials and scrapes DOCSIS channel data from JS arrays embedded in
+/// /php/status_docsis_data.php.
+/// </summary>
+public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisposable
+{
+    /// <inheritdoc/>
+    public string ProviderKey => "vodafone-station";
+
+    /// <inheritdoc/>
+    public string DisplayName => "Vodafone Station (ARRIS TG3442DE)";
+
+    private const string DefaultDocsisPath = "/php/status_docsis_data.php";
+    private const string LoginPath = "/php/ajaxSet_Password.php";
+    private const string SessionPath = "/php/ajaxSet_Session.php";
+    private const string LogoutPath = "/php/logout.php";
+    private const string DeviceStatusPath = "/php/status_status_data.php";
+    private const string CredentialScriptPath = "/base_95x.js";
+
+    private const string LoginAad = "loginPassword";
+    private const string NonceAad = "nonce";
+    private const int PbkdfIterations = 1000;
+    private const int KeyLengthBytes = 16;
+    private const int TagLengthBytes = 16;
+    private const int CsrfNonceLength = 32;
+    private const int TimeoutSeconds = 15;
+
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly ILogger<VodafoneStationProvider> _logger;
+    private readonly ConcurrentDictionary<int, TgSession> _sessions = new();
+
+    public VodafoneStationProvider(ILogger<VodafoneStationProvider> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public async Task<PollResult<CableModemStats>> PollAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+        {
+            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.Id);
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
+        }
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats == null)
+                return PollResult<CableModemStats>.Failed(
+                    $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
+
+            _logger.LogDebug(
+                "Vodafone Station {Name} polled: {Model}, {DsCount} DS channels, {UsCount} US channels",
+                context.Name, stats.DeviceModel,
+                stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
+
+            return PollResult<CableModemStats>.Ok(stats);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _sessions.TryRemove(context.Id, out _);
+            _logger.LogWarning(ex, "Error polling Vodafone Station {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
+            return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
+        }
+    }
+
+    /// <inheritdoc/>
+    public async Task<(bool Success, string Message)> TestConnectionAsync(
+        CmPollContext context,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(context.Host))
+            return (false, "Host is empty");
+
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return (false, "Password is required for the Vodafone Station web interface");
+
+        try
+        {
+            var stats = await TryPollAsync(context, cancellationToken);
+            if (stats != null)
+            {
+                return (true, $"Connected to {stats.DeviceModel} - " +
+                    $"{stats.DownstreamChannels.Count} downstream, {stats.UpstreamChannels.Count} upstream channels detected");
+            }
+
+            return (false, "Could not read DOCSIS data from the Vodafone Station. Check host, password, " +
+                "and that no other admin session is signed in.");
+        }
+        catch (Exception ex)
+        {
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
+        }
+    }
+
+    private async Task<CableModemStats?> TryPollAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.Password))
+            return null;
+
+        var session = await EnsureSessionAsync(context, cancellationToken);
+        if (session == null)
+            return null;
+
+        var html = await TryFetchDocsisAsync(session, context, cancellationToken);
+        if (html == null)
+        {
+            // The modem allows a single active admin session, so another sign-in silently
+            // invalidates ours. Re-authenticate once before giving up.
+            await InvalidateSessionAsync(context, cancellationToken);
+            session = await LoginAsync(context, cancellationToken);
+            if (session == null)
+                return null;
+
+            html = await TryFetchDocsisAsync(session, context, cancellationToken);
+            if (html == null)
+                return null;
+        }
+
+        return ParseDocsis(html, context, session.DeviceModel);
+    }
+
+    private async Task<TgSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (_sessions.TryGetValue(context.Id, out var cached))
+            return cached;
+
+        return await LoginAsync(context, cancellationToken);
+    }
+
+    private async Task<TgSession?> LoginAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var username = string.IsNullOrWhiteSpace(context.Username) ? "admin" : context.Username;
+        var password = context.Password ?? "";
+
+        var cookies = new CookieContainer();
+        using var client = CreateClient(cookies, baseUrl, csrfNonce: null);
+
+        var loginPage = await client.GetStringAsync(baseUrl + "/", cancellationToken);
+
+        var sessionId = ExtractJsVar(loginPage, "currentSessionId");
+        var ivHex = ExtractJsVar(loginPage, "myIv");
+        var saltHex = ExtractJsVar(loginPage, "mySalt");
+
+        if (string.IsNullOrEmpty(sessionId) || string.IsNullOrEmpty(ivHex) || string.IsNullOrEmpty(saltHex))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: login page is missing session variables (sessionId={HasSession}, myIv={HasIv}, mySalt={HasSalt})",
+                context.Name, !string.IsNullOrEmpty(sessionId), !string.IsNullOrEmpty(ivHex), !string.IsNullOrEmpty(saltHex));
+            return null;
+        }
+
+        if (!TryParseHex(saltHex, out var salt) || !TryParseHex(ivHex, out var iv))
+        {
+            _logger.LogWarning("Vodafone Station {Name}: mySalt/myIv are not valid hex", context.Name);
+            return null;
+        }
+
+        if (!IsSupportedNonceSize(iv.Length))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: myIv is {Length} bytes, which AES-CCM does not accept as a nonce",
+                context.Name, iv.Length);
+            return null;
+        }
+
+        var key = Rfc2898DeriveBytes.Pbkdf2(
+            Encoding.UTF8.GetBytes(password), salt, PbkdfIterations, HashAlgorithmName.SHA256, KeyLengthBytes);
+
+        var credentials = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["Password"] = password,
+            ["Nonce"] = sessionId,
+        });
+
+        var encryptData = AesCcmEncryptHex(key, iv, Encoding.UTF8.GetBytes(credentials), LoginAad);
+
+        var loginBody = JsonSerializer.Serialize(new Dictionary<string, string>
+        {
+            ["EncryptData"] = encryptData,
+            ["Name"] = username,
+            ["AuthData"] = LoginAad,
+        });
+
+        using var loginContent = new StringContent(loginBody, Encoding.UTF8, "application/json");
+        using var loginResponse = await client.PostAsync(baseUrl + LoginPath, loginContent, cancellationToken);
+        if (!loginResponse.IsSuccessStatusCode)
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: login POST returned {Status}", context.Name, loginResponse.StatusCode);
+            return null;
+        }
+
+        var loginJson = await loginResponse.Content.ReadAsStringAsync(cancellationToken);
+        using var parsed = TryParseJson(loginJson);
+        if (parsed == null)
+        {
+            _logger.LogWarning("Vodafone Station {Name}: login response was not JSON", context.Name);
+            return null;
+        }
+
+        var status = GetJsonString(parsed.RootElement, "p_status") ?? "";
+        if (status.Equals("Lockout", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning(
+                "Vodafone Station {Name}: account locked out after repeated failed sign-ins. Wait a few minutes or reboot the modem.",
+                context.Name);
+            return null;
+        }
+
+        if (status.Equals("Fail", StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogWarning("Vodafone Station {Name}: authentication failed (incorrect password)", context.Name);
+            return null;
+        }
+
+        var encryptedNonce = GetJsonString(parsed.RootElement, "encryptData")
+            ?? GetJsonString(parsed.RootElement, "EncryptData");
+
+        string csrfNonce;
+        if (!string.IsNullOrEmpty(encryptedNonce))
+        {
+            var decrypted = AesCcmDecryptText(key, iv, encryptedNonce, NonceAad);
+            if (string.IsNullOrEmpty(decrypted))
+            {
+                _logger.LogWarning("Vodafone Station {Name}: could not decrypt the CSRF nonce", context.Name);
+                return null;
+            }
+
+            csrfNonce = decrypted.Length > CsrfNonceLength ? decrypted[..CsrfNonceLength] : decrypted;
+        }
+        else
+        {
+            csrfNonce = GetJsonString(parsed.RootElement, "nonce") ?? sessionId;
+        }
+
+        var session = new TgSession(csrfNonce, cookies, "ARRIS TG3442DE (Vodafone Station)");
+
+        // Later requests need the nonce header, so build a fresh client for the remaining setup.
+        using var authedClient = CreateClient(cookies, baseUrl, csrfNonce);
+
+        // Some firmware only marks the session live once this is posted; failure is not fatal.
+        try
+        {
+            using var sessionResponse = await authedClient.PostAsync(baseUrl + SessionPath, content: null, cancellationToken);
+            _logger.LogDebug(
+                "Vodafone Station {Name}: session init returned {Status}", context.Name, sessionResponse.StatusCode);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: session init failed", context.Name);
+        }
+
+        await ApplyCredentialCookieAsync(authedClient, cookies, baseUrl, context, cancellationToken);
+
+        session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
+        _sessions[context.Id] = session;
+
+        _logger.LogDebug("Vodafone Station {Name}: authenticated (p_status={Status})", context.Name, status);
+        return session;
+    }
+
+    /// <summary>
+    /// Fetch the DOCSIS page, returning null when the session is no longer accepted so the
+    /// caller can re-authenticate. A page without the channel arrays means the modem served
+    /// the login page instead, which is the unauthenticated response rather than an error.
+    /// </summary>
+    private async Task<string?> TryFetchDocsisAsync(
+        TgSession session,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        var baseUrl = BuildBaseUrl(context);
+        var path = string.IsNullOrWhiteSpace(context.StatusPagePath) ? DefaultDocsisPath : context.StatusPagePath;
+
+        using var client = CreateClient(session.Cookies, baseUrl, session.CsrfNonce);
+
+        try
+        {
+            using var response = await client.GetAsync(baseUrl + path, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug(
+                    "Vodafone Station {Name}: DOCSIS page returned {Status}", context.Name, response.StatusCode);
+                return null;
+            }
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            return DownstreamArrayRegex().IsMatch(html) || UpstreamArrayRegex().IsMatch(html) ? html : null;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: DOCSIS page request failed", context.Name);
+            return null;
+        }
+    }
+
+    private async Task InvalidateSessionAsync(CmPollContext context, CancellationToken cancellationToken)
+    {
+        if (!_sessions.TryRemove(context.Id, out var session))
+            return;
+
+        var baseUrl = BuildBaseUrl(context);
+        using var client = CreateClient(session.Cookies, baseUrl, session.CsrfNonce);
+
+        try
+        {
+            using var response = await client.PostAsync(baseUrl + LogoutPath, content: null, cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: logout failed", context.Name);
+        }
+    }
+
+    /// <summary>
+    /// The firmware expects a "credential" cookie that the browser's login script sets from
+    /// base_95x.js. Data requests are rejected without it on some builds.
+    /// </summary>
+    private async Task ApplyCredentialCookieAsync(
+        HttpClient client,
+        CookieContainer cookies,
+        string baseUrl,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var script = await client.GetStringAsync(baseUrl + CredentialScriptPath, cancellationToken);
+            var match = CredentialCookieRegex().Match(script);
+            if (!match.Success)
+            {
+                _logger.LogDebug("Vodafone Station {Name}: no credential cookie in base_95x.js", context.Name);
+                return;
+            }
+
+            cookies.Add(new Uri(baseUrl), new Cookie("credential", match.Groups[1].Value, "/"));
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Vodafone Station {Name}: could not read base_95x.js", context.Name);
+        }
+    }
+
+    private static async Task<string> ReadDeviceModelAsync(
+        HttpClient client,
+        string baseUrl,
+        string fallback,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var status = await client.GetStringAsync(baseUrl + DeviceStatusPath, cancellationToken);
+            var hardware = ExtractJsVar(status, "js_HWTypeVersion");
+            if (string.IsNullOrWhiteSpace(hardware))
+                return fallback;
+
+            return hardware.StartsWith("ARRIS", StringComparison.OrdinalIgnoreCase) ? hardware : $"ARRIS {hardware}";
+        }
+        catch (HttpRequestException)
+        {
+            return fallback;
+        }
+    }
+
+    internal static CableModemStats ParseDocsis(string html, CmPollContext context, string deviceModel)
+    {
+        var stats = new CableModemStats
+        {
+            Timestamp = DateTime.UtcNow,
+            DeviceHost = context.ConfiguredHost ?? context.Host,
+            DeviceName = context.Name,
+            DeviceModel = deviceModel,
+        };
+
+        foreach (var channel in EnumerateChannels(html, DownstreamArrayRegex()))
+        {
+            var type = GetChannelString(channel, "ChannelType");
+            var modulation = GetChannelString(channel, "Modulation");
+            if (string.IsNullOrWhiteSpace(modulation) && type.Contains("OFDM", StringComparison.OrdinalIgnoreCase))
+                modulation = type;
+
+            stats.DownstreamChannels.Add(new DsChannel
+            {
+                ChannelId = (int)GetChannelNumber(channel, "ChannelID"),
+                LockStatus = NormalizeLockStatus(GetChannelString(channel, "LockStatus")),
+                Modulation = modulation,
+                Frequency = ParseFrequencyHz(GetChannelString(channel, "Frequency")),
+                Power = ParsePowerDbmv(GetChannelString(channel, "PowerLevel")),
+                Snr = ParseLevel(GetChannelString(channel, "SNRLevel")),
+                // Codeword counters are absent on the firmware this was built against, so these
+                // stay 0 there; the alternate spellings cover builds that do publish them.
+                Correctables = (long)GetChannelNumber(channel, "CorrectableCodewords", "Correcteds", "CorrErr"),
+                Uncorrectables = (long)GetChannelNumber(channel, "UncorrectableCodewords", "Uncorrectables", "UncorrErr"),
+            });
+        }
+
+        foreach (var channel in EnumerateChannels(html, UpstreamArrayRegex()))
+        {
+            var type = GetChannelString(channel, "ChannelType");
+            if (string.IsNullOrWhiteSpace(type))
+                type = GetChannelString(channel, "Modulation");
+
+            stats.UpstreamChannels.Add(new UsChannel
+            {
+                ChannelId = (int)GetChannelNumber(channel, "ChannelID"),
+                LockStatus = NormalizeLockStatus(GetChannelString(channel, "LockStatus")),
+                ChannelType = type,
+                Frequency = ParseFrequencyHz(GetChannelString(channel, "Frequency")),
+                Power = ParsePowerDbmv(GetChannelString(channel, "PowerLevel")),
+                SymbolRate = (long)GetChannelNumber(channel, "SymbolRate"),
+            });
+        }
+
+        return stats;
+    }
+
+    private static IEnumerable<JsonElement> EnumerateChannels(string html, Regex arrayRegex)
+    {
+        var match = arrayRegex.Match(html);
+        if (!match.Success)
+            yield break;
+
+        JsonDocument? document;
+        try
+        {
+            document = JsonDocument.Parse(match.Groups[1].Value);
+        }
+        catch (JsonException)
+        {
+            yield break;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Array)
+                yield break;
+
+            foreach (var element in document.RootElement.EnumerateArray())
+            {
+                if (element.ValueKind == JsonValueKind.Object)
+                    yield return element.Clone();
+            }
+        }
+    }
+
+    /// <summary>
+    /// The TG reports "ACTIVE" where the rest of the app expects DOCSIS "Locked"; without this
+    /// mapping every locked-channel aggregate reads zero.
+    /// </summary>
+    internal static string NormalizeLockStatus(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Equals("ACTIVE", StringComparison.OrdinalIgnoreCase) ||
+            value.Equals("Locked", StringComparison.OrdinalIgnoreCase))
+        {
+            return "Locked";
+        }
+
+        return value;
+    }
+
+    /// <summary>
+    /// Parse the TG frequency field to Hz. OFDM/OFDMA channels report a "start~end" band, which
+    /// becomes its center. Values below 1 MHz are taken as MHz, which is how narrower firmware
+    /// builds report the same field.
+    /// </summary>
+    internal static long ParseFrequencyHz(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return 0;
+
+        var separator = value.IndexOf('~');
+        if (separator >= 0)
+        {
+            var start = ParseLevel(value[..separator]);
+            var end = ParseLevel(value[(separator + 1)..]);
+            if (start == null || end == null)
+                return 0;
+
+            return ToHz((start.Value + end.Value) / 2);
+        }
+
+        var single = ParseLevel(value);
+        return single == null ? 0 : ToHz(single.Value);
+    }
+
+    private static long ToHz(double value)
+    {
+        if (value <= 0)
+            return 0;
+
+        return value >= 1_000_000 ? (long)value : (long)(value * 1_000_000);
+    }
+
+    /// <summary>
+    /// Parse the TG power field, which pairs both units as "-1.2 dBmV/1158.8 dBuV".
+    /// </summary>
+    internal static double? ParsePowerDbmv(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var separator = value.IndexOf('/');
+        if (separator >= 0)
+            value = value[..separator];
+
+        return ParseLevel(value);
+    }
+
+    /// <summary>
+    /// Parse a leading number from a value that may carry a unit suffix ("41.8 dB").
+    /// </summary>
+    internal static double? ParseLevel(string raw)
+    {
+        var value = raw.Trim();
+        if (value.Length == 0)
+            return null;
+
+        var end = 0;
+        while (end < value.Length && (char.IsAsciiDigit(value[end]) || value[end] is '-' or '+' or '.'))
+            end++;
+
+        var numeric = value[..end];
+        return double.TryParse(numeric, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : null;
+    }
+
+    private static string GetChannelString(JsonElement channel, string name)
+    {
+        if (!channel.TryGetProperty(name, out var value))
+            return "";
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.String => value.GetString() ?? "",
+            JsonValueKind.Number => value.GetRawText(),
+            _ => "",
+        };
+    }
+
+    private static double GetChannelNumber(JsonElement channel, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            var raw = GetChannelString(channel, name);
+            if (raw.Length == 0)
+                continue;
+
+            var parsed = ParseLevel(raw);
+            if (parsed.HasValue)
+                return parsed.Value;
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Encrypt to the layout the modem expects: ciphertext followed by the authentication tag,
+    /// as one lowercase hex string.
+    /// </summary>
+    internal static string AesCcmEncryptHex(byte[] key, byte[] nonce, byte[] plaintext, string associatedData)
+    {
+        var ciphertext = new byte[plaintext.Length];
+        var tag = new byte[TagLengthBytes];
+
+        using var ccm = new AesCcm(key);
+        ccm.Encrypt(nonce, plaintext, ciphertext, tag, Encoding.ASCII.GetBytes(associatedData));
+
+        return Convert.ToHexStringLower(ciphertext) + Convert.ToHexStringLower(tag);
+    }
+
+    internal static string? AesCcmDecryptText(byte[] key, byte[] nonce, string encryptedHex, string associatedData)
+    {
+        if (!TryParseHex(encryptedHex, out var blob) || blob.Length <= TagLengthBytes)
+            return null;
+
+        var ciphertext = blob.AsSpan(0, blob.Length - TagLengthBytes);
+        var tag = blob.AsSpan(blob.Length - TagLengthBytes);
+        var plaintext = new byte[ciphertext.Length];
+
+        try
+        {
+            using var ccm = new AesCcm(key);
+            ccm.Decrypt(nonce, ciphertext, tag, plaintext, Encoding.ASCII.GetBytes(associatedData));
+        }
+        catch (CryptographicException)
+        {
+            return null;
+        }
+
+        return Encoding.UTF8.GetString(plaintext);
+    }
+
+    private static bool IsSupportedNonceSize(int length)
+    {
+        var sizes = AesCcm.NonceByteSizes;
+        if (length < sizes.MinSize || length > sizes.MaxSize)
+            return false;
+
+        return sizes.SkipSize == 0
+            ? length == sizes.MinSize
+            : (length - sizes.MinSize) % sizes.SkipSize == 0;
+    }
+
+    private static bool TryParseHex(string value, out byte[] bytes)
+    {
+        try
+        {
+            bytes = Convert.FromHexString(value.Trim());
+            return true;
+        }
+        catch (FormatException)
+        {
+            bytes = [];
+            return false;
+        }
+    }
+
+    internal static string? ExtractJsVar(string html, string name)
+    {
+        var escaped = Regex.Escape(name);
+        // The bare-assignment form must not match a longer identifier ending in this name; the
+        // firmware's own pages are full of js_-prefixed variables that would otherwise win.
+        string[] patterns =
+        [
+            $"""(?:var|let|const)\s+{escaped}\s*=\s*['"]([^'"]+)['"]""",
+            $"""window\.{escaped}\s*=\s*['"]([^'"]+)['"]""",
+            $"""(?<![\w$.]){escaped}\s*=\s*['"]([^'"]+)['"]""",
+        ];
+
+        foreach (var pattern in patterns)
+        {
+            var match = Regex.Match(html, pattern, RegexOptions.None, RegexTimeout);
+            if (match.Success)
+                return match.Groups[1].Value;
+        }
+
+        return null;
+    }
+
+    private static HttpClient CreateClient(CookieContainer cookies, string baseUrl, string? csrfNonce)
+    {
+        var handler = new HttpClientHandler
+        {
+            CookieContainer = cookies,
+            UseCookies = true,
+            AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+            ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+        };
+
+        var client = new HttpClient(handler)
+        {
+            Timeout = TimeSpan.FromSeconds(TimeoutSeconds),
+            DefaultRequestHeaders =
+            {
+                { "User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" },
+                { "X-Requested-With", "XMLHttpRequest" },
+                { "Origin", baseUrl },
+                { "Referer", baseUrl + "/" },
+            },
+        };
+
+        if (!string.IsNullOrEmpty(csrfNonce))
+            client.DefaultRequestHeaders.TryAddWithoutValidation("csrfNonce", csrfNonce);
+
+        return client;
+    }
+
+    private static string BuildBaseUrl(CmPollContext context)
+    {
+        var port = context.Port > 0 ? context.Port : 80;
+        var scheme = port == 443 ? "https" : "http";
+        var suffix = port is 80 or 443 ? "" : $":{port}";
+        return $"{scheme}://{context.Host}{suffix}";
+    }
+
+    private static JsonDocument? TryParseJson(string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static string? GetJsonString(JsonElement element, string name)
+        => element.TryGetProperty(name, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    public void Dispose()
+    {
+        _sessions.Clear();
+    }
+
+    [GeneratedRegex(@"json_dsData\s*=\s*(\[.+?\])\s*;", RegexOptions.Singleline)]
+    private static partial Regex DownstreamArrayRegex();
+
+    [GeneratedRegex(@"json_usData\s*=\s*(\[.+?\])\s*;", RegexOptions.Singleline)]
+    private static partial Regex UpstreamArrayRegex();
+
+    [GeneratedRegex("""createCookie\(\s*["']credential["']\s*,\s*["'](.+?)["']""")]
+    private static partial Regex CredentialCookieRegex();
+
+    private sealed record TgSession(string CsrfNonce, CookieContainer Cookies, string DeviceModel);
+}

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -2,6 +2,7 @@ using System.Net;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
@@ -33,14 +34,14 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     }
 
     /// <inheritdoc/>
-    public async Task<CableModemStats?> PollAsync(
+    public async Task<PollResult<CableModemStats>> PollAsync(
         CmPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Xfinity Gateway poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
         for (int attempt = 1; attempt <= MaxRetries; attempt++)
@@ -58,16 +59,16 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
                         await Task.Delay(RetryDelay, cancellationToken);
                         continue;
                     }
-                    return null;
+                    return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
                 }
 
                 var stats = ParseNetworkSetup(html, context);
                 _logger.LogDebug(
                     "Xfinity Gateway {Name} polled: {DsCount} DS channels, {UsCount} US channels",
                     context.Name, stats.DownstreamChannels.Count, stats.UpstreamChannels.Count);
-                return stats;
+                return PollResult<CableModemStats>.Ok(stats);
             }
-            catch (OperationCanceledException)
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
                 throw;
             }
@@ -81,11 +82,14 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Error polling Xfinity Gateway {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
             }
         }
 
-        return null;
+        // Every retry is spent. The last attempt's own catch returns before this,
+        // so reaching here means each one came back empty rather than throwing.
+        return PollResult<CableModemStats>.Failed(
+            $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
     }
 
     /// <inheritdoc/>
@@ -119,7 +123,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
@@ -45,16 +45,17 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
     }
 
     /// <inheritdoc/>
-    public async Task<CellularModemStats?> PollAsync(
+    public async Task<PollResult<CellularModemStats>> PollAsync(
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Netgear poll requested for modem {Name} but Host is empty", context.Name);
-            return null;
+            return PollResult<CellularModemStats>.Failed("No address is configured for this modem.");
         }
 
+        var host = context.ConfiguredHost ?? context.Host;
         var hasPassword = !string.IsNullOrEmpty(context.Password);
 
         try
@@ -63,17 +64,22 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
             var json = await FetchModelJsonAsync(context, requireAuth: hasPassword, cancellationToken);
             if (json == null)
             {
-                _logger.LogWarning("Netgear poll for {Name} ({Host}) returned no data", context.Name, context.ConfiguredHost ?? context.Host);
-                return null;
+                _logger.LogWarning("Netgear poll for {Name} ({Host}) returned no data", context.Name, host);
+                return PollResult<CellularModemStats>.Failed(
+                    $"Could not reach {host}, or the hotspot rejected the admin password.");
             }
 
             using var doc = JsonDocument.Parse(json, _jsonOptions);
-            return NetgearModelJsonParser.Parse(doc.RootElement, context);
+            var stats = NetgearModelJsonParser.Parse(doc.RootElement, context);
+            return stats == null
+                ? PollResult<CellularModemStats>.Failed($"{host} answered but returned no signal data.")
+                : PollResult<CellularModemStats>.Ok(stats);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error polling Netgear modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            _logger.LogError(ex, "Error polling Netgear modem {Name} at {Host}", context.Name, host);
+            // Capped: an HTTP failure can carry a paragraph, and this renders inline on the card.
+            return PollResult<CellularModemStats>.Failed($"Could not read stats from {host}: {FirstLine(ex.Message)}");
         }
     }
 
@@ -369,6 +375,14 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         }
     }
 
+
+    /// <summary>The first line of an exception message, capped for inline display.</summary>
+    private static string FirstLine(string? text)
+    {
+        const int maxLength = 160;
+        var line = (text ?? "").Split('\n', '\r').FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))?.Trim() ?? "";
+        return line.Length <= maxLength ? line : line[..maxLength] + "...";
+    }
 
     // Generic helpers for path-based JSON access
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
@@ -1,9 +1,9 @@
 using System.Collections.Concurrent;
 using System.Net;
-using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.CellularModemProviders;
 
@@ -78,8 +78,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error polling Netgear modem {Name} at {Host}", context.Name, host);
-            // Capped: an HTTP failure can carry a paragraph, and this renders inline on the card.
-            return PollResult<CellularModemStats>.Failed($"Could not read stats from {host}: {FirstLine(ex.Message)}");
+            return PollResult<CellularModemStats>.Failed(HttpFailureSummary.Describe(ex, host));
         }
     }
 
@@ -108,7 +107,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         }
         catch (Exception ex)
         {
-            return (false, $"Probe failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 
@@ -373,15 +372,6 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         {
             session.Dispose();
         }
-    }
-
-
-    /// <summary>The first line of an exception message, capped for inline display.</summary>
-    private static string FirstLine(string? text)
-    {
-        const int maxLength = 160;
-        var line = (text ?? "").Split('\n', '\r').FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))?.Trim() ?? "";
-        return line.Length <= maxLength ? line : line[..maxLength] + "...";
     }
 
     // Generic helpers for path-based JSON access

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -1,6 +1,7 @@
 using NetworkOptimizer.Monitoring;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Ssh;
 
 namespace NetworkOptimizer.Web.Services.CellularModemProviders;
 
@@ -33,7 +34,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     }
 
     /// <inheritdoc/>
-    public async Task<CellularModemStats?> PollAsync(
+    public async Task<PollResult<CellularModemStats>> PollAsync(
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
@@ -42,7 +43,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
         // Try uiwwand first - available on all modern UniFi cellular modems
         var stats = await TryPollViaUiwwandAsync(context);
         if (stats != null)
-            return stats;
+            return PollResult<CellularModemStats>.Ok(stats);
 
         // Fall back to raw qmicli commands
         return await PollViaQmicliAsync(context);
@@ -184,7 +185,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     /// <summary>
     /// Poll via raw qmicli commands. Fallback path when uiwwand is unavailable.
     /// </summary>
-    private async Task<CellularModemStats?> PollViaQmicliAsync(ModemPollContext context)
+    private async Task<PollResult<CellularModemStats>> PollViaQmicliAsync(ModemPollContext context)
     {
         var qmiDevice = string.IsNullOrWhiteSpace(context.TransportPath)
             ? "/dev/wwan0qmi0"
@@ -212,7 +213,8 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             if (!success)
             {
                 _logger.LogWarning("Failed to poll modem {Name} via qmicli: {Output}", context.Name, output);
-                return null;
+                return PollResult<CellularModemStats>.Failed(
+                    SshFailureSummary.Describe(output, context.ConfiguredHost ?? context.Host));
             }
 
             var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO");
@@ -257,21 +259,25 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 "Successfully polled modem {Name} via qmicli: {Carrier}, Signal Quality: {Quality}%",
                 context.Name, stats.Carrier, stats.SignalQuality);
 
-            return stats;
+            return PollResult<CellularModemStats>.Ok(stats);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error polling modem {Name}", context.Name);
-            return null;
+            return PollResult<CellularModemStats>.Failed(
+                SshFailureSummary.Describe(ex.Message, context.ConfiguredHost ?? context.Host));
         }
     }
 
     /// <inheritdoc/>
-    public Task<(bool success, string message)> TestConnectionAsync(
+    public async Task<(bool success, string message)> TestConnectionAsync(
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
-        return _sshService.TestConnectionAsync(context.Host);
+        var (success, message) = await _sshService.TestConnectionAsync(context.Host);
+        return success
+            ? (true, message)
+            : (false, SshFailureSummary.Describe(message, context.ConfiguredHost ?? context.Host));
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -34,17 +34,18 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     }
 
     /// <inheritdoc/>
-    public async Task<CellularModemStats?> PollAsync(
+    public async Task<PollResult<CellularModemStats>> PollAsync(
         ModemPollContext context,
         CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("Polling GL-iNet modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
 
+        var host = context.ConfiguredHost ?? context.Host;
         var connection = ToConnectionInfo(context);
         if (!connection.HasCredentials)
         {
             _logger.LogWarning("No SSH credentials configured for modem {Name}", context.Name);
-            return null;
+            return PollResult<CellularModemStats>.Failed("SSH credentials are not configured for this modem.");
         }
 
         try
@@ -55,24 +56,24 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
             if (!result.Success)
             {
                 _logger.LogWarning("AT command failed on {Name}: {Error}", context.Name, result.Error);
-                return null;
+                return PollResult<CellularModemStats>.Failed(SshFailureSummary.Describe(result.CombinedOutput, host));
             }
 
-            var stats = QuectelAtParser.Parse(result.Output, context.ConfiguredHost ?? context.Host, context.Name, context.ModemType);
+            var stats = QuectelAtParser.Parse(result.Output, host, context.Name, context.ModemType);
 
-            if (stats != null)
-            {
-                _logger.LogInformation(
-                    "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",
-                    context.Name, stats.SignalQuality);
-            }
+            if (stats == null)
+                return PollResult<CellularModemStats>.Failed($"{host} answered over SSH but the modem returned no signal data.");
 
-            return stats;
+            _logger.LogInformation(
+                "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",
+                context.Name, stats.SignalQuality);
+
+            return PollResult<CellularModemStats>.Ok(stats);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error polling GL-iNet modem {Name}", context.Name);
-            return null;
+            return PollResult<CellularModemStats>.Failed(SshFailureSummary.Describe(ex.Message, host));
         }
     }
 
@@ -100,7 +101,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
                 return (false, $"SSH connected but modem did not respond. Output: {Truncate(result.Output, 200)}");
             }
 
-            return (false, $"SSH command failed: {Truncate(result.Error, 200)}");
+            return (false, SshFailureSummary.Describe(result.CombinedOutput, context.ConfiguredHost ?? context.Host));
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -194,10 +194,11 @@ public class CellularModemService : ICellularModemService
     /// <summary>
     /// Dispatch a poll to the appropriate provider based on the row's Provider column.
     /// </summary>
-    private async Task<CellularModemStats?> ExecutePollAsync(ModemConfiguration modem)
+    private async Task<PollResult<CellularModemStats>> ExecutePollAsync(ModemConfiguration modem)
     {
         var provider = ResolveProvider(modem);
-        if (provider == null) return null;
+        if (provider == null)
+            return PollResult<CellularModemStats>.Failed($"No provider is registered for '{modem.Provider}'.");
 
         var context = await ToPollContextAsync(modem);
         return await provider.PollAsync(context);
@@ -283,7 +284,8 @@ public class CellularModemService : ICellularModemService
     {
         try
         {
-            var stats = await ExecutePollAsync(modem);
+            var result = await ExecutePollAsync(modem);
+            var stats = result.Stats;
 
             if (stats != null)
             {
@@ -307,8 +309,11 @@ public class CellularModemService : ICellularModemService
             }
             else
             {
-                await UpdateModemConfigAsync(modem.Id, "Poll returned no data", success: false);
-                return (false, "Failed to poll modem - no data returned");
+                var reason = string.IsNullOrWhiteSpace(result.FailureReason)
+                    ? "The modem returned no data."
+                    : result.FailureReason;
+                await UpdateModemConfigAsync(modem.Id, reason, success: false);
+                return (false, reason);
             }
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Services/ICableModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/ICableModemService.cs
@@ -32,7 +32,7 @@ public interface ICableModemService
 
     /// <summary>Polls one cable modem now and caches the result.</summary>
     [RequireRole(Roles.Viewer)]
-    Task PollCmAsync(int cmId);
+    Task<(bool success, string message)> PollCmAsync(int cmId);
 
     /// <summary>Adds or updates a cable modem configuration.</summary>
     [RequireRole(Roles.Admin)]

--- a/src/NetworkOptimizer.Web/Services/IMonitoringTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/IMonitoringTargetService.cs
@@ -23,11 +23,27 @@ public interface IMonitoringTargetService
     [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
     Task<MonitoringTarget> AddAsync(NewMonitoringTarget spec, CancellationToken ct = default);
 
-    /// <summary>Deletes a target. False when it no longer exists.</summary>
+    /// <summary>
+    /// Removes a target from the list. One that has been probed is hidden rather than deleted, so
+    /// its row keeps naming the series filed under its TargetId; one that never was is deleted
+    /// outright. False when it no longer exists.
+    /// </summary>
     /// <remarks>Admin, not Operator: removing a target is the card's one SiteAdminOnly action.</remarks>
     [RequireRole(Roles.Admin)]
     [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
     Task<bool> DeleteAsync(int id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Takes a target off the list, or puts it back, stopping and resuming its probing with it.
+    /// False when it no longer exists.
+    /// </summary>
+    /// <remarks>
+    /// Admin, matching <see cref="DeleteAsync"/>: this is the way back from it, and the two should
+    /// not need different people.
+    /// </remarks>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.MonitoringSetupChanged, TargetType = "monitoring_target")]
+    Task<bool> SetHiddenAsync(int id, bool hidden, CancellationToken ct = default);
 
     /// <summary>Renames a target. False when it no longer exists.</summary>
     /// <remarks>

--- a/src/NetworkOptimizer.Web/Services/IOntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/IOntMonitorService.cs
@@ -36,7 +36,7 @@ public interface IOntMonitorService
 
     /// <summary>Polls one ONT now and caches the result.</summary>
     [RequireRole(Roles.Viewer)]
-    Task<OntStats?> PollOntAsync(int ontId);
+    Task<(OntStats? stats, string? failureReason)> PollOntAsync(int ontId);
 
     /// <summary>Adds or updates an ONT configuration.</summary>
     [RequireRole(Roles.Admin)]

--- a/src/NetworkOptimizer.Web/Services/IStarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/IStarlinkMonitorService.cs
@@ -36,7 +36,7 @@ public interface IStarlinkMonitorService
 
     /// <summary>Polls one dish now and caches the result.</summary>
     [RequireRole(Roles.Viewer)]
-    Task PollStarlinkAsync(int id);
+    Task<(bool success, string message)> PollStarlinkAsync(int id);
 
     /// <summary>Adds or updates a Starlink configuration.</summary>
     [RequireRole(Roles.Admin)]

--- a/src/NetworkOptimizer.Web/Services/Monitoring/HttpFailureSummary.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/HttpFailureSummary.cs
@@ -1,0 +1,94 @@
+using System.Net;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Turns a failed device HTTP poll into one short line the reader can act on.
+/// <para>
+/// The HTTP counterpart of <see cref="Ssh.SshFailureSummary"/>, and it exists for the same
+/// reason: the framework's own text names the socket or the status code, which does not tell
+/// anyone whether the device is unreachable, refusing their password, or answering with
+/// something we cannot read. Those are the only three they can do anything about. The original
+/// text still goes to the log; this is what the UI says.
+/// </para>
+/// </summary>
+public static class HttpFailureSummary
+{
+    /// <summary>
+    /// Describe a transport failure - the request never produced a response.
+    /// </summary>
+    /// <param name="ex">The exception the request threw.</param>
+    /// <param name="host">The device address, for naming what could not be reached.</param>
+    public static string Describe(Exception? ex, string host)
+    {
+        var where = string.IsNullOrWhiteSpace(host) ? "the device" : host;
+
+        return ex switch
+        {
+            TaskCanceledException or OperationCanceledException => $"{where} did not answer in time. Check connectivity or firewall rules.",
+            HttpRequestException { StatusCode: { } status } => ForStatus(status, where),
+            HttpRequestException http => ForTransport(http, where),
+            _ => $"Could not read from {where}: {FirstLine(ex?.Message)}",
+        };
+    }
+
+    /// <summary>
+    /// Describe a response that arrived but was no use - a status the device should not have
+    /// returned, or a body that did not parse.
+    /// </summary>
+    /// <param name="status">The status code returned, or null when the body was the problem.</param>
+    /// <param name="host">The device address.</param>
+    public static string ForResponse(HttpStatusCode? status, string host)
+    {
+        var where = string.IsNullOrWhiteSpace(host) ? "the device" : host;
+        return status is { } code
+            ? ForStatus(code, where)
+            : $"{where} answered, but not with stats this optimizer can read.";
+    }
+
+    private static string ForStatus(HttpStatusCode status, string where) => status switch
+    {
+        HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden =>
+            $"{where} rejected the sign-in. Check the username and password saved for it.",
+        HttpStatusCode.NotFound =>
+            $"{where} answered, but not on the address this model is polled at. Check the model setting.",
+        HttpStatusCode.RequestTimeout or HttpStatusCode.GatewayTimeout =>
+            $"{where} did not answer in time.",
+        _ when (int)status >= 500 =>
+            $"{where} answered with an error of its own ({(int)status}). It may be starting up or overloaded.",
+        _ => $"{where} answered {(int)status}, which is not a reply this optimizer can use.",
+    };
+
+    /// <summary>
+    /// A transport failure with no status: nothing answered. The inner socket error separates a
+    /// host that refused the connection from one that is not there at all, which is the difference
+    /// between a wrong port and a wrong address.
+    /// </summary>
+    private static string ForTransport(HttpRequestException ex, string where)
+    {
+        var socket = ex.InnerException as System.Net.Sockets.SocketException
+            ?? ex.InnerException?.InnerException as System.Net.Sockets.SocketException;
+
+        return socket?.SocketErrorCode switch
+        {
+            System.Net.Sockets.SocketError.ConnectionRefused =>
+                $"{where} refused the connection. It is reachable, but nothing is listening on that port.",
+            System.Net.Sockets.SocketError.HostNotFound or System.Net.Sockets.SocketError.NoData =>
+                $"{where} could not be resolved.",
+            System.Net.Sockets.SocketError.TimedOut =>
+                $"{where} did not answer in time. Check connectivity or firewall rules.",
+            _ => $"Could not reach {where}.",
+        };
+    }
+
+    /// <summary>
+    /// The first line of a message, capped. Exception text can run to paragraphs, and the UI shows
+    /// this inline.
+    /// </summary>
+    private static string FirstLine(string? text)
+    {
+        const int maxLength = 160;
+        var line = (text ?? "").Split('\n', '\r').FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))?.Trim() ?? "";
+        return line.Length <= maxLength ? line : line[..maxLength] + "...";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -1499,9 +1499,10 @@ public class MonitoringCollectionAgent : BackgroundService
 
         // Reconcile fabric targets with the live device list — gateways, switches, and APs
         // should each have a `fabric` target on their management IP (spec 5.4). New devices
-        // add a target; deleted devices leave their targets untouched (history preserved).
-        // This runs even when an agent covers the site: the reconciled targets are what
-        // the tunnel pushes to the agent for probing from inside the network.
+        // add a target; a device that leaves the console, or moves to another address, has its
+        // target retired and (for a move) replaced. Rows are never deleted: their measurements
+        // are filed under the TargetId. This runs even when an agent covers the site: the
+        // reconciled targets are what the tunnel pushes to the agent for probing from inside.
         await ReconcileFabricTargetsAsync(ct);
 
         // Probing itself stands down for every non-default (external) site, agent or not. The
@@ -1513,9 +1514,11 @@ public class MonitoringCollectionAgent : BackgroundService
         if (!_isDefault || AgentOwnsProbing()) return;
 
         await using var db = await CreateSiteDbAsync(ct);
+        // Enabled is the user's intent; RetiredAt is ours. A retired target's address answers to
+        // nothing, so probing it spends a probe to record a loss that means nothing.
         var targets = await db.MonitoringTargets
             .AsNoTracking()
-            .Where(t => t.Enabled)
+            .Where(t => t.Enabled && t.RetiredAt == null)
             .ToListAsync(ct);
         var contextsById = await db.WanContexts.AsNoTracking().ToDictionaryAsync(c => c.Id, ct);
 
@@ -1744,10 +1747,15 @@ public class MonitoringCollectionAgent : BackgroundService
         // below also migrates existing targets seeded with the WAN IP.
         var gatewayLanIp = await ResolveGatewayLanIpAsync(ct);
 
+        // Presence is judged against the console's own device list, unfiltered. The monitorable
+        // list drops anything offline, and an AP rebooting is not an AP that was removed.
+        var knownMacs = await GetKnownDeviceMacsAsync(ct);
+
         await using var db = await CreateSiteDbAsync(ct);
-        var existingByTargetId = await db.MonitoringTargets
+        var allFabric = await db.MonitoringTargets
             .Where(t => t.TargetType == MonitoringTargetType.Fabric)
-            .ToDictionaryAsync(t => t.TargetId, ct);
+            .ToListAsync(ct);
+        var existingByTargetId = allFabric.ToDictionary(t => t.TargetId);
 
         var settings = await db.MonitoringSettings.FirstOrDefaultAsync(ct);
         var needsFlex25GMigration = settings != null && !settings.Flex25GLatencyMigrated;
@@ -1776,20 +1784,25 @@ public class MonitoringCollectionAgent : BackgroundService
             _logger.LogInformation("Flex 2.5G latency migration complete, disabled {Count} target(s)", disabled);
         }
 
+        // Live rows per device, so an address change can find the row it replaces without
+        // relying on the TargetId, which is fixed at creation and outlives the address.
+        var liveByMac = allFabric
+            .Where(t => !t.IsRetired && !string.IsNullOrEmpty(t.DeviceMac))
+            .GroupBy(t => t.DeviceMac!, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.OrdinalIgnoreCase);
+
         bool changed = false;
         foreach (var d in devices)
         {
             if (string.IsNullOrEmpty(d.Ip) || string.IsNullOrEmpty(d.Mac)) continue;
+            var mac = NormalizeMac(d.Mac);
             var address = ResolveSnmpAddress(d, gatewayLanIp);
-            var targetId = $"fabric-{NormalizeMac(d.Mac)}";
-            if (existingByTargetId.TryGetValue(targetId, out var existing))
+            var siblings = liveByMac.TryGetValue(mac, out var rows) ? rows : new List<MonitoringTarget>();
+            var current = siblings.FirstOrDefault(
+                t => string.Equals(t.Address, address, StringComparison.OrdinalIgnoreCase));
+
+            if (current != null)
             {
-                // Refresh address in case the device's management IP changed.
-                if (existing.Address != address)
-                {
-                    existing.Address = address;
-                    changed = true;
-                }
                 // Flex 2.5G switches are poor latency/loss targets (high RTT/jitter),
                 // so they're disabled by default. The one-shot Flex25GLatencyMigrated
                 // pass can miss an existing target if the device's model hadn't resolved
@@ -1797,38 +1810,214 @@ public class MonitoringCollectionAgent : BackgroundService
                 // Re-assert it here every reconcile so a missed target self-heals once
                 // the model is known. Only writes when currently enabled, so steady
                 // state is a no-op (no per-tick DB churn).
-                if (existing.AutoDiscovered && existing.Enabled
+                if (current.AutoDiscovered && current.Enabled
                     && UniFi.UniFiProductDatabase.IsFlex25G(d.Model, d.Shortname))
                 {
-                    existing.Enabled = false;
+                    current.Enabled = false;
                     changed = true;
                     _logger.LogInformation(
                         "Disabled latency probing for Flex 2.5G target {Name} ({Mac})",
-                        existing.Name, existing.DeviceMac);
+                        current.Name, current.DeviceMac);
                 }
                 continue;
             }
 
-            var enableLatency = !UniFi.UniFiProductDatabase.IsFlex25G(d.Model, d.Shortname);
-            db.MonitoringTargets.Add(new MonitoringTarget
+            // No live target on this address. Either the device is new, or it moved.
+            var predecessor = siblings.FirstOrDefault(t => t.AutoDiscovered);
+            var enableLatency = ReplacementEnabled(
+                predecessor, UniFi.UniFiProductDatabase.IsFlex25G(d.Model, d.Shortname));
+
+            if (predecessor != null)
             {
-                TargetId = targetId,
-                Name = string.IsNullOrEmpty(d.Name) ? d.Mac : d.Name,
-                Address = address,
-                ProbeMode = ProbeMode.Icmp,
-                TargetType = MonitoringTargetType.Fabric,
-                DeviceMac = NormalizeMac(d.Mac),
-                VantagePoint = "server",
-                PollIntervalSeconds = 5,
-                PingCount = 3,
-                Enabled = enableLatency,
-                AutoDiscovered = true,
-                AutoLabel = DescribeDeviceType(d.DeviceType),
-                CreatedAt = DateTime.UtcNow
-            });
+                // A gateway's target address is its LAN-side IP, and when that lookup has not
+                // answered yet ResolveSnmpAddress hands back UniFi's WAN public IP instead.
+                // Acting on that would retire a working target in favour of an address nothing
+                // on the LAN answers, so a gateway waits for a resolved LAN IP.
+                if (d.DeviceType == NetworkOptimizer.Core.Enums.DeviceType.Gateway
+                    && string.IsNullOrEmpty(gatewayLanIp))
+                    continue;
+
+                foreach (var stale in siblings.Where(t => t.AutoDiscovered))
+                    Retire(stale, $"Address changed to {address}");
+                changed = true;
+            }
+
+            // A device that comes back to an address it held before rejoins that row rather than
+            // starting a third one: the measurements under its TargetId were taken at this same
+            // address, so they are the same series.
+            var revived = allFabric.FirstOrDefault(
+                t => t.IsRetired
+                    && string.Equals(t.DeviceMac, mac, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(t.Address, address, StringComparison.OrdinalIgnoreCase));
+
+            if (revived != null)
+            {
+                // Comes back however the user last left it, not however a fresh target would start:
+                // a pause survives the round trip out of the console and back.
+                ApplyRevival(revived, fallbackEnabled: enableLatency);
+                if (UniFi.UniFiProductDatabase.IsFlex25G(d.Model, d.Shortname)) revived.Enabled = false;
+                revived.Name = string.IsNullOrEmpty(d.Name) ? d.Mac : d.Name;
+                _logger.LogInformation(
+                    "Fabric target {Name} ({Mac}) returned to {Address}; resuming its existing target",
+                    revived.Name, mac, address);
+            }
+            else
+            {
+                var created = new MonitoringTarget
+                {
+                    TargetId = NextFabricTargetId(mac, address, existingByTargetId),
+                    Name = string.IsNullOrEmpty(d.Name) ? d.Mac : d.Name,
+                    Address = address,
+                    ProbeMode = ProbeMode.Icmp,
+                    TargetType = MonitoringTargetType.Fabric,
+                    DeviceMac = mac,
+                    VantagePoint = "server",
+                    PollIntervalSeconds = predecessor?.PollIntervalSeconds ?? 5,
+                    PingCount = predecessor?.PingCount ?? 3,
+                    Enabled = enableLatency,
+                    AutoDiscovered = true,
+                    AutoLabel = DescribeDeviceType(d.DeviceType),
+                    LanFlakyHintDismissedAt = predecessor?.LanFlakyHintDismissedAt,
+                    // Carried with its original stamp, so a device that moves while removed stays
+                    // removed. Without it the replacement arrived back on the list as a paused row,
+                    // honouring the half of the user's intent about probing and dropping the half
+                    // about not wanting to see it. Null for every other predecessor, so this only
+                    // reaches a device that was removed before it moved.
+                    HiddenAt = predecessor?.HiddenAt,
+                    CreatedAt = DateTime.UtcNow
+                };
+                db.MonitoringTargets.Add(created);
+                existingByTargetId[created.TargetId] = created;
+            }
             changed = true;
         }
+
+        changed |= RetireDepartedDeviceTargets(allFabric, knownMacs);
+
         if (changed || needsFlex25GMigration) await db.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Retire the fabric targets of devices the console no longer lists at all. Skipped whenever
+    /// the device list could not be read: an empty answer is a console that did not respond, and
+    /// acting on it would retire every target on the site.
+    /// </summary>
+    private bool RetireDepartedDeviceTargets(List<MonitoringTarget> allFabric, HashSet<string>? knownMacs)
+    {
+        if (knownMacs == null || knownMacs.Count == 0) return false;
+
+        var changed = false;
+        foreach (var target in allFabric)
+        {
+            if (target.IsRetired || !target.AutoDiscovered) continue;
+            if (string.IsNullOrEmpty(target.DeviceMac)) continue;
+            if (knownMacs.Contains(target.DeviceMac)) continue;
+
+            Retire(target, "No longer in the UniFi device list");
+            changed = true;
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// Stop probing a target and record why, leaving the row in place so the measurements filed
+    /// under its TargetId stay resolvable.
+    /// </summary>
+    private void Retire(MonitoringTarget target, string reason)
+    {
+        ApplyRetirement(target, reason);
+        _logger.LogInformation(
+            "Retired fabric target {Name} ({Address}): {Reason}",
+            target.Name, target.Address, reason);
+    }
+
+    /// <summary>
+    /// The retirement state change, without the logging, so it can be tested as the pair it forms
+    /// with <see cref="ApplyRevival"/>.
+    /// <para>
+    /// Enabled is cleared because a dozen readers treat it as "is this row live" and would
+    /// otherwise count a retired target as active. It is remembered because Enabled is also where
+    /// a user's pause lives - see <see cref="MonitoringTarget.EnabledBeforeRetire"/>.
+    /// </para>
+    /// </summary>
+    internal static void ApplyRetirement(MonitoringTarget target, string reason)
+    {
+        target.EnabledBeforeRetire = target.Enabled;
+        target.Enabled = false;
+        target.RetiredAt = DateTime.UtcNow;
+        target.RetiredReason = reason;
+    }
+
+    /// <summary>
+    /// Whether a replacement target starts probing, carrying the predecessor's answer onto it so a
+    /// device that moves address keeps the state the user chose for it.
+    /// <para>
+    /// Reads through retirement deliberately. The replacement is decided in the same pass that
+    /// retires what it replaces, and retirement clears Enabled - so reading Enabled alone gives
+    /// false for every moved device, whatever the user had set. This asks the question in a way
+    /// that answers the same on either side of that.
+    /// </para>
+    /// </summary>
+    internal static bool ReplacementEnabled(MonitoringTarget? predecessor, bool isFlex25G)
+    {
+        if (isFlex25G) return false;
+        if (predecessor == null) return true;
+        return predecessor.EnabledBeforeRetire ?? predecessor.Enabled;
+    }
+
+    /// <summary>
+    /// Put a retired target back into service, restoring the enabled state retirement took from it.
+    /// </summary>
+    /// <param name="target">The retired row.</param>
+    /// <param name="fallbackEnabled">Used only for a row retired before the remembered value
+    /// existed, where there is nothing to restore.</param>
+    internal static void ApplyRevival(MonitoringTarget target, bool fallbackEnabled)
+    {
+        target.Enabled = target.EnabledBeforeRetire ?? fallbackEnabled;
+        target.EnabledBeforeRetire = null;
+        target.RetiredAt = null;
+        target.RetiredReason = null;
+    }
+
+    /// <summary>
+    /// A TargetId for a device's fabric target. The first one a device gets is bare, so existing
+    /// sites keep the ids their history is filed under; later addresses qualify it, because the
+    /// id is what the measurements are keyed by and cannot be reused for a different address.
+    /// </summary>
+    internal static string NextFabricTargetId(
+        string mac, string address, Dictionary<string, MonitoringTarget> taken)
+    {
+        var bare = $"fabric-{mac}";
+        if (!taken.ContainsKey(bare)) return bare;
+
+        var slug = address.Replace('.', '-').Replace(':', '-');
+        var candidate = $"fabric-{mac}-{slug}";
+        for (var n = 2; taken.ContainsKey(candidate); n++)
+            candidate = $"fabric-{mac}-{slug}-{n}";
+        return candidate;
+    }
+
+    /// <summary>
+    /// Every device MAC the console lists, adopted or not, online or not. Null when the list
+    /// could not be read, which callers must treat as "no answer" rather than "nothing there".
+    /// </summary>
+    private async Task<HashSet<string>?> GetKnownDeviceMacsAsync(CancellationToken ct)
+    {
+        if (!_connectionService.IsConnected || _connectionService.Client == null) return null;
+        try
+        {
+            var devices = await _connectionService.Client.GetDevicesAsync(ct);
+            if (devices == null || devices.Count == 0) return null;
+            return devices
+                .Where(d => !string.IsNullOrEmpty(d.Mac))
+                .Select(d => NormalizeMac(d.Mac))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Fabric reconcile: could not read the device list for presence");
+            return null;
+        }
     }
 
     // ---- Helpers ----

--- a/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringTargetService.cs
@@ -144,12 +144,39 @@ public class MonitoringTargetService : IMonitoringTargetService
         }
 
         _audit.SetTarget(row.TargetId, row.Name);
-        _audit.SetDetails(new { deleted = true, address = row.Address, targetType = row.TargetType.ToString() });
 
-        db.MonitoringTargets.Remove(row);
+        // A target that was probed has points filed under its TargetId, and this row is the only
+        // thing that maps that id to a name, an address and a device. Destroying it leaves the
+        // series unlabelled and unfindable, so it is hidden instead. Never probed means nothing to
+        // orphan, and a mistyped address should not be undeletable.
+        if (row.LastVerified != null)
+        {
+            _audit.SetDetails(new { hidden = true, address = row.Address, targetType = row.TargetType.ToString() });
+            row.HiddenAt = DateTime.UtcNow;
+            row.Enabled = false;
+        }
+        else
+        {
+            _audit.SetDetails(new { deleted = true, address = row.Address, targetType = row.TargetType.ToString() });
+            db.MonitoringTargets.Remove(row);
+        }
+
         await db.SaveChangesAsync(ct);
         return true;
     }
+
+    /// <inheritdoc />
+    public Task<bool> SetHiddenAsync(int id, bool hidden, CancellationToken ct = default) =>
+        UpdateAsync(id, ct, row =>
+        {
+            if (row.IsHidden == hidden) return null;
+            row.HiddenAt = hidden ? DateTime.UtcNow : null;
+            // Probing follows the listing, in both directions: removing a target stopped it, so
+            // putting it back starts it again rather than leaving a restored row silently paused.
+            // A retired one stays dark regardless - the probe paths gate on RetiredAt.
+            row.Enabled = !hidden;
+            return new { field = "HiddenAt", hidden };
+        });
 
     /// <inheritdoc />
     public Task<bool> SetNameAsync(int id, string name, CancellationToken ct = default)

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -120,7 +120,7 @@ public class OntMonitorService : IOntMonitorService, IDisposable
     /// <summary>
     /// Manually poll a single ONT by ID (used by UI refresh button).
     /// </summary>
-    public async Task<OntStats?> PollOntAsync(int ontId)
+    public async Task<(OntStats? stats, string? failureReason)> PollOntAsync(int ontId)
     {
         using var scope = CreateSiteScope();
         var repository = scope.ServiceProvider.GetRequiredService<IOntRepository>();
@@ -129,10 +129,16 @@ public class OntMonitorService : IOntMonitorService, IDisposable
         if (config == null)
         {
             _logger.LogWarning("Cannot poll ONT {Id}: configuration not found", ontId);
-            return null;
+            return (null, "That ONT is no longer configured.");
         }
 
-        return await PollSingleAsync(config, repository, await ResolveThresholdsAsync(scope));
+        var stats = await PollSingleAsync(config, repository, await ResolveThresholdsAsync(scope));
+        if (stats != null) return (stats, null);
+
+        // The poll has just written why to LastError; read it back rather than plumbing it out
+        // of a path the timer loop also uses.
+        var after = await repository.GetOntConfigurationAsync(ontId);
+        return (null, string.IsNullOrEmpty(after?.LastError) ? "The ONT returned no data." : after!.LastError);
     }
 
     /// <summary>
@@ -285,7 +291,8 @@ public class OntMonitorService : IOntMonitorService, IDisposable
 
         try
         {
-            var stats = await provider.PollAsync(context);
+            var result = await provider.PollAsync(context);
+            var stats = result.Stats;
             if (stats != null)
             {
                 // Persist only the poll result (never Enabled). If the config was disabled
@@ -314,14 +321,15 @@ public class OntMonitorService : IOntMonitorService, IDisposable
             }
             else
             {
-                await UpdateConfigErrorAsync(repository, config, "Poll returned no data");
+                await UpdateConfigErrorAsync(
+                    repository, config, result.FailureReason ?? "The ONT returned no data.");
                 return null;
             }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling ONT {Name} at {Host}", config.Name, config.Host);
-            await UpdateConfigErrorAsync(repository, config, ex.Message);
+            await UpdateConfigErrorAsync(repository, config, HttpFailureSummary.Describe(ex, config.Host));
             return null;
         }
     }

--- a/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/AttGatewayOntProvider.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -33,7 +34,7 @@ public class AttGatewayOntProvider : IOntProvider
     public string ProviderKey => "att-gateway";
     public string DisplayName => "AT&T Gateway (HTTP)";
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -42,7 +43,7 @@ public class AttGatewayOntProvider : IOntProvider
             if (baseUrl == null)
             {
                 _logger.LogWarning("Failed to reach AT&T gateway at {Host} via HTTP or HTTPS", context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var stats = new OntStats
@@ -57,7 +58,7 @@ public class AttGatewayOntProvider : IOntProvider
             if (fiberHtml == null)
             {
                 _logger.LogWarning("Failed to fetch fiberstat.ha from {Host}", context.ConfiguredHost ?? context.Host);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             ParseFiberStat(fiberHtml, stats);
@@ -74,12 +75,12 @@ public class AttGatewayOntProvider : IOntProvider
                 "AT&T gateway {Host} polled: Rx={RxPower} dBm, Tx={TxPower} dBm, {PonType}, BWP={Bwp} Mbps",
                 context.Host, stats.RxPowerDbm, stats.TxPowerDbm, stats.PonType, stats.BwpSpeedMbps);
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling AT&T gateway at {Host}", context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -107,11 +108,11 @@ public class AttGatewayOntProvider : IOntProvider
         }
         catch (HttpRequestException ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
-            return (false, "Connection timed out");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/GenericHttpOntProvider.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -21,13 +22,14 @@ public class GenericHttpOntProvider : IOntProvider
     public string ProviderKey => "generic-http-ont";
     public string DisplayName => "Generic HTTP ONT";
 
-    public Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         _logger.LogWarning(
             "Generic HTTP ONT provider cannot poll {Host} - needs configuration for a specific ONT model",
             context.Host);
 
-        return Task.FromResult<OntStats?>(null);
+        return Task.FromResult(PollResult<OntStats>.Failed(
+            "No ONT model is selected for this device, so there is nothing to poll."));
     }
 
     public async Task<(bool Success, string Message)> TestConnectionAsync(
@@ -63,11 +65,11 @@ public class GenericHttpOntProvider : IOntProvider
         }
         catch (HttpRequestException ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
-            return (false, "Connection timed out");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/Lantiq8311OntProvider.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -41,12 +42,12 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("8311 ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -58,7 +59,7 @@ public sealed class Lantiq8311OntProvider : IOntProvider
             if (!await LoginAsync(client, baseUrl, context, cancellationToken))
             {
                 _logger.LogWarning("8311 ONT {Name}: login failed", context.Name);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var json = await client.GetStringAsync($"{baseUrl}{GponStatusPath}", cancellationToken);
@@ -75,13 +76,13 @@ public sealed class Lantiq8311OntProvider : IOntProvider
                 stats.TemperatureC?.ToString("F1") ?? "-",
                 stats.PonType ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling 8311 ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -117,7 +118,7 @@ public sealed class Lantiq8311OntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -50,14 +51,16 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
     public string ProviderKey => "netopt-custom";
     public string DisplayName => "Network Optimizer Custom (HTTP JSON)";
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         var payload = await FetchPayloadAsync(context, cancellationToken);
-        if (payload == null) return null;
+        if (payload == null)
+            return PollResult<OntStats>.Failed(
+                $"No stats could be read from {context.ConfiguredHost ?? context.Host}.");
         var stats = MapToOntStats(payload);
         stats.DeviceHost = context.ConfiguredHost ?? context.Host;
         stats.DeviceName = context.Name;
-        return stats;
+        return PollResult<OntStats>.Ok(stats);
     }
 
     public async Task<PonSupplementalStats?> PollSupplementalAsync(
@@ -91,11 +94,11 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
         }
         catch (HttpRequestException ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
-            return (false, "Connection timed out");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -95,12 +96,12 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -112,7 +113,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
             if (stats is null)
             {
                 _logger.LogWarning("Nokia XS-010X-Q ONT {Name}: login failed", context.Name);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             _logger.LogDebug(
@@ -120,14 +121,14 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
                 context.Name, stats.RxPowerDbm?.ToString("F1") ?? "-",
                 stats.VendorSn ?? "-", stats.LinkState ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling Nokia XS-010X-Q ONT {Name} at {Host}",
                 context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -153,7 +154,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/QuantumQ1000kOntProvider.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -36,12 +37,12 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Quantum Q1000K ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -53,7 +54,7 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
             if (!await LoginAsync(client, baseUrl, context, cancellationToken))
             {
                 _logger.LogWarning("Quantum Q1000K ONT {Name}: login failed", context.Name);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var stats = new OntStats
@@ -80,13 +81,13 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
                 stats.TemperatureC?.ToString("F0") ?? "-",
                 stats.LinkState ?? "-", stats.PonType ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling Quantum Q1000K ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -125,7 +126,7 @@ public sealed class QuantumQ1000kOntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/RealtekOntProvider.cs
@@ -3,6 +3,7 @@ using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -25,12 +26,12 @@ public sealed class RealtekOntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Realtek ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -42,7 +43,7 @@ public sealed class RealtekOntProvider : IOntProvider
             if (!await LoginAsync(client, baseUrl, context, cancellationToken))
             {
                 _logger.LogWarning("Realtek ONT {Name}: login failed", context.Name);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             var ponHtml = await client.GetStringAsync($"{baseUrl}/status_pon.asp", cancellationToken);
@@ -56,13 +57,13 @@ public sealed class RealtekOntProvider : IOntProvider
                 stats.TxPowerDbm?.ToString("F1") ?? "-",
                 stats.TemperatureC?.ToString("F0") ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling Realtek ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -92,7 +93,7 @@ public sealed class RealtekOntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/TelekomModem2OntProvider.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -28,12 +29,12 @@ public sealed class TelekomModem2OntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Telekom Modem 2 ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -55,13 +56,13 @@ public sealed class TelekomModem2OntProvider : IOntProvider
                 context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
                 stats.TxPowerDbm?.ToString("F2") ?? "-", stats.LinkState ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
-        catch (OperationCanceledException) { throw; }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) { throw; }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling Telekom Modem 2 ONT {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -87,7 +88,7 @@ public sealed class TelekomModem2OntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/ZyxelGponSfpOntProvider.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Monitoring;
 
 namespace NetworkOptimizer.Web.Services.OntProviders;
 
@@ -50,12 +51,12 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
         _logger = logger;
     }
 
-    public async Task<OntStats?> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
+    public async Task<PollResult<OntStats>> PollAsync(OntPollContext context, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
             _logger.LogWarning("Zyxel GPON-SFP ONT poll requested but Host is empty (config {Id})", context.Id);
-            return null;
+            return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
         try
@@ -101,7 +102,7 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
                 _logger.LogWarning(
                     "Zyxel GPON-SFP ONT {Name}: get_gpon_info did not contain recognized PON status fields",
                     context.Name);
-                return null;
+                return PollResult<OntStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
             _logger.LogDebug(
@@ -109,7 +110,7 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
                 context.Name, stats.RxPowerDbm?.ToString("F2") ?? "-",
                 stats.TxPowerDbm?.ToString("F2") ?? "-", stats.LinkState ?? "-", stats.VendorSn ?? "-");
 
-            return stats;
+            return PollResult<OntStats>.Ok(stats);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -121,7 +122,7 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
             // token not cancelled) yields null per the IOntProvider contract, not an exception.
             _logger.LogWarning(ex, "Error polling Zyxel GPON-SFP ONT {Name} at {Host}",
                 context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            return PollResult<OntStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
     }
 
@@ -160,12 +161,12 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
             return (true,
                 $"Connected (HTTP) - RX: {stats.RxPowerDbm?.ToString("F2") ?? "?"} dBm, Link: {stats.LinkState ?? "?"}");
         }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested)
         {
             // HttpClient.Timeout elapsed - surfaces as a cancellation not tied to our token.
-            return (false, "Connection timed out");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             throw; // caller-requested cancellation
         }
@@ -175,7 +176,7 @@ public sealed class ZyxelGponSfpOntProvider : IOntProvider
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/Ssh/SshFailureSummary.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/SshFailureSummary.cs
@@ -1,0 +1,64 @@
+namespace NetworkOptimizer.Web.Services.Ssh;
+
+/// <summary>
+/// Turns an SSH failure into one short line the reader can act on.
+/// <para>
+/// SSH.NET names the socket or the protocol - "no identification string", "an established
+/// connection was aborted" - which does not tell anyone whether the device is unreachable or
+/// the credentials are wrong, and those are the only two things they can do anything about.
+/// The original text still goes to the log; this is what the UI says.
+/// </para>
+/// </summary>
+public static class SshFailureSummary
+{
+    /// <summary>
+    /// Describe an SSH failure in one sentence.
+    /// </summary>
+    /// <param name="sshOutput">The combined output or error text from the SSH layer.</param>
+    /// <param name="host">The device address, for naming what could not be reached.</param>
+    public static string Describe(string? sshOutput, string host)
+    {
+        var text = (sshOutput ?? string.Empty).Trim();
+        var where = string.IsNullOrWhiteSpace(host) ? "the device" : host;
+
+        if (text.Length == 0)
+            return $"No response from {where} over SSH.";
+
+        // Already a written-for-the-reader message; passing it through keeps the one place that
+        // knows why an agent site is dark from being paraphrased into something less useful.
+        if (text.Contains("on-site agent", StringComparison.OrdinalIgnoreCase))
+            return text;
+
+        if (text.Contains("credentials not configured", StringComparison.OrdinalIgnoreCase))
+            return "SSH credentials are not configured for this device.";
+
+        if (text.Contains("Authentication failed", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("No authentication method", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("permission denied", StringComparison.OrdinalIgnoreCase))
+            return $"SSH authentication was rejected by {where}. Check the SSH username and password.";
+
+        if (text.Contains("timed out", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("timeout", StringComparison.OrdinalIgnoreCase))
+            return $"{where} did not answer SSH in time. Check connectivity or firewall rules.";
+
+        if (text.Contains("Connection failed", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("could not reach", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("actively refused", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("unreachable", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("No such host", StringComparison.OrdinalIgnoreCase))
+            return $"Could not reach {where} over SSH.";
+
+        return FirstLine(text);
+    }
+
+    /// <summary>
+    /// The first line of a message, capped. Command output can run to pages, and the UI shows
+    /// this inline.
+    /// </summary>
+    private static string FirstLine(string text)
+    {
+        const int maxLength = 160;
+        var line = text.Split('\n', '\r').FirstOrDefault(l => !string.IsNullOrWhiteSpace(l))?.Trim() ?? text;
+        return line.Length <= maxLength ? line : line[..maxLength] + "...";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -140,16 +140,23 @@ public sealed class StarlinkMonitorService : IStarlinkMonitorService, IDisposabl
     /// <summary>
     /// Manually trigger a poll for a specific terminal.
     /// </summary>
-    public async Task PollStarlinkAsync(int id)
+    public async Task<(bool success, string message)> PollStarlinkAsync(int id)
     {
         var config = await GetConfigAsync(id);
         if (config == null)
         {
             _logger.LogWarning("PollStarlinkAsync called for unknown Starlink config {Id}", id);
-            return;
+            return (false, "That terminal is no longer configured.");
         }
 
         await PollSingleAsync(config);
+
+        // Read back rather than plumbing the reason out of the poll: the poll has just written
+        // it to LastError, and the timer loop that shares this path wants no return value.
+        var after = await GetConfigAsync(id);
+        return string.IsNullOrEmpty(after?.LastError)
+            ? (true, "Polled successfully.")
+            : (false, after!.LastError!);
     }
 
     /// <summary>
@@ -290,7 +297,8 @@ public sealed class StarlinkMonitorService : IStarlinkMonitorService, IDisposabl
 
         try
         {
-            var stats = await provider.PollAsync(context);
+            var result = await provider.PollAsync(context);
+            var stats = result.Stats;
 
             if (stats != null)
             {
@@ -307,13 +315,14 @@ public sealed class StarlinkMonitorService : IStarlinkMonitorService, IDisposabl
             }
             else
             {
-                await UpdateConfigErrorAsync(config.Id, "Poll returned no data");
+                await UpdateConfigErrorAsync(
+                    config.Id, result.FailureReason ?? "The terminal returned no data.");
             }
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error polling Starlink terminal {Name} ({Id})", config.Name, config.Id);
-            await UpdateConfigErrorAsync(config.Id, ex.Message);
+            await UpdateConfigErrorAsync(config.Id, HttpFailureSummary.Describe(ex, config.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
@@ -41,10 +41,11 @@ public class StarlinkGrpcProvider : IStarlinkProvider
 
     public string DisplayName => "Starlink (local gRPC)";
 
-    public async Task<StarlinkStats?> PollAsync(
+    public async Task<PollResult<StarlinkStats>> PollAsync(
         StarlinkPollContext context,
         CancellationToken cancellationToken = default)
     {
+        var host = context.ConfiguredHost ?? context.Host;
         try
         {
             using var channel = CreateChannel(context);
@@ -54,8 +55,9 @@ public class StarlinkGrpcProvider : IStarlinkProvider
             if (statusResp?.ResponseCase != Response.ResponseOneofCase.DishGetStatus)
             {
                 _logger.LogWarning("Starlink {Name} ({Host}): status poll returned {Case}",
-                    context.Name, context.ConfiguredHost ?? context.Host, statusResp?.ResponseCase);
-                return null;
+                    context.Name, host, statusResp?.ResponseCase);
+                return PollResult<StarlinkStats>.Failed(
+                    $"{host} answered, but not with dish status. Check that it is the Starlink dish and not a router in front of it.");
             }
 
             var status = statusResp.DishGetStatus;
@@ -84,15 +86,31 @@ public class StarlinkGrpcProvider : IStarlinkProvider
             }
 
             _lastPollUtc[context.Id] = stats.Timestamp;
-            return stats;
+            return PollResult<StarlinkStats>.Ok(stats);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Starlink {Name} ({Host}): poll failed",
-                context.Name, context.ConfiguredHost ?? context.Host);
-            return null;
+            _logger.LogWarning(ex, "Starlink {Name} ({Host}): poll failed", context.Name, host);
+            return PollResult<StarlinkStats>.Failed(DescribeGrpcFailure(ex, host));
         }
     }
+
+    /// <summary>
+    /// One line for a failed dish call. The dish serves gRPC with no authentication at all, so
+    /// unlike the HTTP devices there is no wrong-password case to tell apart - what is left is
+    /// whether anything answered, which is what the status code says.
+    /// </summary>
+    private static string DescribeGrpcFailure(Exception ex, string host) => ex switch
+    {
+        RpcException { StatusCode: StatusCode.Unavailable } =>
+            $"Could not reach {host}. The dish serves stats on its own address, which stays reachable even when the link is down.",
+        RpcException { StatusCode: StatusCode.DeadlineExceeded } =>
+            $"{host} did not answer in time. Check connectivity or firewall rules.",
+        RpcException { StatusCode: StatusCode.Unimplemented } =>
+            $"{host} answered, but does not serve the dish stats API. Check the address.",
+        RpcException rpc => $"{host} refused the request ({rpc.StatusCode}).",
+        _ => $"Could not read stats from {host}.",
+    };
 
     public async Task<StarlinkObstructionMap?> GetObstructionMapAsync(
         StarlinkPollContext context,
@@ -151,11 +169,11 @@ public class StarlinkGrpcProvider : IStarlinkProvider
         }
         catch (RpcException ex)
         {
-            return (false, $"gRPC error: {ex.Status.StatusCode} - {ex.Status.Detail}");
+            return (false, DescribeGrpcFailure(ex, context.ConfiguredHost ?? context.Host));
         }
         catch (Exception ex)
         {
-            return (false, $"Connection failed: {ex.Message}");
+            return (false, DescribeGrpcFailure(ex, context.ConfiguredHost ?? context.Host));
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -419,6 +419,16 @@ h1:focus {
     width: 100%;
 }
 
+.poll-error {
+    font-size: 0.8rem;
+    color: var(--danger-color);
+}
+
+.page-description-footnote {
+    margin-top: 0.75rem;
+    margin-left: 0.5rem;
+}
+
 .unstyled-link {
     color: inherit;
     text-decoration: none;
@@ -15712,10 +15722,17 @@ a.affected-client:hover {
     padding-right: 2rem;
 }
 
-.wan-filter-reset {
+.wan-filter-controls {
     position: absolute;
     right: 0;
     top: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.1rem;
+}
+
+.wan-filter-reset,
+.wan-filter-inactive {
     display: inline-flex;
     align-items: center;
     padding: 0.2rem 0.35rem;
@@ -15726,8 +15743,13 @@ a.affected-client:hover {
     cursor: pointer;
 }
 
-.wan-filter-reset:hover {
+.wan-filter-reset:hover,
+.wan-filter-inactive:hover {
     color: var(--text-primary);
+}
+
+.wan-filter-inactive.active {
+    color: var(--primary-color);
 }
 
 .monitoring-jump-btn {
@@ -15807,6 +15829,11 @@ a.affected-client:hover {
     border-color: #fff;
 }
 
+.wan-filter-badge.wan-badge-unprobed {
+    border-style: dashed;
+    color: var(--text-secondary);
+}
+
 #latency-charts-container .wan-filter-badge,
 #device-health-charts-container .wan-filter-badge,
 #sfp-charts-container .wan-filter-badge,
@@ -15818,7 +15845,8 @@ a.affected-client:hover {
     padding: 0.4rem 0.875rem;
 }
 
-.isp-chart-wrap .wan-filter-reset svg {
+.isp-chart-wrap .wan-filter-reset svg,
+.isp-chart-wrap .wan-filter-inactive svg {
     width: 16px;
     height: 16px;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -4,7 +4,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-filter.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-filter.js
@@ -15,6 +15,7 @@
  * the nine rows filter chart series; the port stats row filters cards, so it passes its own.
  */
 const RESERVED_CLASS = 'wan-filter-badges-reserved';
+const CONTROLS_CLASS = 'wan-filter-controls';
 
 /**
  * The standard clear-filter glyph: funnel with an X. Stroked, currentColor, 24 viewBox - the same
@@ -29,6 +30,18 @@ export const FILTER_RESET_SVG =
     + 'stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
     + '<path d="M3 5h14l-5.25 6.2V17l-3.5 1.75v-7.55z"/>'
     + '<path d="m16.5 16.5 4.5 4.5m0-4.5-4.5 4.5"/>'
+    + '</svg>';
+
+/**
+ * Inactive-series glyph: a plotted line that runs solid and then trails off in dashes, which is
+ * both what the control reveals and how those series are drawn once revealed. Same 24 viewBox and
+ * stroke weight as the funnel above, so the two sit together as one set.
+ */
+export const INACTIVE_SERIES_SVG =
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+    + 'stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    + '<path d="M3 15.5 8.5 9.5l4 4"/>'
+    + '<path d="m12.5 13.5 8-7" stroke-dasharray="2.4 2.7"/>'
     + '</svg>';
 
 /// Do the two rectangles share any area at all.
@@ -79,36 +92,104 @@ function place(container, btn) {
     btn.style.top = `${rows[0]}px`;
 }
 
-export function renderFilterReset(container, isFiltered, onReset, label = 'Clear series filter') {
-    if (!container) return;
+/**
+ * The controls sit in one absolutely-positioned wrapper rather than each placing itself, because
+ * `place` reasons about a single rectangle: two independently placed buttons would each dodge the
+ * chips and then land on each other. The wrapper is created on demand and removed once it holds
+ * nothing, so a row with no controls is exactly as it was before either existed.
+ */
+function controls(container, create) {
+    let el = container.querySelector(`.${CONTROLS_CLASS}`);
+    if (!el && create) {
+        el = document.createElement('div');
+        el.className = CONTROLS_CLASS;
+        container.appendChild(el);
+    }
+    return el;
+}
 
-    const existing = container.querySelector('.wan-filter-reset');
-    if (!isFiltered) {
-        existing?.remove();
+/// Drop the wrapper once it is empty, and give the row its gutter back with it.
+function pruneControls(container) {
+    const el = container.querySelector(`.${CONTROLS_CLASS}`);
+    if (el && !el.childElementCount) {
+        el.remove();
         container.classList.remove(RESERVED_CLASS);
-        return;
     }
-    // Already there: the row may still have reflowed under it (a tab shown, the window resized,
-    // a series come or gone), so the placement is redone rather than left as it was.
-    if (existing) {
-        place(container, existing);
-        return;
-    }
+}
 
+function makeButton(className, svg, label, onClick) {
     const btn = document.createElement('button');
     btn.type = 'button';
-    btn.className = 'wan-filter-reset';
-    btn.innerHTML = FILTER_RESET_SVG;
+    btn.className = className;
+    btn.innerHTML = svg;
     btn.setAttribute('aria-label', label);
     btn.setAttribute('data-tooltip', label);
     btn.addEventListener('click', (e) => {
         // The row itself carries a delegated chip handler. This is not a chip, so that handler
         // ignores it anyway - stopping here keeps it from having to know that.
         e.stopPropagation();
-        onReset();
+        onClick();
     });
-    container.appendChild(btn);
-    place(container, btn);
+    return btn;
+}
+
+export function renderFilterReset(container, isFiltered, onReset, label = 'Clear series filter') {
+    if (!container) return;
+
+    const existing = container.querySelector('.wan-filter-reset');
+    if (!isFiltered) {
+        existing?.remove();
+        pruneControls(container);
+        return;
+    }
+    // Already there: the row may still have reflowed under it (a tab shown, the window resized,
+    // a series come or gone), so the placement is redone rather than left as it was.
+    if (existing) {
+        place(container, controls(container, true));
+        return;
+    }
+
+    const wrap = controls(container, true);
+    wrap.appendChild(makeButton('wan-filter-reset', FILTER_RESET_SVG, label, onReset));
+    place(container, wrap);
+}
+
+/**
+ * Include the series nothing is probing any more - retired, removed and paused alike.
+ *
+ * Conditional on there being any, so the control never appears on the ordinary case where every
+ * target is live and pressing it could only ever be a no-op. Unlike the reset beside it, this one
+ * changes what the server returns rather than what is visible, so the caller refetches.
+ */
+export function renderInactiveToggle(container, hasInactive, isOn, onToggle) {
+    if (!container) return;
+
+    const existing = container.querySelector('.wan-filter-inactive');
+    if (!hasInactive) {
+        existing?.remove();
+        pruneControls(container);
+        return;
+    }
+
+    const label = isOn ? 'Hide inactive series' : 'Show inactive series';
+    if (existing) {
+        existing.classList.toggle('active', isOn);
+        existing.setAttribute('aria-label', label);
+        existing.setAttribute('data-tooltip', label);
+        existing.setAttribute('aria-pressed', String(isOn));
+        place(container, controls(container, true));
+        return;
+    }
+
+    const btn = makeButton('wan-filter-inactive', INACTIVE_SERIES_SVG, label, onToggle);
+    btn.classList.toggle('active', isOn);
+    btn.setAttribute('aria-pressed', String(isOn));
+
+    // Ahead of the reset, so the reset keeps the corner it has always occupied and this one does
+    // not move as the reset comes and goes.
+    const wrap = controls(container, true);
+    wrap.insertBefore(btn, wrap.firstChild);
+    place(container, wrap);
 }
 
 /// True when at least one entry has been switched off, which is what makes a reset meaningful.

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -1,4 +1,4 @@
-import { isFiltered, FILTER_RESET_SVG } from './chart-filter.js?v=5';
+import { isFiltered, FILTER_RESET_SVG } from './chart-filter.js?v=6';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -4,7 +4,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -4,7 +4,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=2';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';

--- a/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/isp-health-charts.js
@@ -4,7 +4,7 @@
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 
 const PALETTE = ['#2ba89a', '#3b82f6', '#a78bfa', '#ef5858', '#f59e0b', '#10b981'];
 const POLL_MS = 60000;

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -7,7 +7,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, renderInactiveToggle, isFiltered } from './chart-filter.js?v=6';
 import { downloadColor, uploadColor } from './chart-colors.js?v=2';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';
@@ -28,6 +28,18 @@ function hashColor(id) {
     _colorCache[id] = PALETTE[idx];
     return PALETTE[idx];
 }
+/**
+ * The same colour, faded, for a series nothing is probing any more. Keeping the hue is the point:
+ * a host's retired line and its live replacement have to read as the same host, so only the
+ * strength changes. Palette entries are #rrggbb, and anything else is returned untouched.
+ */
+function dimmed(hex) {
+    const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex ?? '');
+    if (!m) return hex;
+    const [r, g, b] = m.slice(1).map(h => parseInt(h, 16));
+    return `rgba(${r}, ${g}, ${b}, 0.4)`;
+}
+
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
 const POLL_INTERVALS = { 0: 5000, 1: 5000, 6: 10000, 24: 15000, 168: 30000, 720: 30000 };
@@ -51,6 +63,11 @@ let visibilityObserver = null;
 let isInViewport = true;
 let lastFetchData = null;
 let savedState = null;
+// Whether the fetch asks for the series nothing is probing any more, and how many of them this
+// category has. The count comes back on every response, including one that excluded them, because
+// it is what decides whether the control to ask for them is offered at all.
+let showInactive = false;
+let inactiveCount = 0;
 // Per-WAN scope, set by Blazor (which owns the WAN pill bar and its visibility gate).
 // null = no scoping at all: single-WAN sites never reach this code path and render
 // exactly as before. Shape: { primaryKey, selected: [wanKey...], tokens: {key: 'WAN1'} };
@@ -277,6 +294,7 @@ function buildQueryParams() {
             params = `category=${currentCategory}&from=${from.toISOString()}&to=${to.toISOString()}`;
         }
     }
+    if (showInactive) params += '&includeInactive=true';
     return params;
 }
 
@@ -299,11 +317,20 @@ function renderBadges(container) {
     const el = container.querySelector('.latency-filter-badges');
     if (el) el.dataset.tour = 'chart-series-filter';
     if (!el) return;
-    if (badgeGroups().length <= 1) { el.innerHTML = ''; return; }
+    if (badgeGroups().length <= 1) {
+        // Still offer the toggle: a category whose every target has been retired draws no chips at
+        // all, and without this there would be no way to ask for the ones that are missing.
+        el.innerHTML = '';
+        renderInactiveToggle(el, inactiveCount > 0, showInactive, toggleInactive);
+        return;
+    }
 
     el.innerHTML = badgeGroups().map(g => {
         const vis = g.ids.some(id => visibility[id] !== false);
-        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}" data-target="${escapeHtml(g.key)}">
+        // The chip's own `inactive` class already means "filtered off by this row", so the
+        // not-probed state needs its own name here even though the control calls it inactive.
+        const unprobed = g.unprobed ? ' wan-badge-unprobed' : '';
+        return `<button class="wan-filter-badge ${vis ? 'active' : 'inactive'}${unprobed}" data-target="${escapeHtml(g.key)}">
             <span class="wan-badge-dot" style="background-color: ${g.color}"></span>
             <span>${escapeHtml(g.key)}</span>
         </button>`;
@@ -345,13 +372,26 @@ function renderBadges(container) {
         });
     }
 
-    // Last: the chip rebuild above wipes the row, so the reset is re-added after it.
+    // Last: the chip rebuild above wipes the row, so both controls are re-added after it.
+    renderInactiveToggle(el, inactiveCount > 0, showInactive, toggleInactive);
     renderFilterReset(el, isFiltered(visibility), () => {
         visibility = {};
         updateChartVisibility();
         renderBadges(container);
         if (lastFetchData) renderStatsTable(container, false);
     });
+}
+
+/**
+ * Ask the server for the series nothing is probing, or stop asking. Unlike the reset beside it
+ * this changes what comes back rather than what is drawn, so it reloads instead of redrawing.
+ */
+function toggleInactive() {
+    showInactive = !showInactive;
+    // Visibility is keyed by target id, and the ids on the way in are ones it has never seen.
+    // Left alone they would arrive hidden if the user had soloed something earlier.
+    if (showInactive) visibility = {};
+    loadAndUpdate();
 }
 
 // One entry per host, in the order its series first appear, carrying every series id that host
@@ -361,7 +401,10 @@ function badgeGroups() {
     const byHost = new Map();
     targetMeta.forEach(t => {
         const key = t.hostName ?? t.name;
-        if (!byHost.has(key)) byHost.set(key, { key, color: t.color, ids: [] });
+        // A host is shown as not-probed only when every series it owns is: a host with a retired
+        // target and a live replacement is still being probed, and saying otherwise would be wrong.
+        if (!byHost.has(key)) byHost.set(key, { key, color: t.color, ids: [], unprobed: true });
+        if (!t.inactive) byHost.get(key).unprobed = false;
         byHost.get(key).ids.push(t.id);
     });
     return [...byHost.values()];
@@ -379,7 +422,9 @@ function updateChartVisibility() {
 
     const seriesOf = key => shown.map(t => ({
         name: wanDisplayName(t),
-        color: hashColor(t.name),
+        // Faded rather than dashed for the ones nothing is probing: the dash pattern already says
+        // which WAN a series belongs to in comparison mode, and one pattern cannot mean two things.
+        color: t.inactive ? dimmed(hashColor(t.name)) : hashColor(t.name),
         data: (t[key] || []).map(p => ({ x: new Date(p.time).getTime(), y: p.value })),
     }));
 
@@ -486,11 +531,14 @@ async function loadAndUpdate() {
     // are what tells them apart in comparison mode.
     const scopedTargets = filterTargetsToWanScope(data.targets);
 
+    inactiveCount = data.inactiveCount ?? 0;
+
     targetMeta = scopedTargets.map(t => ({
         id: t.targetId,
         name: wanDisplayName(t),
         hostName: t.name,
         color: hashColor(t.name),
+        inactive: t.inactive === true,
     }));
 
     lastFetchData = { ...data, targets: scopedTargets };
@@ -1039,6 +1087,10 @@ export function setCategory(cat) {
         });
     }
     visibility = {};
+    // Each category answers "are there any inactive series" for itself, so asking for them does
+    // not follow the reader from one tab to the next.
+    showInactive = false;
+    inactiveCount = 0;
     loadAndUpdate();
     startPoll();
 }
@@ -1074,6 +1126,8 @@ export function unmount() {
     customTo = null;
     lastFetchData = null;
     savedState = null;
+    showInactive = false;
+    inactiveCount = 0;
     investigateMarker = null;
     isInViewport = true;
     wanScope = null;

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -4,7 +4,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=2';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -3,7 +3,7 @@
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
 import { renderStatsTable as renderTable } from './chart-stats.js?v=7';
-import { renderFilterReset } from './chart-filter.js?v=5';
+import { renderFilterReset } from './chart-filter.js?v=6';
 
 const _esc = document.createElement('span');
 function escapeHtml(s) { _esc.textContent = s == null ? '' : String(s); return _esc.innerHTML; }

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -4,7 +4,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=2';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -5,7 +5,7 @@
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=14';
-import { renderFilterReset, isFiltered } from './chart-filter.js?v=5';
+import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 

--- a/tests/NetworkOptimizer.Web.Tests/HttpFailureSummaryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/HttpFailureSummaryTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Sockets;
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// The line this produces is what the stats panel and the Settings test button show, and it backs
+/// every HTTP device provider. The point of each case is that the reader can tell an unreachable
+/// device from one refusing their password from one answering with something unreadable.
+/// </summary>
+public class HttpFailureSummaryTests
+{
+    private const string Host = "192.0.2.10";
+
+    private static HttpRequestException WithStatus(HttpStatusCode status)
+        => new("request failed", null, status);
+
+    private static HttpRequestException WithSocket(SocketError error)
+        => new("request failed", new SocketException((int)error));
+
+    // A client timeout surfaces as TaskCanceledException, which derives from
+    // OperationCanceledException, so both must land on the timeout line rather than the
+    // catch-all.
+    [Fact]
+    public void Describe_TaskCanceled_ReadsAsTimeout()
+    {
+        HttpFailureSummary.Describe(new TaskCanceledException(), Host)
+            .Should().Be($"{Host} did not answer in time. Check connectivity or firewall rules.");
+    }
+
+    [Fact]
+    public void Describe_OperationCanceled_ReadsAsTimeout()
+    {
+        HttpFailureSummary.Describe(new OperationCanceledException(), Host)
+            .Should().Be($"{Host} did not answer in time. Check connectivity or firewall rules.");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.Forbidden)]
+    public void Describe_AuthStatuses_PointAtTheSavedCredentials(HttpStatusCode status)
+    {
+        HttpFailureSummary.Describe(WithStatus(status), Host)
+            .Should().Be($"{Host} rejected the sign-in. Check the username and password saved for it.");
+    }
+
+    // A 404 means something answered, so the address is right and the model setting is not.
+    [Fact]
+    public void Describe_NotFound_PointsAtTheModelSetting()
+    {
+        HttpFailureSummary.Describe(WithStatus(HttpStatusCode.NotFound), Host)
+            .Should().Be($"{Host} answered, but not on the address this model is polled at. Check the model setting.");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.RequestTimeout)]
+    [InlineData(HttpStatusCode.GatewayTimeout)]
+    public void Describe_TimeoutStatuses_ReadAsTimeout(HttpStatusCode status)
+    {
+        HttpFailureSummary.Describe(WithStatus(status), Host).Should().Be($"{Host} did not answer in time.");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.InternalServerError, 500)]
+    [InlineData(HttpStatusCode.ServiceUnavailable, 503)]
+    public void Describe_ServerErrors_BlameTheDevice(HttpStatusCode status, int code)
+    {
+        HttpFailureSummary.Describe(WithStatus(status), Host)
+            .Should().Be($"{Host} answered with an error of its own ({code}). It may be starting up or overloaded.");
+    }
+
+    [Fact]
+    public void Describe_OtherStatus_NamesTheCode()
+    {
+        HttpFailureSummary.Describe(WithStatus(HttpStatusCode.BadRequest), Host)
+            .Should().Be($"{Host} answered 400, which is not a reply this optimizer can use.");
+    }
+
+    // Refused and unresolved are the difference between a wrong port and a wrong address, which is
+    // the whole reason the socket error is dug out.
+    [Fact]
+    public void Describe_ConnectionRefused_SaysNothingIsListening()
+    {
+        HttpFailureSummary.Describe(WithSocket(SocketError.ConnectionRefused), Host)
+            .Should().Be($"{Host} refused the connection. It is reachable, but nothing is listening on that port.");
+    }
+
+    [Theory]
+    [InlineData(SocketError.HostNotFound)]
+    [InlineData(SocketError.NoData)]
+    public void Describe_UnresolvableHost_SaysSo(SocketError error)
+    {
+        HttpFailureSummary.Describe(WithSocket(error), Host).Should().Be($"{Host} could not be resolved.");
+    }
+
+    [Fact]
+    public void Describe_SocketTimeout_ReadsAsTimeout()
+    {
+        HttpFailureSummary.Describe(WithSocket(SocketError.TimedOut), Host)
+            .Should().Be($"{Host} did not answer in time. Check connectivity or firewall rules.");
+    }
+
+    [Fact]
+    public void Describe_UnrecognizedSocketError_FallsBackToUnreachable()
+    {
+        HttpFailureSummary.Describe(WithSocket(SocketError.NetworkDown), Host)
+            .Should().Be($"Could not reach {Host}.");
+    }
+
+    // HttpClient wraps the socket error one level deeper on some paths, so both depths resolve.
+    [Fact]
+    public void Describe_NestedSocketError_IsStillFound()
+    {
+        var nested = new HttpRequestException(
+            "outer",
+            new IOException("inner", new SocketException((int)SocketError.ConnectionRefused)));
+
+        HttpFailureSummary.Describe(nested, Host)
+            .Should().Be($"{Host} refused the connection. It is reachable, but nothing is listening on that port.");
+    }
+
+    [Fact]
+    public void Describe_TransportFailureWithNoSocketError_FallsBackToUnreachable()
+    {
+        HttpFailureSummary.Describe(new HttpRequestException("no inner"), Host)
+            .Should().Be($"Could not reach {Host}.");
+    }
+
+    // Anything that is not a transport failure at all (a parse error, say) keeps its own text,
+    // because there is nothing more specific to say about it.
+    [Fact]
+    public void Describe_NonHttpException_KeepsItsMessage()
+    {
+        HttpFailureSummary.Describe(new InvalidOperationException("stats payload was not JSON"), Host)
+            .Should().Be($"Could not read from {Host}: stats payload was not JSON");
+    }
+
+    [Fact]
+    public void Describe_NullException_DoesNotThrow()
+    {
+        HttpFailureSummary.Describe(null, Host).Should().Be($"Could not read from {Host}: ");
+    }
+
+    // This renders inline on a card, so a multi-line or runaway exception cannot be passed through
+    // whole.
+    [Fact]
+    public void Describe_MultiLineMessage_KeepsOnlyTheFirstLine()
+    {
+        var ex = new InvalidOperationException("first line\r\nsecond line\r\nthird line");
+
+        HttpFailureSummary.Describe(ex, Host).Should().Be($"Could not read from {Host}: first line");
+    }
+
+    [Fact]
+    public void Describe_LongMessage_IsCapped()
+    {
+        var ex = new InvalidOperationException(new string('x', 500));
+
+        var result = HttpFailureSummary.Describe(ex, Host);
+
+        result.Should().Be($"Could not read from {Host}: {new string('x', 160)}...");
+    }
+
+    [Fact]
+    public void Describe_MessageAtTheCap_IsNotTruncated()
+    {
+        var ex = new InvalidOperationException(new string('x', 160));
+
+        HttpFailureSummary.Describe(ex, Host).Should().Be($"Could not read from {Host}: {new string('x', 160)}");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Describe_WithoutAHost_NamesTheDeviceGenerically(string host)
+    {
+        HttpFailureSummary.Describe(new HttpRequestException("no inner"), host)
+            .Should().Be("Could not reach the device.");
+    }
+
+    [Fact]
+    public void ForResponse_WithoutAStatus_BlamesTheBody()
+    {
+        HttpFailureSummary.ForResponse(null, Host)
+            .Should().Be($"{Host} answered, but not with stats this optimizer can read.");
+    }
+
+    // A response that arrived carries the same status wording as a thrown one, so the reader is
+    // not told two different things about the same 401.
+    [Fact]
+    public void ForResponse_WithAStatus_MatchesDescribe()
+    {
+        HttpFailureSummary.ForResponse(HttpStatusCode.Unauthorized, Host)
+            .Should().Be(HttpFailureSummary.Describe(WithStatus(HttpStatusCode.Unauthorized), Host));
+    }
+
+    [Fact]
+    public void ForResponse_WithoutAHost_NamesTheDeviceGenerically()
+    {
+        HttpFailureSummary.ForResponse(null, "")
+            .Should().Be("the device answered, but not with stats this optimizer can read.");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Identity/MonitoringGatedServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Identity/MonitoringGatedServiceTests.cs
@@ -47,7 +47,7 @@ public class MonitoringGatedServiceTests : IDisposable
 
     private MonitoringSettingsService Settings() => new(_factory, _siteContext, _audit);
 
-    private async Task<int> SeedTargetAsync(bool enabled = true, int interval = 10)
+    private async Task<int> SeedTargetAsync(bool enabled = true, int interval = 10, bool everProbed = false)
     {
         await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
         var target = new MonitoringTarget
@@ -61,6 +61,7 @@ public class MonitoringGatedServiceTests : IDisposable
             PingCount = 5,
             Enabled = enabled,
             VantagePoint = "server",
+            LastVerified = everProbed ? DateTime.UtcNow.AddMinutes(-5) : null,
             CreatedAt = DateTime.UtcNow
         };
         db.MonitoringTargets.Add(target);
@@ -106,7 +107,49 @@ public class MonitoringGatedServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task Deleting_a_target_names_it_before_it_disappears()
+    public async Task Removing_a_probed_target_keeps_the_row_that_names_its_series()
+    {
+        var id = await SeedTargetAsync(everProbed: true);
+
+        (await Targets().DeleteAsync(id)).Should().BeTrue();
+
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var row = await db.MonitoringTargets.FindAsync(id);
+        row.Should().NotBeNull("its measurements are filed under its TargetId and nothing else names them");
+        row!.IsHidden.Should().BeTrue();
+        row.Enabled.Should().BeFalse("removing a target stops it being probed, however the row is kept");
+        row.TargetId.Should().Be("custom-seed");
+        row.Address.Should().Be("192.0.2.10");
+    }
+
+    [Fact]
+    public async Task A_removed_target_can_be_put_back_and_starts_probing_again()
+    {
+        var id = await SeedTargetAsync(everProbed: true);
+        await Targets().DeleteAsync(id);
+        _audit.Drain();
+
+        (await Targets().SetHiddenAsync(id, false)).Should().BeTrue();
+
+        _audit.Drain().Suppressed.Should().BeFalse();
+        await using var db = _factory.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+        var row = await db.MonitoringTargets.FindAsync(id);
+        row!.IsHidden.Should().BeFalse();
+        row.Enabled.Should().BeTrue("removing it stopped the probing, so restoring it starts again");
+    }
+
+    [Fact]
+    public async Task Restoring_a_target_that_is_already_listed_writes_no_event()
+    {
+        var id = await SeedTargetAsync(everProbed: true);
+
+        (await Targets().SetHiddenAsync(id, false)).Should().BeTrue();
+
+        _audit.Drain().Suppressed.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Deleting_a_target_that_never_probed_names_it_before_it_disappears()
     {
         var id = await SeedTargetAsync();
 

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/FabricTargetIdTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/FabricTargetIdTests.cs
@@ -1,0 +1,50 @@
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+public class FabricTargetIdTests
+{
+    private const string Mac = "aa:bb:cc:dd:ee:ff";
+
+    private static Dictionary<string, MonitoringTarget> Taken(params string[] ids) =>
+        ids.ToDictionary(id => id, id => new MonitoringTarget { TargetId = id });
+
+    [Fact]
+    public void FirstTargetForADeviceKeepsTheBareId()
+    {
+        Assert.Equal($"fabric-{Mac}", MonitoringCollectionAgent.NextFabricTargetId(Mac, "192.0.2.10", Taken()));
+    }
+
+    [Fact]
+    public void SecondAddressIsQualifiedByThatAddress()
+    {
+        var id = MonitoringCollectionAgent.NextFabricTargetId(Mac, "192.0.2.20", Taken($"fabric-{Mac}"));
+        Assert.Equal($"fabric-{Mac}-192-0-2-20", id);
+    }
+
+    [Fact]
+    public void AnAddressAlreadySpokenForGetsACounter()
+    {
+        var id = MonitoringCollectionAgent.NextFabricTargetId(
+            Mac, "192.0.2.20", Taken($"fabric-{Mac}", $"fabric-{Mac}-192-0-2-20"));
+        Assert.Equal($"fabric-{Mac}-192-0-2-20-2", id);
+    }
+
+    [Fact]
+    public void IdsStayUniqueAcrossRepeatedCollisions()
+    {
+        var taken = Taken($"fabric-{Mac}", $"fabric-{Mac}-192-0-2-20", $"fabric-{Mac}-192-0-2-20-2");
+        var id = MonitoringCollectionAgent.NextFabricTargetId(Mac, "192.0.2.20", taken);
+        Assert.Equal($"fabric-{Mac}-192-0-2-20-3", id);
+    }
+
+    [Fact]
+    public void IPv6AddressesProduceAnIdWithNoColons()
+    {
+        var id = MonitoringCollectionAgent.NextFabricTargetId(Mac, "2001:db8::1", Taken($"fabric-{Mac}"));
+        Assert.DoesNotContain(':', id[$"fabric-".Length..].Replace(Mac, ""));
+        Assert.Equal($"fabric-{Mac}-2001-db8--1", id);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/RetiredTargetProbeGateTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/RetiredTargetProbeGateTests.cs
@@ -1,0 +1,125 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Retirement clears Enabled, because a dozen readers treat that column as "is this row live".
+/// Enabled is also where a user's pause lives, so it is remembered and handed back on revival -
+/// without that, a target the user had paused came back probing once its device left the console
+/// and returned.
+/// </summary>
+public class RetiredTargetProbeGateTests
+{
+    private static MonitoringTarget Target(bool enabled) => new()
+    {
+        TargetId = "fabric-aa:bb:cc:dd:ee:ff",
+        Name = "Switch",
+        Address = "192.0.2.10",
+        TargetType = MonitoringTargetType.Fabric,
+        Enabled = enabled,
+    };
+
+    /// <summary>The predicate both probe paths apply.</summary>
+    private static bool WouldBeProbed(MonitoringTarget t) => t.Enabled && t.RetiredAt == null;
+
+    [Fact]
+    public void Retiring_stops_the_probing_and_reads_as_inactive_to_an_Enabled_only_reader()
+    {
+        var target = Target(enabled: true);
+
+        MonitoringCollectionAgent.ApplyRetirement(target, "No longer in the UniFi device list");
+
+        target.Enabled.Should().BeFalse("readers that filter on Enabled alone must not count it as active");
+        target.RetiredAt.Should().NotBeNull();
+        WouldBeProbed(target).Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_target_the_user_had_running_comes_back_running()
+    {
+        var target = Target(enabled: true);
+
+        MonitoringCollectionAgent.ApplyRetirement(target, "Address changed to 192.0.2.20");
+        MonitoringCollectionAgent.ApplyRevival(target, fallbackEnabled: true);
+
+        target.Enabled.Should().BeTrue();
+        target.RetiredAt.Should().BeNull();
+        target.RetiredReason.Should().BeNull();
+        target.EnabledBeforeRetire.Should().BeNull("the remembered value has been handed back and is spent");
+        WouldBeProbed(target).Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_target_the_user_had_paused_comes_back_paused()
+    {
+        var target = Target(enabled: false);
+
+        MonitoringCollectionAgent.ApplyRetirement(target, "No longer in the UniFi device list");
+        // fallbackEnabled is what a brand-new target would get; the remembered pause must beat it.
+        MonitoringCollectionAgent.ApplyRevival(target, fallbackEnabled: true);
+
+        target.Enabled.Should().BeFalse("the pause was the user's and nothing in that round trip was entitled to clear it");
+        WouldBeProbed(target).Should().BeFalse();
+    }
+
+    [Fact]
+    public void A_replacement_inherits_the_state_its_predecessor_was_in_before_being_retired()
+    {
+        // The order the reconcile actually runs in: the predecessor is retired, and only then is
+        // the replacement's state decided from it. Reading Enabled at that point gives false for
+        // every moved device - which shipped once, and is what this pins down.
+        var predecessor = Target(enabled: true);
+        MonitoringCollectionAgent.ApplyRetirement(predecessor, "Address changed to 192.0.2.20");
+
+        MonitoringCollectionAgent.ReplacementEnabled(predecessor, isFlex25G: false)
+            .Should().BeTrue("the user had it running, so its replacement runs");
+    }
+
+    [Fact]
+    public void A_replacement_of_a_paused_target_starts_paused()
+    {
+        var predecessor = Target(enabled: false);
+        MonitoringCollectionAgent.ApplyRetirement(predecessor, "Address changed to 192.0.2.20");
+
+        MonitoringCollectionAgent.ReplacementEnabled(predecessor, isFlex25G: false).Should().BeFalse();
+    }
+
+    [Fact]
+    public void The_inherited_state_is_the_same_whether_it_is_read_before_or_after_retirement()
+    {
+        var before = Target(enabled: true);
+        var after = Target(enabled: true);
+        MonitoringCollectionAgent.ApplyRetirement(after, "Address changed to 192.0.2.20");
+
+        MonitoringCollectionAgent.ReplacementEnabled(after, isFlex25G: false)
+            .Should().Be(MonitoringCollectionAgent.ReplacementEnabled(before, isFlex25G: false),
+                "reordering the retire and the decision must not change the answer");
+    }
+
+    [Fact]
+    public void A_brand_new_device_starts_probing_and_a_Flex_25G_never_does()
+    {
+        MonitoringCollectionAgent.ReplacementEnabled(null, isFlex25G: false).Should().BeTrue();
+        MonitoringCollectionAgent.ReplacementEnabled(null, isFlex25G: true).Should().BeFalse();
+
+        var running = Target(enabled: true);
+        MonitoringCollectionAgent.ReplacementEnabled(running, isFlex25G: true)
+            .Should().BeFalse("the Flex rule is ours and outranks what it inherits");
+    }
+
+    [Fact]
+    public void A_row_retired_before_the_remembered_value_existed_falls_back()
+    {
+        // Rows retired by an earlier build carry RetiredAt with no EnabledBeforeRetire.
+        var target = Target(enabled: false);
+        target.RetiredAt = DateTime.UtcNow;
+        target.EnabledBeforeRetire = null;
+
+        MonitoringCollectionAgent.ApplyRevival(target, fallbackEnabled: true);
+
+        target.Enabled.Should().BeTrue("with nothing remembered, it starts as a fresh target would");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/SshFailureSummaryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/SshFailureSummaryTests.cs
@@ -1,0 +1,78 @@
+using NetworkOptimizer.Web.Services.Ssh;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+public class SshFailureSummaryTests
+{
+    private const string Host = "192.0.2.10";
+
+    [Fact]
+    public void RejectedCredentialsAreNamedAsSuch()
+    {
+        var message = SshFailureSummary.Describe(
+            "Authentication failed: Permission denied (password,keyboard-interactive).", Host);
+
+        Assert.Contains("authentication was rejected", message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(Host, message);
+    }
+
+    [Fact]
+    public void AnUnreachableDeviceIsNotReportedAsAnAuthProblem()
+    {
+        var message = SshFailureSummary.Describe(
+            "Connection failed: No connection could be made because the target machine actively refused it.", Host);
+
+        Assert.Contains("Could not reach", message);
+        Assert.DoesNotContain("authentication", message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void TimeoutsReadAsTimeouts()
+    {
+        var message = SshFailureSummary.Describe("Command timed out: the operation has timed out.", Host);
+        Assert.Contains("did not answer SSH in time", message);
+    }
+
+    [Fact]
+    public void MissingCredentialsPointAtConfigurationRatherThanTheNetwork()
+    {
+        var message = SshFailureSummary.Describe("SSH credentials not configured", Host);
+        Assert.Contains("not configured", message);
+        Assert.DoesNotContain("Could not reach", message);
+    }
+
+    [Fact]
+    public void TheAgentMessagePassesThroughUnchanged()
+    {
+        var message = SshFailureSummary.Describe(UniFiSshServiceMessage, Host);
+        Assert.Equal(UniFiSshServiceMessage, message);
+    }
+
+    [Fact]
+    public void NoOutputAtAllStillSaysSomethingUseful()
+    {
+        var message = SshFailureSummary.Describe(null, Host);
+        Assert.Contains("No response from", message);
+        Assert.Contains(Host, message);
+    }
+
+    [Fact]
+    public void UnrecognizedOutputIsTrimmedToOneLine()
+    {
+        var message = SshFailureSummary.Describe("qmicli: could not open device\nsecond line\nthird line", Host);
+        Assert.Equal("qmicli: could not open device", message);
+    }
+
+    [Fact]
+    public void AVeryLongLineIsCapped()
+    {
+        var message = SshFailureSummary.Describe(new string('x', 500), Host);
+        Assert.True(message.Length < 200);
+        Assert.EndsWith("...", message);
+    }
+
+    private const string UniFiSshServiceMessage =
+        "Waiting for the on-site agent to connect. This site's devices are reached through its agent, "
+        + "and will connect automatically once the agent is online.";
+}

--- a/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/NokiaXs010xOntProviderTests.cs
@@ -271,7 +271,7 @@ public class NokiaXs010xOntProviderTests
             Password = "1234",
         };
 
-        var stats = await provider.PollAsync(context);
+        var stats = (await provider.PollAsync(context)).Stats;
 
         stats.Should().NotBeNull();
         stats!.RxPowerDbm.Should().BeApproximately(-13.3, 0.0001);
@@ -299,7 +299,7 @@ public class NokiaXs010xOntProviderTests
             Password = "1234",
         };
 
-        var stats = await provider.PollAsync(context);
+        var stats = (await provider.PollAsync(context)).Stats;
 
         stats.Should().NotBeNull();
         stats!.RxPowerDbm.Should().BeApproximately(-13.3, 0.0001);

--- a/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class TechnicolorCgaProviderTests
+{
+    private static CmPollContext Context() => new()
+    {
+        Id = 1,
+        Name = "Cable Modem",
+        Host = "192.0.2.10",
+        Port = 80,
+    };
+
+    // Shape of /api/v1/sta_docsis_status: SC-QAM and OFDM channels arrive in separate arrays
+    // under "data", each with its own field naming.
+    private const string DocsisPayload = """
+        {
+          "error": "ok",
+          "data": {
+            "downstream": [
+              {"channelid":"1","locked":"Locked","ChannelType":"SC-QAM","FFT":"256QAM","CentralFrequency":"602000000","power":"1.7","SNR":"37.0"},
+              {"channelid":"2","locked":"Locked","ChannelType":"SC-QAM","FFT":"256QAM","CentralFrequency":"610000000","power":"1.4","SNR":"37.0"}
+            ],
+            "ofdm_downstream": [
+              {"channelid_ofdm":"162","locked":"Locked","FFT_ofdm":"","CentralFrequency_ofdm":"225000000","power_ofdm":"5.8","SNR_ofdm":"41.0"}
+            ],
+            "upstream": [
+              {"channelidup":"1","locked":"Locked","ChannelType":"SC-QAM","FFT":"32QAM","CentralFrequency":"51000000","power":"43.3","SymbolRate":"5120000"}
+            ],
+            "ofdma_upstream": [
+              {"channelidup":"9","locked":"Locked","ChannelType":"","FFT":"","CentralFrequency":"37000000","power":"44.0"}
+            ]
+          }
+        }
+        """;
+
+    private static JsonElement Payload(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void ParseDocsis_ParsesScQamDownstream()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("256QAM");
+        first.Frequency.Should().Be(602_000_000);
+        first.Power.Should().Be(1.7);
+        first.Snr.Should().Be(37.0);
+    }
+
+    // OFDM channels use suffixed field names and are appended to the same downstream list.
+    [Fact]
+    public void ParseDocsis_ParsesOfdmDownstreamWithSuffixedFields()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var ofdm = stats.DownstreamChannels[2];
+        ofdm.ChannelId.Should().Be(162);
+        ofdm.Modulation.Should().Be("OFDM");
+        ofdm.Frequency.Should().Be(225_000_000);
+        ofdm.Power.Should().Be(5.8);
+        ofdm.Snr.Should().Be(41.0);
+    }
+
+    [Fact]
+    public void ParseDocsis_ParsesUpstreamChannels()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var scqam = stats.UpstreamChannels[0];
+        scqam.ChannelId.Should().Be(1);
+        scqam.ChannelType.Should().Be("SC-QAM");
+        scqam.Frequency.Should().Be(51_000_000);
+        scqam.Power.Should().Be(43.3);
+        scqam.SymbolRate.Should().Be(5_120_000);
+
+        // OFDMA channels carry no channel type of their own.
+        stats.UpstreamChannels[1].ChannelType.Should().Be("OFDMA");
+    }
+
+    // Every aggregate on CableModemStats counts "Locked", so the lock vocabulary has to be
+    // normalized or the channels parse while all the aggregates read zero or null.
+    [Fact]
+    public void ParseDocsis_PopulatesAggregates()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), Context(), "Technicolor CGA");
+
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately(2.967, 0.001);
+        stats.DownstreamSnrAvgDb.Should().BeApproximately(38.333, 0.001);
+        stats.UpstreamPowerAvgDbmv.Should().BeApproximately(43.65, 0.001);
+    }
+
+    [Theory]
+    [InlineData("Locked", "Locked")]
+    [InlineData("locked", "Locked")]
+    [InlineData("ACTIVE", "Locked")]
+    [InlineData("YES", "Locked")]
+    [InlineData("1", "Locked")]
+    [InlineData("true", "Locked")]
+    [InlineData("Not Locked", "Not Locked")]
+    [InlineData("", "")]
+    public void NormalizeLockStatus_MapsFirmwareValues(string raw, string expected)
+    {
+        TechnicolorCgaProvider.NormalizeLockStatus(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("602000000", 602_000_000)]
+    [InlineData("602", 602_000_000)]
+    [InlineData("", 0)]
+    [InlineData("n/a", 0)]
+    public void ParseFrequencyHz_HandlesFirmwareFormats(string raw, long expected)
+    {
+        TechnicolorCgaProvider.ParseFrequencyHz(raw).Should().Be(expected);
+    }
+
+    // Some builds report MER as a negative MSE.
+    [Theory]
+    [InlineData("37.0", 37.0)]
+    [InlineData("-37.0", 37.0)]
+    public void ParseSnr_NormalizesSign(string raw, double expected)
+    {
+        TechnicolorCgaProvider.ParseSnr(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParseSnr_ReturnsNullWhenAbsent()
+    {
+        TechnicolorCgaProvider.ParseSnr("").Should().BeNull();
+    }
+
+    // Older builds return the channel arrays at the root rather than under "data".
+    [Fact]
+    public void ParseDocsis_AcceptsUnwrappedPayload()
+    {
+        var payload = """
+            {"downstream":[{"channelid":"1","locked":"Locked","FFT":"256QAM","CentralFrequency":"602000000","power":"1.7","SNR":"37.0"}]}
+            """;
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(payload), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().ContainSingle();
+        stats.DownstreamChannels[0].Frequency.Should().Be(602_000_000);
+    }
+
+    // Numeric fields arrive quoted on some builds and bare on others.
+    [Fact]
+    public void ParseDocsis_AcceptsUnquotedNumericFields()
+    {
+        var payload = """
+            {"data":{"downstream":[{"channelid":1,"locked":"Locked","FFT":"256QAM","CentralFrequency":602000000,"power":1.7,"SNR":37.0}]}}
+            """;
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(payload), Context(), "Technicolor CGA");
+
+        var channel = stats.DownstreamChannels.Should().ContainSingle().Subject;
+        channel.ChannelId.Should().Be(1);
+        channel.Frequency.Should().Be(602_000_000);
+        channel.Power.Should().Be(1.7);
+        channel.Snr.Should().Be(37.0);
+    }
+
+    [Fact]
+    public void ParseDocsis_ReturnsEmptyChannelsWhenArraysAbsent()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload("""{"error":"ok","data":{}}"""), Context(), "Technicolor CGA");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+        stats.UpstreamChannels.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ParseDocsis_CarriesDeviceIdentityFromContext()
+    {
+        var context = Context() with { ConfiguredHost = "198.51.100.5" };
+
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(DocsisPayload), context, "Technicolor CGA437A");
+
+        stats.DeviceHost.Should().Be("198.51.100.5");
+        stats.DeviceName.Should().Be("Cable Modem");
+        stats.DeviceModel.Should().Be("Technicolor CGA437A");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/VodafoneStationProviderTests.cs
@@ -1,0 +1,254 @@
+using System.Text;
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class VodafoneStationProviderTests
+{
+    private static CmPollContext Context() => new()
+    {
+        Id = 1,
+        Name = "Cable Modem",
+        Host = "192.0.2.10",
+        Port = 80,
+    };
+
+    // Shape of /php/status_docsis_data.php: the channel arrays are JS variables embedded in the
+    // page, not a JSON body.
+    private const string DocsisPage = """
+        <html><body><script type="text/javascript">
+        var json_dsData = [
+          {"__id":"1","ChannelID":"9","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":"602000000","PowerLevel":"-1.2 dBmV/1158.8 dBuV","SNRLevel":"41.8 dB"},
+          {"__id":"2","ChannelID":"10","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":"610000000","PowerLevel":"0.8 dBmV/1160.8 dBuV","SNRLevel":"40.2 dB"},
+          {"__id":"3","ChannelID":"33","LockStatus":"ACTIVE","ChannelType":"OFDM","Modulation":"","Frequency":"151000000~299000000","PowerLevel":"2.4 dBmV/1162.4 dBuV","SNRLevel":"43.0 dB"}
+        ];
+        var json_usData = [
+          {"__id":"1","ChannelID":"1","LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"64QAM","Frequency":"51000000","PowerLevel":"43.3 dBmV","SymbolRate":"5120000"},
+          {"__id":"2","ChannelID":"5","LockStatus":"ACTIVE","ChannelType":"OFDMA","Modulation":"","Frequency":"29000000~45000000","PowerLevel":"44.0 dBmV","SymbolRate":"0"}
+        ];
+        </script></body></html>
+        """;
+
+    [Fact]
+    public void ParseDocsis_ParsesDownstreamChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(9);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("256QAM");
+        first.Frequency.Should().Be(602_000_000);
+        first.Power.Should().Be(-1.2);
+        first.Snr.Should().Be(41.8);
+    }
+
+    [Fact]
+    public void ParseDocsis_ParsesUpstreamChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var first = stats.UpstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.ChannelType.Should().Be("SC-QAM");
+        first.Frequency.Should().Be(51_000_000);
+        first.Power.Should().Be(43.3);
+        first.SymbolRate.Should().Be(5_120_000);
+    }
+
+    // OFDM/OFDMA channels report a band rather than a carrier, so the channel takes its center.
+    [Fact]
+    public void ParseDocsis_UsesBandCenterForOfdmChannels()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        var ofdm = stats.DownstreamChannels[2];
+        ofdm.Frequency.Should().Be(225_000_000);
+        ofdm.Modulation.Should().Be("OFDM");
+
+        var ofdma = stats.UpstreamChannels[1];
+        ofdma.Frequency.Should().Be(37_000_000);
+        ofdma.ChannelType.Should().Be("OFDMA");
+    }
+
+    // The TG reports "ACTIVE" where every aggregate on CableModemStats counts "Locked". Without
+    // the mapping the channels still parse but each aggregate silently reads zero or null.
+    [Fact]
+    public void ParseDocsis_MapsActiveToLockedSoAggregatesPopulate()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, Context(), "ARRIS TG3442DE");
+
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately(0.667, 0.001);
+        stats.DownstreamSnrAvgDb.Should().BeApproximately(41.667, 0.001);
+        stats.UpstreamPowerAvgDbmv.Should().BeApproximately(43.65, 0.001);
+    }
+
+    [Theory]
+    [InlineData("ACTIVE", "Locked")]
+    [InlineData("Locked", "Locked")]
+    [InlineData("locked", "Locked")]
+    [InlineData("NOT_LOCKED", "NOT_LOCKED")]
+    [InlineData("", "")]
+    public void NormalizeLockStatus_MapsFirmwareValues(string raw, string expected)
+    {
+        VodafoneStationProvider.NormalizeLockStatus(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("602000000", 602_000_000)]
+    [InlineData("151000000~299000000", 225_000_000)]
+    [InlineData("602", 602_000_000)]
+    [InlineData("", 0)]
+    [InlineData("not-a-number", 0)]
+    public void ParseFrequencyHz_HandlesFirmwareFormats(string raw, long expected)
+    {
+        VodafoneStationProvider.ParseFrequencyHz(raw).Should().Be(expected);
+    }
+
+    // The TG pairs both units in one field; only the dBmV half is meaningful to us.
+    [Theory]
+    [InlineData("-1.2 dBmV/1158.8 dBuV", -1.2)]
+    [InlineData("43.3 dBmV", 43.3)]
+    [InlineData("0.0 dBmV/1160.0 dBuV", 0.0)]
+    public void ParsePowerDbmv_TakesTheDbmvHalf(string raw, double expected)
+    {
+        VodafoneStationProvider.ParsePowerDbmv(raw).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ParsePowerDbmv_ReturnsNullWhenAbsent()
+    {
+        VodafoneStationProvider.ParsePowerDbmv("").Should().BeNull();
+        VodafoneStationProvider.ParsePowerDbmv("n/a").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("var myIv = 'a1b2c3d4e5f60718';", "myIv", "a1b2c3d4e5f60718")]
+    [InlineData("let mySalt = \"0011223344556677\";", "mySalt", "0011223344556677")]
+    [InlineData("window.currentSessionId = 'abc123';", "currentSessionId", "abc123")]
+    [InlineData("currentSessionId = 'bare9876';", "currentSessionId", "bare9876")]
+    public void ExtractJsVar_ReadsDeclarationForms(string script, string name, string expected)
+    {
+        VodafoneStationProvider.ExtractJsVar(script, name).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ExtractJsVar_ReturnsNullWhenMissing()
+    {
+        VodafoneStationProvider.ExtractJsVar("var somethingElse = 'x';", "myIv").Should().BeNull();
+    }
+
+    // The firmware's pages are full of js_-prefixed variables, so a bare assignment must not be
+    // read off a longer identifier that merely ends with the name being looked up.
+    [Fact]
+    public void ExtractJsVar_IgnoresLongerIdentifiersEndingInTheName()
+    {
+        var page = "var js_mySalt = 'deadbeefdeadbeef';\nmySalt = 'cafebabecafebabe';\n";
+
+        VodafoneStationProvider.ExtractJsVar(page, "mySalt").Should().Be("cafebabecafebabe");
+    }
+
+    // The modem expects ciphertext followed by the 16-byte authentication tag as one hex string.
+    // The reverse order still looks like a valid payload and is rejected only by the device.
+    [Fact]
+    public void AesCcmEncryptHex_AppendsTagAndRoundTrips()
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+        const string payload = """{"Password":"secret","Nonce":"session"}""";
+
+        var encrypted = VodafoneStationProvider.AesCcmEncryptHex(
+            key, nonce, Encoding.UTF8.GetBytes(payload), "loginPassword");
+
+        encrypted.Should().HaveLength((Encoding.UTF8.GetByteCount(payload) + 16) * 2);
+        encrypted.Should().MatchRegex("^[0-9a-f]+$");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword")
+            .Should().Be(payload);
+    }
+
+    // The credentials and the returned CSRF nonce are sealed under different associated data, so
+    // mixing the two up has to fail closed.
+    [Fact]
+    public void AesCcmDecryptText_ReturnsNullOnAssociatedDataMismatch()
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+
+        var encrypted = VodafoneStationProvider.AesCcmEncryptHex(
+            key, nonce, Encoding.UTF8.GetBytes("token"), "nonce");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword").Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("not-hex")]
+    [InlineData("00112233")]
+    public void AesCcmDecryptText_ReturnsNullOnMalformedInput(string encrypted)
+    {
+        var key = Convert.FromHexString("000102030405060708090a0b0c0d0e0f");
+        var nonce = Convert.FromHexString("a1b2c3d4e5f60718");
+
+        VodafoneStationProvider.AesCcmDecryptText(key, nonce, encrypted, "loginPassword").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDocsis_ReturnsEmptyChannelsWhenArraysAbsent()
+    {
+        var stats = VodafoneStationProvider.ParseDocsis("<html><body>Login</body></html>", Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+        stats.UpstreamChannels.Should().BeEmpty();
+        stats.DeviceModel.Should().Be("ARRIS TG3442DE");
+    }
+
+    [Fact]
+    public void ParseDocsis_SkipsMalformedChannelArray()
+    {
+        var page = "var json_dsData = [ {\"ChannelID\": ; ];";
+
+        var stats = VodafoneStationProvider.ParseDocsis(page, Context(), "ARRIS TG3442DE");
+
+        stats.DownstreamChannels.Should().BeEmpty();
+    }
+
+    // Numeric fields arrive quoted on some builds and bare on others.
+    [Fact]
+    public void ParseDocsis_AcceptsUnquotedNumericFields()
+    {
+        var page = """
+            var json_dsData = [
+              {"ChannelID":9,"LockStatus":"ACTIVE","ChannelType":"SC-QAM","Modulation":"256QAM","Frequency":602000000,"PowerLevel":"-1.2 dBmV/1158.8 dBuV","SNRLevel":41.8}
+            ];
+            """;
+
+        var stats = VodafoneStationProvider.ParseDocsis(page, Context(), "ARRIS TG3442DE");
+
+        var channel = stats.DownstreamChannels.Should().ContainSingle().Subject;
+        channel.ChannelId.Should().Be(9);
+        channel.Frequency.Should().Be(602_000_000);
+        channel.Snr.Should().Be(41.8);
+    }
+
+    [Fact]
+    public void ParseDocsis_CarriesDeviceIdentityFromContext()
+    {
+        var context = Context() with { ConfiguredHost = "198.51.100.5" };
+
+        var stats = VodafoneStationProvider.ParseDocsis(DocsisPage, context, "ARRIS TG3442DE");
+
+        stats.DeviceHost.Should().Be("198.51.100.5");
+        stats.DeviceName.Should().Be("Cable Modem");
+    }
+}


### PR DESCRIPTION
Rolls up everything on `dev` since v2.6.3.

## Monitoring

- **Polls say why they failed** - A device that stops reporting now says what went wrong on the **CM Stats**, **ONT Stats**, **Cellular Stats**, and **Starlink Stats** panels, and on the Settings test button. An unreachable device, one refusing the saved password, and one answering with something unreadable are the three things a reader can act on, and they now read differently instead of all arriving as the same empty panel. Applies across every cable modem, ONT, cellular, and Starlink provider.

### Network Performance

- **Latency Targets** - Targets now have a lifecycle. A target whose device left the UniFi device list, or moved address and was replaced, is retired rather than deleted: its measurements stay readable under its own history, and the list stops offering to resume something nothing would answer. Retiring is distinct from pausing, and a target that was paused before its device disappeared comes back paused rather than silently resumed. Targets can also be hidden from the list without affecting the history already recorded against them.

### CM Stats

- **Vodafone Station (ARRIS TG3442DE)** - The cable gateway Vodafone ships in Germany, added under **Provider** when adding a cable modem. Reports downstream and upstream channels alongside every other supported modem: frequency, power, SNR, modulation, lock state, and the locked-channel counts and averages behind the charts and alerts. Getting at that data means an encrypted sign-in and reading the figures out of the status page rather than an API, and it allows only one admin session at a time, so a poll that gets turned away re-authenticates itself instead of going quiet. Requested in #1087, thanks @njoerd114 for the reference implementation and firmware detail.
- **Technicolor CGA Series** - Technicolor CGA-series gateways, as shipped by cable ISPs including VOO and Vodafone. These serve their DOCSIS tables from a JSON API behind the web UI, reached through a two-round sign-in. SC-QAM, OFDM, and OFDMA channels are all read. Requested in #1124, thanks @srialmaster for the interface capture. This one has not yet been confirmed against a physical device - it targets the best-matching published description of that generation's API, and the parser is deliberately tolerant of the shapes it may return.

## Fixes

- **Cable modem and ONT sign-in failures name the cause** - Every HTTP-polled device now describes a failure the same way, including the Netgear Nighthawk hotspot, which had been passing the framework's own socket text through to the card.

## Notes for the release

- Three schema migrations land here, all additive and nullable, adding retirement and hidden state to monitoring targets.
- The On-Site Agent is unchanged. The only files in its link closure are provider interfaces and a result type it does not reference, so `LatestAgentVersion` stays at 2.6.3 and enrolled agents need no action.
