### PR TITLE
Pages render without waiting on the network, and a console that goes quiet recovers itself

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -90,8 +90,17 @@ public class UniFiApiClient : IDisposable
     /// </summary>
     public event Action<bool, string?>? AuthProbeCompleted;
 
-    /// <summary>Raised when consecutive timeouts show the console has stopped answering.</summary>
-    public event Action? ConsoleWentSilent;
+    /// <summary>
+    /// Raised when consecutive timeouts show the console has stopped answering. Carries the client
+    /// that saw them so a subscriber can ignore one that is no longer its live client.
+    /// </summary>
+    public event Action<UniFiApiClient>? ConsoleWentSilent;
+
+    /// <summary>
+    /// True for an HttpClient timeout, false for a caller cancelling. Both arrive as
+    /// TaskCanceledException; only the timeout says anything about the console.
+    /// </summary>
+    private static bool IsRequestTimeout(Exception ex) => ex.InnerException is TimeoutException;
 
     /// <summary>Consecutive request timeouts before the console counts as silent.</summary>
     private const int SilentTimeoutStreak = 2;
@@ -141,7 +150,7 @@ public class UniFiApiClient : IDisposable
         // real blip, so it keeps the full backoff. A timeout means the console went silent after
         // the handshake, which no backoff can clear, and each retry costs another full 15s.
         var timeoutRetry = Policy
-            .Handle<TaskCanceledException>()
+            .Handle<TaskCanceledException>(IsRequestTimeout)
             .WaitAndRetryAsync(1, _ => TimeSpan.FromMilliseconds(500), OnRetry);
         var transientRetry = Policy
             .Handle<HttpRequestException>()
@@ -187,14 +196,17 @@ public class UniFiApiClient : IDisposable
             _logger.LogDebug("UniFi API request skipped: client was disposed by a concurrent reconnect");
             return default!;
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex)
         {
             // Rethrown, not swallowed: callers already turn this into their own failure result and
-            // their error reporting should not change just because we counted it.
-            if (Interlocked.Increment(ref _consecutiveTimeouts) >= SilentTimeoutStreak)
+            // their error reporting should not change just because we counted it. A caller
+            // cancelling (page navigation, site switch, shutdown) throws the same type and says
+            // nothing about the console, so it must never count toward silence.
+            if (IsRequestTimeout(ex)
+                && Interlocked.Increment(ref _consecutiveTimeouts) >= SilentTimeoutStreak)
             {
                 Interlocked.Exchange(ref _silentUntilTicks, (DateTime.UtcNow + SilentCooldown).Ticks);
-                ConsoleWentSilent?.Invoke();
+                ConsoleWentSilent?.Invoke(this);
             }
             throw;
         }

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -90,6 +90,18 @@ public class UniFiApiClient : IDisposable
     /// </summary>
     public event Action<bool, string?>? AuthProbeCompleted;
 
+    /// <summary>Raised when consecutive timeouts show the console has stopped answering.</summary>
+    public event Action? ConsoleWentSilent;
+
+    /// <summary>Consecutive request timeouts before the console counts as silent.</summary>
+    private const int SilentTimeoutStreak = 2;
+
+    /// <summary>How long requests fail instantly once it is silent, before one probes for its return.</summary>
+    private static readonly TimeSpan SilentCooldown = TimeSpan.FromSeconds(30);
+
+    private int _consecutiveTimeouts;
+    private long _silentUntilTicks;
+
     public UniFiApiClient(
         ILogger<UniFiApiClient> logger,
         string controllerHost,
@@ -157,14 +169,34 @@ public class UniFiApiClient : IDisposable
     internal async Task<T> ExecuteRequestAsync<T>(Func<Task<T>> action)
     {
         if (_disposed) return default!;
+
+        // A console that answers TCP and then goes quiet costs a full timeout on every call, and a
+        // page makes many - that is what reads as a frozen UI. Once it has proven silent, fail them
+        // instantly and let one through per cooldown to notice it came back, so this cannot latch.
+        if (DateTime.UtcNow.Ticks < Interlocked.Read(ref _silentUntilTicks)) return default!;
+
         try
         {
-            return await _retryPolicy.ExecuteAsync(action);
+            var result = await _retryPolicy.ExecuteAsync(action);
+            Interlocked.Exchange(ref _consecutiveTimeouts, 0);
+            Interlocked.Exchange(ref _silentUntilTicks, 0);
+            return result;
         }
         catch (ObjectDisposedException)
         {
             _logger.LogDebug("UniFi API request skipped: client was disposed by a concurrent reconnect");
             return default!;
+        }
+        catch (TaskCanceledException)
+        {
+            // Rethrown, not swallowed: callers already turn this into their own failure result and
+            // their error reporting should not change just because we counted it.
+            if (Interlocked.Increment(ref _consecutiveTimeouts) >= SilentTimeoutStreak)
+            {
+                Interlocked.Exchange(ref _silentUntilTicks, (DateTime.UtcNow + SilentCooldown).Ticks);
+                ConsoleWentSilent?.Invoke();
+            }
+            throw;
         }
     }
 

--- a/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiApiClient.cs
@@ -41,7 +41,7 @@ public class UniFiApiClient : IDisposable
     private HttpClient? _httpClient;
     private CookieContainer? _cookieContainer;
     private string? _csrfToken;
-    private readonly AsyncRetryPolicy _retryPolicy;
+    private readonly IAsyncPolicy _retryPolicy;
     private readonly SemaphoreSlim _authLock = new(1, 1);
     // Set in Dispose() before the HttpClient is torn down. A concurrent reconnect
     // can dispose this client while a data call is in flight; the flag and the
@@ -120,19 +120,26 @@ public class UniFiApiClient : IDisposable
         // consoles keep the full backoff - a real transient blip there is worth
         // riding out.
         var viaAgentProxy = _agentProxyPort is not null;
-        _retryPolicy = Policy
+
+        void OnRetry(Exception exception, TimeSpan timespan, int retryCount, Context context) =>
+            _logger.LogWarning("Retry {RetryCount} after {Timespan}s due to {Exception}",
+                retryCount, timespan.TotalSeconds, exception.Message);
+
+        // Split by meaning: a refused or reset connection returns in milliseconds and is often a
+        // real blip, so it keeps the full backoff. A timeout means the console went silent after
+        // the handshake, which no backoff can clear, and each retry costs another full 15s.
+        var timeoutRetry = Policy
+            .Handle<TaskCanceledException>()
+            .WaitAndRetryAsync(1, _ => TimeSpan.FromMilliseconds(500), OnRetry);
+        var transientRetry = Policy
             .Handle<HttpRequestException>()
-            .Or<TaskCanceledException>()
             .WaitAndRetryAsync(
                 retryCount: viaAgentProxy ? 1 : 3,
                 sleepDurationProvider: retryAttempt => viaAgentProxy
                     ? TimeSpan.FromMilliseconds(500)
                     : TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
-                onRetry: (exception, timespan, retryCount, context) =>
-                {
-                    _logger.LogWarning("Retry {RetryCount} after {Timespan}s due to {Exception}",
-                        retryCount, timespan.TotalSeconds, exception.Message);
-                });
+                onRetry: OnRetry);
+        _retryPolicy = Policy.WrapAsync(transientRetry, timeoutRetry);
 
         InitializeHttpClient();
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -99,7 +99,7 @@
         </div>
     }
 
-    @if (_loading || _awaitingSiteIdentity)
+    @if (_loading || _awaitingSiteIdentity || _awaitingLocalIp)
     {
         <div class="skeleton-hero card">
             <div class="skeleton-row">
@@ -1138,7 +1138,6 @@
         // which needs JS, so it lands here rather than in OnInitializedAsync.
         if (_awaitingLocalIp)
         {
-            _awaitingLocalIp = false;
             try
             {
                 var address = await JS.InvokeAsync<string?>("eval",
@@ -1152,6 +1151,13 @@
             catch (Exception ex)
             {
                 Logger.LogDebug(ex, "Client address lookup failed; the device picker is the way in");
+            }
+            finally
+            {
+                // Cleared only now, so the skeleton covers the lookup instead of the page flashing
+                // "Device Not Found" on the first pass that had no address yet.
+                _awaitingLocalIp = false;
+                StateHasChanged();
             }
         }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1131,8 +1131,6 @@
         // Must be in OnAfterRenderAsync because JS interop isn't available during prerender
         _isInsecureContext = !await JS.InvokeAsync<bool>("eval", "window.isSecureContext");
         _isMobile = await JS.InvokeAsync<bool>("eval", "window.innerWidth <= 768");
-        // VPN clients have no GPS walk-test flow (no live polling), so never warn them.
-        _showGpsWarning = _isInsecureContext && _isOwnDevice && _client?.IsVpn != true;
 
         // Default-site own-device identity: the viewer's address comes from a browser request,
         // which needs JS, so it lands here rather than in OnInitializedAsync.
@@ -1165,6 +1163,10 @@
         // so it runs here rather than in OnInitializedAsync.
         if (_awaitingSiteIdentity)
             await ResolveSiteIdentityAsync();
+
+        // After identity: VPN clients have no GPS walk-test flow, so never warn them, and _client
+        // is only known once the resolves above have run.
+        _showGpsWarning = _isInsecureContext && _isOwnDevice && _client?.IsVpn != true;
 
         if (_showGpsWarning)
             StateHasChanged();

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -20,7 +20,6 @@
 @inject SiteSpeedTestTargetResolver SiteTarget
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
-@inject IHttpContextAccessor HttpContextAccessor
 @inject ApMapService ApMapService
 @inject PullToRefreshState PtrState
 @inject ILogger<ClientDashboard> Logger
@@ -1135,6 +1134,27 @@
         // VPN clients have no GPS walk-test flow (no live polling), so never warn them.
         _showGpsWarning = _isInsecureContext && _isOwnDevice && _client?.IsVpn != true;
 
+        // Default-site own-device identity: the viewer's address comes from a browser request,
+        // which needs JS, so it lands here rather than in OnInitializedAsync.
+        if (_awaitingLocalIp)
+        {
+            _awaitingLocalIp = false;
+            try
+            {
+                var address = await JS.InvokeAsync<string?>("eval",
+                    "fetch('/api/client-dashboard/address').then(r => r.json()).then(j => j.address)");
+                if (!string.IsNullOrEmpty(address) && address != "unknown")
+                {
+                    _clientIp = NetworkUtilities.NormalizeToIPv4String(address);
+                    await IdentifyAndLoadAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Client address lookup failed; the device picker is the way in");
+            }
+        }
+
         // Managed-site own-device identity needs JS (agent whoami probe / localStorage),
         // so it runs here rather than in OnInitializedAsync.
         if (_awaitingSiteIdentity)
@@ -1179,6 +1199,7 @@
 
     private string? _clientIp;
     private bool _awaitingSiteIdentity;
+    private bool _awaitingLocalIp;
     private System.Threading.Timer? _identityRetryTimer;
     private bool _showClientPicker;
     private List<ClientDashboardService.SelectableClient> _pickerClients = new();
@@ -1203,23 +1224,12 @@
             return null;
         }
 
-        // In Blazor Server, HttpContext is only available during the initial HTTP request.
-        // OnInitializedAsync runs during that first request, so we capture the IP here.
+        // The app does not prerender, so this only ever runs in the circuit, where there is no
+        // HttpContext to read the address from. The browser fetches it after first render instead.
         if (string.IsNullOrEmpty(_clientIp))
         {
-            var httpContext = HttpContextAccessor.HttpContext;
-            if (httpContext != null)
-            {
-                var clientIp = httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-                var forwardedFor = httpContext.Request.Headers["X-Forwarded-For"].FirstOrDefault();
-                if (!string.IsNullOrEmpty(forwardedFor))
-                {
-                    clientIp = forwardedFor.Split(',')[0].Trim();
-                }
-                // An IPv4 client on a dual-stack socket arrives as ::ffff:a.b.c.d; unwrap it
-                // so it matches the UniFi client list and shows as a real IP.
-                _clientIp = NetworkUtilities.NormalizeToIPv4String(clientIp);
-            }
+            _awaitingLocalIp = true;
+            return null;
         }
 
         if (string.IsNullOrEmpty(_clientIp) || _clientIp == "unknown")

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -97,6 +97,29 @@
             </div>
         </div>
     }
+    else if (ConnectionService.IsConsoleUnresponsive)
+    {
+        <div class="connection-banner">
+            <div class="banner-content">
+                <span class="banner-icon">!</span>
+                <div class="banner-text">
+                    <strong>Console isn't responding</strong>
+                    <span>@ConnectionService.LastError</span>
+                </div>
+                <button class="btn btn-primary" @onclick="RefreshConnectionAsync" disabled="@_refreshingConnection">
+                    @if (_refreshingConnection)
+                    {
+                        <span class="spinner-sm"></span>
+                        <span>Refreshing...</span>
+                    }
+                    else
+                    {
+                        <span>Refresh</span>
+                    }
+                </button>
+            </div>
+        </div>
+    }
     else
     {
         <div class="connection-banner @(!string.IsNullOrEmpty(ConnectionService.LastError) ? "connection-error" : "")">

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -822,22 +822,17 @@
         </div>
     };
 
-    // Withheld while the console is down, unlike the Monitoring tab, which stays open so its
-    // timeline can be played back. This card is a live snapshot with nothing to scrub: it would
-    // render only to say the console is disconnected, which the page's own banner already says.
+    // Kept while the console is down: withholding it hid that history still plays back.
     private RenderFragment RenderLiveView => __builder =>
     {
-        @if (ConnectionService.IsConnected || !ConnectionService.IsInitialized)
-        {
-            <div class="card" id="live-view">
-                <a href="/monitoring?tab=live" class="card-header card-title-link" @onclick:stopPropagation>
-                    <h2 class="card-title">Live View</h2>
-                </a>
-                <div class="card-body">
-                    <LiveViewPanel MapMode="@GetLiveViewMapMode()" />
-                </div>
+        <div class="card" id="live-view">
+            <a href="/monitoring?tab=live" class="card-header card-title-link" @onclick:stopPropagation>
+                <h2 class="card-title">Live View</h2>
+            </a>
+            <div class="card-body">
+                <LiveViewPanel MapMode="@GetLiveViewMapMode()" />
             </div>
-        }
+        </div>
     };
 
     private string GetLiveViewMapMode()

--- a/src/NetworkOptimizer.Web/Components/Pages/Login.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Login.razor
@@ -268,6 +268,8 @@
 
     protected override async Task OnInitializedAsync()
     {
+        // TODO: inert while prerender is off - nothing persists, so TryTakeFromJson always misses
+        // and _error falls back to the Error parameter. Kept in case prerender comes back.
         _persisting = PageState.RegisterOnPersisting(() =>
         {
             PageState.PersistAsJson(ErrorStateKey, Error);

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -88,6 +88,28 @@
             </div>
         </div>
     }
+    else if (ConnectionService.IsConsoleUnresponsive)
+    {
+        <div class="connection-banner">
+            <div class="banner-content">
+                <span class="banner-icon">!</span>
+                <div class="banner-text">
+                    <strong>Console isn't responding</strong>
+                    <span>@ConnectionService.LastError</span>
+                </div>
+                <button class="btn btn-primary btn-sm" @onclick="RefreshConnectionAsync" disabled="@_refreshingConnection">
+                    @if (_refreshingConnection)
+                    {
+                        <span class="spinner-sm"></span>
+                    }
+                    else
+                    {
+                        <span>Refresh</span>
+                    }
+                </button>
+            </div>
+        </div>
+    }
     else
     {
         <div class="connection-banner">

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -2979,6 +2979,8 @@
 
         // Restore tab visibility persisted from prerender so the interactive render
         // shows the correct tabs immediately instead of flashing the default (all shown).
+        // TODO: inert while prerender is off - there is no first pass to persist from, so the tabs
+        // flash the default again. Kept in case prerender comes back.
         _tabVisPersistSub = PersistState.RegisterOnPersisting(() =>
         {
             PersistState.PersistAsJson(TabVisStateKey,

--- a/src/NetworkOptimizer.Web/Components/Routes.razor
+++ b/src/NetworkOptimizer.Web/Components/Routes.razor
@@ -1,4 +1,5 @@
-﻿@rendermode InteractiveServer
+﻿@* No prerender: it holds the whole response until every panel's first load returns. *@
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 @using NetworkOptimizer.Storage.Models.Identity
 @using NetworkOptimizer.Web.Services.Authorization
 @using NetworkOptimizer.Web.Services.Identity

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -19,15 +19,16 @@
 @inject NavigationManager NavigationManager
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
-@if (!_ready && !_notConfigured && ShowConsoleDownBanner)
+@* Beats the tiles: a live snapshot with no live source is worth less than saying so. *@
+@if (!_notConfigured && ShowConsoleDownBanner)
 {
     <div class="sqm-unavailable">
         <div class="sqm-status">
             <span class="status-indicator status-disconnected"></span>
-            <span class="status-label">Live View unavailable</span>
+            <span class="status-label">Console unavailable</span>
         </div>
         <p class="status-message">
-            This site's UniFi Console isn't reachable right now. Live stats will return when it reconnects.
+            Live stats are paused until this site's UniFi Console reconnects. Recorded history is still available in <strong>Monitoring - Live View</strong>.
         </p>
     </div>
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -304,6 +304,9 @@ else
 
     /// <summary>Monitoring is genuinely not set up, as opposed to set up but unable to load.</summary>
     private bool _notConfigured;
+
+    /// <summary>Mirrors the markup: true only when the tiles and map are actually on the page.</summary>
+    private bool ShowingPanelBody => _ready && (_notConfigured || !ShowConsoleDownBanner);
     private string? _gatewayMac;
     private List<string> _gatewayWanIfNames = new();
 
@@ -345,7 +348,14 @@ else
             await LiveWan.RestoreAsync();
 
         await EnsureWanCompareHintAsync();
-        if (!_ready) return;
+
+        // Mounting into markup that isn't rendered leaves the flag set and the map never comes
+        // back when it is. Unmount instead, so recovery remounts.
+        if (!ShowingPanelBody)
+        {
+            if (_mapMounted) await UnmountMap();
+            return;
+        }
 
         if (MapMode != "off" && (!_mapMounted || _mountedMode != MapMode))
         {

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -354,6 +354,12 @@ else
         if (!ShowingPanelBody)
         {
             if (_mapMounted) await UnmountMap();
+            if (_chartMounted)
+            {
+                _chartMounted = false;
+                try { await JS.InvokeVoidAsync("eval", "window.__dashWanLiveChart?.unmount();"); }
+                catch { }
+            }
             return;
         }
 
@@ -552,6 +558,7 @@ else
 
     private async Task LoadDataAsync()
     {
+        _notConfigured = false;
         try
         {
             // Per-site: read this site's own MonitoringSettings/targets, and gate on the

--- a/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LiveViewPanel.razor
@@ -19,7 +19,19 @@
 @inject NavigationManager NavigationManager
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
 
-@if (!_ready)
+@if (!_ready && !_notConfigured && ShowConsoleDownBanner)
+{
+    <div class="sqm-unavailable">
+        <div class="sqm-status">
+            <span class="status-indicator status-disconnected"></span>
+            <span class="status-label">Live View unavailable</span>
+        </div>
+        <p class="status-message">
+            This site's UniFi Console isn't reachable right now. Live stats will return when it reconnects.
+        </p>
+    </div>
+}
+else if (!_ready)
 {
     <div class="sqm-unavailable">
         <div class="sqm-status">
@@ -288,6 +300,9 @@ else
 
     private bool _ready;
     private bool _consoleUnreachable;
+
+    /// <summary>Monitoring is genuinely not set up, as opposed to set up but unable to load.</summary>
+    private bool _notConfigured;
     private string? _gatewayMac;
     private List<string> _gatewayWanIfNames = new();
 
@@ -538,6 +553,7 @@ else
             if (settings == null || !settings.Enabled)
             {
                 _ready = false;
+                _notConfigured = true;
                 return;
             }
 
@@ -546,6 +562,7 @@ else
             if (!InfluxClient.IsConfigured)
             {
                 _ready = false;
+                _notConfigured = true;
                 return;
             }
 

--- a/src/NetworkOptimizer.Web/Endpoints/ClientDashboardEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/ClientDashboardEndpoints.cs
@@ -43,6 +43,12 @@ public static class ClientDashboardEndpoints
         // Demo mode masking endpoint (returns mappings from DEMO_MODE_MAPPINGS env var)
         // --- Client Dashboard API ---
 
+        // The page cannot read its own viewer's address: the app does not prerender, so the
+        // component only ever runs in the circuit, where there is no HttpContext. The browser asks
+        // for it here instead, where the request carries the real address.
+        read.MapGet("/api/client-dashboard/address", (HttpContext context) =>
+            Results.Ok(new { address = EndpointHelpers.GetClientIp(context) }));
+
         read.MapGet("/api/client-dashboard/client", async (HttpContext context, ClientDashboardService service) =>
         {
             var clientIp = EndpointHelpers.GetClientIp(context);

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -142,9 +142,8 @@ public class AgentProbeResultSink
 
     /// <summary>
     /// Called once per connection after the hello exchange, and again by the periodic refresh.
-    /// <paramref name="initialConnect"/> separates the two: the console reconnect below belongs to a
-    /// genuine connect and must not run on every refresh, or each cycle re-pushes a config that is
-    /// already current.
+    /// <paramref name="initialConnect"/> separates the two: it forces the post-connect SNMP re-push,
+    /// which a steady-state refresh skips because the config is already current.
     /// </summary>
     public async Task OnAgentConnectedAsync(AgentTunnelConnection connection, CancellationToken ct, bool initialConnect = false)
     {
@@ -157,8 +156,10 @@ public class AgentProbeResultSink
         // before the tunnel is up, exhaust its short retry window, and stay
         // disconnected until a manual reconnect. Now that the tunnel is up,
         // reconnect it - fire-and-forget so we never block the tunnel read loop.
-        if (initialConnect)
-            _ = ReconnectConsoleIfViaAgentAsync(connection);
+        // Never gate this on initialConnect: a tunnel that goes stale and recovers before the 90s
+        // watchdog reaps it never reconnects, so the refresh is the only thing left that can clear
+        // the awaiting-agent state the stale flip set.
+        _ = ReconnectConsoleIfViaAgentAsync(connection, initialConnect);
     }
 
     /// <summary>
@@ -212,7 +213,7 @@ public class AgentProbeResultSink
         });
     }
 
-    private async Task ReconnectConsoleIfViaAgentAsync(AgentTunnelConnection connection)
+    private async Task ReconnectConsoleIfViaAgentAsync(AgentTunnelConnection connection, bool initialConnect)
     {
         try
         {
@@ -220,18 +221,24 @@ public class AgentProbeResultSink
             // still registered (the 90s watchdog hasn't reaped it). Reconnecting the
             // console through a tunnel that's silent past the stale threshold just
             // dials the dead loopback proxy and clobbers the awaiting-agent state the
-            // proxy's unreachable signal set. Skip; a real agent reconnect arrives
-            // with a fresh LastMessageAt and proceeds normally.
+            // proxy's unreachable signal set. Skip; the first refresh after traffic
+            // resumes sees a fresh LastMessageAt and proceeds normally.
             if (connection.IsStale)
                 return;
 
             var siteConnection = _siteConnections.GetFor(connection.SiteSlug);
+            var reconnected = false;
             if (!siteConnection.IsConnected && await siteConnection.IsConsoleViaAgentAsync())
             {
                 _logger.LogInformation(
                     "Agent tunnel up for site {Slug}; reconnecting its console via the tunnel", connection.SiteSlug);
                 await siteConnection.ReconnectAsync();
+                reconnected = true;
             }
+
+            // A refresh that found the console already up has nothing below to do.
+            if (!initialConnect && !reconnected)
+                return;
 
             // The initial SNMP push in OnAgentConnectedAsync was deferred because the console
             // wasn't connected yet (it reaches the console through this same tunnel). Now that it

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -69,13 +69,13 @@ public class AgentTunnelProxyService : IDisposable
     /// lifetime and resolves the site's live agent per accepted connection,
     /// so agent reconnects don't invalidate the endpoint.
     /// </summary>
-    public int GetOrCreateEndpoint(string siteSlug, string host, int port)
+    public int GetOrCreateEndpoint(string siteSlug, string host, int port, bool isConsole = false)
     {
         var listener = _listeners.GetOrAdd($"{siteSlug}|{host}:{port}", key =>
         {
             var tcp = new TcpListener(IPAddress.Loopback, 0);
             tcp.Start();
-            var created = new ProxyListener(tcp, siteSlug, host, port);
+            var created = new ProxyListener(tcp, siteSlug, host, port, isConsole);
             _ = AcceptLoopAsync(created, _shutdown.Token);
             _logger.LogInformation("Agent proxy listening on 127.0.0.1:{Local} -> {Host}:{Port} (site {Slug})",
                 created.LocalPort, host, port, siteSlug);
@@ -198,9 +198,16 @@ public class AgentTunnelProxyService : IDisposable
             {
                 _logger.LogDebug("Proxy open {Host}:{Port} via agent {AgentId} failed: {Error}",
                     listener.TargetHost, listener.TargetPort, agent.AgentId, openError);
-                // Whoever dialed the loopback listener only ever sees it close, so the agent's
-                // reason has to be left where they can find it. SSH.NET, for one, reports the
-                // hang-up as a missing protocol banner and buries the actual cause entirely.
+
+                // The console's own endpoint failing IS the console being down - the flip above only
+                // covers a silent tunnel. Two strikes so one blip can't mark a healthy console down.
+                if (listener.IsConsole
+                    && _consoleOpenFailures.AddOrUpdate(listener.SiteSlug, 1, (_, n) => n + 1) >= ConsoleFailuresBeforeUnreachable)
+                {
+                    NoteConsoleUnreachable(listener.SiteSlug);
+                }
+                // The dialer only sees the socket close, so leave the agent's reason where they can
+                // find it - SSH.NET reports the hang-up as a missing banner and buries the cause.
                 _lastOpenFailure[listener.LocalPort] =
                     ($"{listener.TargetHost}:{listener.TargetPort} via the site's agent - {openError}", DateTime.UtcNow);
                 CloseConnection(connection, notifyAgent: false);
@@ -208,6 +215,7 @@ public class AgentTunnelProxyService : IDisposable
             }
 
             // The tunnel answered, so clear any open breaker for this site.
+            if (listener.IsConsole) _consoleOpenFailures.TryRemove(listener.SiteSlug, out _);
             _openBreaker.TryRemove(listener.SiteSlug, out _);
             _lastOpenFailure.TryRemove(listener.LocalPort, out _);
 
@@ -319,6 +327,23 @@ public class AgentTunnelProxyService : IDisposable
     /// timeout or a stale-gate refusal - so page renders short-circuit console
     /// calls instead of paying dial-and-retry per call until the 90s watchdog.
     /// </summary>
+    /// <summary>Consecutive failed opens on a site's console endpoint before it counts as down.</summary>
+    private const int ConsoleFailuresBeforeUnreachable = 2;
+    private readonly ConcurrentDictionary<string, int> _consoleOpenFailures = new();
+
+    /// <summary>
+    /// The agent is alive but cannot reach the console, so this is not awaiting-agent. Marks the
+    /// console down (fire-and-forget, idempotent) so renders stop paying an open per call.
+    /// </summary>
+    private void NoteConsoleUnreachable(string siteSlug)
+    {
+        _ = Task.Run(async () =>
+        {
+            try { await _siteConnections.GetFor(siteSlug).NoteConsoleUnreachableAsync(); }
+            catch (Exception ex) { _logger.LogDebug(ex, "Console-unreachable flip failed for site {Slug}", siteSlug); }
+        });
+    }
+
     private void FlipConsoleAwaitingAgent(string siteSlug)
     {
         _ = Task.Run(async () =>
@@ -350,7 +375,7 @@ public class AgentTunnelProxyService : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    private sealed record ProxyListener(TcpListener Tcp, string SiteSlug, string TargetHost, int TargetPort)
+    private sealed record ProxyListener(TcpListener Tcp, string SiteSlug, string TargetHost, int TargetPort, bool IsConsole = false)
     {
         public int LocalPort => ((IPEndPoint)Tcp.LocalEndpoint).Port;
     }

--- a/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentTunnelProxyService.cs
@@ -321,12 +321,6 @@ public class AgentTunnelProxyService : IDisposable
                && agent.LastMessageAt <= breaker.OpenedAtLastMsg;
     }
 
-    /// <summary>
-    /// Flips the site's console to awaiting-agent off the dial path (fire-and-
-    /// forget, idempotent) the moment a dead tunnel is proven - by an open
-    /// timeout or a stale-gate refusal - so page renders short-circuit console
-    /// calls instead of paying dial-and-retry per call until the 90s watchdog.
-    /// </summary>
     /// <summary>Consecutive failed opens on a site's console endpoint before it counts as down.</summary>
     private const int ConsoleFailuresBeforeUnreachable = 2;
     private readonly ConcurrentDictionary<string, int> _consoleOpenFailures = new();
@@ -344,6 +338,12 @@ public class AgentTunnelProxyService : IDisposable
         });
     }
 
+    /// <summary>
+    /// Flips the site's console to awaiting-agent off the dial path (fire-and-
+    /// forget, idempotent) the moment a dead tunnel is proven - by an open
+    /// timeout or a stale-gate refusal - so page renders short-circuit console
+    /// calls instead of paying dial-and-retry per call until the 90s watchdog.
+    /// </summary>
     private void FlipConsoleAwaitingAgent(string siteSlug)
     {
         _ = Task.Run(async () =>

--- a/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
+++ b/src/NetworkOptimizer.Web/Services/SponsorshipService.cs
@@ -49,7 +49,7 @@ public class SponsorshipService : ISponsorshipService
         ("Still free. Still no VC funding. Still powered by coffee and spite.", "Fund the spite"),
 
         // Level 6: 31-40 uses - stats flex
-        ("217,000 lines of code. 6,100 tests. One guy on 2 acres in Arkansas. Still cheaper than UI Ground shipping.", "Buy him lunch"),
+        ("360,000 lines of code. 9,073 tests. One guy on 2 acres in Arkansas. Still cheaper than UI Ground shipping.", "Buy him lunch"),
 
         // Level 7: 41-50 uses - former employer dig
         ("You've used this more than some employers used my code. Just saying.", "Money me"),

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -348,6 +348,23 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// or dispose the client - this fires from a request in flight, and the next reconnect owns
     /// both. The background reconnect clears it when the console comes back.
     /// </summary>
+    /// <summary>
+    /// The site's agent is up but cannot open a connection to the console, so awaiting-agent would
+    /// be the wrong answer. Marks it down instead; the next successful connect clears it.
+    /// </summary>
+    public Task NoteConsoleUnreachableAsync()
+    {
+        if (_consoleUnresponsive || _settings is not { IsConfigured: true, HasCredentials: true })
+            return Task.CompletedTask;
+
+        _isConnected = false;
+        _consoleUnresponsive = true;
+        _lastError = ConsoleUnresponsiveMessage;
+        _logger.LogInformation("Site {Slug}'s agent cannot reach its console; marking it unresponsive", SiteSlug);
+        OnConnectionChanged?.Invoke();
+        return Task.CompletedTask;
+    }
+
     private void HandleConsoleWentSilent(UniFiApiClient client)
     {
         // Only the live client may report this. A disposed one's request can fault seconds after a
@@ -475,7 +492,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         if (proxy == null || !Uri.TryCreate(controllerUrl, UriKind.Absolute, out var uri))
             return (controllerUrl, null);
         var port = uri.IsDefaultPort ? (uri.Scheme == Uri.UriSchemeHttps ? 443 : 80) : uri.Port;
-        var localPort = proxy.GetOrCreateEndpoint(SiteSlug, uri.Host, port);
+        var localPort = proxy.GetOrCreateEndpoint(SiteSlug, uri.Host, port, isConsole: true);
         _logger.LogInformation("Console for site {Slug} routed via agent tunnel (127.0.0.1:{LocalPort} -> {Host}:{Port})",
             SiteSlug, localPort, uri.Host, port);
         return (controllerUrl, localPort);

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -732,9 +732,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _client?.Dispose();
             _client = null;
             _isConnected = false;
-            _lastError = null;
+            // Cleared on success, not here: a connect takes up to the full timeout to resolve, and
+            // wiping them on entry left the banner showing a generic "not connected" for that whole
+            // window instead of the reason it already knew.
             _awaitingAgent = false;
-            _consoleUnresponsive = false;
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
@@ -781,6 +782,8 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 }
 
                 _isConnected = true;
+                _lastError = null;
+                _consoleUnresponsive = false;
                 _lastConnectedAt = DateTime.UtcNow;
 
                 // Save configuration to database
@@ -876,9 +879,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _client?.Dispose();
             _client = null;
             _isConnected = false;
-            _lastError = null;
+            // Cleared on success, not here: a connect takes up to the full timeout to resolve, and
+            // wiping them on entry left the banner showing a generic "not connected" for that whole
+            // window instead of the reason it already knew.
             _awaitingAgent = false;
-            _consoleUnresponsive = false;
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
@@ -924,6 +928,8 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 }
 
                 _isConnected = true;
+                _lastError = null;
+                _consoleUnresponsive = false;
                 _lastConnectedAt = DateTime.UtcNow;
 
                 // Cache the console's display name on auto-reconnect too, so the

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -342,6 +342,22 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// is down. The agent-connected hook re-establishes the console when the
     /// tunnel returns.
     /// </summary>
+    /// <summary>
+    /// The client proved the console stopped answering mid-session. Mark it down so pages render
+    /// the banner instead of paying a timeout per call. Deliberately does not take the connect gate
+    /// or dispose the client - this fires from a request in flight, and the next reconnect owns
+    /// both. The background reconnect clears it when the console comes back.
+    /// </summary>
+    private void HandleConsoleWentSilent()
+    {
+        if (!_isConnected) return;
+        _isConnected = false;
+        _consoleUnresponsive = true;
+        _lastError = ConsoleUnresponsiveMessage;
+        _logger.LogWarning("Console for site {Slug} stopped answering; marking it unresponsive", SiteSlug);
+        OnConnectionChanged?.Invoke();
+    }
+
     public async Task OnAgentTunnelDroppedAsync()
     {
         if (IsAgentOnline()) return; // another agent still carries the site
@@ -746,6 +762,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 consoleEndpoint.ProxyPort
             );
             _client.AuthProbeCompleted += HandleAuthProbe;
+            _client.ConsoleWentSilent += HandleConsoleWentSilent;
 
             // Attempt to authenticate
             var success = await _client.LoginAsync();
@@ -889,6 +906,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
                 consoleEndpoint.ProxyPort
             );
             _client.AuthProbeCompleted += HandleAuthProbe;
+            _client.ConsoleWentSilent += HandleConsoleWentSilent;
 
             var success = await _client.LoginAsync(cts.Token);
 

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -348,8 +348,12 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// or dispose the client - this fires from a request in flight, and the next reconnect owns
     /// both. The background reconnect clears it when the console comes back.
     /// </summary>
-    private void HandleConsoleWentSilent()
+    private void HandleConsoleWentSilent(UniFiApiClient client)
     {
+        // Only the live client may report this. A disposed one's request can fault seconds after a
+        // reconnect already succeeded, and acting on it would flip a good connection straight back
+        // down - the subscription outlives the client it was made on.
+        if (!ReferenceEquals(client, _client)) return;
         if (!_isConnected) return;
         _isConnected = false;
         _consoleUnresponsive = true;

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -222,6 +222,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     // path back (every automatic reconnect is gated on !IsConnected).
     private bool _clientViaAgent;
 
+    /// <summary>Shown while a directly-connected console answers the handshake but never replies.</summary>
+    private const string ConsoleUnresponsiveMessage =
+        "Your UniFi Console accepted the connection but stopped responding. It may be restarting or upgrading. Network Optimizer keeps trying and will reconnect on its own.";
+
     /// <summary>Shown while a site's agent-tunneled console waits for the agent to come online.</summary>
     private const string AwaitingAgentMessage =
         "This site's console connects through its on-site agent, which isn't online yet. It'll connect automatically as soon as the agent comes online.";
@@ -575,6 +579,16 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// </summary>
     public bool IsAwaitingAgent =>
         _awaitingAgent && !_isConnected && _settings is { IsConfigured: true, HasCredentials: true };
+
+    private bool _consoleUnresponsive;
+
+    /// <summary>
+    /// True once a connect has timed out against a console that answers TCP but never replies.
+    /// Lets reads fail fast. Never gate the background reconnect on it, and any successful connect
+    /// clears it - this must not be able to latch a site off.
+    /// </summary>
+    public bool IsConsoleUnresponsive =>
+        _consoleUnresponsive && !_isConnected && _settings is { IsConfigured: true, HasCredentials: true };
     public DateTime? LastConnectedAt => _lastConnectedAt;
     public bool IsUniFiOs => _client?.IsUniFiOs ?? false;
 
@@ -704,6 +718,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _isConnected = false;
             _lastError = null;
             _awaitingAgent = false;
+            _consoleUnresponsive = false;
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
@@ -846,6 +861,7 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
             _isConnected = false;
             _lastError = null;
             _awaitingAgent = false;
+            _consoleUnresponsive = false;
 
             // Create new client
             var viaAgent = await IsConsoleViaAgentAsync();
@@ -938,8 +954,11 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            _lastError = "UniFi Console is unreachable. Check that it's powered on and the URL is correct.";
-            _logger.LogWarning("Startup auto-connect timed out - console unreachable");
+            // Nothing answered inside the budget, so every later call would pay the same wait.
+            // Mark it so reads short-circuit; the background reconnect keeps dialing regardless.
+            _consoleUnresponsive = true;
+            _lastError = ConsoleUnresponsiveMessage;
+            _logger.LogWarning("Console connect timed out for site {Slug}; treating it as unresponsive until a connect succeeds", SiteSlug);
             _client?.Dispose();
             _client = null;
             await PreferAwaitingAgentOnDeadTunnelAsync();
@@ -1266,6 +1285,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         // OnConnectionChanged when it does. Waiting here would stall every page
         // render of the site for the full timeout.
         if (IsAwaitingAgent) return false;
+
+        // Same reasoning for a console that answers TCP and then goes quiet: polling it here only
+        // stalls the render, and the background reconnect brings it back via OnConnectionChanged.
+        if (IsConsoleUnresponsive) return false;
 
         // Check if we have saved credentials to connect with
         var settings = await GetSettingsAsync();

--- a/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiConnectionService.cs
@@ -343,12 +343,6 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
     /// tunnel returns.
     /// </summary>
     /// <summary>
-    /// The client proved the console stopped answering mid-session. Mark it down so pages render
-    /// the banner instead of paying a timeout per call. Deliberately does not take the connect gate
-    /// or dispose the client - this fires from a request in flight, and the next reconnect owns
-    /// both. The background reconnect clears it when the console comes back.
-    /// </summary>
-    /// <summary>
     /// The site's agent is up but cannot open a connection to the console, so awaiting-agent would
     /// be the wrong answer. Marks it down instead; the next successful connect clears it.
     /// </summary>
@@ -365,6 +359,10 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// The client proved the console stopped answering mid-session. Marks it down so pages render
+    /// the banner instead of paying a timeout per call; the background reconnect clears it.
+    /// </summary>
     private void HandleConsoleWentSilent(UniFiApiClient client)
     {
         // Only the live client may report this. A disposed one's request can fault seconds after a
@@ -379,6 +377,15 @@ public class UniFiConnectionService : IUniFiClientProvider, IDisposable
         OnConnectionChanged?.Invoke();
     }
 
+    /// <summary>
+    /// Called when this site's agent tunnel drops. When the console is reached
+    /// through that tunnel, flip straight to the awaiting-agent state: the client
+    /// stays "connected" otherwise, and every console call dials the dead loopback
+    /// proxy and burns through the transient-failure retry backoff (~14 s per
+    /// call), which reads as a frozen UI on any page of this site while the agent
+    /// is down. The agent-connected hook re-establishes the console when the
+    /// tunnel returns.
+    /// </summary>
     public async Task OnAgentTunnelDroppedAsync()
     {
         if (IsAgentOnline()) return; // another agent still carries the site


### PR DESCRIPTION
The headline here is not the console fixes - it is that pages stopped waiting on the network before they would draw anything at all.

## Page loads

- **Every page now returns immediately instead of waiting on its data** - Blazor was prerendering, which holds the entire HTML response until every component on the page has finished `OnInitializedAsync`. Every dashboard panel, every stats card and every monitoring tab loads its data there, so the browser got nothing - not a header, not a spinner, not a banner - until the slowest call on the page came back.

That is why so much of the app felt laggy for no visible reason. Anything slow upstream stalled the whole render: a console call waiting on a timeout, an SSH probe to a gateway, an SNMP poll, a large InfluxDB query. Usually that was a second or two of dead air on navigation. When something upstream was actually unhealthy it ran to tens of seconds, and a console that accepted connections but never answered could hold a page for the better part of a minute with a blank window and no way to tell whether the app was broken or just busy.

Pages now send their shell straight away and fill in behind the spinners the panels already render, so a slow or dead dependency delays only the card that needs it. It also stops `OnInitializedAsync` running twice on every page load, halving that duplicated work app-wide.

Two knock-ons came with it and are handled: Client Performance no longer identifies the viewer from the prerender pass (below), and two pieces of state that were carried across the prerender boundary are inert and marked with TODOs rather than silently pretending to work.

## UniFi Console Connection

- **A console reached through an agent tunnel recovers on its own after a brief tunnel outage** - a gateway reboot, a firmware upgrade, or any blip that quiets the tunnel for more than 45 seconds but less than 90 left the site's console stuck showing "waiting for this site's agent" until somebody reconnected it by hand.

The two thresholds create the gap. At 45 seconds of silence the tunnel is treated as black-holed and the console flips to awaiting-agent so its calls fail fast. At 90 seconds the tunnel is dropped and the agent's reconnect brings the console back with it. Silence ending between those two marks gets the flip without the drop: same live connection, no reconnect, nothing left to un-stick the console. Both routes back were closed for that state. The reconnect now runs on the tunnel's periodic refresh again, where the guard above it already exists to skip while the tunnel is black-holed. Behavior on a real agent connect is unchanged in every case.

- **A console that stops answering no longer freezes the page** - one that is paused, restarting or upgrading completes the TCP handshake and then never replies. That is not the same as one switched off: a refused connection comes back in milliseconds, a silent one costs the full 15 second timeout. Both were treated as transient and rode out the whole 2+4+8s backoff, so a single console call took four attempts plus fourteen seconds of waiting, and a page makes many of them.

Timeouts now get one quick retry instead of the full backoff; refused and reset connections keep it. Two consecutive timeouts then trip a breaker: further calls fail immediately rather than dialing, and one call per 30 second cooldown probes for the console's return. Only a genuine timeout counts - a caller cancelling raises the same exception type and says nothing about the console. The breaker's signal carries the client that raised it, so a report from a disposed client cannot flip a good connection back down, and any success resets it.

- **A console the agent cannot reach is recognized as down** - unreachability was only declared when the tunnel itself went silent, which is right for an ordinary device that will not answer but wrong for the console. With the agent alive and the console behind it unreachable, nothing marked it down and every page paid an open per call. Two consecutive failed opens on the console's own endpoint now mark it; device endpoints are untouched.

## Dashboard

- **Live View stays on the page when the console is down** - it was withheld entirely, which left no sign that the Monitoring tab's timeline still plays back. It now stays, says the console is unavailable, and points there. A failed load also no longer falls through to "Monitoring not configured", which sent people to a setup flow they had already completed.

- **The map and WAN chart come back after a reconnect** - hiding the panel took their markup with it while the mount flags stayed set, so neither remounted and both left blank areas.

## Client Performance

- **Identifying your own device no longer depends on the prerender pass** - it read the viewer's address from `HttpContext` during `OnInitializedAsync`, which only worked because that ran inside the initial HTTP request. The browser now asks for its own address after first render, reusing the same forwarded-header and dual-stack handling as the other client endpoints. Managed sites are untouched: they already resolve identity from the on-site agent's whoami probe.
