### PR TITLE
Bump SSH.NET to 2026.0.0 (GHSA-q939-rpr3-3284)

### DIFF
--- a/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
+++ b/src/NetworkOptimizer.Web/NetworkOptimizer.Web.csproj
@@ -40,7 +40,7 @@
 
   <ItemGroup>
     <PackageReference Include="Blazor-ApexCharts" Version="6.1.1-ozarkconnect.2" />
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.7.0" />
     <PackageReference Include="Castle.Core" Version="5.1.1" />
     <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.80.0" />
@@ -61,7 +61,7 @@
     <PackageReference Include="QRCoder" Version="1.8.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="SSH.NET" Version="2025.1.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Clears the NU1903 high-severity advisory on SSH.NET 2025.1.0 (GHSA-q939-rpr3-3284: `ScpClient.Download()` path traversal from a malicious SCP server during recursive downloads).

**Exposure assessment: none in practice.** The codebase never uses `ScpClient` - all SSH goes through `SshClientService`, which builds only `SshClient` (command execution) and an upload-only `SftpClient`. This is scan hygiene, not a live hole.

- SSH.NET 2025.1.0 -> 2026.0.0 (the only fixed release; no 2025.x patch exists)
- BouncyCastle.Cryptography 2.6.2 -> 2.7.0 (required floor of SSH.NET 2026.0.0; our direct pin otherwise fails restore with NU1605)

No code changes needed; 2026.0.0's one breaking change is confined to `ScpClient`, which we don't use.

Verification: restore/build clean with 0 warnings (SSH.NET NU1903 gone), full solution suite 8,873 passed / 0 failed, and the SSH key round-trip tests (the surface most likely to catch a BouncyCastle regression) pass.

Note for the next release gate: `dotnet list package --vulnerable --include-transitive` still reports a pre-existing, unrelated transitive advisory on `System.Security.Cryptography.Xml` via `ITfoxtec.Identity.Saml2` - untouched by this PR.