### PR TITLE
Firmware Rollout: pair a device's color variants as one model

### DIFF
--- a/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
@@ -740,6 +740,33 @@ public static class UniFiProductDatabase
     }
 
     /// <summary>
+    /// The product a device belongs to, with its color variant folded in. Ubiquiti ships the same
+    /// hardware in more than one shell under its own model code - UAPA6A9 is a U7-Pro-XG and
+    /// UAPA6AE is the black one - and they take the same firmware, so anything reasoning about a
+    /// model rather than a device wants them together: excluding a model, pinning it to a channel,
+    /// and pairing one against another as a canary.
+    /// </summary>
+    /// <remarks>
+    /// Only a trailing -B or -W is a color. -M (UAP-AC-M, mesh) and -X (UVP-X) are different
+    /// products and must survive, so this cannot just trim the last suffix. Some lines carry no
+    /// bare name at all: UNAS-2 exists only as UNAS-2-B and UNAS-2-W, which is why both are
+    /// stripped rather than folding one into the other.
+    /// </remarks>
+    /// <param name="model">Console model code, e.g. "UAPA6AE".</param>
+    /// <param name="shortname">Legacy shortname, where the model code is unknown.</param>
+    /// <returns>The family key, or the input unchanged when the catalog does not carry it.</returns>
+    public static string GetModelFamily(string? model, string? shortname = null)
+    {
+        var name = GetBestProductName(model, shortname);
+        if (string.IsNullOrEmpty(name)) return name;
+
+        return name.EndsWith("-B", StringComparison.OrdinalIgnoreCase)
+            || name.EndsWith("-W", StringComparison.OrdinalIgnoreCase)
+                ? name[..^2]
+                : name;
+    }
+
+    /// <summary>
     /// Check if a device can run iperf3 for LAN speed testing
     /// </summary>
     /// <param name="productName">The friendly product name (e.g., "USW-Flex-Mini")</param>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -1,4 +1,5 @@
 @page "/firmware-rollout"
+@using NetworkOptimizer.UniFi
 @attribute [Authorize(Policy = Policies.RequireViewer)]
 @implements IAsyncDisposable
 @inject IFirmwareRolloutService RolloutService
@@ -1041,11 +1042,15 @@ else
     }
 
     /// <summary>Every model on the site, keyed by the console's code and labeled by product name.</summary>
+    /// <summary>
+    /// One row per model family, so a site running the same AP in two colors gets one control
+    /// rather than two that quietly govern each other - the planner resolves both to one key.
+    /// </summary>
     private List<(string Code, string Label)> SiteModels =>
         (_preview?.Devices ?? [])
             .Where(d => !string.IsNullOrEmpty(d.Model))
-            .GroupBy(d => d.Model, StringComparer.OrdinalIgnoreCase)
-            .Select(g => (Code: g.Key, Label: g.First().DisplayModel))
+            .GroupBy(d => UniFiProductDatabase.GetModelFamily(d.Model, d.DisplayModel), StringComparer.OrdinalIgnoreCase)
+            .Select(g => (Code: g.First().Model, Label: g.Key))
             .OrderBy(m => m.Label, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -1041,10 +1041,10 @@ else
         if (!_exSkus.Add(model)) _exSkus.Remove(model);
     }
 
-    /// <summary>Every model on the site, keyed by the console's code and labeled by product name.</summary>
     /// <summary>
-    /// One row per model family, so a site running the same AP in two colors gets one control
-    /// rather than two that quietly govern each other - the planner resolves both to one key.
+    /// Every model on the site, one row per family and labeled by product name. A site running the
+    /// same AP in two colors gets one control rather than two that quietly govern each other, since
+    /// the planner resolves both to one key.
     /// </summary>
     private List<(string Code, string Label)> SiteModels =>
         (_preview?.Devices ?? [])

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi;
 
 namespace NetworkOptimizer.Web.Services.Firmware;
 
@@ -35,8 +36,16 @@ public class PlannerDevice
     /// <summary>Display name; falls back to the friendly model name upstream.</summary>
     public string Name { get; init; } = string.Empty;
 
-    /// <summary>Raw SKU code (e.g. U7PRO) - the canary and timing-store key.</summary>
+    /// <summary>Raw SKU code (e.g. U7PRO) - the timing-store key.</summary>
     public string Model { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The model with its color variant folded in, and the key for anything about a MODEL rather
+    /// than a device: exclusions, per-model channels, and canary pairing. A black U7-Pro-XG has its
+    /// own console code, so keying those on the raw one left two of the same AP unpaired - and a
+    /// site with one of each got no canary at all, because neither model had a second device.
+    /// </summary>
+    public string ModelFamily => UniFiProductDatabase.GetModelFamily(Model, DisplayModel);
 
     /// <summary>Friendly model name (e.g. "U7 Pro") for display and generation heuristics.</summary>
     public string DisplayModel { get; init; } = string.Empty;
@@ -219,9 +228,24 @@ public class RolloutExclusions
         return result;
     }
 
+    /// <summary>
+    /// Whether a device is excluded. A stored SKU is matched on the model FAMILY at both ends, so a
+    /// rule excluding a model covers the same hardware in another color, and rules written against
+    /// a raw console code before this keep working.
+    /// </summary>
     public bool Excludes(PlannerDevice d) =>
-        Macs.Contains(d.Mac) || Skus.Contains(d.Model) ||
+        Macs.Contains(d.Mac) || MatchesSku(d) ||
         DeviceTypes.Contains(FirmwareDeviceTypes.Code(d.Type)) || DeviceTypes.Contains(d.Type.ToString());
+
+    private bool MatchesSku(PlannerDevice d)
+    {
+        if (Skus.Count == 0) return false;
+        if (Skus.Contains(d.Model)) return true;
+
+        var family = d.ModelFamily;
+        return Skus.Any(s => string.Equals(
+            UniFiProductDatabase.GetModelFamily(s), family, StringComparison.OrdinalIgnoreCase));
+    }
 }
 
 /// <summary>Maps the effective device type to the UniFi short code stored on steps.</summary>

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutPlanner.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutPlanner.cs
@@ -229,8 +229,8 @@ public class RolloutPlanner
     /// <summary>Effective channel: per-SKU override, then per-type, then global.</summary>
     public static string ResolveChannel(PlannerDevice d, FirmwareRolloutSettings settings)
     {
-        // Matched on the family at both ends, so a channel pinned to a model covers its other
-        // color, and a map written against a raw console code still resolves.
+        // Exact code first so a pin deliberately set on one color still wins, then the family, so a
+        // pin covers the same hardware in another shell and a map written against a raw code resolves.
         var bySku = ParseMap(settings.PerSkuChannelsJson);
         if (bySku.TryGetValue(d.Model, out var skuChannel) && !string.IsNullOrWhiteSpace(skuChannel))
             return skuChannel;

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutPlanner.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutPlanner.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi;
 
 namespace NetworkOptimizer.Web.Services.Firmware;
 
@@ -61,7 +62,10 @@ public class RolloutPlanner
 
         ordered = ApplyMeshGroupOrdering(ordered, candidates, doc.Notes);
 
-        var skuCounts = candidates.GroupBy(d => d.Model, StringComparer.OrdinalIgnoreCase)
+        // Family, not the raw code: the same AP in another shell has its own console code, and
+        // counting them apart meant one of each was two models of one device - so neither earned
+        // a canary and both went in normal waves with nothing gating them.
+        var skuCounts = candidates.GroupBy(d => d.ModelFamily, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(g => g.Key, g => g.Count(), StringComparer.OrdinalIgnoreCase);
         var canaried = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var deviceWave = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
@@ -225,9 +229,17 @@ public class RolloutPlanner
     /// <summary>Effective channel: per-SKU override, then per-type, then global.</summary>
     public static string ResolveChannel(PlannerDevice d, FirmwareRolloutSettings settings)
     {
+        // Matched on the family at both ends, so a channel pinned to a model covers its other
+        // color, and a map written against a raw console code still resolves.
         var bySku = ParseMap(settings.PerSkuChannelsJson);
         if (bySku.TryGetValue(d.Model, out var skuChannel) && !string.IsNullOrWhiteSpace(skuChannel))
             return skuChannel;
+        foreach (var (sku, channel) in bySku)
+        {
+            if (string.IsNullOrWhiteSpace(channel)) continue;
+            if (string.Equals(UniFiProductDatabase.GetModelFamily(sku), d.ModelFamily, StringComparison.OrdinalIgnoreCase))
+                return channel;
+        }
 
         var byType = ParseMap(settings.PerDeviceTypeChannelsJson);
         if (byType.TryGetValue(FirmwareDeviceTypes.Code(d.Type), out var typeChannel) ||
@@ -338,7 +350,7 @@ public class RolloutPlanner
 
         foreach (var d in level)
         {
-            var isCanary = skuCounts.GetValueOrDefault(d.Model, 0) > 1 && canaried.Add(d.Model);
+            var isCanary = skuCounts.GetValueOrDefault(d.ModelFamily, 0) > 1 && canaried.Add(d.ModelFamily);
             if (isCanary)
             {
                 waves.Add([(d, true, false)]);
@@ -351,7 +363,7 @@ public class RolloutPlanner
             else solo.Add(d);
         }
 
-        bool Held(PlannerDevice d) => canaried.Contains(d.Model) && skuCounts.GetValueOrDefault(d.Model, 0) > 1;
+        bool Held(PlannerDevice d) => canaried.Contains(d.ModelFamily) && skuCounts.GetValueOrDefault(d.ModelFamily, 0) > 1;
 
         Pack(waves, packableAps, spacing.MaxApParallelism,
             (a, b) => neighbors == null || !neighbors.AreNeighbors(a.Mac, b.Mac), Held);

--- a/tests/NetworkOptimizer.UniFi.Tests/ModelFamilyTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/ModelFamilyTests.cs
@@ -1,0 +1,45 @@
+using FluentAssertions;
+using NetworkOptimizer.UniFi;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// Color variants of one product carry their own console model codes, and anything reasoning about
+/// a model rather than a device has to see through that. The negative cases matter as much: -M and
+/// -X are different products, not colors, and merging them would pair a mesh AP with its wired
+/// sibling.
+/// </summary>
+public class ModelFamilyTests
+{
+    [Theory]
+    [InlineData("UAPA6A9", "U7-Pro-XG")]   // white
+    [InlineData("UAPA6AE", "U7-Pro-XG")]   // black, own model code
+    [InlineData("UAPA6A4", "U7-Pro-XGS")]
+    [InlineData("UAPA6AC", "U7-Pro-XGS")]
+    public void GetModelFamily_ColorVariants_ShareOneKey(string modelCode, string expected) =>
+        UniFiProductDatabase.GetModelFamily(modelCode).Should().Be(expected);
+
+    [Fact]
+    public void GetModelFamily_ALineWithNoBareName_StillPairs()
+    {
+        // UNAS-2 exists only as -B and -W, so folding one into the other would leave them apart.
+        UniFiProductDatabase.GetModelFamily("UNAS2B")
+            .Should().Be(UniFiProductDatabase.GetModelFamily("UNAS2W"));
+    }
+
+    [Theory]
+    [InlineData("UAP-AC-M")]   // Mesh, not a color
+    [InlineData("UVP-X")]
+    public void GetModelFamily_SuffixesThatAreNotColors_AreLeftAlone(string productName) =>
+        UniFiProductDatabase.GetModelFamily(productName).Should().Be(productName);
+
+    [Fact]
+    public void GetModelFamily_DifferentProducts_StayApart() =>
+        UniFiProductDatabase.GetModelFamily("UAPA6A9")
+            .Should().NotBe(UniFiProductDatabase.GetModelFamily("UAPA6A4"));
+
+    [Fact]
+    public void GetModelFamily_AModelTheCatalogDoesNotCarry_ComesBackUnchanged() =>
+        UniFiProductDatabase.GetModelFamily("NOTAREALCODE").Should().Be("NOTAREALCODE");
+}

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutPlannerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutPlannerTests.cs
@@ -1237,4 +1237,44 @@ public class RolloutPlannerTests
         result.Steps.Should().HaveCount(2)
             .And.OnlyContain(s => s.State == FirmwareRolloutStepState.SkippedExcluded);
     }
+
+    [Fact]
+    public void Plan_TheSameApInTwoColors_StillGetsACanary()
+    {
+        // UAPA6A9 and UAPA6AE are a U7-Pro-XG and the black one: same hardware, same firmware,
+        // different console codes. Counted apart they were two models of one device each, so
+        // neither earned a canary and both went out with nothing gating them.
+        var devices = new[]
+        {
+            Gw(upgradable: false),
+            Ap(ApMac, "AP-White", "UAPA6A9", GatewayMac),
+            Ap("aa:bb:cc:dd:ee:07", "AP-Black", "UAPA6AE", GatewayMac),
+        };
+
+        var result = Plan(devices);
+
+        var canaries = result.Document.Waves.SelectMany(w => w.Steps).Where(s => s.IsCanary).ToList();
+        canaries.Should().ContainSingle();
+        result.Document.Waves.SelectMany(w => w.Steps)
+            .Single(s => s.Mac != canaries[0].Mac && s.Mac != GatewayMac)
+            .HeldForCanary.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Plan_ExcludingAModel_TakesItsOtherColorToo()
+    {
+        var devices = new[]
+        {
+            Gw(upgradable: false),
+            Ap(ApMac, "AP-White", "UAPA6A9", GatewayMac),
+            Ap("aa:bb:cc:dd:ee:07", "AP-Black", "UAPA6AE", GatewayMac),
+        };
+        var settings = Settings();
+        settings.ExclusionsJson = """{"macs":[],"skus":["UAPA6A9"],"deviceTypes":[]}""";
+
+        var result = Plan(devices, settings);
+
+        result.Steps.Where(s => s.DeviceMac != GatewayMac)
+            .Should().OnlyContain(s => s.State == FirmwareRolloutStepState.SkippedExcluded);
+    }
 }


### PR DESCRIPTION
Ubiquiti ships the same hardware in more than one shell, and each color carries its own console model code - `UAPA6A9` is a U7-Pro-XG and `UAPA6AE` is the black one. They take the same firmware. Three parts of Firmware Rollout keyed on the raw code and so saw two unrelated models: exclusions, per-model channels, and canary pairing.

## Firmware Rollout

- **A canary now pairs a device with the same model in another color.** A canary only exists where a model has more than one device, so a site with one white and one black U7-Pro-XG had a count of one on each and neither was chosen - two identical APs upgraded in normal waves with nothing gating them, and nothing on screen explaining why. This is the case that cost something; the other two were mostly annoyance.
- **Excluding a model excludes its other color**, and **pinning a model to a release channel covers its other color**. An exact code match still wins first, so a pin deliberately set on one color is honoured.
- **Per-model channels list one row per model**, rather than two rows that silently governed each other.

## Notes for review

- `UniFiProductDatabase.GetModelFamily` resolves a code to its product name and drops a trailing color. Only `-B` and `-W` are colors: `UAP-AC-M` is a mesh AP and `UVP-X` a phone, so this cannot simply trim the last suffix, and a generic trim would have paired a mesh AP with its wired sibling. Some lines carry no bare name at all - UNAS-2 exists only as `UNAS-2-B` and `UNAS-2-W` - which is why both suffixes are stripped rather than folding one into the other. A model the catalog does not carry comes back unchanged, so unknown hardware groups exactly as it did before.
- Stored settings are matched on the family at both ends, so exclusions and channel pins written against a raw console code keep working and now cover the other color. Nothing has to be re-saved.
- `PlannerDevice.Model` is unchanged and remains the timing-store key; the new `ModelFamily` is only used where the question is about a model rather than a device.
- Two tests encode the original defect: one white AP plus one black AP produces a canary with the other held, and excluding one color excludes both. The family key has its own tests for the color cases, the two suffixes that must NOT merge, and an unknown code.
- `dotnet build` 0 warnings; 2,385 Web tests and 1,248 UniFi tests green.
- Not in v2.7.0-preview1. Targets `release/2.7` for preview2.
