### PR TITLE
Proxmox: 20 GB default, and reclaim the images Docker never does

### DIFF
--- a/scripts/proxmox/install.sh
+++ b/scripts/proxmox/install.sh
@@ -25,7 +25,7 @@ GITHUB_BRANCH="main"
 
 # Container defaults
 DEFAULT_HOSTNAME="network-optimizer"
-DEFAULT_DISK_SIZE="10"
+DEFAULT_DISK_SIZE="20"
 DEFAULT_RAM="2048"
 DEFAULT_SWAP="512"
 DEFAULT_CPU="2"
@@ -910,6 +910,9 @@ APP_PASSWORD=${APP_PASSWORD}"
 
     msg_info "Starting services..."
     pct exec "$CT_ID" -- bash -c "cd $app_dir && docker compose up -d"
+    # Docker never reclaims the image a pull superseded - it just loses its tag. Left alone
+    # every upgrade leaks a full image, which is what fills a container disk over a year.
+    pct exec "$CT_ID" -- bash -c "docker image prune -f" >/dev/null 2>&1 || true
     msg_ok "Services started"
 }
 
@@ -1049,7 +1052,7 @@ show_completion() {
     echo -e "  Directory:  ${DIM}/opt/network-optimizer${CL}"
     echo -e "  Config:     ${DIM}/opt/network-optimizer/.env${CL}"
     echo -e "  Reference:  ${DIM}/opt/network-optimizer/.env.example${CL} ${DIM}(all options)${CL}"
-    echo -e "  Update:     ${DIM}pct exec $CT_ID -- bash -c 'cd /opt/network-optimizer && docker compose pull && docker compose up -d'${CL}"
+    echo -e "  Update:     ${DIM}pct exec $CT_ID -- bash -c 'cd /opt/network-optimizer && docker compose pull && docker compose up -d && docker image prune -f'${CL}"
 
     if [[ "$APP_TRAEFIK_ENABLED" == "true" ]]; then
         echo -e "\n${BLD}Traefik HTTPS Proxy:${CL}"
@@ -1057,7 +1060,7 @@ show_completion() {
         echo -e "  Directory:  ${DIM}/opt/network-optimizer-proxy${CL}"
         echo -e "  Config:     ${DIM}/opt/network-optimizer-proxy/dynamic/config.yml${CL}"
         echo -e "  Logs:       ${DIM}pct exec $CT_ID -- docker logs -f traefik-proxy${CL}"
-        echo -e "  Update:     ${DIM}pct exec $CT_ID -- bash -c 'cd /opt/network-optimizer-proxy && docker compose pull && docker compose up -d'${CL}"
+        echo -e "  Update:     ${DIM}pct exec $CT_ID -- bash -c 'cd /opt/network-optimizer-proxy && docker compose pull && docker compose up -d && docker image prune -f'${CL}"
     fi
 
     echo -e "\n${BLD}First Run:${CL}"


### PR DESCRIPTION
Docker has no garbage collection. The image a `docker compose pull` supersedes simply loses its tag and stays on disk - nothing ever removes it. Every upgrade therefore leaks a full copy of the app image (652 MB), invisibly, for the life of the container.

A NAS checked while writing this was carrying five of them: **3.2 GB of dead images** purely from routine upgrades.

On the installer's 10 GB default that is enough to fill the disk. A full disk reaches the app as SQLite being unable to write its journal, which surfaces as `SQLite Error 10: 'disk I/O error'` on the very first read at startup, crash looping - looking nothing like a space problem, and pointing the reader at the database rather than the disk.

## Proxmox

- **Default container disk is 20 GB**, up from 10. Sized against a 652 MB app image plus a 94 MB speedtest image, Docker and Debian, and room for upgrades that have not been pruned.
- **Every upgrade path now reclaims what it replaced** - both printed Update hints and the installer's own upgrade step. `docker image prune -f` without `-a`, so it only removes untagged images and can never take one a container still references.

## Notes for review

- Only affects new containers; an existing install keeps whatever disk it was created with. Those want a one-off `docker image prune -f`, which is safe to run at any time.
- The installer's own prune is best-effort (`|| true`) - reclaiming space should never fail an upgrade.
- The release-note Proxmox template in CLAUDE.md (untracked) carries the same prune, so future releases ship the command that keeps the disk flat.
- `bash -n` clean.