### PR TITLE
Firmware Rollout: exclude a model in the wizard the way the rollout excludes it

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -321,9 +321,10 @@ else if (_wizardOpen)
                         <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
                             @foreach (var device in FilteredExclusionCandidates)
                             {
+                                @* Tooltip on the checkbox alone: on the row it fired anywhere along it. *@
                                 var derived = DerivedExclusion(device);
-                                <label class="checkbox-label firmware-rollout-device-row" data-tooltip="@derived">
-                                    <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
+                                <label class="checkbox-label firmware-rollout-device-row">
+                                    <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" data-tooltip="@derived" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
                                     <span>@device.Name</span>
                                     <span class="firmware-rollout-muted">@device.DisplayModel</span>
                                     @if (device.Upgradable)
@@ -331,7 +332,7 @@ else if (_wizardOpen)
                                         <span class="firmware-rollout-chip chip-active"
                                               data-tooltip="@UpdateTooltip(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
                                     }
-                                    <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku(device.Model)" @onclick:stopPropagation="true">@(_exSkus.Contains(device.Model) ? "Include model" : "Exclude model")</button>
+                                    <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
                                 </label>
                             }
                         </div>
@@ -1025,20 +1026,51 @@ else
 
     /// <summary>Excluded by its own rule or by one covering its model or type.</summary>
     private bool IsExcluded(RolloutDeviceView device) =>
-        _exMacs.Contains(device.Mac) || _exSkus.Contains(device.Model) || _exTypes.Contains(device.DeviceType);
+        _exMacs.Contains(device.Mac) || SkuExcluded(device) || _exTypes.Contains(device.DeviceType);
 
-    /// <summary>Why a device is excluded when the rule is not its own, else null.</summary>
+    /// <summary>
+    /// Whether a stored model rule covers this device, matched on the family so a rule written on
+    /// one color covers the same hardware in another. The planner already matches this way, and a
+    /// checkbox that disagreed with it would be showing something the rollout will not do.
+    /// </summary>
+    private bool SkuExcluded(RolloutDeviceView device)
+    {
+        if (_exSkus.Contains(device.Model)) return true;
+        var family = ModelFamilyOf(device);
+        return _exSkus.Any(s => string.Equals(
+            UniFiProductDatabase.GetModelFamily(s), family, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string ModelFamilyOf(RolloutDeviceView device) =>
+        UniFiProductDatabase.GetModelFamily(device.Model, device.DisplayModel);
+
+    /// <summary>
+    /// Why a device is excluded when the rule is not its own MAC, else null. Doubles as the test
+    /// for whether this row's checkbox can clear it, which it cannot.
+    /// </summary>
     private string? DerivedExclusion(RolloutDeviceView device)
     {
         if (_exMacs.Contains(device.Mac)) return null;
-        if (_exSkus.Contains(device.Model)) return $"Excluded by the rule for every {device.DisplayModel}.";
+        if (SkuExcluded(device)) return $"Excluded by the rule for every {ModelFamilyOf(device)}.";
         if (_exTypes.Contains(device.DeviceType)) return "Excluded by the rule for this device type.";
         return null;
     }
 
-    private void ToggleSku(string model)
+    /// <summary>
+    /// Adds or clears a model rule for the device's whole family. Removing has to sweep the family
+    /// too: the stored rule may name the other color's code, and Include would otherwise appear to
+    /// do nothing.
+    /// </summary>
+    private void ToggleSku(RolloutDeviceView device)
     {
-        if (!_exSkus.Add(model)) _exSkus.Remove(model);
+        var family = ModelFamilyOf(device);
+        var existing = _exSkus.Where(s => string.Equals(
+            UniFiProductDatabase.GetModelFamily(s), family, StringComparison.OrdinalIgnoreCase)).ToList();
+
+        if (existing.Count > 0)
+            foreach (var s in existing) _exSkus.Remove(s);
+        else
+            _exSkus.Add(device.Model);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -321,10 +321,13 @@ else if (_wizardOpen)
                         <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
                             @foreach (var device in FilteredExclusionCandidates)
                             {
-                                @* Tooltip on the checkbox alone: on the row it fired anywhere along it. *@
+                                @* The tooltip goes on a wrapper, not the row (it fired anywhere along it)
+                                   and not the input (a disabled control emits no hover). *@
                                 var derived = DerivedExclusion(device);
                                 <label class="checkbox-label firmware-rollout-device-row">
-                                    <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" data-tooltip="@derived" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
+                                    <span data-tooltip="@derived">
+                                        <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
+                                    </span>
                                     <span>@device.Name</span>
                                     <span class="firmware-rollout-muted">@device.DisplayModel</span>
                                     @if (device.Upgradable)


### PR DESCRIPTION
PR #1141 taught the planner that a device's color variants are one model. The wizard was not told, so the two disagreed.

## Firmware Rollout

- **Excluding a model now covers its other color on screen, not just in the plan.** The exclusion list compared raw console codes, so excluding a U7-Pro-XGS left the U7-Pro-XGS-B unticked and still offering **Exclude model** - while the plan would have excluded both. The screen was showing something the rollout was not going to do, which is worse than either behavior on its own.
- **Include model clears the whole family.** This needed more than the same comparison: the stored rule can name the other color's console code, so clearing has to sweep the family or the button appears to do nothing.
- **The derived-exclusion tooltip is on the checkbox** rather than the whole row, where it fired anywhere along it.

## Notes for review

- Three call sites moved onto the family: the checkbox state, the reason text, and the button label. All three go through one `SkuExcluded`, so they cannot drift apart again.
- Matching is robust to what is already stored. A rule saved as a product name (`U7-Pro-XGS`) resolves to the same family as one saved as a console code (`UAPA6A4`), so existing settings keep working and now cover both colors.
- The reason text names the family - "Excluded by the rule for every U7-Pro-XGS" while looking at a `-B` device - which is the useful thing to say, since it explains why a device you did not tick is excluded.
- The tooltip sits on a **wrapper span**, not the input. A disabled form control emits no pointer events at all, and this tooltip only exists for rows whose checkbox IS disabled - so on the input it would have been dead in every case it was written for. The wrapper needs no CSS: the row is a flex container with a gap and nothing targets the input directly, so the span takes the checkbox's place as the flex item.
- No test: this is Razor component logic and the suite has no component harness. The planner-side equivalent is covered by #1141's tests.
- `dotnet build` 0 warnings; 2,385 Web tests green. Deployed to NAS for hands-on.
