### PR TITLE
Fix LAG parent ports falsely flagged by audit and Config Optimizer (#1142)

### DIFF
--- a/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
+++ b/src/NetworkOptimizer.Audit/Analyzers/PortSecurityAnalyzer.cs
@@ -415,11 +415,14 @@ public class PortSecurityAnalyzer
             }
         }
 
-        var ports = device.GetArrayOrEmpty("port_table")
+        var rawPorts = device.GetArrayOrEmpty("port_table").ToList();
+        var ports = rawPorts
             .Select(port => ParsePort(port, switchInfoPlaceholder, networks, clientsByPort, historyByPort, portProfiles, deviceUplinkLookup, wanIfnames))
             .Where(p => p != null)
             .Cast<PortInfo>()
             .ToList();
+
+        PropagateLagParentMetadata(ports, rawPorts);
 
         return new SwitchInfo
         {
@@ -706,6 +709,44 @@ public class PortSecurityAnalyzer
         };
     }
 
+    /// <summary>
+    /// Propagate ConnectedDeviceType and IsUplink from LAG child ports to their parent.
+    /// deviceUplinkLookup only records the single port from uplink_remote_port, which for
+    /// a LAG is a child port, so the aggregate parent misses the fabric/uplink metadata.
+    /// </summary>
+    private void PropagateLagParentMetadata(List<PortInfo> ports, List<JsonElement> rawPorts)
+    {
+        var lagParents = ports.Where(p => p.IsLagParent).ToList();
+        if (lagParents.Count == 0) return;
+
+        var childToParentIdx = new Dictionary<int, int>();
+        foreach (var raw in rawPorts)
+        {
+            var idx = raw.GetIntOrDefault("port_idx", -1);
+            if (idx >= 0 && raw.TryGetProperty("aggregated_by", out var agg) && agg.ValueKind == JsonValueKind.Number)
+                childToParentIdx[idx] = agg.GetInt32();
+        }
+
+        foreach (var parent in lagParents)
+        {
+            var children = ports.Where(p => childToParentIdx.TryGetValue(p.PortIndex, out var parentIdx) && parentIdx == parent.PortIndex);
+            foreach (var child in children)
+            {
+                if (child.ConnectedDeviceType != null && parent.ConnectedDeviceType == null)
+                {
+                    parent.ConnectedDeviceType = child.ConnectedDeviceType;
+                    _logger.LogDebug("LAG parent port {Port} on {Switch}: inherited ConnectedDeviceType '{Type}' from child port {ChildPort}",
+                        parent.PortIndex, parent.Switch.Name, child.ConnectedDeviceType, child.PortIndex);
+                }
+                if (child.IsUplink && !parent.IsUplink)
+                {
+                    parent.IsUplink = true;
+                    _logger.LogDebug("LAG parent port {Port} on {Switch}: inherited IsUplink from child port {ChildPort}",
+                        parent.PortIndex, parent.Switch.Name, child.PortIndex);
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// Analyze all ports across all switches

--- a/src/NetworkOptimizer.Audit/Models/PortInfo.cs
+++ b/src/NetworkOptimizer.Audit/Models/PortInfo.cs
@@ -59,9 +59,16 @@ public class PortInfo
     public bool IsMirrorDestination => string.Equals(OpMode, "mirror", StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Whether this port is a LAG (Link Aggregation Group) parent/aggregate port.
+    /// Used to propagate uplink/fabric metadata from child ports to the parent
+    /// so that trunk audit rules evaluate the aggregate with complete context.
+    /// </summary>
+    public bool IsLagParent => string.Equals(OpMode, "aggregate", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// Whether this is an uplink port
     /// </summary>
-    public bool IsUplink { get; init; }
+    public bool IsUplink { get; set; }
 
     /// <summary>
     /// Whether this is a WAN port
@@ -145,8 +152,9 @@ public class PortInfo
     /// <summary>
     /// Type of UniFi device connected to this port (e.g., "uap" for AP, "usw" for switch).
     /// Determined by matching device uplink info to this port. Null for regular clients.
+    /// May be propagated from a LAG child to the LAG parent during post-parse.
     /// </summary>
-    public string? ConnectedDeviceType { get; init; }
+    public string? ConnectedDeviceType { get; set; }
 
     /// <summary>
     /// 802.1X control mode from the assigned port profile.

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
@@ -636,6 +636,10 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
+                // Skip LAG member ports - their config is managed at the aggregate level
+                if (port.LagIdx.HasValue)
+                    continue;
+
                 // Get profile if assigned
                 var profile = !string.IsNullOrEmpty(port.PortConfId) && profilesById.TryGetValue(port.PortConfId, out var p) ? p : null;
                 var settings = VlanAnalysisHelper.GetEffectiveVlanSettings(port, null, profile);
@@ -952,6 +956,10 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
+                // Skip LAG member ports
+                if (port.LagIdx.HasValue)
+                    continue;
+
                 // Skip ports that already have a profile
                 if (!string.IsNullOrEmpty(port.PortConfId))
                     continue;
@@ -1126,6 +1134,10 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
+                // Skip LAG member ports
+                if (port.LagIdx.HasValue)
+                    continue;
+
                 // Skip uplink and disabled ports
                 if (port.IsUplink || port.Forward == "disabled")
                     continue;

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
@@ -956,8 +956,8 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
-                // Skip LAG member ports
-                if (port.LagIdx.HasValue)
+                // Skip LAG child ports - their config is assimilated into the parent
+                if (port.AggregatedBy.HasValue)
                     continue;
 
                 // Skip ports that already have a profile
@@ -1134,8 +1134,8 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
-                // Skip LAG member ports
-                if (port.LagIdx.HasValue)
+                // Skip LAG child ports - their config is assimilated into the parent
+                if (port.AggregatedBy.HasValue)
                     continue;
 
                 // Skip uplink and disabled ports

--- a/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
+++ b/src/NetworkOptimizer.Diagnostics/Analyzers/PortProfileSuggestionAnalyzer.cs
@@ -636,8 +636,8 @@ public class PortProfileSuggestionAnalyzer
 
             foreach (var port in device.PortTable)
             {
-                // Skip LAG member ports - their config is managed at the aggregate level
-                if (port.LagIdx.HasValue)
+                // Skip LAG child ports - their config is assimilated into the parent
+                if (port.AggregatedBy.HasValue)
                     continue;
 
                 // Get profile if assigned

--- a/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortSecurityAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Audit.Tests/Analyzers/PortSecurityAnalyzerTests.cs
@@ -1760,6 +1760,154 @@ public class PortSecurityAnalyzerTests
             "LAG child port should still be checked by UnusedPortRule");
     }
 
+    [Fact]
+    public void AnalyzePorts_LagParentPort_InheritsUplinkFromChild()
+    {
+        // Reproduces #1142: two devices in a LACP aggregate. The child port has
+        // is_uplink=true but the parent (op_mode=aggregate) does not, so the parent
+        // was falsely flagged for excessive VLANs. The fix propagates IsUplink from
+        // the child to the parent, letting AccessPortVlanRule's uplink exemption work.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""EnterpriseXG-24"",
+                ""mac"": ""aa:bb:cc:dd:ee:01"",
+                ""port_table"": [
+                    { ""port_idx"": 25, ""name"": ""SFP28 25"", ""op_mode"": ""aggregate"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": false, ""is_uplink"": false },
+                    { ""port_idx"": 26, ""name"": ""SFP28 26"", ""op_mode"": ""switch"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": 25, ""is_uplink"": true }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-1", Name = "Default", VlanId = 1 },
+            new() { Id = "net-2", Name = "IoT", VlanId = 20 },
+            new() { Id = "net-3", Name = "Guest", VlanId = 30 }
+        };
+
+        var switches = _engine.ExtractSwitches(deviceData, networks);
+
+        var parent = switches[0].Ports.Single(p => p.PortIndex == 25);
+        parent.IsUplink.Should().BeTrue("LAG parent should inherit IsUplink from child");
+        parent.IsLagParent.Should().BeTrue();
+
+        var issues = _engine.AnalyzePorts(switches, networks);
+        issues.Where(i => i.Port == "25" && i.Type == IssueTypes.AccessPortVlan).Should().BeEmpty(
+            "LAG parent with uplink child should not be flagged for excessive VLANs");
+    }
+
+    [Fact]
+    public void AnalyzePorts_LagParentPort_InheritsFabricDeviceFromChild()
+    {
+        // The gateway (udm) uplinks to port 14 (the child), so deviceUplinkLookup has
+        // (switch MAC, 14) but not (switch MAC, 13). The fix propagates ConnectedDeviceType
+        // from child to parent so the fabric exemption catches port 13.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""udm"",
+                ""name"": ""UDM Beast"",
+                ""mac"": ""aa:bb:cc:dd:ee:02"",
+                ""port_table"": [
+                    { ""port_idx"": 13, ""name"": ""SFP28 1"", ""op_mode"": ""aggregate"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": false, ""is_uplink"": false },
+                    { ""port_idx"": 14, ""name"": ""SFP28 2"", ""op_mode"": ""switch"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": 13, ""is_uplink"": false }
+                ]
+            },
+            {
+                ""type"": ""usw"",
+                ""name"": ""EnterpriseXG-24"",
+                ""mac"": ""aa:bb:cc:dd:ee:01"",
+                ""uplink"": { ""uplink_mac"": ""aa:bb:cc:dd:ee:02"", ""uplink_remote_port"": 14 },
+                ""port_table"": [
+                    { ""port_idx"": 1, ""name"": ""Port 1"", ""up"": true }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-1", Name = "Default", VlanId = 1 },
+            new() { Id = "net-2", Name = "IoT", VlanId = 20 },
+            new() { Id = "net-3", Name = "Guest", VlanId = 30 }
+        };
+
+        var switches = _engine.ExtractSwitches(deviceData, networks);
+
+        var beast = switches.Single(s => s.Name == "UDM Beast");
+        var parent = beast.Ports.Single(p => p.PortIndex == 13);
+        parent.ConnectedDeviceType.Should().Be("usw", "LAG parent should inherit ConnectedDeviceType from child");
+        parent.IsLagParent.Should().BeTrue();
+
+        var issues = _engine.AnalyzePorts(switches, networks);
+        issues.Where(i => i.Port == "13" && i.Type == IssueTypes.AccessPortVlan).Should().BeEmpty(
+            "LAG parent with fabric device on child should not be flagged for excessive VLANs");
+    }
+
+    [Fact]
+    public void AnalyzePorts_LagParentPort_NoFabricDevice_StillFlagged()
+    {
+        // A LAG to a non-fabric device (e.g. server with bonded NICs) should still
+        // be flagged for excessive VLANs since no child has ConnectedDeviceType or IsUplink.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""Switch"",
+                ""mac"": ""aa:bb:cc:dd:ee:01"",
+                ""port_table"": [
+                    { ""port_idx"": 1, ""name"": ""Port 1"", ""up"": true },
+                    { ""port_idx"": 4, ""name"": ""Port 4"", ""op_mode"": ""aggregate"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": false, ""is_uplink"": false },
+                    { ""port_idx"": 5, ""name"": ""Port 5"", ""op_mode"": ""switch"", ""forward"": ""all"", ""up"": true, ""lag_idx"": 1, ""aggregated_by"": 4, ""is_uplink"": false }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-1", Name = "Default", VlanId = 1 },
+            new() { Id = "net-2", Name = "IoT", VlanId = 20 },
+            new() { Id = "net-3", Name = "Guest", VlanId = 30 }
+        };
+
+        var switches = _engine.ExtractSwitches(deviceData, networks);
+
+        var parent = switches[0].Ports.Single(p => p.PortIndex == 4);
+        parent.ConnectedDeviceType.Should().BeNull("no fabric device on the LAG");
+        parent.IsUplink.Should().BeFalse("no uplink on the LAG");
+
+        var issues = _engine.AnalyzePorts(switches, networks);
+        issues.Where(i => i.Port == "4" && i.Type == IssueTypes.AccessPortVlan).Should().HaveCount(1,
+            "LAG parent to a non-fabric device should still be flagged for excessive VLANs");
+    }
+
+    [Fact]
+    public void AnalyzePorts_NonLagTrunkPort_UnaffectedByPropagation()
+    {
+        // A regular trunk port (no LAG) with forward="all" and no connected device
+        // should still be flagged, verifying the propagation code doesn't interfere.
+        var deviceData = JsonDocument.Parse(@"[
+            {
+                ""type"": ""usw"",
+                ""name"": ""Switch"",
+                ""mac"": ""aa:bb:cc:dd:ee:01"",
+                ""port_table"": [
+                    { ""port_idx"": 1, ""name"": ""Port 1"", ""up"": true, ""forward"": ""all"" },
+                    { ""port_idx"": 2, ""name"": ""Port 2"", ""up"": true, ""forward"": ""native"" }
+                ]
+            }
+        ]").RootElement;
+        var networks = new List<NetworkInfo>
+        {
+            new() { Id = "net-1", Name = "Default", VlanId = 1 },
+            new() { Id = "net-2", Name = "IoT", VlanId = 20 },
+            new() { Id = "net-3", Name = "Guest", VlanId = 30 }
+        };
+
+        var switches = _engine.ExtractSwitches(deviceData, networks);
+        var issues = _engine.AnalyzePorts(switches, networks);
+
+        issues.Where(i => i.Port == "1" && i.Type == IssueTypes.AccessPortVlan).Should().HaveCount(1,
+            "regular trunk port with no device should still be flagged");
+        issues.Where(i => i.Port == "2" && i.Type == IssueTypes.AccessPortVlan).Should().BeEmpty(
+            "access port should not be flagged");
+    }
+
     #endregion
 
     #region AddRule Tests

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PortProfileSuggestionAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PortProfileSuggestionAnalyzerTests.cs
@@ -4647,10 +4647,10 @@ public class PortProfileSuggestionAnalyzerTests
     #region LAG Port Exclusion Tests
 
     [Fact]
-    public void Analyze_LagParentAndChildTrunkPorts_ExcludedFromSuggestions()
+    public void Analyze_LagChildTrunkPorts_ExcludedFromSuggestions()
     {
-        // LAG member ports (both parent and child) should not get port profile suggestions
-        // since their config is managed at the aggregate level.
+        // LAG child ports are assimilated into the parent and should not get individual
+        // port profile suggestions. The parent should still be included.
         var device = new UniFiDeviceResponse
         {
             Id = "switch1",
@@ -4659,13 +4659,16 @@ public class PortProfileSuggestionAnalyzerTests
             Type = "usw",
             PortTable = new List<SwitchPort>
             {
-                // LAG parent (op_mode=aggregate)
-                new SwitchPort { PortIdx = 25, Forward = "all", LagIdx = 1 },
-                // LAG child
-                new SwitchPort { PortIdx = 26, Forward = "all", LagIdx = 1, AggregatedBy = 25 },
-                // Regular trunk port (should still be collected)
-                new SwitchPort { PortIdx = 1, Forward = "all" },
-                new SwitchPort { PortIdx = 2, Forward = "all" }
+                // LAG parent - should still be suggested
+                new SwitchPort { PortIdx = 25, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1", LagIdx = 1 },
+                // LAG child - should be excluded
+                new SwitchPort { PortIdx = 26, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1", LagIdx = 1, AggregatedBy = 25 },
+                // Enough regular trunk ports to trigger a CreateNew suggestion (threshold=5)
+                new SwitchPort { PortIdx = 1, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 2, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 3, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 4, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 5, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" }
             }
         };
 
@@ -4680,12 +4683,12 @@ public class PortProfileSuggestionAnalyzerTests
         var result = _analyzer.Analyze(devices, portProfiles, networks);
 
         var allAffectedPorts = result.SelectMany(s => s.AffectedPorts).ToList();
-        allAffectedPorts.Should().NotContain(p => p.PortIndex == 25, "LAG parent should be excluded");
         allAffectedPorts.Should().NotContain(p => p.PortIndex == 26, "LAG child should be excluded");
+        allAffectedPorts.Should().Contain(p => p.PortIndex == 25, "LAG parent should still be included");
     }
 
     [Fact]
-    public void Analyze_LagDisabledPorts_ExcludedFromSuggestions()
+    public void Analyze_LagChildDisabledPorts_ExcludedFromSuggestions()
     {
         var device = new UniFiDeviceResponse
         {
@@ -4695,8 +4698,8 @@ public class PortProfileSuggestionAnalyzerTests
             Type = "usw",
             PortTable = new List<SwitchPort>
             {
-                // LAG member that is disabled
-                new SwitchPort { PortIdx = 25, Forward = "disabled", LagIdx = 1 },
+                // LAG child that is disabled - should be excluded
+                new SwitchPort { PortIdx = 25, Forward = "disabled", LagIdx = 1, AggregatedBy = 24 },
                 // Regular disabled ports (enough to trigger a suggestion)
                 new SwitchPort { PortIdx = 1, Forward = "disabled", PortPoe = true },
                 new SwitchPort { PortIdx = 2, Forward = "disabled", PortPoe = true },
@@ -4713,7 +4716,7 @@ public class PortProfileSuggestionAnalyzerTests
         var result = _analyzer.Analyze(devices, portProfiles, networks);
 
         var allAffectedPorts = result.SelectMany(s => s.AffectedPorts).ToList();
-        allAffectedPorts.Should().NotContain(p => p.PortIndex == 25, "LAG member should be excluded even when disabled");
+        allAffectedPorts.Should().NotContain(p => p.PortIndex == 25, "LAG child should be excluded even when disabled");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PortProfileSuggestionAnalyzerTests.cs
+++ b/tests/NetworkOptimizer.Diagnostics.Tests/Analyzers/PortProfileSuggestionAnalyzerTests.cs
@@ -1,7 +1,7 @@
 using FluentAssertions;
 using NetworkOptimizer.Diagnostics.Analyzers;
-using Xunit;
 using NetworkOptimizer.UniFi.Models;
+using Xunit;
 
 namespace NetworkOptimizer.Diagnostics.Tests.Analyzers;
 
@@ -4640,6 +4640,113 @@ public class PortProfileSuggestionAnalyzerTests
         // Ports 6 and 7 should NOT be included since they have MAC restriction
         accessSuggestion.AffectedPorts.Should().NotContain(p => p.PortIndex == 6);
         accessSuggestion.AffectedPorts.Should().NotContain(p => p.PortIndex == 7);
+    }
+
+    #endregion
+
+    #region LAG Port Exclusion Tests
+
+    [Fact]
+    public void Analyze_LagParentAndChildTrunkPorts_ExcludedFromSuggestions()
+    {
+        // LAG member ports (both parent and child) should not get port profile suggestions
+        // since their config is managed at the aggregate level.
+        var device = new UniFiDeviceResponse
+        {
+            Id = "switch1",
+            Mac = "aa:bb:cc:00:00:01",
+            Name = "Switch 1",
+            Type = "usw",
+            PortTable = new List<SwitchPort>
+            {
+                // LAG parent (op_mode=aggregate)
+                new SwitchPort { PortIdx = 25, Forward = "all", LagIdx = 1 },
+                // LAG child
+                new SwitchPort { PortIdx = 26, Forward = "all", LagIdx = 1, AggregatedBy = 25 },
+                // Regular trunk port (should still be collected)
+                new SwitchPort { PortIdx = 1, Forward = "all" },
+                new SwitchPort { PortIdx = 2, Forward = "all" }
+            }
+        };
+
+        var devices = new List<UniFiDeviceResponse> { device };
+        var portProfiles = new List<UniFiPortProfile>();
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new UniFiNetworkConfig { Id = "net-1", Name = "Default", Vlan = 1 },
+            new UniFiNetworkConfig { Id = "net-2", Name = "IoT", Vlan = 20 }
+        };
+
+        var result = _analyzer.Analyze(devices, portProfiles, networks);
+
+        var allAffectedPorts = result.SelectMany(s => s.AffectedPorts).ToList();
+        allAffectedPorts.Should().NotContain(p => p.PortIndex == 25, "LAG parent should be excluded");
+        allAffectedPorts.Should().NotContain(p => p.PortIndex == 26, "LAG child should be excluded");
+    }
+
+    [Fact]
+    public void Analyze_LagDisabledPorts_ExcludedFromSuggestions()
+    {
+        var device = new UniFiDeviceResponse
+        {
+            Id = "switch1",
+            Mac = "aa:bb:cc:00:00:01",
+            Name = "Switch 1",
+            Type = "usw",
+            PortTable = new List<SwitchPort>
+            {
+                // LAG member that is disabled
+                new SwitchPort { PortIdx = 25, Forward = "disabled", LagIdx = 1 },
+                // Regular disabled ports (enough to trigger a suggestion)
+                new SwitchPort { PortIdx = 1, Forward = "disabled", PortPoe = true },
+                new SwitchPort { PortIdx = 2, Forward = "disabled", PortPoe = true },
+                new SwitchPort { PortIdx = 3, Forward = "disabled", PortPoe = true },
+                new SwitchPort { PortIdx = 4, Forward = "disabled", PortPoe = true },
+                new SwitchPort { PortIdx = 5, Forward = "disabled", PortPoe = true }
+            }
+        };
+
+        var devices = new List<UniFiDeviceResponse> { device };
+        var portProfiles = new List<UniFiPortProfile>();
+        var networks = new List<UniFiNetworkConfig>();
+
+        var result = _analyzer.Analyze(devices, portProfiles, networks);
+
+        var allAffectedPorts = result.SelectMany(s => s.AffectedPorts).ToList();
+        allAffectedPorts.Should().NotContain(p => p.PortIndex == 25, "LAG member should be excluded even when disabled");
+    }
+
+    [Fact]
+    public void Analyze_NonLagTrunkPorts_StillSuggested()
+    {
+        // Regular trunk ports without LAG should still get suggestions
+        var device = new UniFiDeviceResponse
+        {
+            Id = "switch1",
+            Mac = "aa:bb:cc:00:00:01",
+            Name = "Switch 1",
+            Type = "usw",
+            PortTable = new List<SwitchPort>
+            {
+                new SwitchPort { PortIdx = 1, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 2, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 3, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 4, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" },
+                new SwitchPort { PortIdx = 5, Forward = "customize", TaggedVlanMgmt = "custom", NativeNetworkConfId = "net-1" }
+            }
+        };
+
+        var devices = new List<UniFiDeviceResponse> { device };
+        var portProfiles = new List<UniFiPortProfile>();
+        var networks = new List<UniFiNetworkConfig>
+        {
+            new UniFiNetworkConfig { Id = "net-1", Name = "Default", Vlan = 1 },
+            new UniFiNetworkConfig { Id = "net-2", Name = "IoT", Vlan = 20 }
+        };
+
+        var result = _analyzer.Analyze(devices, portProfiles, networks);
+
+        result.Should().NotBeEmpty("non-LAG trunk ports should still get suggestions");
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- **Security Audit**: LAG parent ports (`op_mode=aggregate`) were falsely flagged by AccessPortVlanRule as having excessive tagged VLANs. The root cause: `deviceUplinkLookup` only records the single port from `uplink_remote_port`, which for a LAG is a child port, so the aggregate parent gets no `ConnectedDeviceType` or `IsUplink` and falls through every exemption. A post-parse pass now propagates these from LAG children to their parent, letting the existing fabric and uplink exemptions work naturally. A LAG to a non-fabric device (e.g. server) is still audited.
- **Config Optimizer**: Port profile suggestions now skip LAG child ports (`AggregatedBy.HasValue`) since their config is assimilated into the parent. LAG parents still get suggestions since they carry the aggregate's real trunk config.

Closes #1142

## Test plan

- [x] LAG parent inherits `IsUplink` from child - not flagged (reporter's XG24 scenario)
- [x] LAG parent inherits `ConnectedDeviceType` from child via deviceUplinkLookup - not flagged (reporter's Beast scenario)
- [x] LAG parent to non-fabric device (no child uplink/fabric) - still flagged
- [x] Non-LAG trunk ports unaffected by propagation code
- [x] Config Optimizer excludes LAG child trunk ports from profile suggestions
- [x] Config Optimizer still includes LAG parent in profile suggestions
- [x] Config Optimizer excludes LAG child disabled ports from profile suggestions
- [x] Config Optimizer still suggests profiles for non-LAG trunk ports
- [x] Fable review: traced both reporter devices through the code, confirmed correct exemption paths, no mutation risk to non-LAG ports, no false-positive risk on detection
- [x] Full suite green (3470 audit, 290 diagnostics, 1943 web, 223 storage)