### PR TITLE
Autopilot settings on the page, and the gateway in the report

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/UniFiConsoleSystemInfo.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiConsoleSystemInfo.cs
@@ -123,6 +123,19 @@ public class UniFiConsoleController
     [JsonPropertyName("rollback")]
     public UniFiConsoleControllerRollback? Rollback { get; set; }
 
+    /// <summary>
+    /// This application's own auto-update schedule. Separate from the console's
+    /// firmware.autoUpdate.includeApplications rider, and set independently of it, so an
+    /// application can update itself while that rider reads false.
+    /// </summary>
+    [JsonPropertyName("updateSchedule")]
+    public JsonElement? UpdateSchedule { get; set; }
+
+    /// <summary>Whether this application updates itself on a schedule.</summary>
+    [JsonIgnore]
+    public bool AutoUpdates =>
+        UpdateSchedule is { ValueKind: not JsonValueKind.Null and not JsonValueKind.Undefined };
+
     /// <summary>Whether the console has a newer build staged for this application.</summary>
     [JsonIgnore]
     public bool HasUpdate => !string.IsNullOrWhiteSpace(UpdateAvailable);

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -400,7 +400,7 @@ else
 {
     @* ---- Landing ---- *@
     <div class="card" data-tour="firmware-rollout">
-        <div class="card-body firmware-rollout-landing">
+        <div class="card-body firmware-rollout-landing @(_settings?.Mode == FirmwareRolloutMode.Autopilot ? "firmware-rollout-landing-autopilot" : "")">
             @if (_settings?.Mode == FirmwareRolloutMode.Autopilot)
             {
                 <p class="firmware-rollout-note"><strong>Autopilot is on.</strong> Nothing is scheduled right now. Updates get picked up automatically, scheduled for the site's quietest window, and announced before they run.</p>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -512,27 +512,27 @@ else
                 @if (_reportTyped is { } rep)
                 {
                     <div class="firmware-rollout-stats">
-                        <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesUpgraded</span><span class="detail-label">upgraded</span></div>
+                        <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesUpgraded</span><span class="detail-label">Upgraded</span></div>
                         @if (rep.DevicesFailed > 0)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesFailed</span><span class="detail-label">failed</span></div>
+                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesFailed</span><span class="detail-label">Failed</span></div>
                         }
                         @if (rep.DevicesRolledBack > 0)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesRolledBack</span><span class="detail-label">rolled back</span></div>
+                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesRolledBack</span><span class="detail-label">Rolled back</span></div>
                         }
                         @if (rep.DevicesSkipped > 0)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesSkipped</span><span class="detail-label">skipped</span></div>
+                            <div class="firmware-rollout-stat"><span class="detail-value">@rep.DevicesSkipped</span><span class="detail-label">Skipped</span></div>
                         }
-                        <div class="firmware-rollout-stat"><span class="detail-value">@Duration(rep.TotalSeconds)</span><span class="detail-label">duration</span></div>
+                        <div class="firmware-rollout-stat"><span class="detail-value">@Duration(rep.TotalSeconds)</span><span class="detail-label">Duration</span></div>
                         @if (rep.SiteCpuBeforeMean is { } cb && rep.SiteCpuAfterMean is { } ca)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@($"{cb:0}% → {ca:0}%")</span><span class="detail-label">mean device CPU</span></div>
+                            <div class="firmware-rollout-stat"><span class="detail-value">@($"{cb:0}% → {ca:0}%")</span><span class="detail-label">Mean device CPU</span></div>
                         }
                         @if (rep.SiteMemBeforeMean is { } mb && rep.SiteMemAfterMean is { } ma)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@($"{mb:0}% → {ma:0}%")</span><span class="detail-label">mean device memory</span></div>
+                            <div class="firmware-rollout-stat"><span class="detail-value">@($"{mb:0}% → {ma:0}%")</span><span class="detail-label">Mean device memory</span></div>
                         }
                         @if (rep.UniFiNetworkUpdateOutcome != null)
                         {

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -429,8 +429,24 @@ else
         {
             <SiteAdminOnly>
             <div class="card-body firmware-rollout-autopilot-config">
-                <h4 class="card-title" style="margin-bottom: 0.25rem">Autopilot Configuration</h4>
+                <h4 class="card-title firmware-rollout-config-title">Autopilot Configuration</h4>
                 <small class="form-help firmware-rollout-config-intro">Changes here apply to the next autopilot-initiated rollout.</small>
+                @if (_preview == null)
+                {
+                    <div class="loading-container">
+                        <span class="spinner spinner-sm"></span>
+                        <span>Loading your settings...</span>
+                    </div>
+                }
+                else if (!_preview.ConsoleConnected)
+                {
+                    <div class="alert alert-info">
+                        These settings are read back from your UniFi Console, which is not reachable right now.
+                        They will appear once it reconnects.
+                    </div>
+                }
+                else
+                {
                 <FirmwareChannelConfig
                     Settings="_settings"
                     EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true || _settings.GlobalChannel == FirmwareChannels.Beta"
@@ -453,10 +469,11 @@ else
                     UpdateTooltip="UpdateTooltip"
                     ToggleSku="ToggleSku" />
 
-                <button class="btn btn-primary" style="margin-top: 1.5rem" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
+                <button class="btn btn-primary firmware-rollout-config-save" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
                     @if (_busy) { <span class="spinner spinner-sm"></span> }
                     else { <span>Save</span> }
                 </button>
+                }
             </div>
             </SiteAdminOnly>
         }

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -438,13 +438,6 @@ else
                         <span>Loading your settings...</span>
                     </div>
                 }
-                else if (!_preview.ConsoleDetailsKnown)
-                {
-                    <div class="alert alert-info">
-                        These settings are read back from your UniFi Console, which has not answered yet.
-                        They will appear once it does.
-                    </div>
-                }
                 else
                 {
                 <FirmwareChannelConfig

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -534,15 +534,15 @@ else
                         {
                             <div class="firmware-rollout-stat"><span class="detail-value">@($"{mb:0}% → {ma:0}%")</span><span class="detail-label">mean device memory</span></div>
                         }
+                        @if (rep.UniFiNetworkUpdateOutcome != null)
+                        {
+                            <div class="firmware-rollout-stat"><span class="detail-value">@ConsoleStepSummary(rep.UniFiNetworkUpdateOutcome, rep.UniFiNetworkFromVersion, rep.UniFiNetworkToVersion)</span><span class="detail-label">UniFi Network</span></div>
+                        }
+                        @if (rep.UniFiOsUpdateOutcome != null)
+                        {
+                            <div class="firmware-rollout-stat"><span class="detail-value">@ConsoleStepSummary(rep.UniFiOsUpdateOutcome, rep.UniFiOsFromVersion, rep.UniFiOsToVersion)</span><span class="detail-label">UniFi OS</span></div>
+                        }
                     </div>
-                    @if (rep.UniFiNetworkUpdateOutcome != null)
-                    {
-                        <p class="firmware-rollout-plan-note"><strong>UniFi Network</strong> @ConsoleStepSummary(rep.UniFiNetworkUpdateOutcome, rep.UniFiNetworkFromVersion, rep.UniFiNetworkToVersion)</p>
-                    }
-                    @if (rep.UniFiOsUpdateOutcome != null)
-                    {
-                        <p class="firmware-rollout-plan-note"><strong>UniFi OS</strong> @ConsoleStepSummary(rep.UniFiOsUpdateOutcome, rep.UniFiOsFromVersion, rep.UniFiOsToVersion)</p>
-                    }
                     @foreach (var issue in rep.Issues)
                     {
                         <div class="alert alert-warning firmware-rollout-note">@issue</div>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -435,18 +435,21 @@ else
         {
             <SiteAdminOnly>
             <div class="card-body firmware-rollout-autopilot-config">
+                <h4 class="card-title" style="margin-bottom: 0.75rem">Autopilot Configuration</h4>
+                <p class="text-secondary" style="margin-bottom: 1rem">Changes here apply to the next autopilot-initiated rollout.</p>
                 <FirmwareChannelConfig
                     Settings="_settings"
-                    EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true"
-                    ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
-                    HasCloudGateway="_preview?.HasCloudGateway == true"
+                    EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true || _settings.GlobalChannel == FirmwareChannels.Beta"
+                    ConsoleApiAvailable="true"
+                    HasCloudGateway="_preview?.HasCloudGateway == true || _preview?.HasCloudGatewayHardware == true || _settings.IncludeUniFiOs"
+                    ShowConsolePermissionNote="false"
                     TypeChannelRows="TypeChannelRows"
                     SiteModels="SiteModels"
                     AllDevices="_preview?.Devices ?? []"
                     ExcludedMacs="_exMacs"
                     ExcludedSkus="_exSkus"
                     ExcludedTypes="_exTypes"
-                                        TypeChannel="TypeChannel"
+                    TypeChannel="TypeChannel"
                     SetTypeChannel="SetTypeChannel"
                     SkuChannel="SkuChannel"
                     SetSkuChannel="SetSkuChannel"

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -438,11 +438,11 @@ else
                         <span>Loading your settings...</span>
                     </div>
                 }
-                else if (!_preview.ConsoleConnected)
+                else if (!_preview.ConsoleDetailsKnown)
                 {
                     <div class="alert alert-info">
-                        These settings are read back from your UniFi Console, which is not reachable right now.
-                        They will appear once it reconnects.
+                        These settings are read back from your UniFi Console, which has not answered yet.
+                        They will appear once it does.
                     </div>
                 }
                 else

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -956,6 +956,9 @@ else
     private FirmwareRolloutSettings WorkingSettings()
     {
         var s = _settings!;
+        // The preview answers for what the wizard currently shows, not for what is saved: the mode
+        // is only written on commit, and every save path sets it again before it writes.
+        s.Mode = _scheduleMode == "autopilot" ? FirmwareRolloutMode.Autopilot : FirmwareRolloutMode.ManualOnly;
         s.ExclusionsJson = System.Text.Json.JsonSerializer.Serialize(new
         {
             macs = _exMacs.ToList(),

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -193,161 +193,32 @@ else if (_wizardOpen)
                     <div class="alert alert-info firmware-rollout-note">@notice</div>
                 }
 
-                <div class="form-group">
-                    <label class="form-label">Release channel</label>
-                    <select class="form-control firmware-rollout-select" @bind="_settings.GlobalChannel">
-                        <option value="@FirmwareChannels.Release">Official (GA)</option>
-                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                        @if (_preview?.Channels.EarlyAccessAvailable == true)
-                        {
-                            <option value="@FirmwareChannels.Beta">Early Access</option>
-                        }
-                    </select>
-                    <small class="form-help">
+                <FirmwareChannelConfig
+                    Settings="_settings"
+                    EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true"
+                    ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
+                    HasCloudGateway="_preview?.HasCloudGateway == true"
+                    ShowSequenceHint="true"
+                    TypeChannelRows="TypeChannelRows"
+                    SiteModels="SiteModels"
+                    FilteredDevices="FilteredExclusionCandidates.ToList()"
+                    ExcludedMacs="_exMacs"
+                    ExcludedSkus="_exSkus"
+                    ExcludedTypes="_exTypes"
+                    ExclusionSearch="_exclusionSearch"
+                    TypeChannel="TypeChannel"
+                    SetTypeChannel="SetTypeChannel"
+                    SkuChannel="SkuChannel"
+                    SetSkuChannel="SetSkuChannel"
+                    DerivedExclusion="DerivedExclusion"
+                    UpdateTooltip="UpdateTooltip"
+                    ToggleSku="ToggleSku">
+                    <ChannelHelpText>
                         Everything in this rollout follows this channel@(ConsoleSurfacesLabel).@(_preview != null && !_preview.Channels.EarlyAccessAvailable
                             ? " Early Access is enabled through your Ubiquiti account, so it only appears here once the console offers it."
                             : "")
-                    </small>
-                </div>
-
-                <div class="form-group">
-                    @if (_preview?.ConsoleApiAvailable != false)
-                    {
-                        <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiNetwork" /><span>Update the UniFi Network application first</span></label>
-                    }
-                    @if (_preview?.HasCloudGateway == true && _preview?.ConsoleApiAvailable != false)
-                    {
-                        <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiOs" /><span>Include the UniFi OS update on the Cloud Gateway</span></label>
-                    }
-                    @if (_settings.IncludeUniFiNetwork || (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true))
-                    {
-                        <small class="form-help">
-                            Console firmware and Network upgrades require the console user to have the
-                            Super Admin role, or the Control Plane - Full Admin permission.
-                        </small>
-                    }
-                </div>
-
-                @if (_settings.IncludeUniFiNetwork || (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true))
-                {
-                    <details class="setup-guide firmware-rollout-guide">
-                        <summary>Different channel for the console</summary>
-                        <div class="setup-guide-content">
-                            @if (_settings.IncludeUniFiNetwork)
-                            {
-                                <div class="form-group firmware-rollout-inline">
-                                    <label class="form-label">UniFi Network application</label>
-                                    <select class="form-control firmware-rollout-select" value="@(_settings.NetworkAppChannel ?? "")" @onchange="e => _settings.NetworkAppChannel = Blank(e.Value?.ToString())">
-                                        <option value="">Same as everything else</option>
-                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                        {
-                                            <option value="@FirmwareChannels.Beta">Early Access</option>
-                                        }
-                                    </select>
-                                </div>
-                            }
-                            @if (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true)
-                            {
-                                <div class="form-group firmware-rollout-inline">
-                                    <label class="form-label">UniFi OS</label>
-                                    <select class="form-control firmware-rollout-select" value="@(_settings.UniFiOsChannel ?? "")" @onchange="e => _settings.UniFiOsChannel = Blank(e.Value?.ToString())">
-                                        <option value="">Same as everything else</option>
-                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                        {
-                                            <option value="@FirmwareChannels.Beta">Early Access</option>
-                                        }
-                                    </select>
-                                </div>
-                            }
-                        </div>
-                    </details>
-                }
-
-                <details class="setup-guide firmware-rollout-guide">
-                    <summary>Per-device-type channels</summary>
-                    <div class="setup-guide-content">
-                        @foreach (var (code, label) in TypeChannelRows)
-                        {
-                            <div class="form-group firmware-rollout-inline">
-                                <label class="form-label">@label</label>
-                                <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannel(code, e.Value?.ToString())">
-                                    <option value="">Same as everything else</option>
-                                    <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                    <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                    @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                    {
-                                        <option value="@FirmwareChannels.Beta">Early Access</option>
-                                    }
-                                </select>
-                            </div>
-                        }
-                    </div>
-                </details>
-
-                <details class="setup-guide firmware-rollout-guide">
-                    <summary>Per-model channels</summary>
-                    <div class="setup-guide-content">
-                        @foreach (var model in SiteModels)
-                        {
-                            <div class="form-group firmware-rollout-inline">
-                                <label class="form-label">@model.Label</label>
-                                <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannel(model.Code, e.Value?.ToString())">
-                                    <option value="">Same as its device type</option>
-                                    <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                    <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                    @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                    {
-                                        <option value="@FirmwareChannels.Beta">Early Access</option>
-                                    }
-                                </select>
-                            </div>
-                        }
-                        @if (SiteModels.Count == 0)
-                        {
-                            <small class="form-help">Models appear here once the device list has loaded.</small>
-                        }
-                    </div>
-                </details>
-
-                <details class="setup-guide firmware-rollout-guide">
-                    <summary>Exclude devices @(_exMacs.Count + _exSkus.Count + _exTypes.Count > 0 ? $"({_exMacs.Count + _exSkus.Count + _exTypes.Count} rules)" : "")</summary>
-                    <div class="setup-guide-content">
-                        <div class="form-group">
-                            <input type="text" class="form-control" placeholder="Search devices..." @bind="_exclusionSearch" @bind:event="oninput" />
-                        </div>
-                        <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
-                            @foreach (var (code, label) in TypeChannelRows)
-                            {
-                                <label class="checkbox-label"><input type="checkbox" checked="@_exTypes.Contains(code)" @onchange="e => ToggleSet(_exTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
-                            }
-                        </div>
-                        <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
-                            @foreach (var device in FilteredExclusionCandidates)
-                            {
-                                @* The tooltip goes on a wrapper, not the row (it fired anywhere along it)
-                                   and not the input (a disabled control emits no hover). *@
-                                var derived = DerivedExclusion(device);
-                                <label class="checkbox-label firmware-rollout-device-row">
-                                    <span data-tooltip="@derived">
-                                        <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
-                                    </span>
-                                    <span>@device.Name</span>
-                                    <span class="firmware-rollout-muted">@device.DisplayModel</span>
-                                    @if (device.Upgradable)
-                                    {
-                                        <span class="firmware-rollout-chip chip-active"
-                                              data-tooltip="@UpdateTooltip(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
-                                    }
-                                    <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
-                                </label>
-                            }
-                        </div>
-                    </div>
-                </details>
+                    </ChannelHelpText>
+                </FirmwareChannelConfig>
 
                 <div class="firmware-rollout-wizard-nav">
                     <button class="btn btn-primary" @onclick="() => _step = 2" disabled="@(_busy || _preview?.ConsoleConnected == false)">Next</button>
@@ -536,147 +407,25 @@ else
 
                 <SiteAdminOnly>
                 <div class="firmware-rollout-autopilot-config">
-                    <div class="form-group">
-                        <label class="form-label">Release channel</label>
-                        <select class="form-control firmware-rollout-select" @bind="_settings.GlobalChannel">
-                            <option value="@FirmwareChannels.Release">Official (GA)</option>
-                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                            @if (_preview?.Channels.EarlyAccessAvailable == true)
-                            {
-                                <option value="@FirmwareChannels.Beta">Early Access</option>
-                            }
-                        </select>
-                    </div>
-
-                    <div class="form-group">
-                        @if (_preview?.ConsoleApiAvailable != false)
-                        {
-                            <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiNetwork" /><span>Update the UniFi Network application</span></label>
-                        }
-                        @if (_preview?.HasCloudGateway == true && _preview?.ConsoleApiAvailable != false)
-                        {
-                            <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiOs" /><span>Include UniFi OS updates</span></label>
-                        }
-                    </div>
-
-                    @if (_settings.IncludeUniFiNetwork || (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true))
-                    {
-                        <details class="setup-guide firmware-rollout-guide">
-                            <summary>Console channels</summary>
-                            <div class="setup-guide-content">
-                                @if (_settings.IncludeUniFiNetwork)
-                                {
-                                    <div class="form-group firmware-rollout-inline">
-                                        <label class="form-label">UniFi Network application</label>
-                                        <select class="form-control firmware-rollout-select" value="@(_settings.NetworkAppChannel ?? "")" @onchange="e => _settings.NetworkAppChannel = Blank(e.Value?.ToString())">
-                                            <option value="">Same as everything else</option>
-                                            <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                            @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                            {
-                                                <option value="@FirmwareChannels.Beta">Early Access</option>
-                                            }
-                                        </select>
-                                    </div>
-                                }
-                                @if (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true)
-                                {
-                                    <div class="form-group firmware-rollout-inline">
-                                        <label class="form-label">UniFi OS</label>
-                                        <select class="form-control firmware-rollout-select" value="@(_settings.UniFiOsChannel ?? "")" @onchange="e => _settings.UniFiOsChannel = Blank(e.Value?.ToString())">
-                                            <option value="">Same as everything else</option>
-                                            <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                            @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                            {
-                                                <option value="@FirmwareChannels.Beta">Early Access</option>
-                                            }
-                                        </select>
-                                    </div>
-                                }
-                            </div>
-                        </details>
-                    }
-
-                    <details class="setup-guide firmware-rollout-guide">
-                        <summary>Per-device-type channels</summary>
-                        <div class="setup-guide-content">
-                            @foreach (var (code, label) in TypeChannelRows)
-                            {
-                                <div class="form-group firmware-rollout-inline">
-                                    <label class="form-label">@label</label>
-                                    <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannel(code, e.Value?.ToString())">
-                                        <option value="">Same as everything else</option>
-                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                        {
-                                            <option value="@FirmwareChannels.Beta">Early Access</option>
-                                        }
-                                    </select>
-                                </div>
-                            }
-                        </div>
-                    </details>
-
-                    <details class="setup-guide firmware-rollout-guide">
-                        <summary>Per-model channels</summary>
-                        <div class="setup-guide-content">
-                            @foreach (var model in SiteModels)
-                            {
-                                <div class="form-group firmware-rollout-inline">
-                                    <label class="form-label">@model.Label</label>
-                                    <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannel(model.Code, e.Value?.ToString())">
-                                        <option value="">Same as its device type</option>
-                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
-                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
-                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
-                                        {
-                                            <option value="@FirmwareChannels.Beta">Early Access</option>
-                                        }
-                                    </select>
-                                </div>
-                            }
-                            @if (SiteModels.Count == 0)
-                            {
-                                <small class="form-help">Models appear here once the device list has loaded.</small>
-                            }
-                        </div>
-                    </details>
-
-                    <details class="setup-guide firmware-rollout-guide">
-                        <summary>Exclude devices @(_exMacs.Count + _exSkus.Count + _exTypes.Count > 0 ? $"({_exMacs.Count + _exSkus.Count + _exTypes.Count} rules)" : "")</summary>
-                        <div class="setup-guide-content">
-                            <div class="form-group">
-                                <input type="text" class="form-control" placeholder="Search devices..." @bind="_exclusionSearch" @bind:event="oninput" />
-                            </div>
-                            <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
-                                @foreach (var (code, label) in TypeChannelRows)
-                                {
-                                    <label class="checkbox-label"><input type="checkbox" checked="@_exTypes.Contains(code)" @onchange="e => ToggleSet(_exTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
-                                }
-                            </div>
-                            <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
-                                @foreach (var device in FilteredExclusionCandidates)
-                                {
-                                    var derived = DerivedExclusion(device);
-                                    <label class="checkbox-label firmware-rollout-device-row">
-                                        <span data-tooltip="@derived">
-                                            <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
-                                        </span>
-                                        <span>@device.Name</span>
-                                        <span class="firmware-rollout-muted">@device.DisplayModel</span>
-                                        @if (device.Upgradable)
-                                        {
-                                            <span class="firmware-rollout-chip chip-active"
-                                                  data-tooltip="@UpdateTooltip(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
-                                        }
-                                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
-                                    </label>
-                                }
-                            </div>
-                        </div>
-                    </details>
+                    <FirmwareChannelConfig
+                        Settings="_settings"
+                        EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true"
+                        ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
+                        HasCloudGateway="_preview?.HasCloudGateway == true"
+                        TypeChannelRows="TypeChannelRows"
+                        SiteModels="SiteModels"
+                        FilteredDevices="FilteredExclusionCandidates.ToList()"
+                        ExcludedMacs="_exMacs"
+                        ExcludedSkus="_exSkus"
+                        ExcludedTypes="_exTypes"
+                        ExclusionSearch="_exclusionSearch"
+                        TypeChannel="TypeChannel"
+                        SetTypeChannel="SetTypeChannel"
+                        SkuChannel="SkuChannel"
+                        SetSkuChannel="SetSkuChannel"
+                        DerivedExclusion="DerivedExclusion"
+                        UpdateTooltip="UpdateTooltip"
+                        ToggleSku="ToggleSku" />
 
                     <button class="btn btn-primary" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
                         @if (_busy) { <span class="spinner spinner-sm"></span> }

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -254,7 +254,10 @@ else if (_wizardOpen)
                 @if (_scheduleMode == "autopilot")
                 {
                     <p class="firmware-rollout-note">Autopilot plans a rollout whenever updates are waiting, books it into the site's quietest window, and tells you <strong>@_settings.NotifyHoursAhead hours</strong> ahead so you can postpone with one click.</p>
-                    <div class="alert alert-info firmware-rollout-note">Turn off UniFi's own auto-updates first - devices, the UniFi Network application, and UniFi OS - so two updaters never run at once.</div>
+                    @if (AutoUpdaterList() is string autoUpdaters)
+                    {
+                        <div class="alert alert-info firmware-rollout-note">UniFi still updates @autoUpdaters on its own schedule. Turn that off first so two updaters never run at once.</div>
+                    }
                     <div class="form-group firmware-rollout-inline">
                         <label class="form-label">Heads-up hours</label>
                         <input type="number" class="form-control firmware-rollout-num" min="1" max="168" @bind="_settings.NotifyHoursAhead" />
@@ -866,6 +869,23 @@ else
     {
         _step = 2;
         _ = DisposeVizAsync();
+    }
+
+    /// <summary>The UniFi auto-updaters that are on, or null when none are.</summary>
+    private string? AutoUpdaterList()
+    {
+        var on = new List<string>();
+        if (_preview?.ConsoleAutoUpgradeEnabled == true) on.Add("devices");
+        if (_preview?.ConsoleAppsAutoUpdateEnabled == true) on.Add("the UniFi Network application");
+        if (_preview?.ConsoleOsAutoUpdateEnabled == true) on.Add("UniFi OS");
+
+        return on.Count switch
+        {
+            0 => null,
+            1 => on[0],
+            2 => $"{on[0]} and {on[1]}",
+            _ => $"{string.Join(", ", on.Take(on.Count - 1))}, and {on[^1]}",
+        };
     }
 
     private string CommitLabel => _scheduleMode switch

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -536,11 +536,17 @@ else
                         }
                         @if (rep.UniFiNetworkUpdateOutcome != null)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@ConsoleStepSummary(rep.UniFiNetworkUpdateOutcome, rep.UniFiNetworkFromVersion, rep.UniFiNetworkToVersion)</span><span class="detail-label">UniFi Network</span></div>
+                            <div class="firmware-rollout-stat">
+                                <span class="detail-value">@ConsoleStepMarkup(rep.UniFiNetworkUpdateOutcome, rep.UniFiNetworkFromVersion, rep.UniFiNetworkToVersion)</span>
+                                <span class="detail-label">UniFi Network</span>
+                            </div>
                         }
                         @if (rep.UniFiOsUpdateOutcome != null)
                         {
-                            <div class="firmware-rollout-stat"><span class="detail-value">@ConsoleStepSummary(rep.UniFiOsUpdateOutcome, rep.UniFiOsFromVersion, rep.UniFiOsToVersion)</span><span class="detail-label">UniFi OS</span></div>
+                            <div class="firmware-rollout-stat">
+                                <span class="detail-value">@ConsoleStepMarkup(rep.UniFiOsUpdateOutcome, rep.UniFiOsFromVersion, rep.UniFiOsToVersion)</span>
+                                <span class="detail-label">UniFi OS</span>
+                            </div>
                         }
                     </div>
                     @foreach (var issue in rep.Issues)
@@ -634,21 +640,47 @@ else
         };
     }
 
-    private static string ConsoleStepSummary(string? outcome, string? from, string? to)
+    /// <summary>Verb plus versions, with the verb dropped on mobile where the versions carry it.</summary>
+    private static RenderFragment ConsoleStepMarkup(string? outcome, string? from, string? to) => builder =>
+    {
+        var word = ConsoleStepWord(outcome);
+        var versions = ConsoleStepVersions(outcome, from, to);
+
+        if (versions == null)
+        {
+            builder.AddContent(0, word);
+            return;
+        }
+
+        builder.OpenElement(1, "span");
+        builder.AddAttribute(2, "class", "firmware-rollout-console-verb");
+        builder.AddContent(3, word + " ");
+        builder.CloseElement();
+        builder.AddContent(4, versions);
+    };
+
+    private static string ConsoleStepWord(string? outcome) => outcome switch
+    {
+        "updated" => "Updated",
+        "nothing-to-update" => "Already current",
+        "unchanged" => "No change",
+        "refused" => "Refused",
+        "stuck" => "Did not come back",
+        "skipped" => "Skipped",
+        _ => outcome ?? "Done",
+    };
+
+    private static string? ConsoleStepVersions(string? outcome, string? from, string? to)
     {
         var fromShort = FirmwareVersionFormat.ShortOrNull(from);
         var toShort = FirmwareVersionFormat.ShortOrNull(to);
-        var versions = fromShort != null && toShort != null ? $"{fromShort} → {toShort}" : toShort ?? fromShort;
 
         return outcome switch
         {
-            "updated" => versions != null ? $"updated ({versions})" : "updated",
-            "nothing-to-update" => "already current" + (fromShort != null ? $" ({fromShort})" : ""),
-            "unchanged" => "no change" + (fromShort != null ? $" ({fromShort})" : ""),
-            "refused" => "refused",
-            "stuck" => "did not come back" + (toShort != null ? $" (targeting {toShort})" : ""),
-            "skipped" => "skipped",
-            _ => outcome ?? "done",
+            "updated" => fromShort != null && toShort != null ? $"{fromShort} → {toShort}" : toShort ?? fromShort,
+            "nothing-to-update" or "unchanged" => fromShort,
+            "stuck" => toShort != null ? $"targeting {toShort}" : null,
+            _ => null,
         };
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -533,6 +533,157 @@ else
             @if (_settings?.Mode == FirmwareRolloutMode.Autopilot)
             {
                 <p class="firmware-rollout-note"><strong>Autopilot is on.</strong> Nothing is scheduled right now. Updates get picked up automatically, scheduled for the site's quietest window, and announced before they run.</p>
+
+                <SiteAdminOnly>
+                <div class="firmware-rollout-autopilot-config">
+                    <div class="form-group">
+                        <label class="form-label">Release channel</label>
+                        <select class="form-control firmware-rollout-select" @bind="_settings.GlobalChannel">
+                            <option value="@FirmwareChannels.Release">Official (GA)</option>
+                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                            @if (_preview?.Channels.EarlyAccessAvailable == true)
+                            {
+                                <option value="@FirmwareChannels.Beta">Early Access</option>
+                            }
+                        </select>
+                    </div>
+
+                    <div class="form-group">
+                        @if (_preview?.ConsoleApiAvailable != false)
+                        {
+                            <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiNetwork" /><span>Update the UniFi Network application</span></label>
+                        }
+                        @if (_preview?.HasCloudGateway == true && _preview?.ConsoleApiAvailable != false)
+                        {
+                            <label class="checkbox-label"><input type="checkbox" @bind="_settings.IncludeUniFiOs" /><span>Include UniFi OS updates</span></label>
+                        }
+                    </div>
+
+                    @if (_settings.IncludeUniFiNetwork || (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true))
+                    {
+                        <details class="setup-guide firmware-rollout-guide">
+                            <summary>Console channels</summary>
+                            <div class="setup-guide-content">
+                                @if (_settings.IncludeUniFiNetwork)
+                                {
+                                    <div class="form-group firmware-rollout-inline">
+                                        <label class="form-label">UniFi Network application</label>
+                                        <select class="form-control firmware-rollout-select" value="@(_settings.NetworkAppChannel ?? "")" @onchange="e => _settings.NetworkAppChannel = Blank(e.Value?.ToString())">
+                                            <option value="">Same as everything else</option>
+                                            <option value="@FirmwareChannels.Release">Official (GA)</option>
+                                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                                            @if (_preview?.Channels.EarlyAccessAvailable == true)
+                                            {
+                                                <option value="@FirmwareChannels.Beta">Early Access</option>
+                                            }
+                                        </select>
+                                    </div>
+                                }
+                                @if (_settings.IncludeUniFiOs && _preview?.HasCloudGateway == true)
+                                {
+                                    <div class="form-group firmware-rollout-inline">
+                                        <label class="form-label">UniFi OS</label>
+                                        <select class="form-control firmware-rollout-select" value="@(_settings.UniFiOsChannel ?? "")" @onchange="e => _settings.UniFiOsChannel = Blank(e.Value?.ToString())">
+                                            <option value="">Same as everything else</option>
+                                            <option value="@FirmwareChannels.Release">Official (GA)</option>
+                                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                                            @if (_preview?.Channels.EarlyAccessAvailable == true)
+                                            {
+                                                <option value="@FirmwareChannels.Beta">Early Access</option>
+                                            }
+                                        </select>
+                                    </div>
+                                }
+                            </div>
+                        </details>
+                    }
+
+                    <details class="setup-guide firmware-rollout-guide">
+                        <summary>Per-device-type channels</summary>
+                        <div class="setup-guide-content">
+                            @foreach (var (code, label) in TypeChannelRows)
+                            {
+                                <div class="form-group firmware-rollout-inline">
+                                    <label class="form-label">@label</label>
+                                    <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannel(code, e.Value?.ToString())">
+                                        <option value="">Same as everything else</option>
+                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
+                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
+                                        {
+                                            <option value="@FirmwareChannels.Beta">Early Access</option>
+                                        }
+                                    </select>
+                                </div>
+                            }
+                        </div>
+                    </details>
+
+                    <details class="setup-guide firmware-rollout-guide">
+                        <summary>Per-model channels</summary>
+                        <div class="setup-guide-content">
+                            @foreach (var model in SiteModels)
+                            {
+                                <div class="form-group firmware-rollout-inline">
+                                    <label class="form-label">@model.Label</label>
+                                    <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannel(model.Code, e.Value?.ToString())">
+                                        <option value="">Same as its device type</option>
+                                        <option value="@FirmwareChannels.Release">Official (GA)</option>
+                                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                                        @if (_preview?.Channels.EarlyAccessAvailable == true)
+                                        {
+                                            <option value="@FirmwareChannels.Beta">Early Access</option>
+                                        }
+                                    </select>
+                                </div>
+                            }
+                            @if (SiteModels.Count == 0)
+                            {
+                                <small class="form-help">Models appear here once the device list has loaded.</small>
+                            }
+                        </div>
+                    </details>
+
+                    <details class="setup-guide firmware-rollout-guide">
+                        <summary>Exclude devices @(_exMacs.Count + _exSkus.Count + _exTypes.Count > 0 ? $"({_exMacs.Count + _exSkus.Count + _exTypes.Count} rules)" : "")</summary>
+                        <div class="setup-guide-content">
+                            <div class="form-group">
+                                <input type="text" class="form-control" placeholder="Search devices..." @bind="_exclusionSearch" @bind:event="oninput" />
+                            </div>
+                            <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
+                                @foreach (var (code, label) in TypeChannelRows)
+                                {
+                                    <label class="checkbox-label"><input type="checkbox" checked="@_exTypes.Contains(code)" @onchange="e => ToggleSet(_exTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
+                                }
+                            </div>
+                            <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
+                                @foreach (var device in FilteredExclusionCandidates)
+                                {
+                                    var derived = DerivedExclusion(device);
+                                    <label class="checkbox-label firmware-rollout-device-row">
+                                        <span data-tooltip="@derived">
+                                            <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(_exMacs, device.Mac, e)" />
+                                        </span>
+                                        <span>@device.Name</span>
+                                        <span class="firmware-rollout-muted">@device.DisplayModel</span>
+                                        @if (device.Upgradable)
+                                        {
+                                            <span class="firmware-rollout-chip chip-active"
+                                                  data-tooltip="@UpdateTooltip(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
+                                        }
+                                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
+                                    </label>
+                                }
+                            </div>
+                        </div>
+                    </details>
+
+                    <button class="btn btn-primary" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
+                        @if (_busy) { <span class="spinner spinner-sm"></span> }
+                        else { <span>Save</span> }
+                    </button>
+                </div>
+                </SiteAdminOnly>
             }
             else
             {
@@ -934,6 +1085,28 @@ else
         {
             Logger.LogError(ex, "Committing the rollout failed");
             _wizardError = "Starting the rollout failed. See the logs for details.";
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private async Task SaveAutopilotSettingsAsync()
+    {
+        if (_settings == null) return;
+        _busy = true;
+        StateHasChanged();
+        try
+        {
+            var settings = WorkingSettings();
+            settings.Mode = FirmwareRolloutMode.Autopilot;
+            await RolloutService.SaveSettingsAsync(settings);
+            await ReloadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Saving autopilot settings failed");
         }
         finally
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -400,39 +400,10 @@ else
 {
     @* ---- Landing ---- *@
     <div class="card" data-tour="firmware-rollout">
-        <div class="card-body firmware-rollout-landing @(_settings?.Mode == FirmwareRolloutMode.Autopilot ? "firmware-rollout-landing-autopilot" : "")">
+        <div class="card-body firmware-rollout-landing">
             @if (_settings?.Mode == FirmwareRolloutMode.Autopilot)
             {
                 <p class="firmware-rollout-note"><strong>Autopilot is on.</strong> Nothing is scheduled right now. Updates get picked up automatically, scheduled for the site's quietest window, and announced before they run.</p>
-
-                <SiteAdminOnly>
-                <div class="firmware-rollout-autopilot-config">
-                    <FirmwareChannelConfig
-                        Settings="_settings"
-                        EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true"
-                        ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
-                        HasCloudGateway="_preview?.HasCloudGateway == true"
-                        TypeChannelRows="TypeChannelRows"
-                        SiteModels="SiteModels"
-                        FilteredDevices="FilteredExclusionCandidates.ToList()"
-                        ExcludedMacs="_exMacs"
-                        ExcludedSkus="_exSkus"
-                        ExcludedTypes="_exTypes"
-                        ExclusionSearch="_exclusionSearch"
-                        TypeChannel="TypeChannel"
-                        SetTypeChannel="SetTypeChannel"
-                        SkuChannel="SkuChannel"
-                        SetSkuChannel="SetSkuChannel"
-                        DerivedExclusion="DerivedExclusion"
-                        UpdateTooltip="UpdateTooltip"
-                        ToggleSku="ToggleSku" />
-
-                    <button class="btn btn-primary" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
-                        @if (_busy) { <span class="spinner spinner-sm"></span> }
-                        else { <span>Save</span> }
-                    </button>
-                </div>
-                </SiteAdminOnly>
             }
             else
             {
@@ -447,8 +418,6 @@ else
             }
             <SiteAdminOnly>
                 @{
-                    // Autopilot already has the site covered, so planning by hand is the exception
-                    // here rather than the action the page is for.
                     var autopilotOn = _settings?.Mode == FirmwareRolloutMode.Autopilot;
                 }
                 <button class="btn @(autopilotOn ? "btn-secondary" : "btn-primary")" @onclick="OpenWizardAsync" disabled="@_busy">
@@ -463,6 +432,37 @@ else
                 </button>
             </SiteAdminOnly>
         </div>
+        @if (_settings?.Mode == FirmwareRolloutMode.Autopilot)
+        {
+            <SiteAdminOnly>
+            <div class="card-body firmware-rollout-autopilot-config">
+                <FirmwareChannelConfig
+                    Settings="_settings"
+                    EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true"
+                    ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
+                    HasCloudGateway="_preview?.HasCloudGateway == true"
+                    TypeChannelRows="TypeChannelRows"
+                    SiteModels="SiteModels"
+                    FilteredDevices="FilteredExclusionCandidates.ToList()"
+                    ExcludedMacs="_exMacs"
+                    ExcludedSkus="_exSkus"
+                    ExcludedTypes="_exTypes"
+                    ExclusionSearch="_exclusionSearch"
+                    TypeChannel="TypeChannel"
+                    SetTypeChannel="SetTypeChannel"
+                    SkuChannel="SkuChannel"
+                    SetSkuChannel="SetSkuChannel"
+                    DerivedExclusion="DerivedExclusion"
+                    UpdateTooltip="UpdateTooltip"
+                    ToggleSku="ToggleSku" />
+
+                <button class="btn btn-primary" style="margin-top: 1rem" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
+                    @if (_busy) { <span class="spinner spinner-sm"></span> }
+                    else { <span>Save</span> }
+                </button>
+            </div>
+            </SiteAdminOnly>
+        }
     </div>
 
     @if (_history.Count > 0)
@@ -711,8 +711,11 @@ else
         try
         {
             _settings = await RolloutService.GetSettingsAsync();
+            LoadWorkingSets();
             _active = await RolloutService.GetActivePlanAsync();
             _history = await RolloutService.GetPlanHistoryAsync();
+            if (_active == null && _settings?.Mode == FirmwareRolloutMode.Autopilot)
+                _preview = await RolloutService.BuildPreviewAsync(WorkingSettings());
             // Any live plan polls, not just a running one. A scheduled or announced plan starts
             // on its own clock, and without a timer nothing re-renders to notice it happened -
             // somebody watching the page through the start time would sit on a stale view.

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -256,7 +256,7 @@ else if (_wizardOpen)
                     <p class="firmware-rollout-note">Autopilot plans a rollout whenever updates are waiting, books it into the site's quietest window, and tells you <strong>@_settings.NotifyHoursAhead hours</strong> ahead so you can postpone with one click.</p>
                     @if (AutoUpdaterList() is string autoUpdaters)
                     {
-                        <div class="alert alert-info firmware-rollout-note">UniFi still updates @autoUpdaters on its own schedule. Turn that off first so two updaters never run at once.</div>
+                        <div class="alert alert-warning firmware-rollout-note">UniFi still updates @autoUpdaters on its own schedule. Turn that off first so two updaters never run at once.</div>
                     }
                     <div class="form-group firmware-rollout-inline">
                         <label class="form-label">Heads-up hours</label>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -210,6 +210,8 @@ else if (_wizardOpen)
                     SetTypeChannel="SetTypeChannel"
                     SkuChannel="SkuChannel"
                     SetSkuChannel="SetSkuChannel"
+                    IsExcluded="IsExcluded"
+                    SkuExcluded="SkuExcluded"
                     DerivedExclusion="DerivedExclusion"
                     UpdateTooltip="UpdateTooltip"
                     ToggleSku="ToggleSku">
@@ -428,7 +430,7 @@ else
             <SiteAdminOnly>
             <div class="card-body firmware-rollout-autopilot-config">
                 <h4 class="card-title" style="margin-bottom: 0.25rem">Autopilot Configuration</h4>
-                <small class="form-help" style="display: block; margin-bottom: 1rem">Changes here apply to the next autopilot-initiated rollout.</small>
+                <small class="form-help firmware-rollout-config-intro">Changes here apply to the next autopilot-initiated rollout.</small>
                 <FirmwareChannelConfig
                     Settings="_settings"
                     EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true || _settings.GlobalChannel == FirmwareChannels.Beta"
@@ -445,6 +447,8 @@ else
                     SetTypeChannel="SetTypeChannel"
                     SkuChannel="SkuChannel"
                     SetSkuChannel="SetSkuChannel"
+                    IsExcluded="IsExcluded"
+                    SkuExcluded="SkuExcluded"
                     DerivedExclusion="DerivedExclusion"
                     UpdateTooltip="UpdateTooltip"
                     ToggleSku="ToggleSku" />
@@ -757,7 +761,10 @@ else
                 }
             });
         }
-        catch { }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Could not refresh the rollout preview after a console connection change");
+        }
     }
 
     private async Task ReloadAsync()
@@ -812,7 +819,7 @@ else
         }
     }
 
-    private async void CloseWizard()
+    private async Task CloseWizard()
     {
         _wizardOpen = false;
         _preview = null;

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -441,8 +441,8 @@ else
                 <FirmwareChannelConfig
                     Settings="_settings"
                     EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true || _settings.GlobalChannel == FirmwareChannels.Beta"
-                    ConsoleApiAvailable="true"
-                    HasCloudGateway="_preview?.HasCloudGateway == true || _preview?.HasCloudGatewayHardware == true || _settings.IncludeUniFiOs"
+                    ConsoleApiAvailable="_preview?.ConsoleApiAvailable != false"
+                    HasCloudGateway="_preview?.HasCloudGateway == true || _preview?.HasCloudGatewayHardware == true"
                     ShowConsolePermissionNote="false"
                     TypeChannelRows="TypeChannelRows"
                     SiteModels="SiteModels"

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -463,9 +463,10 @@ else
                     SkuExcluded="SkuExcluded"
                     DerivedExclusion="DerivedExclusion"
                     UpdateTooltip="UpdateTooltip"
-                    ToggleSku="ToggleSku" />
+                    ToggleSku="ToggleSku"
+                    OnChanged="StateHasChanged" />
 
-                <button class="btn btn-primary firmware-rollout-config-save" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
+                <button class="btn btn-primary firmware-rollout-config-save" @onclick="SaveAutopilotSettingsAsync" disabled="@(_busy || !ConfigDirty)">
                     @if (_busy) { <span class="spinner spinner-sm"></span> }
                     else { <span>Save</span> }
                 </button>
@@ -730,6 +731,7 @@ else
     private readonly HashSet<string> _exTypes = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, string> _typeChannels = new(StringComparer.OrdinalIgnoreCase);
     private Dictionary<string, string> _skuChannels = new(StringComparer.OrdinalIgnoreCase);
+    private string? _savedConfig;
 
     private IJSObjectReference? _viz;
     private bool _vizMounted;
@@ -971,7 +973,26 @@ else
         _typeChannels = ParseMap(_settings?.PerDeviceTypeChannelsJson);
         _skuChannels = ParseMap(_settings?.PerSkuChannelsJson);
         _scheduleMode = _settings?.Mode == FirmwareRolloutMode.Autopilot ? "autopilot" : "once";
+        _savedConfig = ConfigSignature();
     }
+
+    /// <summary>
+    /// What the inline editor can change, flattened. The component edits the settings object in
+    /// place, so there is nothing left to compare against once it has - this is taken at load.
+    /// </summary>
+    private string ConfigSignature() => string.Join("|",
+        _settings?.GlobalChannel,
+        _settings?.IncludeUniFiNetwork,
+        _settings?.IncludeUniFiOs,
+        _settings?.NetworkAppChannel,
+        _settings?.UniFiOsChannel,
+        string.Join(",", _exMacs.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+        string.Join(",", _exSkus.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+        string.Join(",", _exTypes.OrderBy(x => x, StringComparer.OrdinalIgnoreCase)),
+        string.Join(",", _typeChannels.OrderBy(k => k.Key).Select(k => $"{k.Key}={k.Value}")),
+        string.Join(",", _skuChannels.OrderBy(k => k.Key).Select(k => $"{k.Key}={k.Value}")));
+
+    private bool ConfigDirty => _savedConfig != null && ConfigSignature() != _savedConfig;
 
     private FirmwareRolloutSettings WorkingSettings()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -762,7 +762,8 @@ else
             LoadWorkingSets();
             // First preview: channel options, device models, and console warnings for step 1.
             _preview = await RolloutService.BuildPreviewAsync(WorkingSettings());
-            SeedChannelsFromConsole();
+            if (_settings.Mode != FirmwareRolloutMode.Autopilot)
+                SeedChannelsFromConsole();
             SeedStartFromProposal();
             _wizardOpen = true;
             _step = 1;
@@ -779,12 +780,14 @@ else
         }
     }
 
-    private void CloseWizard()
+    private async void CloseWizard()
     {
         _wizardOpen = false;
         _preview = null;
         _wizardError = null;
         _ = DisposeVizAsync();
+        await ReloadAsync();
+        StateHasChanged();
     }
 
     private async Task GoToPreviewAsync()

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -348,20 +348,11 @@ else if (_wizardOpen)
                             <span class="firmware-rollout-wave-devices">
                                 @foreach (var step in wave.Steps)
                                 {
-                                    var changelog = ChangelogFor(step.Mac);
                                     <span class="firmware-rollout-wave-device">
                                         @step.Name@(step.IsCanary ? " (canary)" : "")@(step.HeldForCanary ? " (held)" : "")
                                         @if (step.ToVersion != null)
                                         {
-                                            if (changelog != null)
-                                            {
-                                                <a class="firmware-rollout-chip chip-muted firmware-rollout-version-badge" href="@changelog" target="_blank" rel="noopener"
-                                                   data-tooltip="Release notes for @FirmwareVersionFormat.ShortOrNull(step.ToVersion)">@VersionChange(step.FromVersion, step.ToVersion)</a>
-                                            }
-                                            else
-                                            {
-                                                <span class="firmware-rollout-chip chip-muted firmware-rollout-version-badge">@VersionChange(step.FromVersion, step.ToVersion)</span>
-                                            }
+                                            <span class="firmware-rollout-chip chip-muted firmware-rollout-version-badge">@VersionChange(step.FromVersion, step.ToVersion)</span>
                                         }
                                     </span>
                                 }
@@ -546,11 +537,11 @@ else
                     </div>
                     @if (rep.UniFiNetworkUpdateOutcome != null)
                     {
-                        <p class="firmware-rollout-plan-note">UniFi Network application: @rep.UniFiNetworkUpdateOutcome</p>
+                        <p class="firmware-rollout-plan-note"><strong>UniFi Network</strong> @ConsoleStepSummary(rep.UniFiNetworkUpdateOutcome, rep.UniFiNetworkFromVersion, rep.UniFiNetworkToVersion)</p>
                     }
                     @if (rep.UniFiOsUpdateOutcome != null)
                     {
-                        <p class="firmware-rollout-plan-note">UniFi OS: @rep.UniFiOsUpdateOutcome</p>
+                        <p class="firmware-rollout-plan-note"><strong>UniFi OS</strong> @ConsoleStepSummary(rep.UniFiOsUpdateOutcome, rep.UniFiOsFromVersion, rep.UniFiOsToVersion)</p>
                     }
                     @foreach (var issue in rep.Issues)
                     {
@@ -566,16 +557,7 @@ else
                                         <td>@row.Name</td>
                                         <td>@row.Model</td>
                                         <td class="hide-mobile">@(FirmwareVersionFormat.ShortOrNull(row.FromVersion) ?? "-")</td>
-                                        <td>
-                                            @if (row.ChangelogUrl != null)
-                                            {
-                                                <a href="@row.ChangelogUrl" target="_blank" rel="noopener">@(FirmwareVersionFormat.ShortOrNull(row.ToVersion) ?? "-")</a>
-                                            }
-                                            else
-                                            {
-                                                @(FirmwareVersionFormat.ShortOrNull(row.ToVersion) ?? "-")
-                                            }
-                                        </td>
+                                        <td>@(FirmwareVersionFormat.ShortOrNull(row.ToVersion) ?? "-")</td>
                                         <td>@(row.DowntimeSeconds is int d ? Duration(d) : "-")</td>
                                         <td class="hide-mobile">@(row.CpuBeforeMean is { } rcb && row.CpuAfterMean is { } rca ? $"{rcb:0}% → {rca:0}%" : "-")</td>
                                         <td>
@@ -649,6 +631,24 @@ else
             "stuck" => "Stuck",
             "skipped" => "Skipped",
             _ => "Done",
+        };
+    }
+
+    private static string ConsoleStepSummary(string? outcome, string? from, string? to)
+    {
+        var fromShort = FirmwareVersionFormat.ShortOrNull(from);
+        var toShort = FirmwareVersionFormat.ShortOrNull(to);
+        var versions = fromShort != null && toShort != null ? $"{fromShort} → {toShort}" : toShort ?? fromShort;
+
+        return outcome switch
+        {
+            "updated" => versions != null ? $"updated ({versions})" : "updated",
+            "nothing-to-update" => "already current" + (fromShort != null ? $" ({fromShort})" : ""),
+            "unchanged" => "no change" + (fromShort != null ? $" ({fromShort})" : ""),
+            "refused" => "refused",
+            "stuck" => "did not come back" + (toShort != null ? $" (targeting {toShort})" : ""),
+            "skipped" => "skipped",
+            _ => outcome ?? "done",
         };
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -6,6 +6,7 @@
 @inject SiteContextService SiteContext
 @inject IJSRuntime JS
 @inject Microsoft.AspNetCore.Mvc.ViewFeatures.IFileVersionProvider FileVersionProvider
+@inject SiteConnectionRegistry ConnectionRegistry
 @inject ILogger<FirmwareRollout> Logger
 @rendermode InteractiveServer
 @using NetworkOptimizer.Storage.Models
@@ -701,10 +702,30 @@ else
     private IEnumerable<(string Code, string Label)> TypeChannelRows =>
         _preview?.HasCloudGateway == true ? AllTypeRows.Where(r => r.Code != "ugw") : AllTypeRows;
 
+    private UniFiConnectionService? _connection;
+
     protected override async Task OnInitializedAsync()
     {
+        _connection = ConnectionRegistry.GetFor(SiteContext.Slug);
+        _connection.OnConnectionChanged += OnConnectionChanged;
         await ReloadAsync();
         _loading = false;
+    }
+
+    private async void OnConnectionChanged()
+    {
+        try
+        {
+            await InvokeAsync(async () =>
+            {
+                if (_settings?.Mode == FirmwareRolloutMode.Autopilot && _active == null)
+                {
+                    _preview = await RolloutService.BuildPreviewAsync(WorkingSettings());
+                    StateHasChanged();
+                }
+            });
+        }
+        catch { }
     }
 
     private async Task ReloadAsync()
@@ -1474,6 +1495,8 @@ else
 
     public async ValueTask DisposeAsync()
     {
+        if (_connection != null)
+            _connection.OnConnectionChanged -= OnConnectionChanged;
         _pollTimer?.Dispose();
         await DisposeVizAsync();
         if (_viz != null)

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -435,8 +435,8 @@ else
         {
             <SiteAdminOnly>
             <div class="card-body firmware-rollout-autopilot-config">
-                <h4 class="card-title" style="margin-bottom: 0.75rem">Autopilot Configuration</h4>
-                <p class="text-secondary" style="margin-bottom: 1rem">Changes here apply to the next autopilot-initiated rollout.</p>
+                <h4 class="card-title" style="margin-bottom: 0.25rem">Autopilot Configuration</h4>
+                <small class="form-help" style="display: block; margin-bottom: 1rem">Changes here apply to the next autopilot-initiated rollout.</small>
                 <FirmwareChannelConfig
                     Settings="_settings"
                     EarlyAccessAvailable="_preview?.Channels.EarlyAccessAvailable == true || _settings.GlobalChannel == FirmwareChannels.Beta"

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -23,7 +23,7 @@
 
 @if (_loading)
 {
-    <div class="loading-container"><span class="spinner"></span><span>Loading rollout state...</span></div>
+    <div class="loading-container"><span class="spinner"></span> <span>Loading rollout state...</span></div>
 }
 else if (_active != null)
 {
@@ -201,12 +201,11 @@ else if (_wizardOpen)
                     ShowSequenceHint="true"
                     TypeChannelRows="TypeChannelRows"
                     SiteModels="SiteModels"
-                    FilteredDevices="FilteredExclusionCandidates.ToList()"
+                    AllDevices="_preview?.Devices ?? []"
                     ExcludedMacs="_exMacs"
                     ExcludedSkus="_exSkus"
                     ExcludedTypes="_exTypes"
-                    ExclusionSearch="_exclusionSearch"
-                    TypeChannel="TypeChannel"
+                                        TypeChannel="TypeChannel"
                     SetTypeChannel="SetTypeChannel"
                     SkuChannel="SkuChannel"
                     SetSkuChannel="SetSkuChannel"
@@ -443,12 +442,11 @@ else
                     HasCloudGateway="_preview?.HasCloudGateway == true"
                     TypeChannelRows="TypeChannelRows"
                     SiteModels="SiteModels"
-                    FilteredDevices="FilteredExclusionCandidates.ToList()"
+                    AllDevices="_preview?.Devices ?? []"
                     ExcludedMacs="_exMacs"
                     ExcludedSkus="_exSkus"
                     ExcludedTypes="_exTypes"
-                    ExclusionSearch="_exclusionSearch"
-                    TypeChannel="TypeChannel"
+                                        TypeChannel="TypeChannel"
                     SetTypeChannel="SetTypeChannel"
                     SkuChannel="SkuChannel"
                     SetSkuChannel="SetSkuChannel"
@@ -456,7 +454,7 @@ else
                     UpdateTooltip="UpdateTooltip"
                     ToggleSku="ToggleSku" />
 
-                <button class="btn btn-primary" style="margin-top: 1rem" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
+                <button class="btn btn-primary" style="margin-top: 1.5rem" @onclick="SaveAutopilotSettingsAsync" disabled="@_busy">
                     @if (_busy) { <span class="spinner spinner-sm"></span> }
                     else { <span>Save</span> }
                 </button>

--- a/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
@@ -5,7 +5,7 @@
 <div class="firmware-rollout-channel-config">
     <div class="form-group">
         <label class="form-label">Release channel</label>
-        <select class="form-control firmware-rollout-select" @bind="Settings.GlobalChannel">
+        <select class="form-control firmware-rollout-select" value="@Settings.GlobalChannel" @onchange="SetGlobalChannel">
             <option value="@FirmwareChannels.Release">Official (GA)</option>
             <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
             @if (EarlyAccessAvailable)
@@ -22,11 +22,11 @@
     <div class="form-group">
         @if (ConsoleApiAvailable)
         {
-            <label class="checkbox-label"><input type="checkbox" @bind="Settings.IncludeUniFiNetwork" /><span>Update the UniFi Network application@(ShowSequenceHint ? " first" : "")</span></label>
+            <label class="checkbox-label"><input type="checkbox" checked="@Settings.IncludeUniFiNetwork" @onchange="SetNetworkIncluded" /><span>Update the UniFi Network application@(ShowSequenceHint ? " first" : "")</span></label>
         }
         @if (HasCloudGateway && ConsoleApiAvailable)
         {
-            <label class="checkbox-label"><input type="checkbox" @bind="Settings.IncludeUniFiOs" /><span>Include the UniFi OS update on the Cloud Gateway</span></label>
+            <label class="checkbox-label"><input type="checkbox" checked="@Settings.IncludeUniFiOs" @onchange="SetOsIncluded" /><span>Include the UniFi OS update on the Cloud Gateway</span></label>
         }
         @if (ShowConsolePermissionNote && (Settings.IncludeUniFiNetwork || (Settings.IncludeUniFiOs && HasCloudGateway)))
         {
@@ -46,7 +46,7 @@
                 {
                     <div class="form-group firmware-rollout-inline">
                         <label class="form-label">UniFi Network application</label>
-                        <select class="form-control firmware-rollout-select" value="@(Settings.NetworkAppChannel ?? "")" @onchange="e => Settings.NetworkAppChannel = Blank(e.Value?.ToString())">
+                        <select class="form-control firmware-rollout-select" value="@(Settings.NetworkAppChannel ?? "")" @onchange="SetNetworkAppChannel">
                             <option value="">Same as everything else</option>
                             <option value="@FirmwareChannels.Release">Official (GA)</option>
                             <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
@@ -61,7 +61,7 @@
                 {
                     <div class="form-group firmware-rollout-inline">
                         <label class="form-label">UniFi OS</label>
-                        <select class="form-control firmware-rollout-select" value="@(Settings.UniFiOsChannel ?? "")" @onchange="e => Settings.UniFiOsChannel = Blank(e.Value?.ToString())">
+                        <select class="form-control firmware-rollout-select" value="@(Settings.UniFiOsChannel ?? "")" @onchange="SetOsChannel">
                             <option value="">Same as everything else</option>
                             <option value="@FirmwareChannels.Release">Official (GA)</option>
                             <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
@@ -83,7 +83,7 @@
             {
                 <div class="form-group firmware-rollout-inline">
                     <label class="form-label">@label</label>
-                    <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannel(code, e.Value?.ToString())">
+                    <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannelAsync(code, e)">
                         <option value="">Same as everything else</option>
                         <option value="@FirmwareChannels.Release">Official (GA)</option>
                         <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
@@ -104,7 +104,7 @@
             {
                 <div class="form-group firmware-rollout-inline">
                     <label class="form-label">@model.Label</label>
-                    <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannel(model.Code, e.Value?.ToString())">
+                    <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannelAsync(model.Code, e)">
                         <option value="">Same as its device type</option>
                         <option value="@FirmwareChannels.Release">Official (GA)</option>
                         <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
@@ -131,7 +131,7 @@
             <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
                 @foreach (var (code, label) in TypeChannelRows)
                 {
-                    <label class="checkbox-label"><input type="checkbox" checked="@ExcludedTypes.Contains(code)" @onchange="e => ToggleSet(ExcludedTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
+                    <label class="checkbox-label"><input type="checkbox" checked="@ExcludedTypes.Contains(code)" @onchange="e => ToggleSetAsync(ExcludedTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
                 }
             </div>
             <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
@@ -140,7 +140,7 @@
                     var derived = DerivedExclusion?.Invoke(device);
                     <label class="checkbox-label firmware-rollout-device-row">
                         <span data-tooltip="@derived">
-                            <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(ExcludedMacs, device.Mac, e)" />
+                            <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSetAsync(ExcludedMacs, device.Mac, e)" />
                         </span>
                         <span>@device.Name</span>
                         <span class="firmware-rollout-muted">@device.DisplayModel</span>
@@ -149,7 +149,7 @@
                             <span class="firmware-rollout-chip chip-active"
                                   data-tooltip="@UpdateTooltip?.Invoke(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
                         }
-                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku?.Invoke(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
+                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSkuAsync(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
                     </label>
                 }
             </div>
@@ -203,6 +203,65 @@
         : Settings.IncludeUniFiNetwork ? "UniFi Network" : "UniFi OS";
 
     private static string? Blank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    /// <summary>Raised after any edit, so an owner rendering a Save button can re-evaluate.</summary>
+    [Parameter] public EventCallback OnChanged { get; set; }
+
+    private Task Changed() => OnChanged.HasDelegate ? OnChanged.InvokeAsync() : Task.CompletedTask;
+
+    private async Task SetGlobalChannel(ChangeEventArgs e)
+    {
+        Settings.GlobalChannel = e.Value?.ToString() ?? Settings.GlobalChannel;
+        await Changed();
+    }
+
+    private async Task SetNetworkIncluded(ChangeEventArgs e)
+    {
+        Settings.IncludeUniFiNetwork = e.Value is true;
+        await Changed();
+    }
+
+    private async Task SetOsIncluded(ChangeEventArgs e)
+    {
+        Settings.IncludeUniFiOs = e.Value is true;
+        await Changed();
+    }
+
+    private async Task SetNetworkAppChannel(ChangeEventArgs e)
+    {
+        Settings.NetworkAppChannel = Blank(e.Value?.ToString());
+        await Changed();
+    }
+
+    private async Task SetOsChannel(ChangeEventArgs e)
+    {
+        Settings.UniFiOsChannel = Blank(e.Value?.ToString());
+        await Changed();
+    }
+
+    private async Task SetTypeChannelAsync(string code, ChangeEventArgs e)
+    {
+        SetTypeChannel(code, e.Value?.ToString());
+        await Changed();
+    }
+
+    private async Task SetSkuChannelAsync(string code, ChangeEventArgs e)
+    {
+        SetSkuChannel(code, e.Value?.ToString());
+        await Changed();
+    }
+
+    private async Task ToggleSetAsync(HashSet<string> set, string key, ChangeEventArgs e)
+    {
+        ToggleSet(set, key, e);
+        await Changed();
+    }
+
+    private async Task ToggleSkuAsync(RolloutDeviceView device)
+    {
+        ToggleSku?.Invoke(device);
+        await Changed();
+    }
 
     private static void ToggleSet(HashSet<string> set, string key, ChangeEventArgs e)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
@@ -180,10 +180,10 @@
         : AllDevices.Where(d => d.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)
             || d.DisplayModel.Contains(_search, StringComparison.OrdinalIgnoreCase));
 
-    [Parameter] public Func<string, string?>? TypeChannel { get; set; }
-    [Parameter] public Action<string, string?>? SetTypeChannel { get; set; }
-    [Parameter] public Func<string, string?>? SkuChannel { get; set; }
-    [Parameter] public Action<string, string?>? SetSkuChannel { get; set; }
+    [Parameter] public Func<string, string?> TypeChannel { get; set; } = _ => null;
+    [Parameter] public Action<string, string?> SetTypeChannel { get; set; } = (_, _) => { };
+    [Parameter] public Func<string, string?> SkuChannel { get; set; } = _ => null;
+    [Parameter] public Action<string, string?> SetSkuChannel { get; set; } = (_, _) => { };
     [Parameter] public Func<RolloutDeviceView, string?>? DerivedExclusion { get; set; }
     [Parameter] public Func<RolloutDeviceView, string?>? UpdateTooltip { get; set; }
     [Parameter] public Action<RolloutDeviceView>? ToggleSku { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
@@ -126,7 +126,7 @@
         <summary>Exclude devices @(ExclusionCount > 0 ? $"({ExclusionCount} rules)" : "")</summary>
         <div class="setup-guide-content">
             <div class="form-group">
-                <input type="text" class="form-control" placeholder="Search devices..." @bind="ExclusionSearch" @bind:event="oninput" />
+                <input type="text" class="form-control" placeholder="Search devices..." @bind="_search" @bind:event="oninput" />
             </div>
             <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
                 @foreach (var (code, label) in TypeChannelRows)
@@ -168,13 +168,17 @@
 
     [Parameter] public IEnumerable<(string Code, string Label)> TypeChannelRows { get; set; } = [];
     [Parameter] public IEnumerable<(string Code, string Label)> SiteModels { get; set; } = [];
-    [Parameter] public IReadOnlyList<RolloutDeviceView> FilteredDevices { get; set; } = [];
+    [Parameter] public IReadOnlyList<RolloutDeviceView> AllDevices { get; set; } = [];
 
     [Parameter] public HashSet<string> ExcludedMacs { get; set; } = [];
     [Parameter] public HashSet<string> ExcludedSkus { get; set; } = [];
     [Parameter] public HashSet<string> ExcludedTypes { get; set; } = [];
-    [Parameter] public string ExclusionSearch { get; set; } = "";
-    [Parameter] public EventCallback<string> ExclusionSearchChanged { get; set; }
+
+    private string _search = "";
+    private IEnumerable<RolloutDeviceView> FilteredDevices => string.IsNullOrEmpty(_search)
+        ? AllDevices
+        : AllDevices.Where(d => d.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)
+            || d.DisplayModel.Contains(_search, StringComparison.OrdinalIgnoreCase));
 
     [Parameter] public Func<string, string?>? TypeChannel { get; set; }
     [Parameter] public Action<string, string?>? SetTypeChannel { get; set; }

--- a/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
@@ -1,0 +1,196 @@
+@using NetworkOptimizer.Core.Helpers
+@using NetworkOptimizer.Storage.Models
+@using NetworkOptimizer.Web.Services.Firmware
+
+<div class="firmware-rollout-channel-config">
+    <div class="form-group">
+        <label class="form-label">Release channel</label>
+        <select class="form-control firmware-rollout-select" @bind="Settings.GlobalChannel">
+            <option value="@FirmwareChannels.Release">Official (GA)</option>
+            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+            @if (EarlyAccessAvailable)
+            {
+                <option value="@FirmwareChannels.Beta">Early Access</option>
+            }
+        </select>
+        @if (ChannelHelpText != null)
+        {
+            <small class="form-help">@ChannelHelpText</small>
+        }
+    </div>
+
+    <div class="form-group">
+        @if (ConsoleApiAvailable)
+        {
+            <label class="checkbox-label"><input type="checkbox" @bind="Settings.IncludeUniFiNetwork" /><span>Update the UniFi Network application@(ShowSequenceHint ? " first" : "")</span></label>
+        }
+        @if (HasCloudGateway && ConsoleApiAvailable)
+        {
+            <label class="checkbox-label"><input type="checkbox" @bind="Settings.IncludeUniFiOs" /><span>Include the UniFi OS update on the Cloud Gateway</span></label>
+        }
+        @if (ShowConsolePermissionNote && (Settings.IncludeUniFiNetwork || (Settings.IncludeUniFiOs && HasCloudGateway)))
+        {
+            <small class="form-help">
+                Console firmware and Network upgrades require the console user to have the
+                Super Admin role, or the Control Plane - Full Admin permission.
+            </small>
+        }
+    </div>
+
+    @if (Settings.IncludeUniFiNetwork || (Settings.IncludeUniFiOs && HasCloudGateway))
+    {
+        <details class="setup-guide firmware-rollout-guide">
+            <summary>Console channels</summary>
+            <div class="setup-guide-content">
+                @if (Settings.IncludeUniFiNetwork)
+                {
+                    <div class="form-group firmware-rollout-inline">
+                        <label class="form-label">UniFi Network application</label>
+                        <select class="form-control firmware-rollout-select" value="@(Settings.NetworkAppChannel ?? "")" @onchange="e => Settings.NetworkAppChannel = Blank(e.Value?.ToString())">
+                            <option value="">Same as everything else</option>
+                            <option value="@FirmwareChannels.Release">Official (GA)</option>
+                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                            @if (EarlyAccessAvailable)
+                            {
+                                <option value="@FirmwareChannels.Beta">Early Access</option>
+                            }
+                        </select>
+                    </div>
+                }
+                @if (Settings.IncludeUniFiOs && HasCloudGateway)
+                {
+                    <div class="form-group firmware-rollout-inline">
+                        <label class="form-label">UniFi OS</label>
+                        <select class="form-control firmware-rollout-select" value="@(Settings.UniFiOsChannel ?? "")" @onchange="e => Settings.UniFiOsChannel = Blank(e.Value?.ToString())">
+                            <option value="">Same as everything else</option>
+                            <option value="@FirmwareChannels.Release">Official (GA)</option>
+                            <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                            @if (EarlyAccessAvailable)
+                            {
+                                <option value="@FirmwareChannels.Beta">Early Access</option>
+                            }
+                        </select>
+                    </div>
+                }
+            </div>
+        </details>
+    }
+
+    <details class="setup-guide firmware-rollout-guide">
+        <summary>Per-device-type channels</summary>
+        <div class="setup-guide-content">
+            @foreach (var (code, label) in TypeChannelRows)
+            {
+                <div class="form-group firmware-rollout-inline">
+                    <label class="form-label">@label</label>
+                    <select class="form-control firmware-rollout-select" value="@TypeChannel(code)" @onchange="e => SetTypeChannel(code, e.Value?.ToString())">
+                        <option value="">Same as everything else</option>
+                        <option value="@FirmwareChannels.Release">Official (GA)</option>
+                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                        @if (EarlyAccessAvailable)
+                        {
+                            <option value="@FirmwareChannels.Beta">Early Access</option>
+                        }
+                    </select>
+                </div>
+            }
+        </div>
+    </details>
+
+    <details class="setup-guide firmware-rollout-guide">
+        <summary>Per-model channels</summary>
+        <div class="setup-guide-content">
+            @foreach (var model in SiteModels)
+            {
+                <div class="form-group firmware-rollout-inline">
+                    <label class="form-label">@model.Label</label>
+                    <select class="form-control firmware-rollout-select" value="@SkuChannel(model.Code)" @onchange="e => SetSkuChannel(model.Code, e.Value?.ToString())">
+                        <option value="">Same as its device type</option>
+                        <option value="@FirmwareChannels.Release">Official (GA)</option>
+                        <option value="@FirmwareChannels.ReleaseCandidate">Release Candidate</option>
+                        @if (EarlyAccessAvailable)
+                        {
+                            <option value="@FirmwareChannels.Beta">Early Access</option>
+                        }
+                    </select>
+                </div>
+            }
+            @if (!SiteModels.Any())
+            {
+                <small class="form-help">Models appear here once the device list has loaded.</small>
+            }
+        </div>
+    </details>
+
+    <details class="setup-guide firmware-rollout-guide">
+        <summary>Exclude devices @(ExclusionCount > 0 ? $"({ExclusionCount} rules)" : "")</summary>
+        <div class="setup-guide-content">
+            <div class="form-group">
+                <input type="text" class="form-control" placeholder="Search devices..." @bind="ExclusionSearch" @bind:event="oninput" />
+            </div>
+            <div class="firmware-rollout-exclusion-groups firmware-rollout-exclude">
+                @foreach (var (code, label) in TypeChannelRows)
+                {
+                    <label class="checkbox-label"><input type="checkbox" checked="@ExcludedTypes.Contains(code)" @onchange="e => ToggleSet(ExcludedTypes, code, e)" /><span>Exclude all @label.ToLowerInvariant()</span></label>
+                }
+            </div>
+            <div class="firmware-rollout-exclusion-list firmware-rollout-exclude">
+                @foreach (var device in FilteredDevices)
+                {
+                    var derived = DerivedExclusion?.Invoke(device);
+                    <label class="checkbox-label firmware-rollout-device-row">
+                        <span data-tooltip="@derived">
+                            <input type="checkbox" checked="@ExcludedMacs.Contains(device.Mac)" disabled="@(derived != null)" @onchange="e => ToggleSet(ExcludedMacs, device.Mac, e)" />
+                        </span>
+                        <span>@device.Name</span>
+                        <span class="firmware-rollout-muted">@device.DisplayModel</span>
+                        @if (device.Upgradable)
+                        {
+                            <span class="firmware-rollout-chip chip-active"
+                                  data-tooltip="@UpdateTooltip?.Invoke(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
+                        }
+                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku?.Invoke(device)" @onclick:stopPropagation="true">@(ExcludedSkus.Contains(device.Model) ? "Include model" : "Exclude model")</button>
+                    </label>
+                }
+            </div>
+        </div>
+    </details>
+</div>
+
+@code {
+    [Parameter, EditorRequired] public FirmwareRolloutSettings Settings { get; set; } = null!;
+    [Parameter] public bool EarlyAccessAvailable { get; set; }
+    [Parameter] public bool ConsoleApiAvailable { get; set; } = true;
+    [Parameter] public bool HasCloudGateway { get; set; }
+    [Parameter] public bool ShowConsolePermissionNote { get; set; } = true;
+    [Parameter] public bool ShowSequenceHint { get; set; }
+    [Parameter] public RenderFragment? ChannelHelpText { get; set; }
+
+    [Parameter] public IEnumerable<(string Code, string Label)> TypeChannelRows { get; set; } = [];
+    [Parameter] public IEnumerable<(string Code, string Label)> SiteModels { get; set; } = [];
+    [Parameter] public IReadOnlyList<RolloutDeviceView> FilteredDevices { get; set; } = [];
+
+    [Parameter] public HashSet<string> ExcludedMacs { get; set; } = [];
+    [Parameter] public HashSet<string> ExcludedSkus { get; set; } = [];
+    [Parameter] public HashSet<string> ExcludedTypes { get; set; } = [];
+    [Parameter] public string ExclusionSearch { get; set; } = "";
+    [Parameter] public EventCallback<string> ExclusionSearchChanged { get; set; }
+
+    [Parameter] public Func<string, string?>? TypeChannel { get; set; }
+    [Parameter] public Action<string, string?>? SetTypeChannel { get; set; }
+    [Parameter] public Func<string, string?>? SkuChannel { get; set; }
+    [Parameter] public Action<string, string?>? SetSkuChannel { get; set; }
+    [Parameter] public Func<RolloutDeviceView, string?>? DerivedExclusion { get; set; }
+    [Parameter] public Func<RolloutDeviceView, string?>? UpdateTooltip { get; set; }
+    [Parameter] public Action<RolloutDeviceView>? ToggleSku { get; set; }
+
+    private int ExclusionCount => ExcludedMacs.Count + ExcludedSkus.Count + ExcludedTypes.Count;
+
+    private static string? Blank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
+
+    private static void ToggleSet(HashSet<string> set, string key, ChangeEventArgs e)
+    {
+        if (e.Value is true) set.Add(key);
+        else set.Remove(key);
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/FirmwareChannelConfig.razor
@@ -40,7 +40,7 @@
     @if (Settings.IncludeUniFiNetwork || (Settings.IncludeUniFiOs && HasCloudGateway))
     {
         <details class="setup-guide firmware-rollout-guide">
-            <summary>Console channels</summary>
+            <summary>Console channels (@ConsoleChannelSurfaces)</summary>
             <div class="setup-guide-content">
                 @if (Settings.IncludeUniFiNetwork)
                 {
@@ -140,7 +140,7 @@
                     var derived = DerivedExclusion?.Invoke(device);
                     <label class="checkbox-label firmware-rollout-device-row">
                         <span data-tooltip="@derived">
-                            <input type="checkbox" checked="@ExcludedMacs.Contains(device.Mac)" disabled="@(derived != null)" @onchange="e => ToggleSet(ExcludedMacs, device.Mac, e)" />
+                            <input type="checkbox" checked="@IsExcluded(device)" disabled="@(derived != null)" @onchange="e => ToggleSet(ExcludedMacs, device.Mac, e)" />
                         </span>
                         <span>@device.Name</span>
                         <span class="firmware-rollout-muted">@device.DisplayModel</span>
@@ -149,7 +149,7 @@
                             <span class="firmware-rollout-chip chip-active"
                                   data-tooltip="@UpdateTooltip?.Invoke(device)">@(FirmwareVersionFormat.ShortOrNull(device.TargetVersion) ?? "Update waiting")</span>
                         }
-                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku?.Invoke(device)" @onclick:stopPropagation="true">@(ExcludedSkus.Contains(device.Model) ? "Include model" : "Exclude model")</button>
+                        <button type="button" class="btn btn-sm btn-tertiary firmware-rollout-sku-btn" @onclick="() => ToggleSku?.Invoke(device)" @onclick:stopPropagation="true">@(SkuExcluded(device) ? "Include model" : "Exclude model")</button>
                     </label>
                 }
             </div>
@@ -175,20 +175,32 @@
     [Parameter] public HashSet<string> ExcludedTypes { get; set; } = [];
 
     private string _search = "";
-    private IEnumerable<RolloutDeviceView> FilteredDevices => string.IsNullOrEmpty(_search)
-        ? AllDevices
-        : AllDevices.Where(d => d.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)
-            || d.DisplayModel.Contains(_search, StringComparison.OrdinalIgnoreCase));
+    private IEnumerable<RolloutDeviceView> FilteredDevices => (string.IsNullOrEmpty(_search)
+            ? AllDevices
+            : AllDevices.Where(d => d.Name.Contains(_search, StringComparison.OrdinalIgnoreCase)
+                || d.DisplayModel.Contains(_search, StringComparison.OrdinalIgnoreCase)))
+        .OrderByDescending(d => d.Upgradable)
+        .ThenBy(d => d.Name);
 
     [Parameter] public Func<string, string?> TypeChannel { get; set; } = _ => null;
     [Parameter] public Action<string, string?> SetTypeChannel { get; set; } = (_, _) => { };
     [Parameter] public Func<string, string?> SkuChannel { get; set; } = _ => null;
     [Parameter] public Action<string, string?> SetSkuChannel { get; set; } = (_, _) => { };
+    /// <summary>Whether any rule covers this device: its MAC, its model family, or its type.</summary>
+    [Parameter] public Func<RolloutDeviceView, bool> IsExcluded { get; set; } = _ => false;
+
+    /// <summary>Whether a model rule covers this device, matched on the family as the planner does.</summary>
+    [Parameter] public Func<RolloutDeviceView, bool> SkuExcluded { get; set; } = _ => false;
+
     [Parameter] public Func<RolloutDeviceView, string?>? DerivedExclusion { get; set; }
     [Parameter] public Func<RolloutDeviceView, string?>? UpdateTooltip { get; set; }
     [Parameter] public Action<RolloutDeviceView>? ToggleSku { get; set; }
 
     private int ExclusionCount => ExcludedMacs.Count + ExcludedSkus.Count + ExcludedTypes.Count;
+
+    private string ConsoleChannelSurfaces => Settings.IncludeUniFiNetwork && Settings.IncludeUniFiOs && HasCloudGateway
+        ? "UniFi Network / UniFi OS"
+        : Settings.IncludeUniFiNetwork ? "UniFi Network" : "UniFi OS";
 
     private static string? Blank(string? s) => string.IsNullOrWhiteSpace(s) ? null : s;
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareCommandClient.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareCommandClient.cs
@@ -56,6 +56,9 @@ public class FirmwareCommandClient : IFirmwareCommandClient
         return client;
     }
 
+    /// <inheritdoc />
+    public bool UsesApiKey => _connection.Client?.UseApiKey == true;
+
     /// <summary>How long a console command waits for a connection that is still coming up.</summary>
     private static readonly TimeSpan ConnectWait = TimeSpan.FromSeconds(20);
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -933,6 +933,12 @@ public class FirmwareRolloutOrchestrator : BackgroundService
 
         if (info == null)
         {
+            if (state.WentDownAt == null)
+            {
+                state.WentDownAt = Now;
+                await PersistDocumentAsync(plan, document, cancellationToken);
+            }
+
             if (ElapsedReachable(triggeredAt) < UniFiOsUpdateBudget)
                 return false;
 
@@ -955,6 +961,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         {
             if (OsVersionMatches(installed, state.TargetVersion))
             {
+                state.BackAt ??= Now;
                 await SettleUniFiOsAsync(plan, document, "updated", cancellationToken);
                 _logger.LogInformation(
                     "The console on site {Site} is back on UniFi OS {Version}", _siteSlug, installed);

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -265,7 +265,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
                 var soaking = await _repositories.UseAsync((r, c) => r.GetStepsAsync(plan.Id, c), cancellationToken);
                 await WatchRollbacksAsync(plan, soaking, cancellationToken);
                 var soakDoc = ParseDocument(plan);
-                await RunDueResourceComparisonsAsync(soaking, cancellationToken, plan, soakDoc);
+                await RunDueResourceComparisonsAsync(soaking, plan, soakDoc, cancellationToken);
                 await BuildSoakReportIfDueAsync(plan, soaking, cancellationToken);
                 return;
             }
@@ -738,7 +738,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         }
 
         await PropagateCanaryOutcomesAsync(document, steps, cancellationToken);
-        await RunDueResourceComparisonsAsync(steps, cancellationToken, plan, document);
+        await RunDueResourceComparisonsAsync(steps, plan, document, cancellationToken);
         EnqueueDueMeshRepairs(document, steps);
 
         // Wave 0. The UniFi Network application update aligns the firmware catalog every device
@@ -957,11 +957,26 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         // The installed version is the definitive answer. Check it before progress state,
         // which can report stale "started"/"updating" after the install has already finished.
         var installed = info.InstalledOsVersion;
+
+        // Downtime is observed, not judged, so it is recorded outside the judge delay below.
+        // Answering on the old version means the reboot is still ahead: a null we saw earlier was
+        // a blip during the download, not the console going away, so the clock restarts.
+        var onTarget = installed != null && OsVersionMatches(installed, state.TargetVersion);
+        if (!onTarget && state.WentDownAt != null && state.BackAt == null)
+        {
+            state.WentDownAt = null;
+            await PersistDocumentAsync(plan, document, cancellationToken);
+        }
+        else if (onTarget && state.WentDownAt != null && state.BackAt == null)
+        {
+            state.BackAt = Now;
+            await PersistDocumentAsync(plan, document, cancellationToken);
+        }
+
         if (installed != null && ElapsedReachable(triggeredAt) >= UniFiOsJudgeDelay)
         {
             if (OsVersionMatches(installed, state.TargetVersion))
             {
-                state.BackAt ??= Now;
                 await SettleUniFiOsAsync(plan, document, "updated", cancellationToken);
                 _logger.LogInformation(
                     "The console on site {Site} is back on UniFi OS {Version}", _siteSlug, installed);
@@ -1437,8 +1452,8 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         }
     }
 
-    private async Task RunDueResourceComparisonsAsync(List<FirmwareRolloutStep> steps, CancellationToken cancellationToken,
-        FirmwareRolloutPlan? plan = null, RolloutPlanDocument? document = null)
+    private async Task RunDueResourceComparisonsAsync(List<FirmwareRolloutStep> steps,
+        FirmwareRolloutPlan? plan, RolloutPlanDocument? document, CancellationToken cancellationToken)
     {
         var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
         var window = ResourceWindowFor(settings);
@@ -1781,6 +1796,21 @@ public class FirmwareRolloutOrchestrator : BackgroundService
     /// moves it to Reported. The wait is what makes the report worth reading: every device's
     /// before/after resource window has closed by then, so nothing in it is still provisional.
     /// </summary>
+    /// <summary>
+    /// Whether the report must wait for the console's own before/after numbers. Bounded: a capture
+    /// that never lands (no telemetry, Influx down) stops holding the report one window past due.
+    /// </summary>
+    private bool AwaitingGatewayPostStats(RolloutPlanDocument document, TimeSpan window)
+    {
+        var os = document.UniFiOsUpdate;
+        if (os is not { Outcome: "updated", PostStatsJson: null } || string.IsNullOrWhiteSpace(document.ConsoleMac))
+            return false;
+        if (os.TriggeredAt is not DateTime triggered)
+            return false;
+
+        return Now < triggered + GatewayCoolDown + window + window;
+    }
+
     private async Task BuildSoakReportIfDueAsync(
         FirmwareRolloutPlan plan, List<FirmwareRolloutStep> steps, CancellationToken cancellationToken)
     {
@@ -1800,6 +1830,11 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         var measured = steps.Where(s => s.State is FirmwareRolloutStepState.LitmusPassed
             or FirmwareRolloutStepState.RegressionFlagged).ToList();
         if (measured.Count > 0 && measured.Any(s => s.PostStatsJson == null))
+            return;
+
+        // The console's window opens a gateway cool-down after ITS trigger, which is always after
+        // the last device wave - so the device comparisons finishing is not enough to report.
+        if (AwaitingGatewayPostStats(ParseDocument(plan), ResourceWindowFor(settings)))
             return;
 
         var completedAt = plan.CompletedAt ?? Now;

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -954,6 +954,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         {
             if (OsVersionMatches(installed, state.TargetVersion))
             {
+                await CaptureOsPostStatsAsync(document, cancellationToken);
                 await SettleUniFiOsAsync(plan, document, "updated", cancellationToken);
                 _logger.LogInformation(
                     "The console on site {Site} is back on UniFi OS {Version}", _siteSlug, installed);
@@ -1041,6 +1042,15 @@ public class FirmwareRolloutOrchestrator : BackgroundService
             && !string.IsNullOrWhiteSpace(installedOs)
             && NetworkOptimizer.Core.Helpers.FirmwareVersionFormat.IsNewer(pending.Version, installedOs);
 
+        // Capture the gateway's pre-update stats for the report.
+        if (!string.IsNullOrWhiteSpace(document.ConsoleMac) && document.UniFiOsUpdate.PreStatsJson == null)
+        {
+            var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
+            var preWindow = ResourceWindowFor(settings);
+            document.UniFiOsUpdate.PreStatsJson = JsonSerializer.Serialize(
+                await _litmus.CaptureStatsAsync(document.ConsoleMac, Now - preWindow, Now, cancellationToken));
+        }
+
         if (apiPathAvailable)
         {
             document.UniFiOsUpdate.TargetVersion = pending!.Version;
@@ -1093,6 +1103,23 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         var outcome = apiPathAvailable ? "refused" : "nothing-to-update";
         await SettleUniFiOsAsync(plan, document, outcome, cancellationToken);
         return true;
+    }
+
+    private async Task CaptureOsPostStatsAsync(RolloutPlanDocument document, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(document.ConsoleMac) || document.UniFiOsUpdate.PostStatsJson != null)
+            return;
+        try
+        {
+            var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
+            var window = ResourceWindowFor(settings);
+            var post = await _litmus.CaptureStatsAsync(document.ConsoleMac, Now - window, Now, cancellationToken);
+            document.UniFiOsUpdate.PostStatsJson = JsonSerializer.Serialize(post);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Could not capture post-OS-update stats for site {Site}", _siteSlug);
+        }
     }
 
     private async Task SettleUniFiOsAsync(

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -264,7 +264,8 @@ public class FirmwareRolloutOrchestrator : BackgroundService
             {
                 var soaking = await _repositories.UseAsync((r, c) => r.GetStepsAsync(plan.Id, c), cancellationToken);
                 await WatchRollbacksAsync(plan, soaking, cancellationToken);
-                await RunDueResourceComparisonsAsync(soaking, cancellationToken);
+                var soakDoc = ParseDocument(plan);
+                await RunDueResourceComparisonsAsync(soaking, cancellationToken, plan, soakDoc);
                 await BuildSoakReportIfDueAsync(plan, soaking, cancellationToken);
                 return;
             }
@@ -737,7 +738,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         }
 
         await PropagateCanaryOutcomesAsync(document, steps, cancellationToken);
-        await RunDueResourceComparisonsAsync(steps, cancellationToken);
+        await RunDueResourceComparisonsAsync(steps, cancellationToken, plan, document);
         EnqueueDueMeshRepairs(document, steps);
 
         // Wave 0. The UniFi Network application update aligns the firmware catalog every device
@@ -954,7 +955,6 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         {
             if (OsVersionMatches(installed, state.TargetVersion))
             {
-                await CaptureOsPostStatsAsync(document, cancellationToken);
                 await SettleUniFiOsAsync(plan, document, "updated", cancellationToken);
                 _logger.LogInformation(
                     "The console on site {Site} is back on UniFi OS {Version}", _siteSlug, installed);
@@ -1103,23 +1103,6 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         var outcome = apiPathAvailable ? "refused" : "nothing-to-update";
         await SettleUniFiOsAsync(plan, document, outcome, cancellationToken);
         return true;
-    }
-
-    private async Task CaptureOsPostStatsAsync(RolloutPlanDocument document, CancellationToken cancellationToken)
-    {
-        if (string.IsNullOrWhiteSpace(document.ConsoleMac) || document.UniFiOsUpdate.PostStatsJson != null)
-            return;
-        try
-        {
-            var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
-            var window = ResourceWindowFor(settings);
-            var post = await _litmus.CaptureStatsAsync(document.ConsoleMac, Now - window, Now, cancellationToken);
-            document.UniFiOsUpdate.PostStatsJson = JsonSerializer.Serialize(post);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogWarning(ex, "Could not capture post-OS-update stats for site {Site}", _siteSlug);
-        }
     }
 
     private async Task SettleUniFiOsAsync(
@@ -1447,7 +1430,8 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         }
     }
 
-    private async Task RunDueResourceComparisonsAsync(List<FirmwareRolloutStep> steps, CancellationToken cancellationToken)
+    private async Task RunDueResourceComparisonsAsync(List<FirmwareRolloutStep> steps, CancellationToken cancellationToken,
+        FirmwareRolloutPlan? plan = null, RolloutPlanDocument? document = null)
     {
         var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
         var window = ResourceWindowFor(settings);
@@ -1487,6 +1471,25 @@ public class FirmwareRolloutOrchestrator : BackgroundService
                     $"Lighter After Upgrade: {step.DeviceName}{_siteSuffix}",
                     $"{step.DeviceName} ({step.Model}) went from {step.FromVersion ?? "its previous firmware"} to {step.ToVersion ?? "its new firmware"} and is working less hard since. {comparison.Detail}",
                     step.DeviceMac, step.DeviceName, cancellationToken);
+            }
+        }
+
+        if (plan != null && document != null
+            && document.UniFiOsUpdate is { Outcome: "updated", PostStatsJson: null }
+            && !string.IsNullOrWhiteSpace(document.ConsoleMac)
+            && document.UniFiOsUpdate.TriggeredAt is DateTime osTriggered
+            && Now >= osTriggered + GatewayCoolDown + window)
+        {
+            try
+            {
+                var from = osTriggered + GatewayCoolDown;
+                var post = await _litmus.CaptureStatsAsync(document.ConsoleMac, from, from + window, cancellationToken);
+                document.UniFiOsUpdate.PostStatsJson = JsonSerializer.Serialize(post);
+                await PersistDocumentAsync(plan, document, cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Could not capture post-OS-update stats for site {Site}", _siteSlug);
             }
         }
     }

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
@@ -454,6 +454,12 @@ public class RolloutConsoleStepState
     /// <summary>Direct download URL for the SSH fallback path, captured at plan time.</summary>
     public string? Url { get; set; }
 
+    /// <summary>Resource stats captured before the update was triggered.</summary>
+    public string? PreStatsJson { get; set; }
+
+    /// <summary>Resource stats captured after the update settled.</summary>
+    public string? PostStatsJson { get; set; }
+
     /// <summary>Wave this phase runs in: 0 for the application, after the last device for UniFi OS.</summary>
     public int Wave { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
@@ -460,6 +460,12 @@ public class RolloutConsoleStepState
     /// <summary>Resource stats captured after the update settled.</summary>
     public string? PostStatsJson { get; set; }
 
+    /// <summary>First tick the console stopped answering after the trigger.</summary>
+    public DateTime? WentDownAt { get; set; }
+
+    /// <summary>When the console answered again on its new version.</summary>
+    public DateTime? BackAt { get; set; }
+
     /// <summary>Wave this phase runs in: 0 for the application, after the last device for UniFi OS.</summary>
     public int Wave { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -191,7 +191,13 @@ public class FirmwareRolloutService : IFirmwareRolloutService
                 FirmwareTimingEstimator.Classify(d) == FirmwareDeviceClass.CloudGatewayUniFiOs),
             ConsoleAutoUpgradeEnabled = autoUpgrade == true,
             ConsoleOsAutoUpdateEnabled = console?.Firmware?.AutoUpdate?.IsScheduled == true,
-            ConsoleAppsAutoUpdateEnabled = console?.Firmware?.AutoUpdate is { IsScheduled: true, IncludeApplications: true },
+            // Two independent settings reach the same outcome: the console's schedule can carry the
+            // applications along, and each application can also carry a schedule of its own.
+            ConsoleAppsAutoUpdateEnabled =
+                console?.Firmware?.AutoUpdate is { IsScheduled: true, IncludeApplications: true }
+                || console?.Apps?.Controllers?.Any(c =>
+                    string.Equals(c.Name, UniFiConsoleController.NetworkName, StringComparison.OrdinalIgnoreCase)
+                    && c.AutoUpdates) == true,
             HasActivePlan = active != null,
         };
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -183,6 +183,7 @@ public class FirmwareRolloutService : IFirmwareRolloutService
             ConsoleApiAvailable = !_commands.UsesApiKey,
             HasCloudGatewayHardware = context.Devices.Any(d =>
                 FirmwareTimingEstimator.Classify(d) == FirmwareDeviceClass.CloudGatewayUniFiOs),
+            ConsoleDetailsKnown = console != null,
             // The step only exists where a Cloud Gateway runs the console: a self-hosted console
             // is out of scope, and a UXG-class gateway has network firmware only.
             HasCloudGateway = console?.IsStandaloneConsole == false && context.Devices.Any(d =>

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -495,9 +495,15 @@ public class FirmwareRolloutService : IFirmwareRolloutService
 
         if (preview.UpgradableCount == 0)
         {
-            preview.Notices.Add(
-                "You're all up to date. Turn on Autopilot in the Schedule step to have it manage " +
-                "firmware and Console updates automatically.");
+            // Naming a surface the rollout was not asked to cover would promise something Autopilot
+            // will not do, so the console half is named only when it is actually included.
+            var covers = settings.IncludeUniFiNetwork || (settings.IncludeUniFiOs && preview.HasCloudGateway)
+                ? "firmware and Console updates"
+                : "firmware";
+
+            preview.Notices.Add(settings.Mode == FirmwareRolloutMode.Autopilot
+                ? $"You're all up to date. Autopilot will pick up new {covers} on its own."
+                : $"You're all up to date. Turn on Autopilot in the Schedule step to have it manage {covers} automatically.");
         }
 
         // Each UniFi auto-update layer races a rollout in its own way, so name the ones that are on.

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -183,10 +183,11 @@ public class FirmwareRolloutService : IFirmwareRolloutService
             ConsoleApiAvailable = !_commands.UsesApiKey,
             HasCloudGatewayHardware = context.Devices.Any(d =>
                 FirmwareTimingEstimator.Classify(d) == FirmwareDeviceClass.CloudGatewayUniFiOs),
-            ConsoleDetailsKnown = console != null,
             // The step only exists where a Cloud Gateway runs the console: a self-hosted console
-            // is out of scope, and a UXG-class gateway has network firmware only.
-            HasCloudGateway = console?.IsStandaloneConsole == false && context.Devices.Any(d =>
+            // is out of scope, and a UXG-class gateway has network firmware only. Only a console
+            // KNOWN to be standalone rules it out - /api/system answers intermittently on an
+            // agent-proxied site, and treating silence as "self-hosted" made the step flicker.
+            HasCloudGateway = console?.IsStandaloneConsole != true && context.Devices.Any(d =>
                 FirmwareTimingEstimator.Classify(d) == FirmwareDeviceClass.CloudGatewayUniFiOs),
             ConsoleAutoUpgradeEnabled = autoUpgrade == true,
             ConsoleOsAutoUpdateEnabled = console?.Firmware?.AutoUpdate?.IsScheduled == true,

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -180,9 +180,7 @@ public class FirmwareRolloutService : IFirmwareRolloutService
             }).OrderBy(d => d.Name, StringComparer.OrdinalIgnoreCase).ToList(),
             ConsoleConnected = context.ConsoleConnected,
             IsStandaloneConsole = console?.IsStandaloneConsole == true,
-            // An empty answer means the console API is out of reach (API-key auth), not that the
-            // console has nothing to say.
-            ConsoleApiAvailable = console?.Firmware != null || console?.Apps != null,
+            ConsoleApiAvailable = !_commands.UsesApiKey,
             HasCloudGatewayHardware = context.Devices.Any(d =>
                 FirmwareTimingEstimator.Classify(d) == FirmwareDeviceClass.CloudGatewayUniFiOs),
             // The step only exists where a Cloud Gateway runs the console: a self-hosted console

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -490,14 +490,14 @@ public class FirmwareRolloutService : IFirmwareRolloutService
     {
         if (!preview.ConsoleConnected)
             preview.Warnings.Add(
-                "The UniFi Console is not answering, so this preview may be out of date and nothing can " +
-                "start until it is back.");
+                "Your UniFi Console isn't responding. What you're seeing here might be stale, and you " +
+                "can't start a rollout until it's back.");
 
         if (preview.UpgradableCount == 0)
         {
             preview.Notices.Add(
-                "No firmware updates are waiting on this site, so there is nothing to schedule. Choose " +
-                "Autopilot on the Schedule step to have one planned as soon as they arrive.");
+                "You're all up to date. Turn on Autopilot in the Schedule step to have it manage " +
+                "firmware and Console updates automatically.");
         }
 
         // Each UniFi auto-update layer races a rollout in its own way, so name the ones that are on.

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -515,8 +515,8 @@ public class FirmwareRolloutService : IFirmwareRolloutService
         // Each UniFi auto-update layer races a rollout in its own way, so name the ones that are on.
         var autoUpdaters = new List<string>();
         if (preview.ConsoleAutoUpgradeEnabled) autoUpdaters.Add("devices");
+        if (preview.ConsoleAppsAutoUpdateEnabled) autoUpdaters.Add("the UniFi Network application");
         if (preview.ConsoleOsAutoUpdateEnabled) autoUpdaters.Add("UniFi OS");
-        if (preview.ConsoleAppsAutoUpdateEnabled) autoUpdaters.Add("the applications");
         if (autoUpdaters.Count > 0)
         {
             var list = autoUpdaters.Count switch

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -523,7 +523,7 @@ public class FirmwareRolloutService : IFirmwareRolloutService
             {
                 1 => autoUpdaters[0],
                 2 => $"{autoUpdaters[0]} and {autoUpdaters[1]}",
-                _ => $"{string.Join(", ", autoUpdaters.Take(autoUpdaters.Count - 1))} and {autoUpdaters[^1]}",
+                _ => $"{string.Join(", ", autoUpdaters.Take(autoUpdaters.Count - 1))}, and {autoUpdaters[^1]}",
             };
             preview.Warnings.Add(
                 $"UniFi updates {list} on its own schedule. Rollouts still run; turning that off rules " +

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutViewModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutViewModels.cs
@@ -224,13 +224,6 @@ public class RolloutPreviewView
     public bool HasCloudGatewayHardware { get; set; }
 
     /// <summary>
-    /// Whether the console described itself. Everything derived from it - the UniFi OS step above,
-    /// the channels, the standalone test - reads false until it does, which is not the same answer
-    /// as no. A caller showing those must wait for this rather than render the difference away.
-    /// </summary>
-    public bool ConsoleDetailsKnown { get; set; }
-
-    /// <summary>
     /// Whether the console's own API answered. An API key reaches the UniFi Network application
     /// but not the console, so a key-authenticated site can upgrade devices and nothing else.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutViewModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutViewModels.cs
@@ -224,6 +224,13 @@ public class RolloutPreviewView
     public bool HasCloudGatewayHardware { get; set; }
 
     /// <summary>
+    /// Whether the console described itself. Everything derived from it - the UniFi OS step above,
+    /// the channels, the standalone test - reads false until it does, which is not the same answer
+    /// as no. A caller showing those must wait for this rather than render the difference away.
+    /// </summary>
+    public bool ConsoleDetailsKnown { get; set; }
+
+    /// <summary>
     /// Whether the console's own API answered. An API key reaches the UniFi Network application
     /// but not the console, so a key-authenticated site can upgrade devices and nothing else.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/Firmware/IFirmwareCommandClient.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/IFirmwareCommandClient.cs
@@ -158,6 +158,9 @@ public interface IFirmwareCommandClient
     /// <returns>True when the console accepted the install. Acceptance is not success.</returns>
     Task<bool> TriggerUniFiOsUpdateAsync(CancellationToken cancellationToken = default);
 
+    /// <summary>Whether this site connects with an API key rather than a user account.</summary>
+    bool UsesApiKey { get; }
+
     /// <summary>
     /// SSH fallback: install a UniFi Network application .deb on the gateway via
     /// <c>curl</c> + <c>apt-get install</c>. The gateway host is resolved from the controller URL.

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
@@ -108,6 +108,10 @@ public static class RolloutReportBuilder
                 DeviceType = "ugw",
                 FromVersion = document.UniFiOsUpdate.FromVersion,
                 ToVersion = document.UniFiOsUpdate.TargetVersion,
+                UpgradedAt = document.UniFiOsUpdate.BackAt,
+                DowntimeSeconds = document.UniFiOsUpdate is { WentDownAt: DateTime osDown, BackAt: DateTime osBack }
+                    ? (int)Math.Max(0, (osBack - osDown).TotalSeconds)
+                    : null,
                 Outcome = osOutcome,
                 CpuBeforeMean = osPre?.CpuPercent,
                 CpuAfterMean = osPost?.CpuPercent,

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
@@ -94,11 +94,14 @@ public static class RolloutReportBuilder
         {
             var osPre = ParseStats(document.UniFiOsUpdate.PreStatsJson);
             var osPost = ParseStats(document.UniFiOsUpdate.PostStatsJson);
+            // Every row carries a canonical outcome: the console's own vocabulary would reach the
+            // chip as raw text and be counted by no summary tile.
             var osOutcome = document.UniFiOsUpdate.Outcome switch
             {
                 "updated" => RolloutOutcomes.Upgraded,
                 "stuck" => RolloutOutcomes.Failed,
-                _ => document.UniFiOsUpdate.Outcome ?? RolloutOutcomes.Skipped,
+                "refused" => RolloutOutcomes.Failed,
+                _ => RolloutOutcomes.Skipped,
             };
             report.Rows.Add(new RolloutReportRow
             {

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
@@ -45,7 +45,11 @@ public static class RolloutReportBuilder
                 ? (int)Math.Max(0, (completed - started).TotalSeconds)
                 : 0,
             UniFiNetworkUpdateOutcome = document.IncludesUniFiNetworkUpdate ? document.NetworkAppUpdate.Outcome : null,
+            UniFiNetworkFromVersion = document.NetworkAppUpdate.FromVersion,
+            UniFiNetworkToVersion = document.NetworkAppUpdate.TargetVersion,
             UniFiOsUpdateOutcome = document.IncludesUniFiOsUpdate ? document.UniFiOsUpdate.Outcome : null,
+            UniFiOsFromVersion = document.UniFiOsUpdate.FromVersion,
+            UniFiOsToVersion = document.UniFiOsUpdate.TargetVersion,
             Notes = [.. document.Notes],
         };
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportBuilder.cs
@@ -88,6 +88,34 @@ public static class RolloutReportBuilder
             report.Rows.Add(row);
         }
 
+        // Add the gateway as a row when the OS step ran and it isn't already a device step.
+        if (document.IncludesUniFiOsUpdate && !string.IsNullOrWhiteSpace(document.ConsoleMac)
+            && !report.Rows.Any(r => string.Equals(r.Mac, document.ConsoleMac, StringComparison.OrdinalIgnoreCase)))
+        {
+            var osPre = ParseStats(document.UniFiOsUpdate.PreStatsJson);
+            var osPost = ParseStats(document.UniFiOsUpdate.PostStatsJson);
+            var osOutcome = document.UniFiOsUpdate.Outcome switch
+            {
+                "updated" => RolloutOutcomes.Upgraded,
+                "stuck" => RolloutOutcomes.Failed,
+                _ => document.UniFiOsUpdate.Outcome ?? RolloutOutcomes.Skipped,
+            };
+            report.Rows.Add(new RolloutReportRow
+            {
+                Mac = document.ConsoleMac,
+                Name = "Console (UniFi OS)",
+                Model = "Cloud Gateway",
+                DeviceType = "ugw",
+                FromVersion = document.UniFiOsUpdate.FromVersion,
+                ToVersion = document.UniFiOsUpdate.TargetVersion,
+                Outcome = osOutcome,
+                CpuBeforeMean = osPre?.CpuPercent,
+                CpuAfterMean = osPost?.CpuPercent,
+                MemBeforeMean = osPre?.MemoryUsedPercent,
+                MemAfterMean = osPost?.MemoryUsedPercent,
+            });
+        }
+
         report.DevicesUpgraded = report.Rows.Count(r => r.Outcome is RolloutOutcomes.Upgraded or RolloutOutcomes.RegressionFlagged);
         report.DevicesRolledBack = report.Rows.Count(r => r.Outcome == RolloutOutcomes.RolledBack);
         report.DevicesFailed = report.Rows.Count(r => r.Outcome == RolloutOutcomes.Failed);

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportModels.cs
@@ -47,9 +47,13 @@ public class RolloutReport
 
     /// <summary>How the UniFi Network application update ended, when one was included.</summary>
     public string? UniFiNetworkUpdateOutcome { get; set; }
+    public string? UniFiNetworkFromVersion { get; set; }
+    public string? UniFiNetworkToVersion { get; set; }
 
     /// <summary>How the console's UniFi OS update ended, when one was included.</summary>
     public string? UniFiOsUpdateOutcome { get; set; }
+    public string? UniFiOsFromVersion { get; set; }
+    public string? UniFiOsToVersion { get; set; }
 
     /// <summary>One row per device the plan covered.</summary>
     public List<RolloutReportRow> Rows { get; set; } = [];

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportPdfGenerator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportPdfGenerator.cs
@@ -135,8 +135,8 @@ public class RolloutReportPdfGenerator
                     LabelledLine(detail, "Failed", report.DevicesFailed.ToString());
                     LabelledLine(detail, "Rolled back", report.DevicesRolledBack.ToString());
                     LabelledLine(detail, "Skipped", report.DevicesSkipped.ToString());
-                    LabelledLine(detail, "UniFi Network application", ConsoleOutcomeLabel(report.UniFiNetworkUpdateOutcome));
-                    LabelledLine(detail, "UniFi OS", ConsoleOutcomeLabel(report.UniFiOsUpdateOutcome));
+                    LabelledLine(detail, "UniFi Network", ConsoleOutcomeWithVersions(report.UniFiNetworkUpdateOutcome, report.UniFiNetworkFromVersion, report.UniFiNetworkToVersion));
+                    LabelledLine(detail, "UniFi OS", ConsoleOutcomeWithVersions(report.UniFiOsUpdateOutcome, report.UniFiOsFromVersion, report.UniFiOsToVersion));
                 });
             });
 
@@ -270,6 +270,20 @@ public class RolloutReportPdfGenerator
         "skipped" => "not included",
         _ => outcome,
     };
+
+    private static string ConsoleOutcomeWithVersions(string? outcome, string? from, string? to)
+    {
+        var label = ConsoleOutcomeLabel(outcome);
+        var fromShort = FirmwareVersionFormat.ShortOrNull(from);
+        var toShort = FirmwareVersionFormat.ShortOrNull(to);
+        if (outcome == "updated" && fromShort != null && toShort != null)
+            return $"{fromShort} → {toShort}";
+        if (outcome is "nothing-to-update" or "unchanged" && fromShort != null)
+            return $"{label} ({fromShort})";
+        if (outcome == "stuck" && toShort != null)
+            return $"{label} (targeting {toShort})";
+        return label;
+    }
 
     private string OutcomeColor(string outcome) => outcome switch
     {

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportPdfGenerator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutReportPdfGenerator.cs
@@ -261,13 +261,13 @@ public class RolloutReportPdfGenerator
 
     private static string ConsoleOutcomeLabel(string? outcome) => outcome switch
     {
-        null or "" => "not included",
-        "updated" => "updated",
-        "nothing-to-update" => "already current",
-        "unchanged" => "accepted but unchanged",
-        "refused" => "refused by the console",
-        "stuck" => "did not come back",
-        "skipped" => "not included",
+        null or "" => "Not included",
+        "updated" => "Updated",
+        "nothing-to-update" => "Already current",
+        "unchanged" => "Accepted but unchanged",
+        "refused" => "Refused by the console",
+        "stuck" => "Did not come back",
+        "skipped" => "Not included",
         _ => outcome,
     };
 
@@ -279,9 +279,9 @@ public class RolloutReportPdfGenerator
         if (outcome == "updated" && fromShort != null && toShort != null)
             return $"{fromShort} → {toShort}";
         if (outcome is "nothing-to-update" or "unchanged" && fromShort != null)
-            return $"{label} ({fromShort})";
+            return $"{label} {fromShort}";
         if (outcome == "stuck" && toShort != null)
-            return $"{label} (targeting {toShort})";
+            return $"{label}, targeting {toShort}";
         return label;
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20484,15 +20484,9 @@ body.kiosk-mode .status-indicators {
     flex-shrink: 0;
 }
 
-.firmware-rollout-landing-autopilot {
-    flex-direction: column;
-    align-items: flex-start;
-}
-
-.firmware-rollout-landing-autopilot .firmware-rollout-autopilot-config {
-    width: 100%;
+.firmware-rollout-autopilot-config {
     max-width: 600px;
-    margin-top: 0.5rem;
+    padding-top: 0;
 }
 
 @media (max-width: 768px) {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20484,6 +20484,17 @@ body.kiosk-mode .status-indicators {
     flex-shrink: 0;
 }
 
+.firmware-rollout-landing-autopilot {
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.firmware-rollout-landing-autopilot .firmware-rollout-autopilot-config {
+    width: 100%;
+    max-width: 600px;
+    margin-top: 0.5rem;
+}
+
 @media (max-width: 768px) {
     .firmware-rollout-landing {
         flex-direction: column;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20485,7 +20485,6 @@ body.kiosk-mode .status-indicators {
 }
 
 .firmware-rollout-autopilot-config {
-    max-width: 600px;
     padding-top: 0;
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20488,9 +20488,17 @@ body.kiosk-mode .status-indicators {
     padding-top: 0;
 }
 
+.firmware-rollout-config-title {
+    margin-bottom: 0.25rem;
+}
+
 .firmware-rollout-config-intro {
     display: block;
     margin-bottom: 1rem;
+}
+
+.firmware-rollout-config-save {
+    margin-top: 1.5rem;
 }
 
 @media (max-width: 768px) {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19563,6 +19563,8 @@ body.kiosk-mode .status-indicators {
 .site-wizard-steps {
     display: flex;
     margin-bottom: 1.25rem;
+    user-select: none;
+    cursor: default;
 }
 
 .site-wizard-step {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20488,6 +20488,11 @@ body.kiosk-mode .status-indicators {
     padding-top: 0;
 }
 
+.firmware-rollout-config-intro {
+    display: block;
+    margin-bottom: 1rem;
+}
+
 @media (max-width: 768px) {
     .firmware-rollout-console-verb {
         display: none;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20489,6 +20489,10 @@ body.kiosk-mode .status-indicators {
 }
 
 @media (max-width: 768px) {
+    .firmware-rollout-console-verb {
+        display: none;
+    }
+
     .firmware-rollout-landing {
         flex-direction: column;
         align-items: flex-start;

--- a/tests/NetworkOptimizer.UniFi.Tests/ConsoleAutoUpdateTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/ConsoleAutoUpdateTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// The two places /api/system records that something updates itself. They are set independently,
+/// so reading only the console's rider misses an application on its own schedule.
+/// </summary>
+public class ConsoleAutoUpdateTests
+{
+    private static UniFiConsoleSystemInfo Parse(string json) =>
+        JsonSerializer.Deserialize<UniFiConsoleSystemInfo>(json)!;
+
+    [Fact]
+    public void AnApplicationOnItsOwnSchedule_AutoUpdates_EvenWhenTheConsoleRiderIsOff()
+    {
+        var info = Parse("""
+            {
+              "firmware": {
+                "autoUpdate": {
+                  "schedule": { "frequency": "daily", "hour": 0 },
+                  "includeApplications": false
+                }
+              },
+              "apps": {
+                "controllers": [
+                  { "name": "network", "type": "controller", "version": "10.6.94",
+                    "updateSchedule": { "frequency": "daily", "hour": 0 } }
+                ]
+              }
+            }
+            """);
+
+        info.Firmware!.AutoUpdate!.IncludeApplications.Should().BeFalse();
+        info.Apps!.Controllers.Single(c => c.Name == UniFiConsoleController.NetworkName)
+            .AutoUpdates.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AnApplicationWithNoSchedule_DoesNotAutoUpdate()
+    {
+        var info = Parse("""
+            {
+              "apps": {
+                "controllers": [
+                  { "name": "network", "type": "controller", "updateSchedule": null },
+                  { "name": "innerspace", "type": "controller" }
+                ]
+              }
+            }
+            """);
+
+        info.Apps!.Controllers.Should().OnlyContain(c => !c.AutoUpdates);
+    }
+
+    [Fact]
+    public void TheConsoleSchedulePresenceIsWhatCounts_NotItsShape()
+    {
+        Parse("""{"firmware":{"autoUpdate":{"schedule":{"frequency":"weekly","hour":0,"day":0}}}}""")
+            .Firmware!.AutoUpdate!.IsScheduled.Should().BeTrue();
+
+        Parse("""{"firmware":{"autoUpdate":{"schedule":null}}}""")
+            .Firmware!.AutoUpdate!.IsScheduled.Should().BeFalse();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleUpdateTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleUpdateTests.cs
@@ -191,7 +191,10 @@ public class RolloutConsoleUpdateTests
         await harness.TickAsync(TimeSpan.FromMinutes(5));
         (await harness.PlanAsync(plan.Id))!.Status.Should().Be(FirmwareRolloutStatus.Running);
 
-        harness.Commands.ConsoleInfo = new UniFiConsoleSystemInfo();
+        harness.Commands.ConsoleInfo = new UniFiConsoleSystemInfo
+        {
+            Hardware = new UniFiConsoleHardware { FirmwareVersion = "4.3.6" },
+        };
         harness.Commands.PendingUniFiOs = null;
         await harness.TickAsync(TimeSpan.FromMinutes(5));
 
@@ -384,13 +387,15 @@ public class RolloutConsoleUpdateTests
     private static async Task RunDeviceToLitmusAsync(RolloutHarness harness, string mac)
     {
         var existing = harness.Observer.Devices[mac];
+        var isGateway = existing.Model is "UDMA6A8" or "UCGF" or "UDR" or "UDMPRO";
         harness.Observer.Devices[mac] = existing with { State = (int)UniFiDeviceState.Disconnected };
         await harness.TickAsync(TimeSpan.FromSeconds(20));
 
         harness.Observer.Devices[mac] = existing with { State = Online, Firmware = ToVersion, UpgradeToFirmware = null };
         await harness.TickAsync(TimeSpan.FromMinutes(4));
         await harness.TickAsync(TimeSpan.FromSeconds(20));
-        await harness.TickAsync(FirmwareRolloutOrchestrator.CoolDown);
+        var cooldown = isGateway ? FirmwareRolloutOrchestrator.GatewayCoolDown : FirmwareRolloutOrchestrator.CoolDown;
+        await harness.TickAsync(cooldown);
     }
 }
 

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutGatewayReportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutGatewayReportTests.cs
@@ -1,0 +1,191 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.UniFi.Models;
+using NetworkOptimizer.Web.Services.Firmware;
+using Xunit;
+using static NetworkOptimizer.Web.Tests.Firmware.RolloutFixtures;
+
+namespace NetworkOptimizer.Web.Tests.Firmware;
+
+/// <summary>
+/// The console's own before/after numbers. A UCG's device firmware IS UniFi OS, so the console
+/// earns a report row like any other device - but its measurements come off the console step
+/// rather than a device step, which is where every gap below lived.
+/// </summary>
+public class RolloutGatewayReportTests
+{
+    private const int Online = (int)UniFiDeviceState.Connected;
+
+    private static RolloutPlanDocument UniFiOsPlan()
+    {
+        var document = Document(Wave(1, PlanStep(ApMac)));
+        document.IncludesUniFiOsUpdate = true;
+        document.ConsoleMac = GatewayMac;
+        return document;
+    }
+
+    private static RolloutPlanDocument Stored(FirmwareRolloutPlan plan) =>
+        JsonSerializer.Deserialize<RolloutPlanDocument>(plan.PlanJson)!;
+
+    private static UniFiConsoleSystemInfo ConsoleOn(string version) => new()
+    {
+        Hardware = new UniFiConsoleHardware { FirmwareVersion = version },
+    };
+
+    private static async Task RunDeviceToLitmusAsync(RolloutHarness harness, string mac)
+    {
+        var existing = harness.Observer.Devices[mac];
+        harness.Observer.Devices[mac] = existing with { State = (int)UniFiDeviceState.Disconnected };
+        await harness.TickAsync(TimeSpan.FromSeconds(20));
+
+        harness.Observer.Devices[mac] = existing with { State = Online, Firmware = ToVersion, UpgradeToFirmware = null };
+        await harness.TickAsync(TimeSpan.FromMinutes(4));
+        await harness.TickAsync(TimeSpan.FromSeconds(20));
+        await harness.TickAsync(FirmwareRolloutOrchestrator.CoolDown);
+    }
+
+    /// <summary>Trigger the OS update and leave the console back up on its new build.</summary>
+    private static async Task<FirmwareRolloutPlan> RunOsUpdateAsync(RolloutHarness harness)
+    {
+        harness.Commands.PendingUniFiOs = new UniFiConsoleFirmwareRelease { Version = "4.3.6" };
+        harness.Commands.ConsoleInfo = ConsoleOn("4.3.5");
+        var plan = await harness.SeedRunningPlanAsync(UniFiOsPlan(), Step(ApMac));
+        harness.Observer.Set(ApMac, Online, FromVersion, upgradeTo: ToVersion);
+
+        await harness.TickAsync();
+        await RunDeviceToLitmusAsync(harness, ApMac);
+        return plan;
+    }
+
+    [Fact]
+    public async Task PreStats_AreCapturedBeforeTheConsoleIsCommanded()
+    {
+        using var harness = new RolloutHarness();
+        harness.Litmus.StatsByMac[GatewayMac] =
+            new RolloutResourceStats { CpuPercent = 30, MemoryUsedPercent = 70, SampleCount = 40 };
+
+        var plan = await RunOsUpdateAsync(harness);
+
+        var os = Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate;
+        os.Triggered.Should().BeTrue();
+        os.PreStatsJson.Should().NotBeNull();
+        JsonSerializer.Deserialize<RolloutResourceStats>(os.PreStatsJson!)!.CpuPercent.Should().Be(30);
+    }
+
+    [Fact]
+    public async Task ATransientApiFailureDuringTheDownload_DoesNotStartTheDowntimeClock()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await RunOsUpdateAsync(harness);
+
+        // One failed poll while the console is still up and downloading.
+        harness.Commands.ConsoleInfo = null;
+        await harness.TickAsync(TimeSpan.FromSeconds(30));
+        Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate.WentDownAt.Should().NotBeNull();
+
+        // It answers again on the OLD version, so the reboot is still ahead of us.
+        harness.Commands.ConsoleInfo = ConsoleOn("4.3.5");
+        await harness.TickAsync(TimeSpan.FromSeconds(30));
+
+        Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate.WentDownAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DowntimeIsMeasuredFromTheRealDarkStretch_NotTheJudgeDelay()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await RunOsUpdateAsync(harness);
+
+        harness.Commands.ConsoleInfo = null;
+        await harness.TickAsync(TimeSpan.FromSeconds(10));
+
+        // Back on the new build well inside the 2 minute judge delay.
+        harness.Commands.ConsoleInfo = ConsoleOn("4.3.6");
+        harness.Commands.PendingUniFiOs = null;
+        await harness.TickAsync(TimeSpan.FromSeconds(40));
+
+        var os = Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate;
+        os.WentDownAt.Should().NotBeNull();
+        os.BackAt.Should().NotBeNull();
+
+        // Observed, not judged: roughly the 40s it was actually away, nowhere near the delay.
+        (os.BackAt!.Value - os.WentDownAt!.Value).Should().BeLessThan(TimeSpan.FromMinutes(2));
+    }
+
+    [Fact]
+    public async Task TheReportWaitsForTheConsoleWindow_AndCarriesTheGatewayRow()
+    {
+        using var harness = new RolloutHarness();
+        harness.Litmus.StatsByMac[GatewayMac] =
+            new RolloutResourceStats { CpuPercent = 30, MemoryUsedPercent = 70, SampleCount = 40 };
+
+        var plan = await RunOsUpdateAsync(harness);
+
+        harness.Commands.ConsoleInfo = null;
+        await harness.TickAsync(TimeSpan.FromMinutes(3));
+        harness.Commands.ConsoleInfo = ConsoleOn("4.3.6");
+        harness.Commands.PendingUniFiOs = null;
+        await harness.TickAsync(TimeSpan.FromMinutes(1));
+
+        (await harness.PlanAsync(plan.Id))!.Status.Should().Be(FirmwareRolloutStatus.SoakWait);
+
+        // The device's own window closes first. The report must NOT freeze here: the console's
+        // window opens a gateway cool-down after its own trigger, which is later in every path.
+        await harness.TickAsync(TimeSpan.FromHours(2));
+        var midSoak = await harness.PlanAsync(plan.Id);
+        midSoak!.ReportJson.Should().BeNull("the console's after-window has not opened yet");
+
+        harness.Litmus.StatsByMac[GatewayMac] =
+            new RolloutResourceStats { CpuPercent = 18, MemoryUsedPercent = 62, SampleCount = 40 };
+        await harness.TickAsync(TimeSpan.FromHours(3));
+
+        var done = await harness.PlanAsync(plan.Id);
+        done!.ReportJson.Should().NotBeNull();
+
+        var report = RolloutReport.Parse(done.ReportJson)!;
+        var gateway = report.Rows.Single(r => string.Equals(r.Mac, GatewayMac, StringComparison.OrdinalIgnoreCase));
+        gateway.CpuBeforeMean.Should().Be(30);
+        gateway.CpuAfterMean.Should().Be(18);
+        gateway.MemBeforeMean.Should().Be(70);
+        gateway.MemAfterMean.Should().Be(62);
+        gateway.DowntimeSeconds.Should().NotBeNull();
+        gateway.Outcome.Should().Be(RolloutOutcomes.Upgraded);
+    }
+
+    [Fact]
+    public async Task AStuckConsoleDoesNotHoldTheReportForever()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await RunOsUpdateAsync(harness);
+
+        harness.Commands.ConsoleInfo = null;
+        await harness.TickAsync(TimeSpan.FromMinutes(3));
+        harness.Commands.ConsoleInfo = ConsoleOn("4.3.6");
+        harness.Commands.PendingUniFiOs = null;
+        await harness.TickAsync(TimeSpan.FromMinutes(1));
+
+        // Far past the console's own window: a capture that never lands stops blocking.
+        await harness.TickAsync(TimeSpan.FromHours(12));
+
+        (await harness.PlanAsync(plan.Id))!.ReportJson.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ARolloutWithNoConsoleUpdate_GetsNoGatewayRow()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await harness.SeedRunningPlanAsync(Document(Wave(1, PlanStep(ApMac))), Step(ApMac));
+        harness.Observer.Set(ApMac, Online, FromVersion, upgradeTo: ToVersion);
+
+        await harness.TickAsync();
+        await RunDeviceToLitmusAsync(harness, ApMac);
+        await harness.TickAsync(TimeSpan.FromHours(3));
+
+        var done = await harness.PlanAsync(plan.Id);
+        done!.ReportJson.Should().NotBeNull();
+        RolloutReport.Parse(done.ReportJson)!.Rows
+            .Should().NotContain(r => string.Equals(r.Mac, GatewayMac, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutPlannerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutPlannerTests.cs
@@ -15,6 +15,8 @@ namespace NetworkOptimizer.Web.Tests.Firmware;
 /// </summary>
 public class RolloutPlannerTests
 {
+    private static readonly int Cd = (int)FirmwareRolloutOrchestrator.CoolDown.TotalSeconds;
+    private static readonly int GwCd = (int)FirmwareRolloutOrchestrator.GatewayCoolDown.TotalSeconds;
     private const string GatewayMac = "aa:bb:cc:dd:ee:01";
     private const string DistSwitchMac = "aa:bb:cc:dd:ee:02";
     private const string AccessSwitchMac = "aa:bb:cc:dd:ee:03";
@@ -834,7 +836,7 @@ public class RolloutPlannerTests
         doc.IncludesUniFiNetworkUpdate.Should().BeTrue();
         doc.UniFiNetworkUpdateSeconds.Should().Be(RolloutPlanner.UniFiNetworkUpdateSeconds);
         doc.Waves[0].StartOffsetSeconds.Should().Be(300);
-        doc.TotalEstimatedSeconds.Should().Be(300 + 240 + RolloutPlanner.CommandOverheadSeconds);
+        doc.TotalEstimatedSeconds.Should().Be(300 + 240 + (int)FirmwareRolloutOrchestrator.CoolDown.TotalSeconds + RolloutPlanner.CommandOverheadSeconds);
     }
 
     [Fact]
@@ -860,7 +862,7 @@ public class RolloutPlannerTests
         doc.ChannelGroups.Single().RequiresConsoleChange.Should().BeTrue();
         doc.Waves[0].StartOffsetSeconds.Should().Be(RolloutPlanner.ChannelChangeSeconds);
         doc.TotalEstimatedSeconds.Should().Be(
-            RolloutPlanner.ChannelChangeSeconds + 240 + RolloutPlanner.CommandOverheadSeconds
+            RolloutPlanner.ChannelChangeSeconds + 240 + Cd + RolloutPlanner.CommandOverheadSeconds
             + RolloutPlanner.ChannelChangeSeconds);
     }
 
@@ -873,7 +875,7 @@ public class RolloutPlannerTests
 
         doc.ChannelGroups.Single().RequiresConsoleChange.Should().BeFalse();
         doc.Waves[0].StartOffsetSeconds.Should().Be(0);
-        doc.TotalEstimatedSeconds.Should().Be(240 + RolloutPlanner.CommandOverheadSeconds);
+        doc.TotalEstimatedSeconds.Should().Be(240 + Cd + RolloutPlanner.CommandOverheadSeconds);
     }
 
     [Fact]
@@ -894,8 +896,8 @@ public class RolloutPlannerTests
         doc.Waves[0].Steps.Should().HaveCount(2);
         doc.Waves[0].StartOffsetSeconds.Should().Be(0);
         // Slowest of the pair (the older AP at 420s), the command allowance, then the AP gap.
-        doc.Waves[1].StartOffsetSeconds.Should().Be(420 + RolloutPlanner.CommandOverheadSeconds + 100);
-        doc.TotalEstimatedSeconds.Should().Be(550 + 240 + RolloutPlanner.CommandOverheadSeconds);
+        doc.Waves[1].StartOffsetSeconds.Should().Be(420 + Cd + RolloutPlanner.CommandOverheadSeconds + 100);
+        doc.TotalEstimatedSeconds.Should().Be(550 + Cd + 240 + Cd + RolloutPlanner.CommandOverheadSeconds);
     }
 
     [Fact]
@@ -911,12 +913,14 @@ public class RolloutPlannerTests
         var doc = Plan(devices).Document;
 
         doc.Waves[0].StartOffsetSeconds.Should().Be(0);
-        // AP wave: 240 down + 30 overhead + 120 AP gap.
-        doc.Waves[1].StartOffsetSeconds.Should().Be(390);
-        // Switch wave: 480 down + 30 overhead + 180 switch gap.
-        doc.Waves[2].StartOffsetSeconds.Should().Be(1080);
+        // AP wave: 240 down + Cd cooldown + 30 overhead + 120 AP gap.
+        doc.Waves[1].StartOffsetSeconds.Should().Be(240 + Cd + RolloutPlanner.CommandOverheadSeconds + 120);
+        // Switch wave: 480 down + Cd cooldown + 30 overhead + 180 switch gap.
+        var w1 = doc.Waves[1].StartOffsetSeconds;
+        doc.Waves[2].StartOffsetSeconds.Should().Be(w1 + 480 + Cd + RolloutPlanner.CommandOverheadSeconds + 180);
         // The gateway closes the only group, so its gateway gap is never charged.
-        doc.TotalEstimatedSeconds.Should().Be(1080 + 300 + RolloutPlanner.CommandOverheadSeconds);
+        var w2 = doc.Waves[2].StartOffsetSeconds;
+        doc.TotalEstimatedSeconds.Should().Be(w2 + 300 + GwCd + RolloutPlanner.CommandOverheadSeconds);
     }
 
     [Fact]
@@ -957,7 +961,7 @@ public class RolloutPlannerTests
         var last = doc.Waves.Last();
         doc.TotalEstimatedSeconds.Should().Be(
             last.StartOffsetSeconds + last.Steps.Max(s => s.EstimatedDowntimeSeconds)
-            + RolloutPlanner.CommandOverheadSeconds);
+            + Cd + RolloutPlanner.CommandOverheadSeconds);
     }
 
     [Fact]
@@ -971,7 +975,7 @@ public class RolloutPlannerTests
         var doc = Plan(devices, estimator: estimator).Document;
 
         StepOf(doc, ApMac).EstimatedDowntimeSeconds.Should().Be(195);
-        doc.TotalEstimatedSeconds.Should().Be(195 + RolloutPlanner.CommandOverheadSeconds);
+        doc.TotalEstimatedSeconds.Should().Be(195 + Cd + RolloutPlanner.CommandOverheadSeconds);
     }
 
     // ---- Effective class ------------------------------------------------------------

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutTestDoubles.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutTestDoubles.cs
@@ -50,6 +50,7 @@ internal sealed class CapturingBus : IAlertEventBus
 /// </summary>
 internal sealed class FakeFirmwareCommandClient : IFirmwareCommandClient
 {
+    public bool UsesApiKey { get; set; }
     public FirmwareCommandResult UpgradeResult { get; set; } = FirmwareCommandResult.Ok();
     public FirmwareCommandResult ExternalResult { get; set; } = FirmwareCommandResult.Ok();
     public FirmwareCommandResult SshResult { get; set; } = FirmwareCommandResult.Ok();


### PR DESCRIPTION
Autopilot's settings were only reachable by walking back through the wizard, and the post-rollout report ignored the one device that matters most on a console rollout: the console itself.

## Firmware Rollout

- **Autopilot settings on the idle view** - when Autopilot is on and nothing is pending or scheduled, the page shows the full channel configuration (global, per console application, per device type, per model) and exclusions inline, with a Save button. The controls are the wizard's, factored out into a shared `FirmwareChannelConfig` component rather than duplicated.

- **The gateway gets a report row** - a UCG's device firmware IS UniFi OS, so the console now appears in the report and the PDF with its version from and to, its downtime, and CPU and memory before and after. Stats are captured before the OS trigger and after the gateway cool-down, the same windows every device step uses.

- **Console steps show versions** - the report said "updated" for UniFi Network and UniFi OS. It now says what they went from and to, in the UI and the PDF.

- **Saved Autopilot channel survives the wizard** - `SeedChannelsFromConsole` overwrote the saved global channel with whatever the console currently ran, so a saved Early Access setting came back as Release Candidate. Skipped when Autopilot is on, and canceling reloads from the database rather than leaving in-memory edits on screen.

- **Console API detection reads the connection, not a probe** - `ConsoleApiAvailable` was inferred from the shape of an `/api/system` response, which on agent-served sites with a slow tunnel read an empty response as API key auth. It now reads `Client.UseApiKey` directly.

- Firmware changelog links removed from the plan preview and the report. They resolved incorrectly and required a sign-in for Early Access builds.

## Review fixes

A Fable review of this branch against `release/2.7` found several defects in the new execution paths, all fixed here and covered by `RolloutGatewayReportTests`:

- **The report froze before the gateway's numbers existed.** The soak report built as soon as every device step had post-stats, but the console's after-window opens a gateway cool-down past its own trigger, which lands later than the last device's in every path. The gateway's stats could never reach a report. The gate now waits for them, bounded so a capture that never lands stops holding the report.

- **Downtime started on the wrong signal.** `WentDownAt` latched on any null from `GetConsoleSystemInfoAsync`, including a single timeout while the console was up and downloading, and never cleared. A console answering on the old version now resets the clock, since the reboot is still ahead.

- **Downtime had a two minute floor.** `BackAt` sat inside the `UniFiOsJudgeDelay` gate. Observation no longer shares the judgment gate. (Four real UCG upgrades across the test sites ran 2m50s to 4m43s, so this never distorted a live number, but it would on a faster console.)

- **Wizard parity from the extraction.** The exclusion checkbox and the per-model button matched on the exact model code where the page had always matched on the model family, so a family rule stored under another color's code left the button reading "Exclude model" while clicking it removed the exclusion. Both take the page's family-aware predicates again, and upgradable devices sort first again.

- **Gateway rows carry a canonical outcome.** `refused` and `nothing-to-update` reached the chip as raw kebab-case in both UI and PDF, and were counted by no summary tile.

## Console reachability

`/api/system` answers fast but unusably on an agent-proxied site, often enough to be visible as UI that comes and goes between page loads. Everything derived from it was treating silence as a negative answer.

- **UniFi OS no longer flickers.** `HasCloudGateway` required `console?.IsStandaloneConsole == false`, so a null console read as "self-hosted" and withheld the UniFi OS checkbox, its channel picker, and the OS step. Only a console that actually says it is standalone withholds them now.

- **The preview answers for the wizard, not for what is saved.** The Schedule step's choice lives in page state until commit, so the up-to-date notice read the persisted mode and told someone already on Autopilot to go turn on Autopilot. `WorkingSettings()` now carries the mode, as it already did for exclusions and per-model channels.

## Firmware Rollout, continued

- **Save is disabled until something changes.** The shared component edited the settings object in place and raised nothing, so the owner's Save button could not react to an edit at all. It now raises `OnChanged`, and the page compares against a signature taken at load. Save re-disables after a successful save. The wizard instance does not pass the callback and is unaffected.

- **The UniFi Network application's own auto-update is read.** An application updating itself is `apps.controllers[].updateSchedule`, not the console's `firmware.autoUpdate.includeApplications` rider. The two are set independently, so a site with Network on a daily schedule and the rider off reported no application auto-updater at all. Three parse tests cover the shape.

## Copy

- The console-unreachable warning and the nothing-to-update notice were rewritten. The latter now varies on whether Autopilot is on and on whether the plan actually includes Console updates, rather than naming surfaces it will not touch.

- The Autopilot note on the Schedule step told every site to turn off all three UniFi auto-updaters regardless of their state. It now names only the ones that are on, renders nothing when none are, and is a warning rather than an info block.

- Auto-updater lists name the UniFi Network application rather than "the applications", read in the order the rollout runs them, and take an Oxford comma.

- Known gap, deliberately left: on an API-key connection the two console-level auto-update flags are unreadable and read as off, so that note under-reports there.

- The wizard step bar is no longer selectable text.

## Testing

`dotnet build` clean, 0 warnings. 2391 Web tests and 1251 UniFi tests pass. Six new tests cover the pre-stats capture, the transient-null reset, the observed downtime, the report gate, the bounded wait, and the no-console-update case. The report-gate test was verified to fail without its fix.

Not covered by tests, and worth a preview4 tester's attention: whether a real console's boot HTML and reachability behave as assumed on installs other than ours.
