### PR TITLE
Autopilot keeps its own standing config

### DIFF
--- a/src/NetworkOptimizer.Storage/Interfaces/IFirmwareRolloutRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IFirmwareRolloutRepository.cs
@@ -15,9 +15,16 @@ public interface IFirmwareRolloutRepository
 
     /// <summary>
     /// Writes the settings singleton. Updates copy every field onto the stored row, so a
-    /// detached instance from the UI replaces the persisted state exactly.
+    /// detached instance from the UI replaces the persisted state exactly - except the autopilot
+    /// snapshot, which only <see cref="SaveAutopilotSnapshotAsync"/> writes.
     /// </summary>
     Task SaveSettingsAsync(FirmwareRolloutSettings settings, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes the standing Autopilot configuration, and nothing else on the row.
+    /// </summary>
+    /// <param name="snapshotJson">Serialized settings, or null to forget them.</param>
+    Task SaveAutopilotSnapshotAsync(string? snapshotJson, CancellationToken cancellationToken = default);
 
     /// <summary>Inserts a new plan and returns it with its assigned Id.</summary>
     Task<FirmwareRolloutPlan> CreatePlanAsync(FirmwareRolloutPlan plan, CancellationToken cancellationToken = default);

--- a/src/NetworkOptimizer.Storage/Migrations/20260816220000_AddAutopilotSettingsSnapshot.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260816220000_AddAutopilotSettingsSnapshot.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260816220000_AddAutopilotSettingsSnapshot")]
+    partial class AddAutopilotSettingsSnapshot
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260816220000_AddAutopilotSettingsSnapshot.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260816220000_AddAutopilotSettingsSnapshot.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAutopilotSettingsSnapshot : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Additive only. Existing Autopilot sites seed themselves from the live row on the
+            // first autopilot tick, which serializes with the same model that reads it.
+            migrationBuilder.AddColumn<string>(
+                name: "AutopilotSettingsJson",
+                table: "FirmwareRolloutSettings",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AutopilotSettingsJson",
+                table: "FirmwareRolloutSettings");
+        }
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/FirmwareRolloutSettings.cs
+++ b/src/NetworkOptimizer.Storage/Models/FirmwareRolloutSettings.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace NetworkOptimizer.Storage.Models;
 
@@ -134,6 +135,17 @@ public class FirmwareRolloutSettings
 
     /// <summary>Pause at every wave boundary until a Site Admin approves the next wave.</summary>
     public bool PerWaveApproval { get; set; }
+
+    /// <summary>
+    /// The standing Autopilot configuration, serialized. The row itself is a working copy - the
+    /// executor reads it live, so committing any rollout writes this row - which left Autopilot's
+    /// own settings with nowhere to live. Written only by an explicit Autopilot save, never
+    /// inferred from <see cref="Mode"/>: a manual rollout on an Autopilot site carries
+    /// Autopilot mode too, so inferring it would let a one-off overwrite the standing config.
+    /// Null means never captured.
+    /// </summary>
+    [JsonIgnore]
+    public string? AutopilotSettingsJson { get; set; }
 
     /// <summary>When these settings were last written.</summary>
     public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;

--- a/src/NetworkOptimizer.Storage/Repositories/FirmwareRolloutRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/FirmwareRolloutRepository.cs
@@ -78,6 +78,10 @@ public class FirmwareRolloutRepository : IFirmwareRolloutRepository
                 existing.SoakHours = settings.SoakHours;
                 existing.MinReleaseAgeDays = settings.MinReleaseAgeDays;
                 existing.PerWaveApproval = settings.PerWaveApproval;
+                // AutopilotSettingsJson is deliberately NOT copied. Every rollout commit comes
+                // through here, including a one-off on an Autopilot site, and copying it would let
+                // that one-off's scope become the standing config. SaveAutopilotSnapshotAsync is
+                // the only writer.
                 existing.UpdatedAt = DateTime.UtcNow;
             }
             else
@@ -92,6 +96,30 @@ public class FirmwareRolloutRepository : IFirmwareRolloutRepository
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to save firmware rollout settings");
+            throw;
+        }
+    }
+
+    public async Task SaveAutopilotSnapshotAsync(string? snapshotJson, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Only this column, so a seed running on the autopilot tick cannot clobber a settings
+            // save a user is making at the same moment.
+            var existing = await _context.FirmwareRolloutSettings.FirstOrDefaultAsync(cancellationToken);
+            if (existing == null)
+            {
+                _logger.LogWarning("No firmware rollout settings row to write the autopilot snapshot to");
+                return;
+            }
+
+            existing.AutopilotSettingsJson = snapshotJson;
+            await _context.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Saved the autopilot settings snapshot");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save the autopilot settings snapshot");
             throw;
         }
     }

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -401,6 +401,17 @@ else
             {
                 <p class="firmware-rollout-note"><strong>Autopilot is on.</strong> Nothing is scheduled right now. Updates get picked up automatically, scheduled for the site's quietest window, and announced before they run.</p>
             }
+            else if (HasStoredAutopilotConfig)
+            {
+                <SiteAdminOnly>
+                    <ChildContent>
+                        <p class="firmware-rollout-note"><strong>Autopilot is off.</strong> Your channels and exclusions are still saved.</p>
+                    </ChildContent>
+                    <NotAuthorized>
+                        <p class="firmware-rollout-note">No rollout is scheduled or running. When an admin plans one, its progress and report show up here.</p>
+                    </NotAuthorized>
+                </SiteAdminOnly>
+            }
             else
             {
                 <SiteAdminOnly>
@@ -415,17 +426,33 @@ else
             <SiteAdminOnly>
                 @{
                     var autopilotOn = _settings?.Mode == FirmwareRolloutMode.Autopilot;
+                    var offWithConfig = !autopilotOn && HasStoredAutopilotConfig;
                 }
-                <button class="btn @(autopilotOn ? "btn-secondary" : "btn-primary")" @onclick="OpenWizardAsync" disabled="@_busy">
-                    @if (_busy)
+                <div class="firmware-rollout-controls">
+                    @if (offWithConfig)
                     {
-                        <span class="spinner spinner-sm"></span>
+                        <button class="btn btn-primary" @onclick="ReEnableAutopilotAsync" disabled="@_busy">
+                            @if (_busy)
+                            {
+                                <span class="spinner spinner-sm"></span>
+                            }
+                            else
+                            {
+                                <span>Re-enable Autopilot</span>
+                            }
+                        </button>
                     }
-                    else
-                    {
-                        <span>@(autopilotOn ? "Plan Rollout Now" : "Plan a Rollout")</span>
-                    }
-                </button>
+                    <button class="btn @(autopilotOn || offWithConfig ? "btn-secondary" : "btn-primary")" @onclick="OpenWizardAsync" disabled="@_busy">
+                        @if (_busy)
+                        {
+                            <span class="spinner spinner-sm"></span>
+                        }
+                        else
+                        {
+                            <span>@(autopilotOn ? "Plan Rollout Now" : "Plan a Rollout")</span>
+                        }
+                    </button>
+                </div>
             </SiteAdminOnly>
         </div>
         @if (_settings?.Mode == FirmwareRolloutMode.Autopilot)
@@ -466,10 +493,13 @@ else
                     ToggleSku="ToggleSku"
                     OnChanged="StateHasChanged" />
 
-                <button class="btn btn-primary firmware-rollout-config-save" @onclick="SaveAutopilotSettingsAsync" disabled="@(_busy || !ConfigDirty)">
-                    @if (_busy) { <span class="spinner spinner-sm"></span> }
-                    else { <span>Save</span> }
-                </button>
+                <div class="firmware-rollout-controls firmware-rollout-config-save">
+                    <button class="btn btn-primary" @onclick="SaveAutopilotSettingsAsync" disabled="@(_busy || !ConfigDirty)">
+                        @if (_busy) { <span class="spinner spinner-sm"></span> }
+                        else { <span>Save</span> }
+                    </button>
+                    <button class="btn btn-secondary" @onclick="DisableAutopilotAsync" disabled="@_busy">Turn off Autopilot</button>
+                </div>
                 }
             </div>
             </SiteAdminOnly>
@@ -787,6 +817,7 @@ else
         try
         {
             _settings = await RolloutService.GetSettingsAsync();
+            AdoptStandingAutopilotConfig();
             LoadWorkingSets();
             _active = await RolloutService.GetActivePlanAsync();
             _history = await RolloutService.GetPlanHistoryAsync();
@@ -813,6 +844,7 @@ else
         try
         {
             _settings = await RolloutService.GetSettingsAsync();
+            AdoptStandingAutopilotConfig();
             LoadWorkingSets();
             // First preview: channel options, device models, and console warnings for step 1.
             _preview = await RolloutService.BuildPreviewAsync(WorkingSettings());
@@ -947,9 +979,8 @@ else
         StateHasChanged();
         try
         {
-            var settings = WorkingSettings();
-            settings.Mode = FirmwareRolloutMode.Autopilot;
-            await RolloutService.SaveSettingsAsync(settings);
+            // The capturing save: this is the standing configuration, not one rollout's scope.
+            await RolloutService.SaveAutopilotSettingsAsync(WorkingSettings());
             await ReloadAsync();
         }
         catch (Exception ex)
@@ -960,6 +991,66 @@ else
         {
             _busy = false;
         }
+    }
+
+    private async Task DisableAutopilotAsync()
+    {
+        _busy = true;
+        StateHasChanged();
+        try
+        {
+            await RolloutService.DisableAutopilotAsync();
+            await ReloadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Turning autopilot off failed");
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    private async Task ReEnableAutopilotAsync()
+    {
+        _busy = true;
+        StateHasChanged();
+        try
+        {
+            await RolloutService.ReEnableAutopilotAsync();
+            await ReloadAsync();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Re-enabling autopilot failed");
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+
+    /// <summary>Whether Autopilot has a captured configuration to come back to.</summary>
+    private bool HasStoredAutopilotConfig => !string.IsNullOrWhiteSpace(_settings?.AutopilotSettingsJson);
+
+    /// <summary>
+    /// On an Autopilot site the page edits the standing configuration, not the row, which any
+    /// one-off rollout since has overwritten with its own scope. Without this the panel shows that
+    /// leftover scope, and the wizard - which preselects Autopilot on such a site - would capture
+    /// it on a click-through commit.
+    /// </summary>
+    private void AdoptStandingAutopilotConfig()
+    {
+        if (_settings?.Mode != FirmwareRolloutMode.Autopilot) return;
+
+        var standing = AutopilotSettingsSnapshot.Deserialize(_settings.AutopilotSettingsJson);
+        if (standing == null) return;
+
+        standing.Id = _settings.Id;
+        standing.Mode = _settings.Mode;
+        standing.AutopilotSettingsJson = _settings.AutopilotSettingsJson;
+        _settings = standing;
     }
 
     // ---- Settings working copies ----

--- a/src/NetworkOptimizer.Web/Services/Firmware/AutopilotSettingsSnapshot.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/AutopilotSettingsSnapshot.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services.Firmware;
+
+/// <summary>
+/// Round-trips the standing Autopilot configuration through the settings column that holds it.
+/// Serializing the entity itself is what makes this safe to evolve: a field added to
+/// <see cref="FirmwareRolloutSettings"/> is captured without touching this file, which is why the
+/// snapshot is not a hand-maintained DTO and not built in SQL.
+/// </summary>
+public static class AutopilotSettingsSnapshot
+{
+    private static readonly JsonSerializerOptions Options = new() { WriteIndented = false };
+
+    /// <summary>Captures settings as the standing Autopilot configuration.</summary>
+    /// <param name="settings">Settings to capture.</param>
+    public static string Serialize(FirmwareRolloutSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        // AutopilotSettingsJson carries [JsonIgnore], so a capture never nests the previous one.
+        return JsonSerializer.Serialize(settings, Options);
+    }
+
+    /// <summary>
+    /// Reads a captured configuration back, or null when there is none or it is unreadable.
+    /// The row's own identity is not restored - the caller is updating the existing row.
+    /// </summary>
+    /// <param name="snapshotJson">The stored snapshot.</param>
+    public static FirmwareRolloutSettings? Deserialize(string? snapshotJson)
+    {
+        if (string.IsNullOrWhiteSpace(snapshotJson)) return null;
+
+        try
+        {
+            var restored = JsonSerializer.Deserialize<FirmwareRolloutSettings>(snapshotJson, Options);
+            if (restored == null) return null;
+
+            restored.Id = 0;
+            return restored;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutService.cs
@@ -230,6 +230,62 @@ public class FirmwareRolloutService : IFirmwareRolloutService
     }
 
     /// <inheritdoc />
+    public async Task SaveAutopilotSettingsAsync(
+        FirmwareRolloutSettings settings, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        settings.Mode = FirmwareRolloutMode.Autopilot;
+        settings.UpdatedAt = DateTime.UtcNow;
+        await _repository.SaveSettingsAsync(settings, cancellationToken);
+        await _repository.SaveAutopilotSnapshotAsync(
+            AutopilotSettingsSnapshot.Serialize(settings), cancellationToken);
+
+        _audit.SetDetails(new
+        {
+            mode = settings.Mode.ToString(),
+            globalChannel = settings.GlobalChannel,
+            networkAppChannel = settings.NetworkAppChannel,
+            unifiOsChannel = settings.UniFiOsChannel,
+            includeUniFiOs = settings.IncludeUniFiOs,
+            includeUniFiNetwork = settings.IncludeUniFiNetwork,
+            capturedAutopilotConfig = true,
+        });
+    }
+
+    /// <inheritdoc />
+    public async Task DisableAutopilotAsync(CancellationToken cancellationToken = default)
+    {
+        var settings = await _repository.GetSettingsAsync(cancellationToken);
+        settings.Mode = FirmwareRolloutMode.ManualOnly;
+        await _repository.SaveSettingsAsync(settings, cancellationToken);
+
+        _audit.SetDetails(new { mode = settings.Mode.ToString(), autopilotConfigRetained = true });
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> ReEnableAutopilotAsync(CancellationToken cancellationToken = default)
+    {
+        var stored = await _repository.GetSettingsAsync(cancellationToken);
+        var restored = AutopilotSettingsSnapshot.Deserialize(stored.AutopilotSettingsJson);
+        if (restored == null)
+            return false;
+
+        // The snapshot is the standing config, so it becomes the live row wholesale: the executor
+        // reads that row live, and a rollout must run under what it was planned from.
+        restored.Mode = FirmwareRolloutMode.Autopilot;
+        await _repository.SaveSettingsAsync(restored, cancellationToken);
+
+        _audit.SetDetails(new
+        {
+            mode = restored.Mode.ToString(),
+            globalChannel = restored.GlobalChannel,
+            restoredFromCapturedConfig = true,
+        });
+        return true;
+    }
+
+    /// <inheritdoc />
     public async Task<int> SchedulePlanAsync(
         FirmwareRolloutSettings settings, DateTime startAtUtc, CancellationToken cancellationToken = default)
     {
@@ -351,6 +407,11 @@ public class FirmwareRolloutService : IFirmwareRolloutService
         // Committing a plan commits the settings it was planned from: the executor reads settings
         // live (suppression, spacing, per-wave approval), so a plan built from unsaved ones would
         // run under whatever was stored instead.
+        //
+        // The mode is the exception, and it is not the caller's to change: planning a one-off is
+        // not a decision to stop autopiloting. The wizard sets it on its working copy to shape the
+        // preview, so it is overwritten here rather than trusted.
+        settings.Mode = (await _repository.GetSettingsAsync(cancellationToken)).Mode;
         settings.UpdatedAt = DateTime.UtcNow;
         await _repository.SaveSettingsAsync(settings, cancellationToken);
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/IFirmwareRolloutService.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/IFirmwareRolloutService.cs
@@ -55,6 +55,34 @@ public interface IFirmwareRolloutService
     Task SaveSettingsAsync(FirmwareRolloutSettings settings, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Writes the settings AND captures them as the standing Autopilot configuration. The only
+    /// writer of that snapshot: a plain save cannot capture one, because every rollout commit goes
+    /// through <see cref="SaveSettingsAsync"/> carrying whatever scope that one rollout used.
+    /// </summary>
+    /// <param name="settings">Settings to store and capture.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.FirmwareRolloutSettingsChanged, TargetType = "firmware_rollout")]
+    Task SaveAutopilotSettingsAsync(FirmwareRolloutSettings settings, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Turns Autopilot off, keeping its captured configuration so it can be re-enabled as it was.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.FirmwareRolloutSettingsChanged, TargetType = "firmware_rollout")]
+    Task DisableAutopilotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Turns Autopilot back on, restoring the configuration captured when it was last saved.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>False when there is no captured configuration to restore.</returns>
+    [RequireRole(Roles.Admin)]
+    [AuditAction(AuditActions.FirmwareRolloutSettingsChanged, TargetType = "firmware_rollout")]
+    Task<bool> ReEnableAutopilotAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Plans a rollout and books it for a start time. The settings it was planned from are saved as
     /// part of committing it, because the executor reads them live as it runs.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
@@ -86,11 +86,25 @@ public class RolloutAutopilot : IRolloutAutopilot
         if (Now - _lastCheckedAt < CheckInterval)
             return null;
 
-        var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
-        if (settings.Mode != FirmwareRolloutMode.Autopilot)
+        var stored = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
+        if (stored.Mode != FirmwareRolloutMode.Autopilot)
             return null;
 
         _lastCheckedAt = Now;
+
+        // Plan from the standing configuration, not from the row, which any one-off rollout since
+        // has overwritten with its own scope. A site upgrading into this has no snapshot yet: the
+        // row is still faithful there, because a one-off used to turn autopilot off.
+        var settings = AutopilotSettingsSnapshot.Deserialize(stored.AutopilotSettingsJson);
+        if (settings == null)
+        {
+            settings = stored;
+            await _repositories.UseAsync(
+                (r, c) => r.SaveAutopilotSnapshotAsync(AutopilotSettingsSnapshot.Serialize(stored), c),
+                cancellationToken);
+            _logger.LogInformation(
+                "Captured the existing settings as the standing autopilot configuration for site {Site}", _siteSlug);
+        }
 
         // Anything non-terminal owns the site: a scheduled, announced, postponed, running or
         // soaking plan all mean autopilot has nothing to add.
@@ -139,6 +153,15 @@ public class RolloutAutopilot : IRolloutAutopilot
 
         await _planning.UseAsync(
             (p, c) => p.PopulatePriorVersionsAsync(result.Document, result.Steps, c), cancellationToken);
+
+        // The executor reads the row live - channels, spacing, suppression, soak - so committing a
+        // plan built from the standing configuration has to leave the row holding it. Without this
+        // the rollout would apply whatever channel the last one-off left behind.
+        if (!ReferenceEquals(settings, stored))
+        {
+            settings.Mode = FirmwareRolloutMode.Autopilot;
+            await _repositories.UseAsync((r, c) => r.SaveSettingsAsync(settings, c), cancellationToken);
+        }
 
         var plan = await _repositories.UseAsync((r, c) => r.CreatePlanAsync(new FirmwareRolloutPlan
         {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20482,7 +20482,8 @@ body.kiosk-mode .status-indicators {
     margin: 0;
 }
 
-.firmware-rollout-landing .btn {
+.firmware-rollout-landing .btn,
+.firmware-rollout-landing .firmware-rollout-controls {
     flex-shrink: 0;
 }
 
@@ -20518,6 +20519,7 @@ body.kiosk-mode .status-indicators {
     display: flex;
     gap: 0.5rem;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .firmware-rollout-note {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20512,6 +20512,7 @@ body.kiosk-mode .status-indicators {
     .firmware-rollout-landing {
         flex-direction: column;
         align-items: flex-start;
+        padding-top: 0.25rem;
     }
 
     .firmware-rollout-autopilot-config {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -20513,6 +20513,10 @@ body.kiosk-mode .status-indicators {
         flex-direction: column;
         align-items: flex-start;
     }
+
+    .firmware-rollout-autopilot-config {
+        margin-top: 1rem;
+    }
 }
 
 .firmware-rollout-controls {

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/AutopilotStandingConfigTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/AutopilotStandingConfigTests.cs
@@ -1,0 +1,219 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Firmware;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Firmware;
+
+/// <summary>
+/// The settings row is a working copy - the executor reads it live, so committing any rollout
+/// writes it - which left Autopilot's own configuration with nowhere to live. These cover the
+/// separation: a one-off cannot become the standing config, and the standing config is what
+/// Autopilot both plans and runs from.
+/// </summary>
+public class AutopilotStandingConfigTests
+{
+    private const string ApMac = "aa:bb:cc:dd:ee:01";
+
+    private static PlannerDevice Ap(string mac = ApMac) => new()
+    {
+        Mac = mac,
+        Name = "AP 1",
+        Model = "SKU-AP1",
+        DisplayModel = "SKU-AP1",
+        Type = DeviceType.AccessPoint,
+        Upgradable = true,
+        FromVersion = "1.0.0",
+        ToVersion = "1.1.0",
+        IpAddress = "192.0.2.10",
+    };
+
+    private static async Task<RolloutHarness> AutopilotSiteAsync()
+    {
+        var harness = new RolloutHarness();
+        harness.Planning.Devices.Add(Ap());
+        await harness.WithSettingsAsync(s =>
+        {
+            s.Mode = FirmwareRolloutMode.Autopilot;
+            s.GlobalChannel = FirmwareChannels.Beta;
+            s.IncludeUniFiNetwork = false;
+            s.IncludeUniFiOs = false;
+        });
+        return harness;
+    }
+
+    // ---- The snapshot round trip ------------------------------------------------------------
+
+    [Fact]
+    public void ACaptureDoesNotNestThePreviousOne()
+    {
+        var settings = new FirmwareRolloutSettings { GlobalChannel = FirmwareChannels.Beta };
+
+        settings.AutopilotSettingsJson = AutopilotSettingsSnapshot.Serialize(settings);
+        var second = AutopilotSettingsSnapshot.Serialize(settings);
+
+        second.Should().NotContain("AutopilotSettingsJson");
+        AutopilotSettingsSnapshot.Deserialize(second)!.GlobalChannel.Should().Be(FirmwareChannels.Beta);
+    }
+
+    [Fact]
+    public void AnUnreadableOrAbsentCaptureIsNull()
+    {
+        AutopilotSettingsSnapshot.Deserialize(null).Should().BeNull();
+        AutopilotSettingsSnapshot.Deserialize("   ").Should().BeNull();
+        AutopilotSettingsSnapshot.Deserialize("{ not json").Should().BeNull();
+    }
+
+    // ---- Who may write it -------------------------------------------------------------------
+
+    [Fact]
+    public async Task APlainSettingsSave_NeverCapturesTheStandingConfig()
+    {
+        using var harness = new RolloutHarness();
+        var settings = await harness.Repository.GetSettingsAsync();
+        settings.Mode = FirmwareRolloutMode.Autopilot;
+
+        await harness.Repository.SaveSettingsAsync(settings);
+
+        (await harness.Repository.GetSettingsAsync()).AutopilotSettingsJson.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task TheSnapshotWriterTouchesNothingElseOnTheRow()
+    {
+        using var harness = new RolloutHarness();
+        await harness.WithSettingsAsync(s => s.GlobalChannel = FirmwareChannels.ReleaseCandidate);
+
+        await harness.Repository.SaveAutopilotSnapshotAsync("""{"GlobalChannel":"beta"}""");
+
+        var stored = await harness.Repository.GetSettingsAsync();
+        stored.GlobalChannel.Should().Be(FirmwareChannels.ReleaseCandidate);
+        stored.AutopilotSettingsJson.Should().Be("""{"GlobalChannel":"beta"}""");
+    }
+
+    // ---- Seeding ----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task AnUpgradedSiteCapturesItsExistingSettingsOnTheFirstCheck()
+    {
+        using var harness = await AutopilotSiteAsync();
+        (await harness.Repository.GetSettingsAsync()).AutopilotSettingsJson.Should().BeNull();
+
+        await harness.Autopilot.CreatePlanIfDueAsync();
+
+        var captured = AutopilotSettingsSnapshot.Deserialize(
+            (await harness.Repository.GetSettingsAsync()).AutopilotSettingsJson);
+        captured.Should().NotBeNull();
+        captured!.GlobalChannel.Should().Be(FirmwareChannels.Beta);
+    }
+
+    [Fact]
+    public async Task ASiteThatIsNotOnAutopilot_CapturesNothing()
+    {
+        using var harness = new RolloutHarness();
+        harness.Planning.Devices.Add(Ap());
+        await harness.WithSettingsAsync(s => s.Mode = FirmwareRolloutMode.ManualOnly);
+
+        await harness.Autopilot.CreatePlanIfDueAsync();
+
+        (await harness.Repository.GetSettingsAsync()).AutopilotSettingsJson.Should().BeNull();
+    }
+
+    // ---- The point of the whole thing --------------------------------------------------------
+
+    [Fact]
+    public async Task AutopilotPlansFromItsOwnConfig_NotWhatAOneOffLeftBehind()
+    {
+        using var harness = await AutopilotSiteAsync();
+
+        // Capture beta as the standing config, then let a one-off overwrite the row with GA.
+        await harness.Repository.SaveAutopilotSnapshotAsync(
+            AutopilotSettingsSnapshot.Serialize(await harness.Repository.GetSettingsAsync()));
+        var oneOff = await harness.Repository.GetSettingsAsync();
+        oneOff.GlobalChannel = FirmwareChannels.Release;
+        await harness.Repository.SaveSettingsAsync(oneOff);
+
+        await harness.Autopilot.CreatePlanIfDueAsync();
+
+        // I2: what it planned from is what the executor will read live.
+        (await harness.Repository.GetSettingsAsync()).GlobalChannel.Should().Be(FirmwareChannels.Beta);
+    }
+
+    [Fact]
+    public async Task CommittingAOneOff_LeavesTheModeAlone()
+    {
+        using var harness = await AutopilotSiteAsync();
+
+        var working = await harness.Repository.GetSettingsAsync();
+        working.Mode = FirmwareRolloutMode.ManualOnly;
+        await harness.Service.SchedulePlanAsync(working, DateTime.UtcNow.AddHours(6));
+
+        (await harness.Repository.GetSettingsAsync()).Mode.Should().Be(FirmwareRolloutMode.Autopilot);
+    }
+
+    [Fact]
+    public async Task CommittingAOneOff_NeverCapturesItsScope()
+    {
+        using var harness = await AutopilotSiteAsync();
+        await harness.Repository.SaveAutopilotSnapshotAsync(
+            AutopilotSettingsSnapshot.Serialize(await harness.Repository.GetSettingsAsync()));
+
+        var working = await harness.Repository.GetSettingsAsync();
+        working.GlobalChannel = FirmwareChannels.Release;
+        await harness.Service.SchedulePlanAsync(working, DateTime.UtcNow.AddHours(6));
+
+        var captured = AutopilotSettingsSnapshot.Deserialize(
+            (await harness.Repository.GetSettingsAsync()).AutopilotSettingsJson);
+        captured!.GlobalChannel.Should().Be(FirmwareChannels.Beta);
+    }
+
+    // ---- Off and back on ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task TurningAutopilotOffKeepsItsConfig_AndReEnablingRestoresIt()
+    {
+        using var harness = await AutopilotSiteAsync();
+        await harness.Service.SaveAutopilotSettingsAsync(await harness.Repository.GetSettingsAsync());
+
+        await harness.Service.DisableAutopilotAsync();
+
+        var off = await harness.Repository.GetSettingsAsync();
+        off.Mode.Should().Be(FirmwareRolloutMode.ManualOnly);
+        off.AutopilotSettingsJson.Should().NotBeNull();
+
+        // A one-off while it is off must not survive the restore.
+        off.GlobalChannel = FirmwareChannels.Release;
+        await harness.Repository.SaveSettingsAsync(off);
+
+        (await harness.Service.ReEnableAutopilotAsync()).Should().BeTrue();
+
+        var back = await harness.Repository.GetSettingsAsync();
+        back.Mode.Should().Be(FirmwareRolloutMode.Autopilot);
+        back.GlobalChannel.Should().Be(FirmwareChannels.Beta);
+    }
+
+    [Fact]
+    public async Task ReEnablingWithNothingCaptured_ReportsThereIsNothingToRestore()
+    {
+        using var harness = new RolloutHarness();
+
+        (await harness.Service.ReEnableAutopilotAsync()).Should().BeFalse();
+        (await harness.Repository.GetSettingsAsync()).Mode.Should().NotBe(FirmwareRolloutMode.Autopilot);
+    }
+
+    [Fact]
+    public async Task SavingAutopilotSettings_CapturesThemAndTurnsItOn()
+    {
+        using var harness = new RolloutHarness();
+        var settings = await harness.Repository.GetSettingsAsync();
+        settings.GlobalChannel = FirmwareChannels.ReleaseCandidate;
+
+        await harness.Service.SaveAutopilotSettingsAsync(settings);
+
+        var stored = await harness.Repository.GetSettingsAsync();
+        stored.Mode.Should().Be(FirmwareRolloutMode.Autopilot);
+        AutopilotSettingsSnapshot.Deserialize(stored.AutopilotSettingsJson)!
+            .GlobalChannel.Should().Be(FirmwareChannels.ReleaseCandidate);
+    }
+}


### PR DESCRIPTION
Committing a one-off rollout used to turn Autopilot off. Nothing said so, and the only hint was the Autopilot Configuration panel disappearing from the page afterwards.

Underneath that was a worse one it happened to be hiding. The settings row is a working copy: the executor reads it live as it runs, so committing any rollout writes the row. Autopilot's own configuration had nowhere else to live, so a one-off's scope overwrote it. Switching Autopilot off on the way past meant nothing acted on the overwritten scope, so nobody saw it. Fix only the visible half and Autopilot resumes when that one-off finishes, running with whatever scope it left behind.

## Firmware Rollout

- **Autopilot keeps its own configuration.** A new `AutopilotSettingsJson` column holds the standing config. Autopilot plans from it rather than from the row, so a one-off can no longer redefine what unattended rollouts do.

- **Committing a rollout no longer changes the mode.** Planning a one-off is not a decision to stop autopiloting.

- **Turn off Autopilot** on the config panel, and **Re-enable Autopilot** on the landing when it is off. These replace what the wizard used to do by accident. The config survives being turned off, so re-enabling restores it rather than starting blank.

- A site that has never used Autopilot sees the page exactly as before. The off-state block only appears once there is a configuration to come back to.

## Two invariants this rests on

**The snapshot is written by explicit intent, never inferred from `Mode`.** After this change a one-off on an Autopilot site carries Autopilot mode too, so any "capture when `Mode == Autopilot`" rule would reintroduce the exact overwrite being fixed. Only `SaveAutopilotSettingsAsync` writes it, and `FirmwareRolloutRepository.SaveSettingsAsync` deliberately does not copy the column, so a plain save cannot capture one by accident. That is also what makes a snapshot's existence mean Autopilot was configured at least once, which the landing relies on.

**Whatever Autopilot planned from is what the executor runs under.** The orchestrator reads the row live for channels, spacing, suppression and soak, so Autopilot writes the snapshot back to the row when it commits a plan. Without this the design would trade one divergence for another: plan a beta rollout, then apply the last one-off's GA channel at start time.

## Implementation notes

- **The mode fix had to be server-side.** Deleting the two `Mode = ManualOnly` assignments in `CommitAsync` would have been a no-op: `WorkingSettings()` sets the mode on every call and mutates the settings object in place, having already run at preview time, so the page holds no clean copy of the stored mode. `CreatePlanAsync` restores it from the stored row instead.

- **Seeding is lazy, not a migration data step.** Building the JSON in SQL drifts from the C# model the moment a field is added; the code path serializes with the same model that reads it. An upgraded Autopilot site captures its existing settings on the first Autopilot check, which runs every 30s per site. Null therefore means exactly "never captured", and the row is still faithful at that point because a one-off used to turn Autopilot off.

- `AutopilotSettingsJson` carries `[JsonIgnore]` so capturing settings that already hold a snapshot does not nest the previous one. EF ignores STJ attributes, so the column still maps.

- The snapshot write updates only its own column, so a seed on the Autopilot tick cannot clobber a settings save a user is making at the same moment.

- The page adopts the standing config on load. Without it the panel would show one-off leftovers, and the wizard - which preselects Autopilot on such a site - would capture them on a click-through commit.

## UI

No new CSS beyond `flex-wrap` on the existing `.firmware-rollout-controls` and extending one `flex-shrink` rule to it. The off-state block and the button group reuse `.firmware-rollout-landing`, which already stacks at 768px, so the responsive behavior is the existing one rather than a new one. Both buttons use the standard `.btn` classes and the same spinner-while-busy pattern as their neighbors. Mobile spacing tweaks went into the existing 768px block.

## Testing

`dotnet build` clean, 0 warnings. All 13 suites pass. 12 new tests in `AutopilotStandingConfigTests` cover the snapshot round trip and its non-nesting, that a plain save never captures, that the snapshot writer touches nothing else on the row, seeding on and only on Autopilot sites, that Autopilot plans from its own config rather than a one-off's leftovers and syncs it back to the row, that a one-off leaves both mode and snapshot alone, and the off/re-enable pair including the nothing-captured case.

Not covered by tests: the migration against a real upgraded database. Worth watching on the first deploy to a site that already had Autopilot on.
