### PR TITLE
Wi-Fi Optimizer - Channels: spectrum-aware channel memory, neighbor-weighted confidence, and client-outcome evidence

### DIFF
--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2698,6 +2698,76 @@ from(bucket: ""{_longtermBucket}"")
     /// AP MAC (tag), optionally by band (tag) and by client MAC (field). Returns
     /// rows ordered by time.
     /// </summary>
+    /// <summary>
+    /// Client PHY-rate telemetry aggregated for the channel recommender: one row per AP, band,
+    /// channel, client and signal band. Aggregated server-side because the raw sample count runs
+    /// to hundreds of thousands per site.
+    /// </summary>
+    public record ClientChannelRatePoint
+    {
+        public string? ApMac { get; init; }
+        public string? Band { get; init; }
+        public int Channel { get; init; }
+        public string? ClientMac { get; init; }
+        public int SignalBandDbm { get; init; }
+        public int SampleCount { get; init; }
+        public double MeanTxRateMbps { get; init; }
+    }
+
+    /// <summary>
+    /// Throughput (bps, either direction) above which a client counts as actually moving traffic.
+    /// Idle clients are the large majority of samples and their PHY rate decays toward the floor,
+    /// so including them measures how busy the place was rather than what the channel can carry -
+    /// on one radio it reversed which channel looked better.
+    /// </summary>
+    public const double ClientActiveThroughputBps = 50_000;
+
+    /// <summary>Signal bucket width (dB) for matching like-for-like clients across channels.</summary>
+    private const int SignalBandStepDb = 5;
+
+    /// <summary>
+    /// Per-channel client PHY rates for the channel recommender. Returns an empty list when
+    /// InfluxDB is not configured or the query fails, which the recommender treats as "no opinion".
+    /// </summary>
+    public async Task<IReadOnlyList<ClientChannelRatePoint>> QueryClientChannelRatesAsync(
+        DateTime from,
+        DateTime to,
+        CancellationToken ct = default)
+    {
+        if (!IsConfigured) return Array.Empty<ClientChannelRatePoint>();
+
+        var flux = $@"import ""math""
+from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""wifi_client"")
+  |> filter(fn: (r) => r._field == ""channel"" or r._field == ""client_mac"" or r._field == ""signal_dbm"" or r._field == ""tx_rate_kbps"" or r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"")
+  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => exists r.channel and exists r.client_mac and exists r.signal_dbm and exists r.tx_rate_kbps)
+  |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > {ClientActiveThroughputBps}) or (exists r.rx_throughput_bps and r.rx_throughput_bps > {ClientActiveThroughputBps}))
+  |> map(fn: (r) => ({{ ap: r.device_mac, bandTag: r.band, ch: string(v: int(v: r.channel)), cm: r.client_mac, sb: string(v: int(v: math.floor(x: float(v: r.signal_dbm) / {SignalBandStepDb}.0) * {SignalBandStepDb}.0)), tx: float(v: r.tx_rate_kbps) }}))
+  |> group(columns: [""ap"", ""bandTag"", ""ch"", ""cm"", ""sb""])
+  |> reduce(identity: {{n: 0.0, tx: 0.0}}, fn: (r, accumulator) => ({{n: accumulator.n + 1.0, tx: accumulator.tx + r.tx}}))
+  |> map(fn: (r) => ({{ ap: r.ap, bandTag: r.bandTag, ch: r.ch, cm: r.cm, sb: r.sb, n: r.n, meanTx: r.tx / r.n / 1000.0 }}))";
+
+        var results = new List<ClientChannelRatePoint>();
+        await foreach (var record in QueryFluxAsync(flux, ct))
+        {
+            if (!int.TryParse(record.GetValueByKey("ch") as string, out var channel)) continue;
+            if (!int.TryParse(record.GetValueByKey("sb") as string, out var signalBand)) continue;
+            results.Add(new ClientChannelRatePoint
+            {
+                ApMac = record.GetValueByKey("ap") as string,
+                Band = record.GetValueByKey("bandTag") as string,
+                Channel = channel,
+                ClientMac = record.GetValueByKey("cm") as string,
+                SignalBandDbm = signalBand,
+                SampleCount = (int)(AsDoubleOrNull(record.GetValueByKey("n")) ?? 0),
+                MeanTxRateMbps = AsDoubleOrNull(record.GetValueByKey("meanTx")) ?? 0,
+            });
+        }
+        return results;
+    }
+
     public record ClientThroughputPoint
     {
         public DateTime Time { get; init; }

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2707,6 +2707,7 @@ from(bucket: ""{_longtermBucket}"")
         public string? ApMac { get; init; }
         public string? Band { get; init; }
         public int Channel { get; init; }
+        public int WidthMhz { get; init; }
         public int SignalBandDbm { get; init; }
         public DateTime Day { get; init; }
         public int WindowCount { get; init; }
@@ -2762,25 +2763,26 @@ means = from(bucket: ""{_bucket}"")
 chan = from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""wifi_client"")
-  |> filter(fn: (r) => r._field == ""channel"")
+  |> filter(fn: (r) => r._field == ""channel"" or r._field == ""channel_width"")
   |> aggregateWindow(every: {ClientRateWindowEvery}, fn: last, createEmpty: false)
   |> toFloat()
 
 union(tables: [means, chan])
   |> pivot(rowKey: [""_time""], columnKey: [""_field""], valueColumn: ""_value"")
-  |> filter(fn: (r) => exists r.tx_rate_kbps and exists r.channel and exists r.signal_dbm)
+  |> filter(fn: (r) => exists r.tx_rate_kbps and exists r.channel and exists r.channel_width and exists r.signal_dbm)
   |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > {ClientActiveThroughputBps}) or (exists r.rx_throughput_bps and r.rx_throughput_bps > {ClientActiveThroughputBps}))
   |> map(fn: (r) => ({{
       device_mac: r.device_mac,
       band: r.band,
       day: string(v: date.truncate(t: r._time, unit: 1d)),
       channel: int(v: r.channel),
+      width: int(v: r.channel_width),
       signal_band: {SignalBandStepDb} * int(v: math.floor(x: r.signal_dbm / {SignalBandStepDb}.0)),
       tx_rate_mbps: r.tx_rate_kbps / 1000.0
   }}))
-  |> group(columns: [""device_mac"", ""band"", ""channel"", ""signal_band"", ""day""])
+  |> group(columns: [""device_mac"", ""band"", ""channel"", ""width"", ""signal_band"", ""day""])
   |> reduce(fn: (r, accumulator) => ({{n: accumulator.n + 1, sum: accumulator.sum + r.tx_rate_mbps}}), identity: {{n: 0, sum: 0.0}})
-  |> map(fn: (r) => ({{device_mac: r.device_mac, band: r.band, channel: r.channel, signal_band: r.signal_band, day: r.day, n: r.n, mean_tx_rate_mbps: r.sum / float(v: r.n)}}))
+  |> map(fn: (r) => ({{device_mac: r.device_mac, band: r.band, channel: r.channel, width: r.width, signal_band: r.signal_band, day: r.day, n: r.n, mean_tx_rate_mbps: r.sum / float(v: r.n)}}))
   |> group()";
 
         var results = new List<ClientChannelRatePoint>();
@@ -2795,6 +2797,7 @@ union(tables: [means, chan])
                 ApMac = record.GetValueByKey("device_mac") as string,
                 Band = record.GetValueByKey("band") as string,
                 Channel = (int)(AsDoubleOrNull(record.GetValueByKey("channel")) ?? 0),
+                WidthMhz = (int)(AsDoubleOrNull(record.GetValueByKey("width")) ?? 0),
                 SignalBandDbm = (int)(AsDoubleOrNull(record.GetValueByKey("signal_band")) ?? 0),
                 Day = day,
                 WindowCount = windows,

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2700,22 +2700,21 @@ from(bucket: ""{_longtermBucket}"")
     /// </summary>
     /// <summary>
     /// Client PHY-rate telemetry aggregated for the channel recommender: one row per AP, band,
-    /// channel, client and signal band. Aggregated server-side because the raw sample count runs
-    /// to hundreds of thousands per site.
+    /// channel, signal band and day.
     /// </summary>
     public record ClientChannelRatePoint
     {
         public string? ApMac { get; init; }
         public string? Band { get; init; }
         public int Channel { get; init; }
-        public string? ClientMac { get; init; }
         public int SignalBandDbm { get; init; }
-        public int SampleCount { get; init; }
+        public DateTime Day { get; init; }
+        public int WindowCount { get; init; }
         public double MeanTxRateMbps { get; init; }
     }
 
     /// <summary>
-    /// Throughput (bps, either direction) above which a client counts as actually moving traffic.
+    /// Throughput (bps, either direction) above which a window counts as carrying real traffic.
     /// Idle clients are the large majority of samples and their PHY rate decays toward the floor,
     /// so including them measures how busy the place was rather than what the channel can carry -
     /// on one radio it reversed which channel looked better.
@@ -2725,9 +2724,24 @@ from(bucket: ""{_longtermBucket}"")
     /// <summary>Signal bucket width (dB) for matching like-for-like clients across channels.</summary>
     private const int SignalBandStepDb = 5;
 
+    /// <summary>Aggregation window. See the pushdown notes on the query below before changing it.</summary>
+    private const string ClientRateWindowEvery = "15m";
+
     /// <summary>
     /// Per-channel client PHY rates for the channel recommender. Returns an empty list when
     /// InfluxDB is not configured or the query fails, which the recommender treats as "no opinion".
+    ///
+    /// Two things in this Flux are load-bearing for performance, both measured on ~4.1M points per
+    /// field over 90 days (the naive raw-pivot form of this query took 33s):
+    ///
+    /// 1. Each branch repeats its own full from/range/filter chain. Hoisting the common prefix into
+    ///    a shared variable makes Flux materialize that node and read the entire measurement into
+    ///    memory before windowing - it never finishes inside 45s. Do not "tidy up" the duplication.
+    /// 2. toFloat() comes AFTER aggregateWindow on the channel branch. Ahead of it, the window
+    ///    aggregate stops being pushed down into storage: 0.5s becomes 11.8s.
+    ///
+    /// The channel branch uses last(), never mean() - averaging ch 1 and ch 11 would yield ch 6,
+    /// a real channel that was never in use.
     /// </summary>
     public async Task<IReadOnlyList<ClientChannelRatePoint>> QueryClientChannelRatesAsync(
         DateTime from,
@@ -2736,33 +2750,55 @@ from(bucket: ""{_longtermBucket}"")
     {
         if (!IsConfigured) return Array.Empty<ClientChannelRatePoint>();
 
-        var flux = $@"import ""math""
-from(bucket: ""{_bucket}"")
+        var flux = $@"import ""date""
+import ""math""
+
+means = from(bucket: ""{_bucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""wifi_client"")
-  |> filter(fn: (r) => r._field == ""channel"" or r._field == ""client_mac"" or r._field == ""signal_dbm"" or r._field == ""tx_rate_kbps"" or r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"")
-  |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
-  |> filter(fn: (r) => exists r.channel and exists r.client_mac and exists r.signal_dbm and exists r.tx_rate_kbps)
+  |> filter(fn: (r) => r._field == ""tx_rate_kbps"" or r._field == ""tx_throughput_bps"" or r._field == ""rx_throughput_bps"" or r._field == ""signal_dbm"")
+  |> aggregateWindow(every: {ClientRateWindowEvery}, fn: mean, createEmpty: false)
+
+chan = from(bucket: ""{_bucket}"")
+  |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
+  |> filter(fn: (r) => r._measurement == ""wifi_client"")
+  |> filter(fn: (r) => r._field == ""channel"")
+  |> aggregateWindow(every: {ClientRateWindowEvery}, fn: last, createEmpty: false)
+  |> toFloat()
+
+union(tables: [means, chan])
+  |> pivot(rowKey: [""_time""], columnKey: [""_field""], valueColumn: ""_value"")
+  |> filter(fn: (r) => exists r.tx_rate_kbps and exists r.channel and exists r.signal_dbm)
   |> filter(fn: (r) => (exists r.tx_throughput_bps and r.tx_throughput_bps > {ClientActiveThroughputBps}) or (exists r.rx_throughput_bps and r.rx_throughput_bps > {ClientActiveThroughputBps}))
-  |> map(fn: (r) => ({{ ap: r.device_mac, bandTag: r.band, ch: string(v: int(v: r.channel)), cm: r.client_mac, sb: string(v: int(v: math.floor(x: float(v: r.signal_dbm) / {SignalBandStepDb}.0) * {SignalBandStepDb}.0)), tx: float(v: r.tx_rate_kbps) }}))
-  |> group(columns: [""ap"", ""bandTag"", ""ch"", ""cm"", ""sb""])
-  |> reduce(identity: {{n: 0.0, tx: 0.0}}, fn: (r, accumulator) => ({{n: accumulator.n + 1.0, tx: accumulator.tx + r.tx}}))
-  |> map(fn: (r) => ({{ ap: r.ap, bandTag: r.bandTag, ch: r.ch, cm: r.cm, sb: r.sb, n: r.n, meanTx: r.tx / r.n / 1000.0 }}))";
+  |> map(fn: (r) => ({{
+      device_mac: r.device_mac,
+      band: r.band,
+      day: string(v: date.truncate(t: r._time, unit: 1d)),
+      channel: int(v: r.channel),
+      signal_band: {SignalBandStepDb} * int(v: math.floor(x: r.signal_dbm / {SignalBandStepDb}.0)),
+      tx_rate_mbps: r.tx_rate_kbps / 1000.0
+  }}))
+  |> group(columns: [""device_mac"", ""band"", ""channel"", ""signal_band"", ""day""])
+  |> reduce(fn: (r, accumulator) => ({{n: accumulator.n + 1, sum: accumulator.sum + r.tx_rate_mbps}}), identity: {{n: 0, sum: 0.0}})
+  |> map(fn: (r) => ({{device_mac: r.device_mac, band: r.band, channel: r.channel, signal_band: r.signal_band, day: r.day, n: r.n, mean_tx_rate_mbps: r.sum / float(v: r.n)}}))
+  |> group()";
 
         var results = new List<ClientChannelRatePoint>();
         await foreach (var record in QueryFluxAsync(flux, ct))
         {
-            if (!int.TryParse(record.GetValueByKey("ch") as string, out var channel)) continue;
-            if (!int.TryParse(record.GetValueByKey("sb") as string, out var signalBand)) continue;
+            var windows = (int)(AsDoubleOrNull(record.GetValueByKey("n")) ?? 0);
+            if (windows <= 0) continue;
+            DateTime.TryParse(record.GetValueByKey("day") as string, null,
+                System.Globalization.DateTimeStyles.AdjustToUniversal, out var day);
             results.Add(new ClientChannelRatePoint
             {
-                ApMac = record.GetValueByKey("ap") as string,
-                Band = record.GetValueByKey("bandTag") as string,
-                Channel = channel,
-                ClientMac = record.GetValueByKey("cm") as string,
-                SignalBandDbm = signalBand,
-                SampleCount = (int)(AsDoubleOrNull(record.GetValueByKey("n")) ?? 0),
-                MeanTxRateMbps = AsDoubleOrNull(record.GetValueByKey("meanTx")) ?? 0,
+                ApMac = record.GetValueByKey("device_mac") as string,
+                Band = record.GetValueByKey("band") as string,
+                Channel = (int)(AsDoubleOrNull(record.GetValueByKey("channel")) ?? 0),
+                SignalBandDbm = (int)(AsDoubleOrNull(record.GetValueByKey("signal_band")) ?? 0),
+                Day = day,
+                WindowCount = windows,
+                MeanTxRateMbps = AsDoubleOrNull(record.GetValueByKey("mean_tx_rate_mbps")) ?? 0,
             });
         }
         return results;

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -9,7 +9,7 @@
 @implements IDisposable
 
 <div class="channel-analysis-container wifi-sections">
-    <div class="channel-header">
+    <div class="channel-header" data-tour="channel-recommendations">
         <h3>@(_showRecommendations ? "Channel Analysis - Recommended" : "Channel Analysis - Current")</h3>
         <div class="header-actions">
             @if (!_showRecommendations && _accessPoints.Any(ap => ap.IsOnline && ap.Radios.Any(r => r.Channel.HasValue)))

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -106,7 +106,7 @@
             <div class="recommendation-view">
                 <div class="section-header">
                     <h4>Recommended Channel Plan - @_selectedBand.ToDisplayString()</h4>
-                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans.Clear(); }"><span class="btn-label-full">Show Current Channels</span><span class="btn-label-compact">Show Current</span></button>
+                    <button class="btn btn-sm btn-ghost" @onclick="() => { _showRecommendations = false; _channelPlans = new(); }"><span class="btn-label-full">Show Current Channels</span><span class="btn-label-compact">Show Current</span></button>
                 </div>
 
                 @* Auto-hide once every scannable radio has a measurement (no gaps): the rec is then

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -6,6 +6,7 @@
 @inject WiFiOptimizerService WiFiService
 @inject UniFiConnectionService ConnectionService
 @inject ISystemSettingsService SettingsService
+@implements IDisposable
 
 <div class="channel-analysis-container wifi-sections">
     <div class="channel-header">
@@ -23,6 +24,12 @@
                         <span>Recommend Best Channels</span>
                     }
                 </button>
+            }
+            @if (_showRecommendations && PlanComputedAtUtc is { } computedAt)
+            {
+                <span class="text-muted channel-plan-age">
+                    Last computed: @TimeFormatHelper.FormatRelativeTimeShort(computedAt)
+                </span>
             }
             <button class="btn btn-sm btn-secondary" @onclick="RefreshData" disabled="@_loading">
                 @if (_loading)
@@ -637,6 +644,34 @@
 
     // Channel recommendation state
     private bool _showRecommendations;
+    private System.Threading.Timer? _ageTimer;
+
+    /// <summary>When the displayed plan was computed - the same for every band in one run.</summary>
+    private DateTime? PlanComputedAtUtc =>
+        _channelPlans.Values.FirstOrDefault(p => p.ComputedAtUtc != default)?.ComputedAtUtc;
+
+    /// <summary>
+    /// Re-render periodically so "Last computed" ages on its own. Without this the label freezes at
+    /// whatever it said when the plan loaded, which is worse than showing nothing - a plan served
+    /// from cache would keep claiming it was just computed.
+    /// </summary>
+    private void StartAgeTicker()
+    {
+        _ageTimer?.Dispose();
+        _ageTimer = new System.Threading.Timer(_ =>
+        {
+            try
+            {
+                InvokeAsync(() =>
+                {
+                    if (_showRecommendations && PlanComputedAtUtc != null) StateHasChanged();
+                });
+            }
+            catch { /* a dead circuit must not kill the timer callback */ }
+        }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+    }
+
+    public void Dispose() => _ageTimer?.Dispose();
     private bool _loadingRecommendations;
     private Dictionary<RadioBand, ChannelPlan> _channelPlans = new();
     private ChannelPlan? _channelPlan => _channelPlans.TryGetValue(_selectedBand, out var plan) ? plan : null;
@@ -661,6 +696,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        StartAgeTicker();
         try
         {
             var dismissed = await SettingsService.GetGlobalAsync(SystemSettingKeys.ChannelDisclaimerDismissed);

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -27,9 +27,7 @@
             }
             @if (_showRecommendations && PlanComputedAtUtc is { } computedAt)
             {
-                <span class="text-muted channel-plan-age">
-                    Last computed: @TimeFormatHelper.FormatRelativeTimeShort(computedAt)
-                </span>
+                <span class="channel-plan-age">Last computed: @TimeFormatHelper.FormatRelativeTimeShort(computedAt)</span>
             }
             <button class="btn btn-sm btn-secondary" @onclick="RefreshData" disabled="@_loading">
                 @if (_loading)

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -8,8 +8,8 @@
 @inject ISystemSettingsService SettingsService
 @implements IDisposable
 
-<div class="channel-analysis-container wifi-sections">
-    <div class="channel-header" data-tour="channel-recommendations">
+<div class="channel-analysis-container wifi-sections" data-tour="channel-analysis">
+    <div class="channel-header">
         <h3>@(_showRecommendations ? "Channel Analysis - Recommended" : "Channel Analysis - Current")</h3>
         <div class="header-actions">
             @if (!_showRecommendations && _accessPoints.Any(ap => ap.IsOnline && ap.Radios.Any(r => r.Channel.HasValue)))

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -725,7 +725,7 @@
             if (_showRecommendations)
             {
                 var options = new RecommendationOptions { DfsPreference = _dfsPreference };
-                _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+                _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options, forceRefresh: true);
             }
         }
         finally
@@ -1062,7 +1062,7 @@
 
             // Re-run recommendations on the fresh spectrum data, then re-check what's still missing.
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };
-            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options, forceRefresh: true);
             await LoadScanGapsAsync();
             await LoadStaleScanTargetsAsync();
         }
@@ -1098,7 +1098,7 @@
 
             // Re-run recommendations on the fresh spectrum data, then re-evaluate both banners.
             var options = new RecommendationOptions { DfsPreference = _dfsPreference };
-            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options);
+            _channelPlans = await WiFiService.GetAllChannelRecommendationsAsync(options, forceRefresh: true);
             await LoadScanGapsAsync();
             await LoadStaleScanTargetsAsync();
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -9,7 +9,7 @@
 
 <div class="channel-analysis-container wifi-sections">
     <div class="channel-header">
-        <h3>Channel Analysis</h3>
+        <h3>@(_showRecommendations ? "Channel Analysis - Recommended" : "Channel Analysis - Current")</h3>
         <div class="header-actions">
             @if (!_showRecommendations && _accessPoints.Any(ap => ap.IsOnline && ap.Radios.Any(r => r.Channel.HasValue)))
             {

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -31,7 +31,7 @@
                 }
                 else
                 {
-                    <span>Refresh</span>
+                    <span>@(_showRecommendations ? "Recompute" : "Refresh")</span>
                 }
             </button>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -8,7 +8,7 @@
 @inject ISystemSettingsService SettingsService
 @implements IDisposable
 
-<div class="channel-analysis-container wifi-sections" data-tour="channel-analysis">
+<div class="channel-analysis-container wifi-sections" data-tour="wifi-channels">
     <div class="channel-header">
         <h3>@(_showRecommendations ? "Channel Analysis - Recommended" : "Channel Analysis - Current")</h3>
         <div class="header-actions">

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -766,6 +766,7 @@ builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, Ne
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, NetworkOptimizer.WiFi.Rules.HighPowerOverlapRule>();
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.IWiFiOptimizerRule, NetworkOptimizer.WiFi.Rules.WideChannelWidthRule>();
 builder.Services.AddSingleton<NetworkOptimizer.WiFi.Rules.WiFiOptimizerEngine>();
+builder.Services.AddSingleton<ChannelPlanCache>();
 builder.Services.AddScoped<WiFiOptimizerService>();
 builder.Services.AddMutatingService<IWiFiScanService>(sp => sp.GetRequiredService<WiFiOptimizerService>());
 // Mesh backhaul re-scan (Optimize Mesh button); scoped - forwards to the current

--- a/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
@@ -52,14 +52,16 @@ public class ChannelPlanCache
     public async Task<Dictionary<RadioBand, ChannelPlan>> GetOrBuildPlanAsync(
         string key,
         bool forceRefresh,
-        Func<Task<Dictionary<RadioBand, ChannelPlan>>> build)
+        Func<Task<Dictionary<RadioBand, ChannelPlan>>> build,
+        Func<Dictionary<RadioBand, ChannelPlan>?, bool>? shouldCache = null)
     {
         Func<Task<Dictionary<RadioBand, ChannelPlan>?>> nullable = async () => await build();
         // An empty result means the console was unreachable or the build threw, NOT that this site
         // has no plan. Caching it pinned "channel analysis unavailable" for the full hour even once
         // the console came back - a six-second window after a restart was enough to do it.
         var plan = await GetOrBuildAsync(
-            _plans, key, forceRefresh, PlanTtl, nullable, shouldCache: p => p is { Count: > 0 });
+            _plans, key, forceRefresh, PlanTtl, nullable,
+            shouldCache: shouldCache ?? (p => p is { Count: > 0 }));
 
         // Hand out a copy, never the cached instance. Callers own what they are given and do mutate
         // it - Channel Analysis clears the dictionary when switching back to Show Current Channels,

--- a/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
@@ -22,11 +22,15 @@ public class ChannelPlanCache
     public static readonly TimeSpan PlanTtl = TimeSpan.FromHours(1);
 
     /// <summary>
-    /// Client-rate history TTL, deliberately longer than <see cref="PlanTtl"/> and NOT cleared by
-    /// Refresh. It is a 90-day aggregate that measured ~33s to run and shifts negligibly within a
-    /// few hours, so tying it to Refresh would make the button feel broken for no gain in accuracy.
+    /// Client-rate history TTL. Deliberately the same as <see cref="PlanTtl"/> so there is one rule
+    /// to reason about: everything is an hour old at most, and Refresh rebuilds all of it.
+    ///
+    /// It earns a cache at all for two reasons rather than cost - the query runs in well under a
+    /// second: several option sets building plans inside the same hour share one fetch, and a null
+    /// result is cached too, so an unreachable InfluxDB costs one timeout per hour instead of one
+    /// per plan build.
     /// </summary>
-    public static readonly TimeSpan ClientRatesTtl = TimeSpan.FromHours(6);
+    public static readonly TimeSpan ClientRatesTtl = PlanTtl;
 
     private sealed class Entry<T>
     {
@@ -56,14 +60,14 @@ public class ChannelPlanCache
     }
 
     /// <summary>
-    /// Client-rate history for a site. Never force-refreshed - see <see cref="ClientRatesTtl"/>.
-    /// A failed lookup caches its null result too, so an unreachable InfluxDB costs one timeout
-    /// per TTL instead of one per plan build.
+    /// Client-rate history for a site. A failed lookup caches its null result too, so an
+    /// unreachable InfluxDB costs one timeout per TTL instead of one per plan build.
     /// </summary>
     public Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?> GetOrBuildClientRatesAsync(
         string siteSlug,
+        bool forceRefresh,
         Func<Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?>> build)
-        => GetOrBuildAsync(_clientRates, siteSlug, forceRefresh: false, ClientRatesTtl, build);
+        => GetOrBuildAsync(_clientRates, siteSlug, forceRefresh, ClientRatesTtl, build);
 
     /// <summary>Drops every cached plan for a site (e.g. its console connection changed).</summary>
     public void InvalidateSite(string siteSlug)

--- a/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Process-wide cache for computed channel plans and the client-rate history they read.
+///
+/// The analysis is expensive enough to be user-visible: it fans out across UniFi topology, scan
+/// results, propagation, persisted outcome memory and an InfluxDB history query, then runs a
+/// combinatorial search. Recomputing it on every page interaction is what made the page feel slow.
+///
+/// Lifetime: singleton, partitioned by site slug so one site's plan can never be served to another.
+/// </summary>
+public class ChannelPlanCache
+{
+    /// <summary>
+    /// How long a computed plan stays fresh. The inputs (neighbor environment, persisted outcome
+    /// memory, client history) move on the order of hours, not seconds - and Refresh always
+    /// bypasses this, so the user is never stuck with a stale answer they can see is stale.
+    /// </summary>
+    public static readonly TimeSpan PlanTtl = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// Client-rate history TTL, deliberately longer than <see cref="PlanTtl"/> and NOT cleared by
+    /// Refresh. It is a 90-day aggregate that measured ~33s to run and shifts negligibly within a
+    /// few hours, so tying it to Refresh would make the button feel broken for no gain in accuracy.
+    /// </summary>
+    public static readonly TimeSpan ClientRatesTtl = TimeSpan.FromHours(6);
+
+    private sealed class Entry<T>
+    {
+        public T? Value;
+        public bool Populated;
+        public DateTime AtUtc = DateTime.MinValue;
+        public readonly SemaphoreSlim Lock = new(1, 1);
+    }
+
+    private readonly ConcurrentDictionary<string, Entry<Dictionary<RadioBand, ChannelPlan>>> _plans = new();
+    private readonly ConcurrentDictionary<string, Entry<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>>> _clientRates = new();
+
+    /// <summary>
+    /// Returns the cached plan for this site and option set, or builds one. Concurrent callers
+    /// coalesce onto a single build rather than each starting their own multi-second run.
+    /// </summary>
+    /// <param name="key">Site slug plus a fingerprint of the options the plan was built for</param>
+    /// <param name="forceRefresh">Bypass the cached value and rebuild (the Refresh button)</param>
+    public async Task<Dictionary<RadioBand, ChannelPlan>> GetOrBuildPlanAsync(
+        string key,
+        bool forceRefresh,
+        Func<Task<Dictionary<RadioBand, ChannelPlan>>> build)
+    {
+        Func<Task<Dictionary<RadioBand, ChannelPlan>?>> nullable = async () => await build();
+        var plan = await GetOrBuildAsync(_plans, key, forceRefresh, PlanTtl, nullable);
+        return plan ?? new Dictionary<RadioBand, ChannelPlan>();
+    }
+
+    /// <summary>
+    /// Client-rate history for a site. Never force-refreshed - see <see cref="ClientRatesTtl"/>.
+    /// A failed lookup caches its null result too, so an unreachable InfluxDB costs one timeout
+    /// per TTL instead of one per plan build.
+    /// </summary>
+    public Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?> GetOrBuildClientRatesAsync(
+        string siteSlug,
+        Func<Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?>> build)
+        => GetOrBuildAsync(_clientRates, siteSlug, forceRefresh: false, ClientRatesTtl, build);
+
+    /// <summary>Drops every cached plan for a site (e.g. its console connection changed).</summary>
+    public void InvalidateSite(string siteSlug)
+    {
+        foreach (var key in _plans.Keys.Where(k => k.StartsWith(siteSlug + "|", StringComparison.Ordinal)).ToList())
+            _plans.TryRemove(key, out _);
+        _clientRates.TryRemove(siteSlug, out _);
+    }
+
+    private static async Task<T?> GetOrBuildAsync<T>(
+        ConcurrentDictionary<string, Entry<T>> store,
+        string key,
+        bool forceRefresh,
+        TimeSpan ttl,
+        Func<Task<T?>> build)
+    {
+        var entry = store.GetOrAdd(key, _ => new Entry<T>());
+
+        if (!forceRefresh && IsFresh(entry, ttl)) return entry.Value;
+
+        // Timestamp seen before queuing: if it moves while we wait, someone else rebuilt.
+        var seenAt = entry.AtUtc;
+        await entry.Lock.WaitAsync();
+        try
+        {
+            // A rebuild that finished while we were queued is newer than this request, so it
+            // satisfies a forced refresh too - building again would just duplicate the work.
+            if (entry.AtUtc > seenAt && entry.Populated) return entry.Value;
+            if (!forceRefresh && IsFresh(entry, ttl)) return entry.Value;
+
+            entry.Value = await build();
+            entry.Populated = true;
+            entry.AtUtc = DateTime.UtcNow;
+            return entry.Value;
+        }
+        finally
+        {
+            entry.Lock.Release();
+        }
+    }
+
+    private static bool IsFresh<T>(Entry<T> entry, TimeSpan ttl) =>
+        entry.Populated && DateTime.UtcNow - entry.AtUtc <= ttl;
+}

--- a/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
@@ -88,19 +88,6 @@ public class ChannelPlanCache
             : new Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>(rates);
     }
 
-    /// <summary>Drops every cached plan for a site (e.g. its console connection changed).</summary>
-    public void InvalidateSite(string siteSlug)
-    {
-        foreach (var key in _plans.Keys.Where(k => k.StartsWith(siteSlug + "|", StringComparison.Ordinal)).ToList())
-            _plans.TryRemove(key, out _);
-        _clientRates.TryRemove(siteSlug, out _);
-    }
-
-    /// <param name="shouldCache">
-    /// Whether a freshly built value is worth keeping. Defaults to caching everything, including
-    /// nulls - deliberate for client-rate history, where a null is a bounded timeout we do not want
-    /// to repeat on every build. Results that represent a transient failure must opt out.
-    /// </param>
     private static async Task<T?> GetOrBuildAsync<T>(
         ConcurrentDictionary<string, Entry<T>> store,
         string key,

--- a/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
+++ b/src/NetworkOptimizer.Web/Services/ChannelPlanCache.cs
@@ -55,19 +55,36 @@ public class ChannelPlanCache
         Func<Task<Dictionary<RadioBand, ChannelPlan>>> build)
     {
         Func<Task<Dictionary<RadioBand, ChannelPlan>?>> nullable = async () => await build();
-        var plan = await GetOrBuildAsync(_plans, key, forceRefresh, PlanTtl, nullable);
-        return plan ?? new Dictionary<RadioBand, ChannelPlan>();
+        // An empty result means the console was unreachable or the build threw, NOT that this site
+        // has no plan. Caching it pinned "channel analysis unavailable" for the full hour even once
+        // the console came back - a six-second window after a restart was enough to do it.
+        var plan = await GetOrBuildAsync(
+            _plans, key, forceRefresh, PlanTtl, nullable, shouldCache: p => p is { Count: > 0 });
+
+        // Hand out a copy, never the cached instance. Callers own what they are given and do mutate
+        // it - Channel Analysis clears the dictionary when switching back to Show Current Channels,
+        // which emptied the shared entry in place and made the next Recommend Best Channels look
+        // like it did nothing. Before caching, every call got a fresh dictionary and that was safe.
+        return plan == null
+            ? new Dictionary<RadioBand, ChannelPlan>()
+            : new Dictionary<RadioBand, ChannelPlan>(plan);
     }
 
     /// <summary>
     /// Client-rate history for a site. A failed lookup caches its null result too, so an
     /// unreachable InfluxDB costs one timeout per TTL instead of one per plan build.
     /// </summary>
-    public Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?> GetOrBuildClientRatesAsync(
+    public async Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?> GetOrBuildClientRatesAsync(
         string siteSlug,
         bool forceRefresh,
         Func<Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?>> build)
-        => GetOrBuildAsync(_clientRates, siteSlug, forceRefresh, ClientRatesTtl, build);
+    {
+        var rates = await GetOrBuildAsync(_clientRates, siteSlug, forceRefresh, ClientRatesTtl, build);
+        // Copied for the same reason as plans; the inner lists are IReadOnlyList and stay shared.
+        return rates == null
+            ? null
+            : new Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>(rates);
+    }
 
     /// <summary>Drops every cached plan for a site (e.g. its console connection changed).</summary>
     public void InvalidateSite(string siteSlug)
@@ -77,12 +94,18 @@ public class ChannelPlanCache
         _clientRates.TryRemove(siteSlug, out _);
     }
 
+    /// <param name="shouldCache">
+    /// Whether a freshly built value is worth keeping. Defaults to caching everything, including
+    /// nulls - deliberate for client-rate history, where a null is a bounded timeout we do not want
+    /// to repeat on every build. Results that represent a transient failure must opt out.
+    /// </param>
     private static async Task<T?> GetOrBuildAsync<T>(
         ConcurrentDictionary<string, Entry<T>> store,
         string key,
         bool forceRefresh,
         TimeSpan ttl,
-        Func<Task<T?>> build)
+        Func<Task<T?>> build,
+        Func<T?, bool>? shouldCache = null)
     {
         var entry = store.GetOrAdd(key, _ => new Entry<T>());
 
@@ -98,7 +121,11 @@ public class ChannelPlanCache
             if (entry.AtUtc > seenAt && entry.Populated) return entry.Value;
             if (!forceRefresh && IsFresh(entry, ttl)) return entry.Value;
 
-            entry.Value = await build();
+            var built = await build();
+            if (shouldCache != null && !shouldCache(built))
+                return built;
+
+            entry.Value = built;
             entry.Populated = true;
             entry.AtUtc = DateTime.UtcNow;
             return entry.Value;

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -31,7 +31,13 @@ public class WiFiOptimizerService : IWiFiScanService
     private readonly PlannedApService _plannedApService;
     private readonly ChannelRecommendationService _channelRecommendationService;
     private readonly NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository _channelMemoryRepository;
-    private readonly NetworkOptimizer.Storage.Services.MonitoringInfluxClient _influx;
+    /// <summary>
+    /// The registry rather than a MonitoringInfluxClient directly: the client is IAsyncDisposable,
+    /// and injecting it here put one into scopes this service creates and disposes synchronously,
+    /// which throws and took down propagation loading and the whole channel analysis with it. The
+    /// registry owns its clients, so nothing scope-owned is added.
+    /// </summary>
+    private readonly MonitoringInfluxRegistry _influxRegistry;
     private readonly ChannelPlanCache _planCache;
 
     /// <summary>
@@ -70,7 +76,7 @@ public class WiFiOptimizerService : IWiFiScanService
         PlannedApService plannedApService,
         ChannelRecommendationService channelRecommendationService,
         NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository channelMemoryRepository,
-        NetworkOptimizer.Storage.Services.MonitoringInfluxClient influx,
+        MonitoringInfluxRegistry influxRegistry,
         ChannelPlanCache planCache,
         SiteContextService siteContext,
         Licensing.LicenseStateService licenseState,
@@ -88,7 +94,7 @@ public class WiFiOptimizerService : IWiFiScanService
         _plannedApService = plannedApService;
         _channelRecommendationService = channelRecommendationService;
         _channelMemoryRepository = channelMemoryRepository;
-        _influx = influx;
+        _influxRegistry = influxRegistry;
         _planCache = planCache;
         _logger = logger;
         _loggerFactory = loggerFactory;
@@ -949,7 +955,7 @@ public class WiFiOptimizerService : IWiFiScanService
             // simply scores without client evidence, which is its documented fallback.
             using var timeout = new CancellationTokenSource(ClientRateQueryTimeout);
             var sw = System.Diagnostics.Stopwatch.StartNew();
-            var rows = await _influx.QueryClientChannelRatesAsync(
+            var rows = await _influxRegistry.GetFor(_siteSlug).QueryClientChannelRatesAsync(
                 to - ClientOutcomeHelper.ClientRateWindow, to, timeout.Token);
             _logger.LogDebug("[ChannelRec] client rate query returned {Rows} row(s) in {Elapsed} ms",
                 rows.Count, sw.ElapsedMilliseconds);
@@ -1379,7 +1385,8 @@ public class WiFiOptimizerService : IWiFiScanService
                     var bandSoak = historicalContext?.Soak.GetValueOrDefault(band);
                     var graph = _channelRecommendationService.BuildInterferenceGraph(
                         aps, band, propCtx, scanResults, regulatoryData, options, bandStress, bandSoak,
-                        clientRates?.GetValueOrDefault(band));
+                        clientRates?.GetValueOrDefault(band),
+                        historicalContext?.Credibility.GetValueOrDefault(band));
 
                     var plan = _channelRecommendationService.Optimize(
                         graph, band, regulatoryData, options, hasBuildingData);
@@ -1415,6 +1422,9 @@ public class WiFiOptimizerService : IWiFiScanService
         /// <summary>Soak-period state keyed by band → AP MAC (lower). An entry exists only
         /// when the radio changed channels within the soak window.</summary>
         public Dictionary<RadioBand, Dictionary<string, ChannelSoakInfo>> Soak { get; } = new();
+
+        /// <summary>How far each channel's remembered stress is trusted, 0-1, per band and AP.</summary>
+        public Dictionary<RadioBand, Dictionary<string, Dictionary<int, double>>> Credibility { get; } = new();
     }
 
     /// <summary>
@@ -1634,13 +1644,15 @@ public class WiFiOptimizerService : IWiFiScanService
                         if (buckets.Count == 0) continue;
 
                         var recent = context.Stress[band].GetValueOrDefault(macLower);
+                        var credibility = new Dictionary<int, double>();
                         var confidence = ChannelMemoryHelper.HistoryConfidenceFromNeighbors(
                             neighborLoad.GetValueOrDefault((macLower, bandCode)));
                         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
                             recent, buckets, radio.ChannelWidth ?? 20, now,
                             ChannelMemoryHelper.MinLongTermSamples, band, confidence,
                             trace: msg => _logger.LogDebug("[ChannelRec] {ApName} {Band}: {Message}",
-                                ap.Name, band, msg));
+                                ap.Name, band, msg),
+                            credibilityOut: credibility);
                         if (merged == null) continue;
 
                         // Logged unconditionally: when confidence suppresses the memory the channel
@@ -1651,6 +1663,13 @@ public class WiFiOptimizerService : IWiFiScanService
                             ap.Name, band, merged.Count - (recent?.Count ?? 0),
                             neighborLoad.GetValueOrDefault((macLower, bandCode)), confidence);
                         context.Stress[band][macLower] = merged;
+                        if (credibility.Count > 0)
+                        {
+                            if (!context.Credibility.TryGetValue(band, out var bandCred))
+                                context.Credibility[band] = bandCred =
+                                    new Dictionary<string, Dictionary<int, double>>(StringComparer.OrdinalIgnoreCase);
+                            bandCred[macLower] = credibility;
+                        }
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1278,21 +1278,32 @@ public class WiFiOptimizerService : IWiFiScanService
             : "none";
         var key = $"{_siteSlug}|{opts.DfsPreference}|{opts.OptimizeWidths}|{pinned}";
 
+        // A run that lost a band is served but never cached: caching it would hide that band for
+        // the rest of the hour behind a plan that looks complete.
+        var partial = false;
         return _planCache.GetOrBuildPlanAsync(key, forceRefresh,
-            () => BuildAllChannelRecommendationsAsync(options, forceRefresh));
+            async () =>
+            {
+                var (plans, anyBandFailed) = await BuildAllChannelRecommendationsAsync(options, forceRefresh);
+                partial = anyBandFailed;
+                return plans;
+            },
+            shouldCache: p => p is { Count: > 0 } && !partial);
     }
 
-    private async Task<Dictionary<RadioBand, ChannelPlan>> BuildAllChannelRecommendationsAsync(
+    private async Task<(Dictionary<RadioBand, ChannelPlan> Plans, bool AnyBandFailed)>
+        BuildAllChannelRecommendationsAsync(
         RecommendationOptions? options,
         bool forceRefresh)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var results = new Dictionary<RadioBand, ChannelPlan>();
+        var anyBandFailed = false;
 
         if (!_connectionService.IsConnected)
         {
             _logger.LogDebug("Cannot get channel recommendations - not connected to UniFi");
-            return results;
+            return (results, false);
         }
 
         try
@@ -1316,7 +1327,7 @@ public class WiFiOptimizerService : IWiFiScanService
             if (aps.Count == 0)
             {
                 _logger.LogDebug("No APs available for channel recommendations");
-                return results;
+                return (results, false);
             }
 
             // Load propagation context once (same pattern as BuildOptimizerContextAsync)
@@ -1396,6 +1407,7 @@ public class WiFiOptimizerService : IWiFiScanService
                 }
                 catch (Exception ex)
                 {
+                    anyBandFailed = true;
                     _logger.LogError(ex, "Failed to get channel recommendations for {Band}", band);
                 }
             }
@@ -1406,9 +1418,10 @@ public class WiFiOptimizerService : IWiFiScanService
         }
 
         _logger.LogDebug(
-            "[ChannelRec] built plans for {Bands} band(s) in {Elapsed} ms (cached for {Ttl})",
-            results.Count, sw.ElapsedMilliseconds, ChannelPlanCache.PlanTtl);
-        return results;
+            "[ChannelRec] built plans for {Bands} band(s) in {Elapsed} ms ({Cacheable})",
+            results.Count, sw.ElapsedMilliseconds,
+            anyBandFailed ? "not cached - a band failed" : $"cached for {ChannelPlanCache.PlanTtl}");
+        return (results, anyBandFailed);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1273,11 +1273,12 @@ public class WiFiOptimizerService : IWiFiScanService
         var key = $"{_siteSlug}|{opts.DfsPreference}|{opts.OptimizeWidths}|{pinned}";
 
         return _planCache.GetOrBuildPlanAsync(key, forceRefresh,
-            () => BuildAllChannelRecommendationsAsync(options));
+            () => BuildAllChannelRecommendationsAsync(options, forceRefresh));
     }
 
     private async Task<Dictionary<RadioBand, ChannelPlan>> BuildAllChannelRecommendationsAsync(
-        RecommendationOptions? options)
+        RecommendationOptions? options,
+        bool forceRefresh)
     {
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var results = new Dictionary<RadioBand, ChannelPlan>();
@@ -1361,7 +1362,8 @@ public class WiFiOptimizerService : IWiFiScanService
 
             // What clients actually achieved per channel. Entirely optional - any failure leaves
             // this null and the recommender scores exactly as it did before it existed.
-            var clientRates = await _planCache.GetOrBuildClientRatesAsync(_siteSlug, GetClientRatesAsync);
+            var clientRates = await _planCache.GetOrBuildClientRatesAsync(
+                _siteSlug, forceRefresh, GetClientRatesAsync);
 
             // Generate recommendations for each band that has APs
             var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -980,7 +980,7 @@ public class WiFiOptimizerService : IWiFiScanService
                 if (!byAp.TryGetValue(mac, out var list))
                     byAp[mac] = list = new List<ClientRateSample>();
                 list.Add(new ClientRateSample(
-                    row.Channel, row.SignalBandDbm, row.Day, row.WindowCount, row.MeanTxRateMbps));
+                    row.Channel, row.WidthMhz, row.SignalBandDbm, row.Day, row.WindowCount, row.MeanTxRateMbps));
             }
 
             foreach (var (band, byAp) in byBand)

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -1391,6 +1391,7 @@ public class WiFiOptimizerService : IWiFiScanService
                     var plan = _channelRecommendationService.Optimize(
                         graph, band, regulatoryData, options, hasBuildingData);
 
+                    plan.ComputedAtUtc = DateTime.UtcNow;
                     results[band] = plan;
                 }
                 catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -32,6 +32,13 @@ public class WiFiOptimizerService : IWiFiScanService
     private readonly ChannelRecommendationService _channelRecommendationService;
     private readonly NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository _channelMemoryRepository;
     private readonly NetworkOptimizer.Storage.Services.MonitoringInfluxClient _influx;
+    private readonly ChannelPlanCache _planCache;
+
+    /// <summary>
+    /// Ceiling on the client-rate history query. Client evidence is an enhancement; waiting on it
+    /// is never worth making the analysis feel broken.
+    /// </summary>
+    private static readonly TimeSpan ClientRateQueryTimeout = TimeSpan.FromSeconds(10);
     // Captured at construction (when this scope's site is known) so the fresh scopes
     // below can be pinned to the same site - they may run after the original scope's
     // ambient HTTP context is gone, or inside a pinned background scope whose pin a
@@ -64,6 +71,7 @@ public class WiFiOptimizerService : IWiFiScanService
         ChannelRecommendationService channelRecommendationService,
         NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository channelMemoryRepository,
         NetworkOptimizer.Storage.Services.MonitoringInfluxClient influx,
+        ChannelPlanCache planCache,
         SiteContextService siteContext,
         Licensing.LicenseStateService licenseState,
         ILogger<WiFiOptimizerService> logger,
@@ -81,6 +89,7 @@ public class WiFiOptimizerService : IWiFiScanService
         _channelRecommendationService = channelRecommendationService;
         _channelMemoryRepository = channelMemoryRepository;
         _influx = influx;
+        _planCache = planCache;
         _logger = logger;
         _loggerFactory = loggerFactory;
         _healthScorer = new SiteHealthScorer();
@@ -936,14 +945,20 @@ public class WiFiOptimizerService : IWiFiScanService
         try
         {
             var to = DateTime.UtcNow;
+            // Hard bound: this must never be what makes the page slow. On timeout the recommender
+            // simply scores without client evidence, which is its documented fallback.
+            using var timeout = new CancellationTokenSource(ClientRateQueryTimeout);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
             var rows = await _influx.QueryClientChannelRatesAsync(
-                to - ClientOutcomeHelper.ClientRateWindow, to);
+                to - ClientOutcomeHelper.ClientRateWindow, to, timeout.Token);
+            _logger.LogDebug("[ChannelRec] client rate query returned {Rows} row(s) in {Elapsed} ms",
+                rows.Count, sw.ElapsedMilliseconds);
             if (rows.Count == 0) return null;
 
             var byBand = new Dictionary<RadioBand, Dictionary<string, List<ClientRateSample>>>();
             foreach (var row in rows)
             {
-                if (string.IsNullOrEmpty(row.ApMac) || string.IsNullOrEmpty(row.ClientMac)) continue;
+                if (string.IsNullOrEmpty(row.ApMac)) continue;
                 var band = row.Band switch
                 {
                     "2.4ghz" => RadioBand.Band2_4GHz,
@@ -959,12 +974,15 @@ public class WiFiOptimizerService : IWiFiScanService
                 if (!byAp.TryGetValue(mac, out var list))
                     byAp[mac] = list = new List<ClientRateSample>();
                 list.Add(new ClientRateSample(
-                    row.Channel, row.ClientMac, row.SignalBandDbm, row.SampleCount, row.MeanTxRateMbps));
+                    row.Channel, row.SignalBandDbm, row.Day, row.WindowCount, row.MeanTxRateMbps));
             }
 
-            _logger.LogDebug(
-                "[ChannelRec] client rate history: {Rows} aggregate(s) across {Bands} band(s)",
-                rows.Count, byBand.Count);
+            foreach (var (band, byAp) in byBand)
+                _logger.LogDebug(
+                    "[ChannelRec] client rate history {Band}: {Aps} AP(s), channels per AP: {Detail}",
+                    band, byAp.Count,
+                    string.Join("; ", byAp.Select(ap =>
+                        $"{ap.Key}=[{string.Join(",", ap.Value.Select(v => v.Channel).Distinct().OrderBy(c => c))}]")));
 
             return byBand.ToDictionary(
                 b => b.Key,
@@ -1242,9 +1260,26 @@ public class WiFiOptimizerService : IWiFiScanService
     /// Get channel recommendations for a specific band.
     /// Coordinates data loading and calls the recommendation engine for all bands.
     /// </summary>
-    public async Task<Dictionary<RadioBand, ChannelPlan>> GetAllChannelRecommendationsAsync(
-        RecommendationOptions? options = null)
+    public Task<Dictionary<RadioBand, ChannelPlan>> GetAllChannelRecommendationsAsync(
+        RecommendationOptions? options = null,
+        bool forceRefresh = false)
     {
+        // Keyed by option set as well as site: pinning an AP or allowing DFS is a different
+        // question, not a stale answer to the same one.
+        var opts = options ?? new RecommendationOptions();
+        var pinned = opts.PinnedApMacs is { Count: > 0 }
+            ? string.Join("+", opts.PinnedApMacs.OrderBy(m => m, StringComparer.Ordinal))
+            : "none";
+        var key = $"{_siteSlug}|{opts.DfsPreference}|{opts.OptimizeWidths}|{pinned}";
+
+        return _planCache.GetOrBuildPlanAsync(key, forceRefresh,
+            () => BuildAllChannelRecommendationsAsync(options));
+    }
+
+    private async Task<Dictionary<RadioBand, ChannelPlan>> BuildAllChannelRecommendationsAsync(
+        RecommendationOptions? options)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
         var results = new Dictionary<RadioBand, ChannelPlan>();
 
         if (!_connectionService.IsConnected)
@@ -1326,7 +1361,7 @@ public class WiFiOptimizerService : IWiFiScanService
 
             // What clients actually achieved per channel. Entirely optional - any failure leaves
             // this null and the recommender scores exactly as it did before it existed.
-            var clientRates = await GetClientRatesAsync();
+            var clientRates = await _planCache.GetOrBuildClientRatesAsync(_siteSlug, GetClientRatesAsync);
 
             // Generate recommendations for each band that has APs
             var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
@@ -1360,6 +1395,9 @@ public class WiFiOptimizerService : IWiFiScanService
             _logger.LogError(ex, "Failed to get channel recommendations");
         }
 
+        _logger.LogDebug(
+            "[ChannelRec] built plans for {Bands} band(s) in {Elapsed} ms (cached for {Ttl})",
+            results.Count, sw.ElapsedMilliseconds, ChannelPlanCache.PlanTtl);
         return results;
     }
 
@@ -1598,14 +1636,18 @@ public class WiFiOptimizerService : IWiFiScanService
                             neighborLoad.GetValueOrDefault((macLower, bandCode)));
                         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
                             recent, buckets, radio.ChannelWidth ?? 20, now,
-                            ChannelMemoryHelper.MinLongTermSamples, band, confidence);
+                            ChannelMemoryHelper.MinLongTermSamples, band, confidence,
+                            trace: msg => _logger.LogDebug("[ChannelRec] {ApName} {Band}: {Message}",
+                                ap.Name, band, msg));
                         if (merged == null) continue;
 
-                        if (merged.Count > (recent?.Count ?? 0))
-                            _logger.LogDebug(
-                                "[ChannelRec] {ApName} {Band}: outcome memory added measured stress for " +
-                                "{Added} channel(s) beyond the UniFi metrics window (history confidence {Confidence:F2})",
-                                ap.Name, band, merged.Count - (recent?.Count ?? 0), confidence);
+                        // Logged unconditionally: when confidence suppresses the memory the channel
+                        // count does not move, and that silent case is exactly the one worth seeing.
+                        _logger.LogDebug(
+                            "[ChannelRec] {ApName} {Band}: outcome memory added {Added} channel(s) beyond " +
+                            "the UniFi metrics window (neighbor load {Load:F1}, history confidence {Confidence:F2})",
+                            ap.Name, band, merged.Count - (recent?.Count ?? 0),
+                            neighborLoad.GetValueOrDefault((macLower, bandCode)), confidence);
                         context.Stress[band][macLower] = merged;
                     }
                 }

--- a/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
+++ b/src/NetworkOptimizer.Web/Services/WiFiOptimizerService.cs
@@ -31,6 +31,7 @@ public class WiFiOptimizerService : IWiFiScanService
     private readonly PlannedApService _plannedApService;
     private readonly ChannelRecommendationService _channelRecommendationService;
     private readonly NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository _channelMemoryRepository;
+    private readonly NetworkOptimizer.Storage.Services.MonitoringInfluxClient _influx;
     // Captured at construction (when this scope's site is known) so the fresh scopes
     // below can be pinned to the same site - they may run after the original scope's
     // ambient HTTP context is gone, or inside a pinned background scope whose pin a
@@ -62,6 +63,7 @@ public class WiFiOptimizerService : IWiFiScanService
         PlannedApService plannedApService,
         ChannelRecommendationService channelRecommendationService,
         NetworkOptimizer.Storage.Interfaces.IChannelMemoryRepository channelMemoryRepository,
+        NetworkOptimizer.Storage.Services.MonitoringInfluxClient influx,
         SiteContextService siteContext,
         Licensing.LicenseStateService licenseState,
         ILogger<WiFiOptimizerService> logger,
@@ -78,6 +80,7 @@ public class WiFiOptimizerService : IWiFiScanService
         _plannedApService = plannedApService;
         _channelRecommendationService = channelRecommendationService;
         _channelMemoryRepository = channelMemoryRepository;
+        _influx = influx;
         _logger = logger;
         _loggerFactory = loggerFactory;
         _healthScorer = new SiteHealthScorer();
@@ -923,6 +926,61 @@ public class WiFiOptimizerService : IWiFiScanService
     }
 
     /// <summary>
+    /// Per-band, per-AP client PHY-rate history for the channel recommender, from InfluxDB.
+    /// Returns null when Influx is unconfigured, unreachable, or has nothing to say - the
+    /// recommender treats that as "no opinion" and behaves exactly as it does without it.
+    /// </summary>
+    private async Task<Dictionary<RadioBand, Dictionary<string, IReadOnlyList<ClientRateSample>>>?>
+        GetClientRatesAsync()
+    {
+        try
+        {
+            var to = DateTime.UtcNow;
+            var rows = await _influx.QueryClientChannelRatesAsync(
+                to - ClientOutcomeHelper.ClientRateWindow, to);
+            if (rows.Count == 0) return null;
+
+            var byBand = new Dictionary<RadioBand, Dictionary<string, List<ClientRateSample>>>();
+            foreach (var row in rows)
+            {
+                if (string.IsNullOrEmpty(row.ApMac) || string.IsNullOrEmpty(row.ClientMac)) continue;
+                var band = row.Band switch
+                {
+                    "2.4ghz" => RadioBand.Band2_4GHz,
+                    "5ghz" => RadioBand.Band5GHz,
+                    "6ghz" => RadioBand.Band6GHz,
+                    _ => RadioBand.Unknown
+                };
+                if (band == RadioBand.Unknown) continue;
+
+                if (!byBand.TryGetValue(band, out var byAp))
+                    byBand[band] = byAp = new Dictionary<string, List<ClientRateSample>>(StringComparer.OrdinalIgnoreCase);
+                var mac = row.ApMac.ToLowerInvariant();
+                if (!byAp.TryGetValue(mac, out var list))
+                    byAp[mac] = list = new List<ClientRateSample>();
+                list.Add(new ClientRateSample(
+                    row.Channel, row.ClientMac, row.SignalBandDbm, row.SampleCount, row.MeanTxRateMbps));
+            }
+
+            _logger.LogDebug(
+                "[ChannelRec] client rate history: {Rows} aggregate(s) across {Bands} band(s)",
+                rows.Count, byBand.Count);
+
+            return byBand.ToDictionary(
+                b => b.Key,
+                b => b.Value.ToDictionary(
+                    ap => ap.Key,
+                    ap => (IReadOnlyList<ClientRateSample>)ap.Value,
+                    StringComparer.OrdinalIgnoreCase));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Client rate history unavailable; scoring channels without it");
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Fold the persisted long-term neighbor memory into the pooled scan results (see
     /// <see cref="ChannelMemoryHelper.MergeRememberedNeighbors"/>). Used by the channel
     /// recommendation only; degrades gracefully to the live-only picture on any failure.
@@ -1266,6 +1324,10 @@ public class WiFiOptimizerService : IWiFiScanService
             // window + persisted long-term outcome memory) and soak-period state
             var historicalContext = await GetHistoricalContextAsync(aps);
 
+            // What clients actually achieved per channel. Entirely optional - any failure leaves
+            // this null and the recommender scores exactly as it did before it existed.
+            var clientRates = await GetClientRatesAsync();
+
             // Generate recommendations for each band that has APs
             var bands = new[] { RadioBand.Band2_4GHz, RadioBand.Band5GHz, RadioBand.Band6GHz };
             foreach (var band in bands)
@@ -1279,7 +1341,8 @@ public class WiFiOptimizerService : IWiFiScanService
                     var bandStress = historicalContext?.Stress?.GetValueOrDefault(band);
                     var bandSoak = historicalContext?.Soak.GetValueOrDefault(band);
                     var graph = _channelRecommendationService.BuildInterferenceGraph(
-                        aps, band, propCtx, scanResults, regulatoryData, options, bandStress, bandSoak);
+                        aps, band, propCtx, scanResults, regulatoryData, options, bandStress, bandSoak,
+                        clientRates?.GetValueOrDefault(band));
 
                     var plan = _channelRecommendationService.Optimize(
                         graph, band, regulatoryData, options, hasBuildingData);
@@ -1489,6 +1552,26 @@ public class WiFiOptimizerService : IWiFiScanService
             if (outcomes.Count > 0)
             {
                 var outcomeLookup = outcomes.ToLookup(o => (o.ApMac, o.Band));
+
+                // Band-level neighbor load sets how far remembered outcomes are trusted. Weighted by
+                // the same CCA curve the interference score uses, so a sighting too weak to make a
+                // radio defer contributes nothing. Losing this must not cost us the memory itself.
+                var neighborLoad = new Dictionary<(string Mac, string Band), double>();
+                try
+                {
+                    var sightings = await _channelMemoryRepository.GetNeighborSightingsSinceAsync(
+                        now.UtcDateTime - ChannelMemoryHelper.NeighborMemoryWindow);
+                    foreach (var sighting in sightings)
+                    {
+                        var key = (sighting.ApMac.ToLowerInvariant(), sighting.Band);
+                        neighborLoad[key] = neighborLoad.GetValueOrDefault(key)
+                            + ChannelSpanHelper.SignalToInterferenceWeight(sighting.SignalDbm);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "Neighbor load unavailable; trusting outcome memory at full strength");
+                }
                 context.Stress ??= bands.ToDictionary(
                     b => b,
                     _ => new Dictionary<string, Dictionary<int, (double, double, double)>>(StringComparer.OrdinalIgnoreCase));
@@ -1511,15 +1594,18 @@ public class WiFiOptimizerService : IWiFiScanService
                         if (buckets.Count == 0) continue;
 
                         var recent = context.Stress[band].GetValueOrDefault(macLower);
+                        var confidence = ChannelMemoryHelper.HistoryConfidenceFromNeighbors(
+                            neighborLoad.GetValueOrDefault((macLower, bandCode)));
                         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
-                            recent, buckets, radio.ChannelWidth ?? 20, now);
+                            recent, buckets, radio.ChannelWidth ?? 20, now,
+                            ChannelMemoryHelper.MinLongTermSamples, band, confidence);
                         if (merged == null) continue;
 
                         if (merged.Count > (recent?.Count ?? 0))
                             _logger.LogDebug(
                                 "[ChannelRec] {ApName} {Band}: outcome memory added measured stress for " +
-                                "{Added} channel(s) beyond the UniFi metrics window",
-                                ap.Name, band, merged.Count - (recent?.Count ?? 0));
+                                "{Added} channel(s) beyond the UniFi metrics window (history confidence {Confidence:F2})",
+                                ap.Name, band, merged.Count - (recent?.Count ?? 0), confidence);
                         context.Stress[band][macLower] = merged;
                     }
                 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -11385,6 +11385,12 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-primary);
 }
 
+.channel-plan-age {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
 .channel-loading,
 .channel-empty {
     display: flex;

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
@@ -20,7 +20,7 @@
       "level": "minor",
       "badge": "improved",
       "url": "/wifi-optimizer?tab=channels&recommend=true",
-      "selector": "[data-tour=\"channel-analysis\"]",
+      "selector": "[data-tour=\"wifi-channels\"]",
       "title": "Wi-Fi Channel Recommendation",
       "listLabel": "Channel recommendations weigh measured performance, not just airtime",
       "body": "Recommendations now weigh what your network measured, not just how busy the air was - including the speeds your clients actually got, where InfluxDB is collecting.",

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
@@ -19,7 +19,7 @@
       "id": "channel-recommendations",
       "level": "minor",
       "badge": "improved",
-      "url": "/wifi-optimizer?tab=channels",
+      "url": "/wifi-optimizer?tab=channels&recommend=true",
       "selector": "[data-tour=\"channel-recommendations\"]",
       "title": "Wi-Fi Channel Recommendation",
       "listLabel": "Channel recommendations weigh measured performance, not just airtime",

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
@@ -2,7 +2,7 @@
   "id": "2.7.0",
   "kind": "whats-new",
   "title": "What's new in v2.7.0",
-  "summary": "Upgrade a whole site's firmware based on your network activity and schedule, read the gateway's kernel diagnostics, and generate a UniFi Support File - all from Network Optimizer.",
+  "summary": "Upgrade a whole site's firmware based on your network activity and schedule, read the gateway's kernel diagnostics, and generate a UniFi Support File - all from Network Optimizer. Channel recommendations now weigh measured performance too.",
   "steps": [
     {
       "id": "firmware-rollout",
@@ -12,6 +12,18 @@
       "title": "Firmware Rollout",
       "listLabel": "Upgrade your whole site without babysitting it",
       "body": "Upgrade every device on a site while intelligently maximizing network availability, at the most optimal time according to the site's traffic history. One device per model goes first and the rest wait on how it went: actually running the new firmware, and steady on its own CPU, memory and health stats. Hold one model back on Official, push another to Early Access, or leave a device out entirely. Switch on **Autopilot** and it does all of this on its own, every time new firmware lands - with a heads-up first, and a way to stop it.",
+      "placement": "top",
+      "optional": true
+    },
+    {
+      "id": "channel-recommendations",
+      "level": "minor",
+      "badge": "improved",
+      "url": "/wifi-optimizer?tab=channels",
+      "selector": "[data-tour=\"channel-recommendations\"]",
+      "title": "Wi-Fi Channel Recommendation",
+      "listLabel": "Channel recommendations weigh measured performance, not just airtime",
+      "body": "Recommendations now weigh what your network measured, not just how busy the air was - including the speeds your clients actually got, where InfluxDB is collecting.",
       "placement": "top",
       "optional": true
     },

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.7.0.json
@@ -20,7 +20,7 @@
       "level": "minor",
       "badge": "improved",
       "url": "/wifi-optimizer?tab=channels&recommend=true",
-      "selector": "[data-tour=\"channel-recommendations\"]",
+      "selector": "[data-tour=\"channel-analysis\"]",
       "title": "Wi-Fi Channel Recommendation",
       "listLabel": "Channel recommendations weigh measured performance, not just airtime",
       "body": "Recommendations now weigh what your network measured, not just how busy the air was - including the speeds your clients actually got, where InfluxDB is collecting.",

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -28,6 +28,17 @@ public static class ChannelMemoryHelper
     public const int MinLongTermSamples = 12;
 
     /// <summary>
+    /// Fraction of <see cref="MinLongTermSamples"/> at which a channel's evidence still speaks,
+    /// at reduced credibility. Below the full floor a measured average is noisier, not wrong, and
+    /// discarding it outright reverts the channel to "never measured" - where the mild
+    /// unknown-channel penalty beats a channel we know to be mediocre, and the optimizer moves
+    /// onto the worse one. Observed on a live site: a radio's worst 2.4 GHz channel sat at 11.1
+    /// effective samples against a floor of 12 and was recommended precisely because it had been
+    /// forgotten. Evidence below this fraction is still dropped - it is too thin to mean anything.
+    /// </summary>
+    public const double SoftFloorFraction = 0.5;
+
+    /// <summary>
     /// Half-life for aging long-term outcomes: a bucket's weight halves every 60 days, so
     /// month-old evidence speaks nearly at full strength while a five-month-old outcome
     /// contributes ~25% - the RF neighborhood drifts, and the average should tilt toward
@@ -173,7 +184,8 @@ public static class ChannelMemoryHelper
         int minSampleCount = MinLongTermSamples,
         RadioBand band = RadioBand.Unknown,
         double historyConfidence = 1.0,
-        Action<string>? trace = null)
+        Action<string>? trace = null,
+        IDictionary<int, double>? credibilityOut = null)
     {
         Dictionary<int, (double, double, double)>? merged = recentStress != null
             ? new Dictionary<int, (double, double, double)>(recentStress)
@@ -201,15 +213,21 @@ public static class ChannelMemoryHelper
             var pooledChannels = group.Select(b => b.Channel).Distinct().Count();
             // Confidence scales the evidence bar, not the averages: on a churning band the same
             // history has to be larger or fresher to speak at all, but what it says is unchanged.
-            if (effectiveWeight * historyConfidence < minSampleCount)
+            var credibility = Math.Min(1.0, effectiveWeight * historyConfidence / minSampleCount);
+            if (credibility < SoftFloorFraction)
             {
                 trace?.Invoke(
                     $"span {group.Key} rejected: {effectiveWeight:F1} effective x {historyConfidence:F2} " +
-                    $"confidence < {minSampleCount} floor ({pooledChannels} control channel(s) pooled)");
+                    $"confidence = {credibility:F2} of floor {minSampleCount} " +
+                    $"({pooledChannels} control channel(s) pooled)");
                 continue;
             }
 
-            if (pooledChannels > 1)
+            if (credibility < 1.0)
+                trace?.Invoke(
+                    $"span {group.Key} admitted at {credibility:F2} credibility " +
+                    $"({effectiveWeight:F1} effective x {historyConfidence:F2} confidence, floor {minSampleCount})");
+            else if (pooledChannels > 1)
                 trace?.Invoke(
                     $"span {group.Key} pooled {pooledChannels} control channels to {effectiveWeight:F1} " +
                     $"effective samples (floor {minSampleCount}, confidence {historyConfidence:F2})");
@@ -225,6 +243,7 @@ public static class ChannelMemoryHelper
                 // Recent data still wins per channel - it reflects today's RF neighborhood.
                 if (merged.ContainsKey(channel)) continue;
                 merged[channel] = stats;
+                if (credibilityOut != null) credibilityOut[channel] = credibility;
             }
         }
 

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -172,7 +172,8 @@ public static class ChannelMemoryHelper
         DateTimeOffset now,
         int minSampleCount = MinLongTermSamples,
         RadioBand band = RadioBand.Unknown,
-        double historyConfidence = 1.0)
+        double historyConfidence = 1.0,
+        Action<string>? trace = null)
     {
         Dictionary<int, (double, double, double)>? merged = recentStress != null
             ? new Dictionary<int, (double, double, double)>(recentStress)
@@ -196,9 +197,22 @@ public static class ChannelMemoryHelper
             }
 
             if (effectiveWeight <= 0) continue;
+
+            var pooledChannels = group.Select(b => b.Channel).Distinct().Count();
             // Confidence scales the evidence bar, not the averages: on a churning band the same
             // history has to be larger or fresher to speak at all, but what it says is unchanged.
-            if (effectiveWeight * historyConfidence < minSampleCount) continue;
+            if (effectiveWeight * historyConfidence < minSampleCount)
+            {
+                trace?.Invoke(
+                    $"span {group.Key} rejected: {effectiveWeight:F1} effective x {historyConfidence:F2} " +
+                    $"confidence < {minSampleCount} floor ({pooledChannels} control channel(s) pooled)");
+                continue;
+            }
+
+            if (pooledChannels > 1)
+                trace?.Invoke(
+                    $"span {group.Key} pooled {pooledChannels} control channels to {effectiveWeight:F1} " +
+                    $"effective samples (floor {minSampleCount}, confidence {historyConfidence:F2})");
 
             var stats = (
                 utilSum / effectiveWeight,

--- a/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ChannelMemoryHelper.cs
@@ -170,20 +170,20 @@ public static class ChannelMemoryHelper
         IEnumerable<ChannelOutcomeBucket> longTermBuckets,
         int currentWidthMhz,
         DateTimeOffset now,
-        int minSampleCount = MinLongTermSamples)
+        int minSampleCount = MinLongTermSamples,
+        RadioBand band = RadioBand.Unknown,
+        double historyConfidence = 1.0)
     {
         Dictionary<int, (double, double, double)>? merged = recentStress != null
             ? new Dictionary<int, (double, double, double)>(recentStress)
             : null;
 
-        var byChannel = longTermBuckets
+        var bySpan = longTermBuckets
             .Where(b => b.WidthMhz == 0 || b.WidthMhz == currentWidthMhz)
-            .GroupBy(b => b.Channel);
+            .GroupBy(b => SpanKey(band, b.Channel, currentWidthMhz));
 
-        foreach (var group in byChannel)
+        foreach (var group in bySpan)
         {
-            if (merged != null && merged.ContainsKey(group.Key)) continue;
-
             double effectiveWeight = 0, utilSum = 0, interfSum = 0, txRetrySum = 0;
             foreach (var bucket in group)
             {
@@ -195,16 +195,84 @@ public static class ChannelMemoryHelper
                 txRetrySum += bucket.TxRetrySum * decay;
             }
 
-            if (effectiveWeight < minSampleCount) continue;
+            if (effectiveWeight <= 0) continue;
+            // Confidence scales the evidence bar, not the averages: on a churning band the same
+            // history has to be larger or fresher to speak at all, but what it says is unchanged.
+            if (effectiveWeight * historyConfidence < minSampleCount) continue;
 
-            merged ??= new Dictionary<int, (double, double, double)>();
-            merged[group.Key] = (
+            var stats = (
                 utilSum / effectiveWeight,
                 interfSum / effectiveWeight,
                 txRetrySum / effectiveWeight);
+
+            merged ??= new Dictionary<int, (double, double, double)>();
+            foreach (var channel in SpanChannels(band, group.Key, currentWidthMhz))
+            {
+                // Recent data still wins per channel - it reflects today's RF neighborhood.
+                if (merged.ContainsKey(channel)) continue;
+                merged[channel] = stats;
+            }
         }
 
         return merged;
+    }
+
+    /// <summary>
+    /// Groups history by occupied spectrum rather than control channel. At 5/6 GHz a bonded radio
+    /// on ch 149@80 and one on ch 157@80 sit in the identical 80 MHz block, so their outcomes are
+    /// evidence about the same thing; keying on the control channel filed them apart and let each
+    /// half fall under the sample floor. 2.4 GHz keeps control-channel keying - its spans overlap
+    /// partially rather than in discrete blocks, which is a different problem.
+    /// </summary>
+    private static int SpanKey(RadioBand band, int channel, int widthMhz) =>
+        UsesBondingGroups(band, widthMhz)
+            ? (band == RadioBand.Band5GHz
+                ? ChannelSpanHelper.GetBondingGroupStart5GHz(channel, widthMhz)
+                : ChannelSpanHelper.GetBondingGroupStart6GHz(channel, widthMhz))
+            : channel;
+
+    /// <summary>
+    /// Every control channel a pooled span answers for. Callers look the map up by candidate
+    /// control channel, so pooled stats must be written back to all of them or the pooling is
+    /// invisible to the lookup that needs it.
+    /// </summary>
+    private static IEnumerable<int> SpanChannels(RadioBand band, int spanKey, int widthMhz) =>
+        UsesBondingGroups(band, widthMhz)
+            ? ChannelSpanHelper.GetChannelWidthSpan(band, spanKey, widthMhz)
+            : new[] { spanKey };
+
+    private static bool UsesBondingGroups(RadioBand band, int widthMhz) =>
+        widthMhz >= 40 && band is RadioBand.Band5GHz or RadioBand.Band6GHz;
+
+    /// <summary>
+    /// How far a band's neighbor load has to climb before remembered outcomes are trusted at half
+    /// strength. Calibrated against measured per-AP, per-band weighted load: an empty 5/6 GHz band
+    /// reads 0-1, a suburban 2.4 GHz band 10-24, and a dense urban 2.4 GHz band 108-134.
+    /// </summary>
+    public const double NeighborConfidenceScale = 25.0;
+
+    /// <summary>
+    /// Floor on history confidence. Even a heavily contested band's own measured past beats
+    /// inference, so crowding discounts memory rather than switching it off.
+    /// </summary>
+    public const double MinHistoryConfidence = 0.35;
+
+    /// <summary>
+    /// How far remembered outcomes should be trusted on a band, from its weighted neighbor load.
+    /// Neighbors are what churns: with few of them the environment is largely self-determined and
+    /// last month's measurement still describes today, so history speaks at full strength. As the
+    /// band fills, old outcomes describe a neighborhood that has since moved on.
+    ///
+    /// Load is the summed <see cref="ChannelSpanHelper.SignalToInterferenceWeight"/> of remembered
+    /// sightings, so a neighbor below the CCA threshold contributes nothing - it never made anyone
+    /// defer. Band-level on purpose: per-channel neighbor pressure is already priced into the
+    /// interference score, and applying it again here would count it twice.
+    /// </summary>
+    public static double HistoryConfidenceFromNeighbors(double weightedNeighborLoad)
+    {
+        if (weightedNeighborLoad <= 0) return 1.0;
+        return MinHistoryConfidence
+            + (1.0 - MinHistoryConfidence) / (1.0 + weightedNeighborLoad / NeighborConfidenceScale);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
@@ -7,6 +7,13 @@ namespace NetworkOptimizer.WiFi.Helpers;
 /// involved. The airtime score measures the medium; this measures the experience, and the two
 /// can disagree. Pure logic - callers supply already-aggregated samples so the engine keeps no
 /// dependency on the telemetry store.
+///
+/// Link rate is the only metric scored, and deliberately so: rate adaptation has already folded
+/// signal, noise, interference and client capability into it, and it responds to channel choice in
+/// a way none of them do alone. Signal is a matching key rather than an input - within a band it
+/// tracks distance and transmit power, so a difference between two channels is a client-mix
+/// artifact. Noise floor was measured and rejected: it reads as a per-radio constant (0-1 dB across
+/// channels on one radio against 6 dB between radios), so SNR would be signal minus a constant.
 /// </summary>
 public static class ClientOutcomeHelper
 {

--- a/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
@@ -11,19 +11,26 @@ namespace NetworkOptimizer.WiFi.Helpers;
 public static class ClientOutcomeHelper
 {
     /// <summary>
-    /// Active samples a channel needs before it may raise the bar on a move. Lower than the
-    /// impetus floor on purpose: declining to move is the cheap error.
+    /// Active 15-minute windows a channel needs before it may raise the bar on a move - about five
+    /// hours of real traffic. Lower than the impetus floor on purpose: declining to move is the
+    /// cheap error.
     /// </summary>
-    public const int MinSamplesForVeto = 200;
+    public const int MinWindowsForVeto = 20;
 
     /// <summary>
-    /// Active samples a channel needs before it may lower the bar. Moving costs client
-    /// disruption and a soak period, so originating one demands more evidence than blocking one.
+    /// Active windows a channel needs before it may lower the bar, about half a day of real
+    /// traffic. Moving costs client disruption and a soak period, so originating a move demands
+    /// more evidence than blocking one.
     /// </summary>
-    public const int MinSamplesForImpetus = 500;
+    public const int MinWindowsForImpetus = 50;
 
-    /// <summary>Distinct clients required per channel, so one chatty device cannot speak for a channel.</summary>
-    public const int MinDistinctClients = 2;
+    /// <summary>
+    /// Distinct days a channel's evidence must span. Windows alone can all come from one unusual
+    /// evening; days force the comparison to survive more than a single session. This replaces a
+    /// distinct-client floor: client_mac is a field rather than a tag, so per-client aggregation
+    /// needs a pivot over raw points that measured 33s against 1s for the windowed query.
+    /// </summary>
+    public const int MinDistinctDays = 3;
 
     /// <summary>Candidate must beat the current channel by this much before it lowers the bar.</summary>
     public const double ImpetusRatio = 1.15;
@@ -48,10 +55,10 @@ public static class ClientOutcomeHelper
     /// measured on the current channel versus the candidate. Returns 1.0 - changing nothing -
     /// whenever the evidence is missing, thin, or equivocal, which is the common case.
     /// </summary>
-    /// <param name="samples">Per-channel, per-client, per-signal-band aggregates for this AP radio</param>
+    /// <param name="samples">Per-channel, per-signal-band, per-day aggregates for this AP radio</param>
     /// <param name="currentChannel">Channel the radio is on now</param>
     /// <param name="candidateChannel">Channel the search wants to move it to</param>
-    /// <param name="reason">Human-readable justification when the factor is not 1.0</param>
+    /// <param name="reason">Why the factor came out as it did, for the recommendation log</param>
     public static double MoveThresholdFactor(
         IReadOnlyList<ClientRateSample>? samples,
         int currentChannel,
@@ -59,82 +66,104 @@ public static class ClientOutcomeHelper
         out string? reason)
     {
         reason = null;
-        if (samples == null || samples.Count == 0 || currentChannel == candidateChannel) return 1.0;
+        if (samples == null || samples.Count == 0)
+        {
+            reason = "no client history for this radio";
+            return 1.0;
+        }
+        if (currentChannel == candidateChannel) return 1.0;
 
         var current = Summarize(samples, currentChannel);
         var candidate = Summarize(samples, candidateChannel);
-        if (current == null || candidate == null) return 1.0;
+        if (current == null || candidate == null)
+        {
+            reason = current == null
+                ? $"no client history on current ch {currentChannel}"
+                : $"no client history on candidate ch {candidateChannel}";
+            return 1.0;
+        }
 
         // Compare only where the two channels overlap in signal strength. Rate tracks distance
         // hard enough that an unmatched band would report the client mix, not the channel.
         var sharedBands = current.ByBand.Keys.Intersect(candidate.ByBand.Keys).ToList();
-        if (sharedBands.Count == 0) return 1.0;
+        if (sharedBands.Count == 0)
+        {
+            reason = "no overlapping signal bands between the two channels";
+            return 1.0;
+        }
 
-        double curWeighted = 0, candWeighted = 0, weightTotal = 0;
-        var sharedSamples = 0;
+        double curWeighted = 0, candWeighted = 0;
+        var sharedWindows = 0;
         foreach (var band in sharedBands)
         {
             var c = current.ByBand[band];
             var k = candidate.ByBand[band];
             // Weight by the thinner side: a band one channel barely visited must not dominate.
-            var weight = Math.Min(c.Samples, k.Samples);
+            var weight = Math.Min(c.Windows, k.Windows);
             if (weight <= 0) continue;
             curWeighted += c.MeanRateMbps * weight;
             candWeighted += k.MeanRateMbps * weight;
-            weightTotal += weight;
-            sharedSamples += weight;
+            sharedWindows += weight;
         }
 
-        if (weightTotal <= 0 || curWeighted <= 0) return 1.0;
+        if (sharedWindows <= 0 || curWeighted <= 0)
+        {
+            reason = "no comparable windows in the shared signal bands";
+            return 1.0;
+        }
 
-        var currentMean = curWeighted / weightTotal;
-        var candidateMean = candWeighted / weightTotal;
+        var currentMean = curWeighted / sharedWindows;
+        var candidateMean = candWeighted / sharedWindows;
         var ratio = candidateMean / currentMean;
 
-        var clientsOk = current.DistinctClients >= MinDistinctClients
-                        && candidate.DistinctClients >= MinDistinctClients;
-        if (!clientsOk) return 1.0;
-
-        if (ratio >= ImpetusRatio && sharedSamples >= MinSamplesForImpetus)
+        if (current.DistinctDays < MinDistinctDays || candidate.DistinctDays < MinDistinctDays)
         {
-            reason = $"clients averaged {candidateMean:F0} Mbps on ch {candidateChannel} vs " +
-                     $"{currentMean:F0} Mbps on ch {currentChannel} at matched signal " +
-                     $"({sharedSamples} samples, {candidate.DistinctClients} clients)";
+            reason = $"evidence spans too few days (current {current.DistinctDays}, " +
+                     $"candidate {candidate.DistinctDays}, need {MinDistinctDays})";
+            return 1.0;
+        }
+
+        var summary = $"clients averaged {candidateMean:F0} Mbps on ch {candidateChannel} vs " +
+                      $"{currentMean:F0} Mbps on ch {currentChannel} at matched signal " +
+                      $"({sharedWindows} shared windows over {candidate.DistinctDays} days)";
+
+        if (ratio >= ImpetusRatio && sharedWindows >= MinWindowsForImpetus)
+        {
+            reason = summary;
             return ImpetusFactor;
         }
 
-        if (ratio <= VetoRatio && sharedSamples >= MinSamplesForVeto)
+        if (ratio <= VetoRatio && sharedWindows >= MinWindowsForVeto)
         {
-            reason = $"clients averaged {candidateMean:F0} Mbps on ch {candidateChannel} vs " +
-                     $"{currentMean:F0} Mbps on ch {currentChannel} at matched signal " +
-                     $"({sharedSamples} samples, {candidate.DistinctClients} clients)";
+            reason = summary;
             return VetoFactor;
         }
 
+        reason = $"inconclusive: ratio {ratio:F2} over {sharedWindows} shared windows";
         return 1.0;
     }
 
     private sealed class ChannelSummary
     {
-        public Dictionary<int, (int Samples, double MeanRateMbps)> ByBand { get; } = new();
-        public int DistinctClients { get; set; }
+        public Dictionary<int, (int Windows, double MeanRateMbps)> ByBand { get; } = new();
+        public int DistinctDays { get; set; }
     }
 
     private static ChannelSummary? Summarize(IReadOnlyList<ClientRateSample> samples, int channel)
     {
-        var rows = samples.Where(s => s.Channel == channel && s.SampleCount > 0).ToList();
+        var rows = samples.Where(s => s.Channel == channel && s.WindowCount > 0).ToList();
         if (rows.Count == 0) return null;
 
         var summary = new ChannelSummary
         {
-            DistinctClients = rows.Select(r => r.ClientMac).Distinct(StringComparer.OrdinalIgnoreCase).Count()
+            DistinctDays = rows.Select(r => r.Day.Date).Distinct().Count()
         };
 
         foreach (var group in rows.GroupBy(r => r.SignalBandDbm))
         {
-            var n = group.Sum(r => r.SampleCount);
+            var n = group.Sum(r => r.WindowCount);
             if (n <= 0) continue;
-            var mean = group.Sum(r => r.MeanTxRateMbps * r.SampleCount) / n;
+            var mean = group.Sum(r => r.MeanTxRateMbps * r.WindowCount) / n;
             summary.ByBand[group.Key] = (n, mean);
         }
 

--- a/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
@@ -83,12 +83,15 @@ public static class ClientOutcomeHelper
             return 1.0;
         }
 
-        // Compare only where the two channels overlap in signal strength. Rate tracks distance
-        // hard enough that an unmatched band would report the client mix, not the channel.
+        // Compare only where the two channels overlap in BOTH width and signal strength. Rate
+        // tracks distance hard enough that an unmatched signal band would report where the clients
+        // were standing; width matters just as much, and doubling it roughly doubles the rate -
+        // enough on its own to clear the impetus ratio and argue for a move the spectrum does not
+        // justify. Clients often run narrower than the AP, so this buckets by their capability too.
         var sharedBands = current.ByBand.Keys.Intersect(candidate.ByBand.Keys).ToList();
         if (sharedBands.Count == 0)
         {
-            reason = "no overlapping signal bands between the two channels";
+            reason = "no overlapping width/signal buckets between the two channels";
             return 1.0;
         }
 
@@ -108,7 +111,7 @@ public static class ClientOutcomeHelper
 
         if (sharedWindows <= 0 || curWeighted <= 0)
         {
-            reason = "no comparable windows in the shared signal bands";
+            reason = "no comparable windows in the shared width/signal buckets";
             return 1.0;
         }
 
@@ -145,7 +148,7 @@ public static class ClientOutcomeHelper
 
     private sealed class ChannelSummary
     {
-        public Dictionary<int, (int Windows, double MeanRateMbps)> ByBand { get; } = new();
+        public Dictionary<(int WidthMhz, int SignalBandDbm), (int Windows, double MeanRateMbps)> ByBand { get; } = new();
         public int DistinctDays { get; set; }
     }
 
@@ -159,7 +162,7 @@ public static class ClientOutcomeHelper
             DistinctDays = rows.Select(r => r.Day.Date).Distinct().Count()
         };
 
-        foreach (var group in rows.GroupBy(r => r.SignalBandDbm))
+        foreach (var group in rows.GroupBy(r => (r.WidthMhz, r.SignalBandDbm)))
         {
             var n = group.Sum(r => r.WindowCount);
             if (n <= 0) continue;

--- a/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
+++ b/src/NetworkOptimizer.WiFi/Helpers/ClientOutcomeHelper.cs
@@ -1,0 +1,143 @@
+using NetworkOptimizer.WiFi.Models;
+
+namespace NetworkOptimizer.WiFi.Helpers;
+
+/// <summary>
+/// Weighs a proposed channel move against what clients actually achieved on the channels
+/// involved. The airtime score measures the medium; this measures the experience, and the two
+/// can disagree. Pure logic - callers supply already-aggregated samples so the engine keeps no
+/// dependency on the telemetry store.
+/// </summary>
+public static class ClientOutcomeHelper
+{
+    /// <summary>
+    /// Active samples a channel needs before it may raise the bar on a move. Lower than the
+    /// impetus floor on purpose: declining to move is the cheap error.
+    /// </summary>
+    public const int MinSamplesForVeto = 200;
+
+    /// <summary>
+    /// Active samples a channel needs before it may lower the bar. Moving costs client
+    /// disruption and a soak period, so originating one demands more evidence than blocking one.
+    /// </summary>
+    public const int MinSamplesForImpetus = 500;
+
+    /// <summary>Distinct clients required per channel, so one chatty device cannot speak for a channel.</summary>
+    public const int MinDistinctClients = 2;
+
+    /// <summary>Candidate must beat the current channel by this much before it lowers the bar.</summary>
+    public const double ImpetusRatio = 1.15;
+
+    /// <summary>At or below this the candidate measured worse than where we already are.</summary>
+    public const double VetoRatio = 0.95;
+
+    /// <summary>Bar multiplier when client history backs the move.</summary>
+    public const double ImpetusFactor = 0.7;
+
+    /// <summary>Bar multiplier when client history contradicts it.</summary>
+    public const double VetoFactor = 1.6;
+
+    /// <summary>
+    /// How far back client telemetry is read. Matched to the fast bucket's 90-day retention -
+    /// asking for more returns nothing extra and just widens the query.
+    /// </summary>
+    public static readonly TimeSpan ClientRateWindow = TimeSpan.FromDays(90);
+
+    /// <summary>
+    /// Multiplier for the "is this AP suffering enough to move?" threshold, from what clients
+    /// measured on the current channel versus the candidate. Returns 1.0 - changing nothing -
+    /// whenever the evidence is missing, thin, or equivocal, which is the common case.
+    /// </summary>
+    /// <param name="samples">Per-channel, per-client, per-signal-band aggregates for this AP radio</param>
+    /// <param name="currentChannel">Channel the radio is on now</param>
+    /// <param name="candidateChannel">Channel the search wants to move it to</param>
+    /// <param name="reason">Human-readable justification when the factor is not 1.0</param>
+    public static double MoveThresholdFactor(
+        IReadOnlyList<ClientRateSample>? samples,
+        int currentChannel,
+        int candidateChannel,
+        out string? reason)
+    {
+        reason = null;
+        if (samples == null || samples.Count == 0 || currentChannel == candidateChannel) return 1.0;
+
+        var current = Summarize(samples, currentChannel);
+        var candidate = Summarize(samples, candidateChannel);
+        if (current == null || candidate == null) return 1.0;
+
+        // Compare only where the two channels overlap in signal strength. Rate tracks distance
+        // hard enough that an unmatched band would report the client mix, not the channel.
+        var sharedBands = current.ByBand.Keys.Intersect(candidate.ByBand.Keys).ToList();
+        if (sharedBands.Count == 0) return 1.0;
+
+        double curWeighted = 0, candWeighted = 0, weightTotal = 0;
+        var sharedSamples = 0;
+        foreach (var band in sharedBands)
+        {
+            var c = current.ByBand[band];
+            var k = candidate.ByBand[band];
+            // Weight by the thinner side: a band one channel barely visited must not dominate.
+            var weight = Math.Min(c.Samples, k.Samples);
+            if (weight <= 0) continue;
+            curWeighted += c.MeanRateMbps * weight;
+            candWeighted += k.MeanRateMbps * weight;
+            weightTotal += weight;
+            sharedSamples += weight;
+        }
+
+        if (weightTotal <= 0 || curWeighted <= 0) return 1.0;
+
+        var currentMean = curWeighted / weightTotal;
+        var candidateMean = candWeighted / weightTotal;
+        var ratio = candidateMean / currentMean;
+
+        var clientsOk = current.DistinctClients >= MinDistinctClients
+                        && candidate.DistinctClients >= MinDistinctClients;
+        if (!clientsOk) return 1.0;
+
+        if (ratio >= ImpetusRatio && sharedSamples >= MinSamplesForImpetus)
+        {
+            reason = $"clients averaged {candidateMean:F0} Mbps on ch {candidateChannel} vs " +
+                     $"{currentMean:F0} Mbps on ch {currentChannel} at matched signal " +
+                     $"({sharedSamples} samples, {candidate.DistinctClients} clients)";
+            return ImpetusFactor;
+        }
+
+        if (ratio <= VetoRatio && sharedSamples >= MinSamplesForVeto)
+        {
+            reason = $"clients averaged {candidateMean:F0} Mbps on ch {candidateChannel} vs " +
+                     $"{currentMean:F0} Mbps on ch {currentChannel} at matched signal " +
+                     $"({sharedSamples} samples, {candidate.DistinctClients} clients)";
+            return VetoFactor;
+        }
+
+        return 1.0;
+    }
+
+    private sealed class ChannelSummary
+    {
+        public Dictionary<int, (int Samples, double MeanRateMbps)> ByBand { get; } = new();
+        public int DistinctClients { get; set; }
+    }
+
+    private static ChannelSummary? Summarize(IReadOnlyList<ClientRateSample> samples, int channel)
+    {
+        var rows = samples.Where(s => s.Channel == channel && s.SampleCount > 0).ToList();
+        if (rows.Count == 0) return null;
+
+        var summary = new ChannelSummary
+        {
+            DistinctClients = rows.Select(r => r.ClientMac).Distinct(StringComparer.OrdinalIgnoreCase).Count()
+        };
+
+        foreach (var group in rows.GroupBy(r => r.SignalBandDbm))
+        {
+            var n = group.Sum(r => r.SampleCount);
+            if (n <= 0) continue;
+            var mean = group.Sum(r => r.MeanTxRateMbps * r.SampleCount) / n;
+            summary.ByBand[group.Key] = (n, mean);
+        }
+
+        return summary.ByBand.Count == 0 ? null : summary;
+    }
+}

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -65,19 +65,23 @@ public record RememberedNeighborSighting(
     string? Ssid);
 
 /// <summary>
-/// One aggregate of client PHY-rate telemetry for an AP radio, already bucketed by channel,
-/// client and signal band. Storage-neutral so the engine project stays decoupled from the
-/// telemetry store. Only samples where the client was actually moving traffic belong here:
-/// an idle client's rate decays and describes nothing about the channel.
+/// One aggregate of client PHY-rate telemetry for an AP radio, bucketed by channel, signal band
+/// and day. Storage-neutral so the engine project stays decoupled from the telemetry store.
+///
+/// A "window" is a fixed slice of time (15 minutes) in which the radio carried real traffic; idle
+/// windows are excluded upstream, because an idle client's rate decays and describes nothing about
+/// the channel. Windows rather than raw samples because per-client aggregation is not affordable:
+/// client_mac is a field rather than a tag, so isolating clients requires a pivot over every raw
+/// point, which measured 33s against 1s for the windowed form.
 /// </summary>
-/// <param name="Channel">Control channel the radio was on when these samples were taken</param>
-/// <param name="ClientMac">Client the samples belong to, for the distinct-client floor</param>
+/// <param name="Channel">Control channel the radio was on for these windows</param>
 /// <param name="SignalBandDbm">Signal bucket (dBm, rounded down to a fixed step)</param>
-/// <param name="SampleCount">Active samples in this bucket</param>
-/// <param name="MeanTxRateMbps">Mean AP-to-client PHY rate across those samples</param>
+/// <param name="Day">UTC day, used for the distinct-day evidence floor</param>
+/// <param name="WindowCount">Active windows in this bucket</param>
+/// <param name="MeanTxRateMbps">Mean AP-to-client PHY rate across those windows</param>
 public record ClientRateSample(
     int Channel,
-    string ClientMac,
     int SignalBandDbm,
-    int SampleCount,
+    DateTime Day,
+    int WindowCount,
     double MeanTxRateMbps);

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -75,12 +75,17 @@ public record RememberedNeighborSighting(
 /// point, which measured 33s against 1s for the windowed form.
 /// </summary>
 /// <param name="Channel">Control channel the radio was on for these windows</param>
+/// <param name="WidthMhz">
+/// The client's own channel width, which is commonly narrower than the AP's configuration - so
+/// this buckets clients by capability as well as catching a width change on the radio itself.
+/// </param>
 /// <param name="SignalBandDbm">Signal bucket (dBm, rounded down to a fixed step)</param>
 /// <param name="Day">UTC day, used for the distinct-day evidence floor</param>
 /// <param name="WindowCount">Active windows in this bucket</param>
 /// <param name="MeanTxRateMbps">Mean AP-to-client PHY rate across those windows</param>
 public record ClientRateSample(
     int Channel,
+    int WidthMhz,
     int SignalBandDbm,
     DateTime Day,
     int WindowCount,

--- a/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelMemory.cs
@@ -63,3 +63,21 @@ public record RememberedNeighborSighting(
     int SightingCount,
     DateTimeOffset LastSeenAt,
     string? Ssid);
+
+/// <summary>
+/// One aggregate of client PHY-rate telemetry for an AP radio, already bucketed by channel,
+/// client and signal band. Storage-neutral so the engine project stays decoupled from the
+/// telemetry store. Only samples where the client was actually moving traffic belong here:
+/// an idle client's rate decays and describes nothing about the channel.
+/// </summary>
+/// <param name="Channel">Control channel the radio was on when these samples were taken</param>
+/// <param name="ClientMac">Client the samples belong to, for the distinct-client floor</param>
+/// <param name="SignalBandDbm">Signal bucket (dBm, rounded down to a fixed step)</param>
+/// <param name="SampleCount">Active samples in this bucket</param>
+/// <param name="MeanTxRateMbps">Mean AP-to-client PHY rate across those samples</param>
+public record ClientRateSample(
+    int Channel,
+    string ClientMac,
+    int SignalBandDbm,
+    int SampleCount,
+    double MeanTxRateMbps);

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -125,6 +125,12 @@ public class InterferenceGraph
 {
     public List<ApNode> Nodes { get; set; } = new();
 
+    /// <summary>
+    /// Per-AP client PHY-rate history, keyed by lowercase MAC. Null or absent whenever the
+    /// telemetry store has nothing to say, which the move decision treats as "no opinion".
+    /// </summary>
+    public Dictionary<string, IReadOnlyList<ClientRateSample>>? ClientRates { get; set; }
+
     /// <summary>True when DFS avoidance was requested but at least one AP had to fall back to DFS channels</summary>
     public bool DfsAvoidanceFallback { get; set; }
 

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -213,6 +213,14 @@ public class InterferenceGraph
 /// </summary>
 public class ApNode
 {
+    /// <summary>
+    /// How far each entry in <see cref="HistoricalStress"/> is trusted, 0-1, keyed by channel.
+    /// Absent or 1.0 means full strength. Below 1.0 the measurement stands but its penalty and
+    /// its claim to having "observed" the channel are scaled down together, so thin evidence
+    /// fades toward the unknown-channel treatment instead of falling off a cliff into it.
+    /// </summary>
+    public Dictionary<int, double>? HistoricalStressCredibility { get; set; }
+
     public string Mac { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public int CurrentChannel { get; set; }

--- a/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
+++ b/src/NetworkOptimizer.WiFi/Models/ChannelRecommendation.cs
@@ -80,6 +80,12 @@ public class ApChannelRecommendation
 /// </summary>
 public class ChannelPlan
 {
+    /// <summary>
+    /// When this plan was computed (UTC). Stamped at build time rather than read time, so a plan
+    /// served from cache reports its real age instead of looking freshly made.
+    /// </summary>
+    public DateTime ComputedAtUtc { get; set; }
+
     public RadioBand Band { get; set; }
     public List<ApChannelRecommendation> Recommendations { get; set; } = new();
     public double CurrentNetworkScore { get; set; }

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -427,7 +427,8 @@ public class ChannelRecommendationService
         RegulatoryChannelData? regulatoryData,
         RecommendationOptions? options = null,
         Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>? historicalStress = null,
-        Dictionary<string, ChannelSoakInfo>? soakInfo = null)
+        Dictionary<string, ChannelSoakInfo>? soakInfo = null,
+        Dictionary<string, IReadOnlyList<ClientRateSample>>? clientRates = null)
     {
         var opts = options ?? new RecommendationOptions();
 
@@ -448,7 +449,8 @@ public class ChannelRecommendationService
             HistoricallyObservedChannels = new Dictionary<int, double>[n],
             ScanChannelData = new Dictionary<(int Channel, int Width), (int Utilization, int? NoiseFloor)>[n],
             MeshConstraints = new List<MeshConstraint>(),
-            DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? [])
+            DfsChannels = new HashSet<int>(regulatoryData?.DfsChannels ?? []),
+            ClientRates = clientRates
         };
 
         // Build nodes
@@ -814,12 +816,25 @@ public class ChannelRecommendationService
                 var absoluteImprovement = currentApScore - recommendedApScore;
                 var percentImprovement = currentApScore > 0 ? absoluteImprovement / currentApScore : 0;
 
-                if (currentApScore < MinApScoreToMove)
+                // What clients actually got on these two channels moves the bar in both
+                // directions: evidence the candidate is better lowers it, evidence it is worse
+                // raises it. Absent or thin telemetry returns 1.0 and nothing changes.
+                var clientFactor = ClientOutcomeHelper.MoveThresholdFactor(
+                    graph.ClientRates?.GetValueOrDefault(node.Mac.ToLowerInvariant()),
+                    node.CurrentChannel, recommendedChannel, out var clientReason);
+                var moveThreshold = MinApScoreToMove * clientFactor;
+                if (clientReason != null)
+                    _logger.LogDebug(
+                        "[ChannelRec] {ApName} client history {Direction} the move to ch{Channel}: {Reason}",
+                        node.Name, clientFactor < 1.0 ? "supports" : "contradicts",
+                        recommendedChannel, clientReason);
+
+                if (currentApScore < moveThreshold)
                 {
                     _logger.LogDebug(
                         "[ChannelRec] {ApName} current score {Score:F3} below threshold {Threshold:F3}, " +
                         "keeping current ch{Channel}/{Width} MHz",
-                        node.Name, currentApScore, MinApScoreToMove, node.CurrentChannel, node.CurrentWidth);
+                        node.Name, currentApScore, moveThreshold, node.CurrentChannel, node.CurrentWidth);
                     recommendedChannel = node.CurrentChannel;
                     recommendedWidth = node.CurrentWidth;
                     recommendedApScore = currentApScore;

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -825,9 +825,11 @@ public class ChannelRecommendationService
                 var moveThreshold = MinApScoreToMove * clientFactor;
                 if (clientReason != null)
                     _logger.LogDebug(
-                        "[ChannelRec] {ApName} client history {Direction} the move to ch{Channel}: {Reason}",
-                        node.Name, clientFactor < 1.0 ? "supports" : "contradicts",
-                        recommendedChannel, clientReason);
+                        "[ChannelRec] {ApName} client history {Direction} the move to ch{Channel} " +
+                        "(threshold x{Factor:F2}): {Reason}",
+                        node.Name,
+                        clientFactor < 1.0 ? "supports" : clientFactor > 1.0 ? "contradicts" : "has no opinion on",
+                        recommendedChannel, clientFactor, clientReason);
 
                 if (currentApScore < moveThreshold)
                 {

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -1731,6 +1731,7 @@ public class ChannelRecommendationService
         var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
         foreach (var (histChannel, stress) in node.HistoricalStress)
         {
+            if (!IsFullyCredible(node, histChannel)) continue;
             var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
             if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
                 return stress.Interference < ComfortableInterferencePct;
@@ -1860,6 +1861,7 @@ public class ChannelRecommendationService
             var siblingSpan = ChannelSpanHelper.GetChannelSpan(band, sibling.CurrentChannel, sibling.CurrentWidth);
             if (!ChannelSpanHelper.SpansOverlap(span, siblingSpan)) continue;
             if (!sibling.HistoricalStress.TryGetValue(sibling.CurrentChannel, out var stress)) continue;
+            if (!IsFullyCredible(sibling, sibling.CurrentChannel)) continue;
             var scaled = stress.Interference * graph.InternalWeights[apIndex, j];
             if (worst is not double w || scaled > w) worst = scaled;
         }
@@ -1881,6 +1883,7 @@ public class ChannelRecommendationService
             foreach (var (ch, stress) in node.HistoricalStress)
                 if (ChannelSpanHelper.SpansOverlap(span, ChannelSpanHelper.GetChannelSpan(band, ch, node.CurrentWidth)))
                 {
+                if (!IsFullyCredible(node, ch)) continue;
                     interferencePct = stress.Interference;
                     return true;
                 }
@@ -1916,6 +1919,7 @@ public class ChannelRecommendationService
         var currentSpan = ChannelSpanHelper.GetChannelSpan(band, node.CurrentChannel, node.CurrentWidth);
         foreach (var (histChannel, stress) in node.HistoricalStress)
         {
+            if (!IsFullyCredible(node, histChannel)) continue;
             var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
             if (ChannelSpanHelper.SpansOverlap(currentSpan, histSpan))
                 return stress.Interference >= escapePct;
@@ -2578,6 +2582,16 @@ public class ChannelRecommendationService
     /// AP B gets that channel's stress added, scaled by the proximity weight.
     /// Only propagates between placed APs (where we have real propagation data).
     /// </summary>
+    /// <summary>
+    /// Whether a remembered channel's evidence is at full strength. Scoring blends thin evidence by
+    /// credibility, but the gates below are binary - comfortable or not, suffering or not, escape
+    /// the soak or not - and a yes/no answer cannot carry a confidence. So they only listen to
+    /// evidence that would have existed before the soft floor admitted anything, which keeps their
+    /// behavior identical to what it was rather than letting six samples flip a lock.
+    /// </summary>
+    private static bool IsFullyCredible(ApNode node, int channel) =>
+        (node.HistoricalStressCredibility?.GetValueOrDefault(channel, 1.0) ?? 1.0) >= 1.0;
+
     private static void PropagateHistoricalStress(InterferenceGraph graph, RadioBand band)
     {
         var n = graph.Nodes.Count;
@@ -2604,6 +2618,9 @@ public class ChannelRecommendationService
 
                 foreach (var (histChannel, stress) in source.HistoricalStress)
                 {
+                    // Credibility does not travel with a propagated estimate, so thin evidence
+                    // would arrive at the neighbor as full-strength. Only propagate what is solid.
+                    if (!IsFullyCredible(source, histChannel)) continue;
                     // Scale stress by proximity weight, dampened by 50%.
                     // Even at weight 1.0, only inherit half the neighbor's stress.
                     // Without dampening, 2.4 GHz (where all weights are high) gets

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -2201,6 +2201,10 @@ public class ChannelRecommendationService
             // How well the assigned channel is evidenced, 0 (never measured) to 1 (full strength).
             // Propagated estimates carry no credibility entry and count at full weight, as before.
             double assignedCredibility = 0;
+            // Pooled memory is written to every control channel in a bonding group, and those
+            // entries all carry the identical span - so charging each one would multiply the same
+            // measurement by the group size (4x at 80 MHz, 8x at 160). Count each span once.
+            var countedSpans = new HashSet<(int Low, int High)>();
 
             foreach (var (histChannel, stress) in effectiveStress)
             {
@@ -2209,6 +2213,8 @@ public class ChannelRecommendationService
                 {
                     var cred = node.HistoricalStressCredibility?.GetValueOrDefault(histChannel, 1.0) ?? 1.0;
                     assignedCredibility = Math.Max(assignedCredibility, cred);
+
+                    if (!countedSpans.Add(histSpan)) continue;
 
                     if (stress.TxRetryPct < StressMinThreshold &&
                         stress.Utilization < StressMinThreshold &&

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -428,7 +428,8 @@ public class ChannelRecommendationService
         RecommendationOptions? options = null,
         Dictionary<string, Dictionary<int, (double Utilization, double Interference, double TxRetryPct)>>? historicalStress = null,
         Dictionary<string, ChannelSoakInfo>? soakInfo = null,
-        Dictionary<string, IReadOnlyList<ClientRateSample>>? clientRates = null)
+        Dictionary<string, IReadOnlyList<ClientRateSample>>? clientRates = null,
+        Dictionary<string, Dictionary<int, double>>? historicalCredibility = null)
     {
         var opts = options ?? new RecommendationOptions();
 
@@ -495,6 +496,7 @@ public class ChannelRecommendationService
                 Interference = radio.Interference ?? 0,
                 TxRetriesPct = radio.TxRetriesPct ?? 0,
                 HistoricalStress = apHistStress,
+                HistoricalStressCredibility = historicalCredibility?.GetValueOrDefault(macLower),
                 SoakInfo = soakInfo?.GetValueOrDefault(macLower)
             });
 
@@ -2130,8 +2132,10 @@ public class ChannelRecommendationService
                 var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
                 if (ChannelSpanHelper.SpansOverlap(apSpan, histSpan))
                 {
-                    confidence = Math.Max(confidence, HistoricOccupancyConfidence);
-                    break;
+                    // Thin evidence buys a proportionally weaker claim to having observed the
+                    // channel, so the unknown-channel penalty is only partly waived.
+                    var cred = node.HistoricalStressCredibility?.GetValueOrDefault(histChannel, 1.0) ?? 1.0;
+                    confidence = Math.Max(confidence, HistoricOccupancyConfidence * cred);
                 }
             }
         }
@@ -2194,29 +2198,34 @@ public class ChannelRecommendationService
             // a busy AP whose only co-channel neighbor relocates would read as perfectly idle.
             double contentionPenalty = 0;
             double utilizationPenalty = 0;
-            bool hasDataForAssignedChannel = false;
+            // How well the assigned channel is evidenced, 0 (never measured) to 1 (full strength).
+            // Propagated estimates carry no credibility entry and count at full weight, as before.
+            double assignedCredibility = 0;
 
             foreach (var (histChannel, stress) in effectiveStress)
             {
                 var histSpan = ChannelSpanHelper.GetChannelSpan(band, histChannel, node.CurrentWidth);
                 if (ChannelSpanHelper.SpansOverlap(assignedSpan, histSpan))
                 {
-                    hasDataForAssignedChannel = true;
+                    var cred = node.HistoricalStressCredibility?.GetValueOrDefault(histChannel, 1.0) ?? 1.0;
+                    assignedCredibility = Math.Max(assignedCredibility, cred);
 
                     if (stress.TxRetryPct < StressMinThreshold &&
                         stress.Utilization < StressMinThreshold &&
                         stress.Interference < StressMinThreshold)
                         continue;
 
-                    contentionPenalty += (stress.TxRetryPct / 100.0) * TxRetryStressWeight
-                        + (stress.Interference / 100.0) * InterferenceStressWeight;
-                    utilizationPenalty += (stress.Utilization / 100.0) * UtilizationStressWeight;
+                    contentionPenalty += ((stress.TxRetryPct / 100.0) * TxRetryStressWeight
+                        + (stress.Interference / 100.0) * InterferenceStressWeight) * cred;
+                    utilizationPenalty += (stress.Utilization / 100.0) * UtilizationStressWeight * cred;
                 }
             }
 
-            // Unknown channels carry more risk than measured ones
-            if (!hasDataForAssignedChannel)
-                contentionPenalty += UnknownChannelPenalty;
+            // Unknown channels carry more risk than measured ones. Faded rather than switched:
+            // a channel measured on thin evidence is part known, and paying the full unknown
+            // penalty for it would erase what we did measure - which is how a radio's worst
+            // channel came to look like its best one once its record aged past the floor.
+            contentionPenalty += UnknownChannelPenalty * (1.0 - assignedCredibility);
 
             // Apply co-channel resolution scaling. TX-retry and interference are pure contention,
             // already counted by the internal weight term, so they scale all the way down to avoid

--- a/tests/NetworkOptimizer.Web.Tests/ChannelPlanCacheTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ChannelPlanCacheTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using NetworkOptimizer.WiFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class ChannelPlanCacheTests
+{
+    private static Dictionary<RadioBand, ChannelPlan> Plan() =>
+        new() { [RadioBand.Band2_4GHz] = new ChannelPlan() };
+
+    private static Dictionary<RadioBand, ChannelPlan> Empty() => new();
+
+    [Fact]
+    public async Task EmptyPlanIsNotCached()
+    {
+        // An empty result means the console was unreachable, not that this site has no plan.
+        // Caching it would pin "channel analysis unavailable" for the whole TTL.
+        var cache = new ChannelPlanCache();
+        var builds = 0;
+
+        var first = await cache.GetOrBuildPlanAsync("site|x", false, () =>
+        {
+            builds++;
+            return Task.FromResult(Empty());
+        });
+        var second = await cache.GetOrBuildPlanAsync("site|x", false, () =>
+        {
+            builds++;
+            return Task.FromResult(Plan());
+        });
+
+        first.Should().BeEmpty();
+        second.Should().NotBeEmpty("the failed attempt must not have been cached");
+        builds.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task NonEmptyPlanIsCached()
+    {
+        var cache = new ChannelPlanCache();
+        var builds = 0;
+
+        for (var i = 0; i < 3; i++)
+            await cache.GetOrBuildPlanAsync("site|x", false, () =>
+            {
+                builds++;
+                return Task.FromResult(Plan());
+            });
+
+        builds.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ForceRefreshRebuilds()
+    {
+        var cache = new ChannelPlanCache();
+        var builds = 0;
+        Task<Dictionary<RadioBand, ChannelPlan>> Build()
+        {
+            builds++;
+            return Task.FromResult(Plan());
+        }
+
+        await cache.GetOrBuildPlanAsync("site|x", false, Build);
+        await cache.GetOrBuildPlanAsync("site|x", true, Build);
+
+        builds.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task DifferentOptionSetsDoNotShareAnEntry()
+    {
+        var cache = new ChannelPlanCache();
+        var builds = 0;
+        Task<Dictionary<RadioBand, ChannelPlan>> Build()
+        {
+            builds++;
+            return Task.FromResult(Plan());
+        }
+
+        await cache.GetOrBuildPlanAsync("site|dfs-include", false, Build);
+        await cache.GetOrBuildPlanAsync("site|dfs-avoid", false, Build);
+
+        builds.Should().Be(2, "pinning an AP or changing DFS is a different question, not a stale answer");
+    }
+
+    [Fact]
+    public async Task InvalidateSiteDropsThatSitesEntries()
+    {
+        var cache = new ChannelPlanCache();
+        var builds = 0;
+        Task<Dictionary<RadioBand, ChannelPlan>> Build()
+        {
+            builds++;
+            return Task.FromResult(Plan());
+        }
+
+        await cache.GetOrBuildPlanAsync("alpha|x", false, Build);
+        await cache.GetOrBuildPlanAsync("beta|x", false, Build);
+        cache.InvalidateSite("alpha");
+        await cache.GetOrBuildPlanAsync("alpha|x", false, Build);
+        await cache.GetOrBuildPlanAsync("beta|x", false, Build);
+
+        builds.Should().Be(3, "only alpha should have been evicted");
+    }
+
+    [Fact]
+    public async Task CallerMutationDoesNotPoisonTheCache()
+    {
+        // Channel Analysis clears this dictionary when the user switches back to Show Current
+        // Channels. That must not empty the shared entry: every later Recommend Best Channels,
+        // and the Dashboard card, would come back empty until the TTL expired.
+        var cache = new ChannelPlanCache();
+        var first = await cache.GetOrBuildPlanAsync("site|x", false, () => Task.FromResult(Plan()));
+
+        first.Clear();
+
+        var second = await cache.GetOrBuildPlanAsync("site|x", false,
+            () => throw new InvalidOperationException("must be served from cache"));
+        second.Should().NotBeEmpty("the caller was given a copy, not the cached instance");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/ChannelPlanCacheTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ChannelPlanCacheTests.cs
@@ -87,26 +87,6 @@ public class ChannelPlanCacheTests
     }
 
     [Fact]
-    public async Task InvalidateSiteDropsThatSitesEntries()
-    {
-        var cache = new ChannelPlanCache();
-        var builds = 0;
-        Task<Dictionary<RadioBand, ChannelPlan>> Build()
-        {
-            builds++;
-            return Task.FromResult(Plan());
-        }
-
-        await cache.GetOrBuildPlanAsync("alpha|x", false, Build);
-        await cache.GetOrBuildPlanAsync("beta|x", false, Build);
-        cache.InvalidateSite("alpha");
-        await cache.GetOrBuildPlanAsync("alpha|x", false, Build);
-        await cache.GetOrBuildPlanAsync("beta|x", false, Build);
-
-        builds.Should().Be(3, "only alpha should have been evicted");
-    }
-
-    [Fact]
     public async Task CallerMutationDoesNotPoisonTheCache()
     {
         // Channel Analysis clears this dictionary when the user switches back to Show Current

--- a/tests/NetworkOptimizer.Web.Tests/WiFiOptimizerServiceDisposalTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/WiFiOptimizerServiceDisposalTests.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// Guards the dependency shape of services that create and dispose DI scopes synchronously.
+/// </summary>
+public class WiFiOptimizerServiceDisposalTests
+{
+    /// <summary>
+    /// <see cref="WiFiOptimizerService"/> creates scopes with IServiceScopeFactory.CreateScope()
+    /// and disposes them synchronously. A scope containing a service that implements only
+    /// IAsyncDisposable throws on synchronous disposal ("type only implements IAsyncDisposable"),
+    /// which does not surface as a DI error - it surfaces as the feature silently failing. Injecting
+    /// MonitoringInfluxClient here did exactly that: propagation loading threw on scope disposal and
+    /// the whole channel analysis reported "unavailable, ensure APs are online".
+    ///
+    /// Take the owning registry instead, which hands back an instance the scope does not own.
+    /// </summary>
+    /// <remarks>
+    /// Targets the scoped registration specifically. The registry is also IAsyncDisposable but is a
+    /// singleton, so it is disposed by the root container and never by one of these scopes - which
+    /// is exactly why it is the safe dependency. Reflection cannot see DI lifetimes, so this names
+    /// the offending type rather than inferring the rule.
+    /// </remarks>
+    [Fact]
+    public void Constructor_DoesNotTakeTheScopedInfluxClient()
+    {
+        var ctor = typeof(WiFiOptimizerService).GetConstructors(
+            BindingFlags.Public | BindingFlags.Instance).Single();
+
+        ctor.GetParameters().Select(p => p.ParameterType)
+            .Should().NotContain(typeof(NetworkOptimizer.Storage.Services.MonitoringInfluxClient),
+                "it is registered scoped and implements only IAsyncDisposable, so a synchronously "
+                + "disposed scope throws; take MonitoringInfluxRegistry instead");
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
@@ -153,13 +153,43 @@ public class ChannelMemoryHelperTests
     }
 
     [Fact]
-    public void MergeLongTermOutcomes_BelowMinSamples_Ignored()
+    public void MergeLongTermOutcomes_JustBelowFloor_AdmittedAtReducedCredibility()
     {
+        // Nearly-there evidence is kept and marked, not discarded: dropping it reverts the channel
+        // to "never measured", where the mild unknown penalty beats a channel known to be mediocre.
         var buckets = new[] { Bucket(1, 20, samples: ChannelMemoryHelper.MinLongTermSamples - 1, util: 50, interf: 40, txRetry: 15) };
+        var credibility = new Dictionary<int, double>();
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 20, Now, credibilityOut: credibility);
+
+        merged.Should().NotBeNull();
+        merged![1].Utilization.Should().BeApproximately(50, 0.001, "the average itself is unchanged");
+        credibility[1].Should().BeInRange(ChannelMemoryHelper.SoftFloorFraction, 1.0);
+        credibility[1].Should().BeLessThan(1.0);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_FarBelowFloor_StillIgnored()
+    {
+        // Genuinely too thin to mean anything - the soft floor is not an open door.
+        var buckets = new[] { Bucket(1, 20, samples: 3, util: 50, interf: 40, txRetry: 15) };
 
         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(null, buckets, currentWidthMhz: 20, Now);
 
         merged.Should().BeNull();
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_FullStrengthEvidence_IsFullyCredible()
+    {
+        var buckets = new[] { Bucket(1, 20, samples: 200, util: 50, interf: 40, txRetry: 15) };
+        var credibility = new Dictionary<int, double>();
+
+        ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 20, Now, credibilityOut: credibility);
+
+        credibility[1].Should().Be(1.0);
     }
 
     [Fact]
@@ -417,13 +447,13 @@ public class ChannelMemoryHelperTests
         // pooled they clear it - which is the whole point of keying on occupied spectrum.
         var buckets = new[]
         {
-            Bucket(149, 80, samples: 8, util: 20, interf: 10, txRetry: 5),
-            Bucket(157, 80, samples: 8, util: 20, interf: 10, txRetry: 5)
+            Bucket(149, 80, samples: 5, util: 20, interf: 10, txRetry: 5),
+            Bucket(157, 80, samples: 5, util: 20, interf: 10, txRetry: 5)
         };
 
         var apart = ChannelMemoryHelper.MergeLongTermOutcomes(
             null, buckets, currentWidthMhz: 80, Now, band: RadioBand.Unknown);
-        apart.Should().BeNull("neither bucket clears the floor on its own");
+        apart.Should().BeNull("neither bucket clears even the soft floor on its own");
 
         var pooled = ChannelMemoryHelper.MergeLongTermOutcomes(
             null, buckets, currentWidthMhz: 80, Now, band: RadioBand.Band5GHz);
@@ -457,8 +487,8 @@ public class ChannelMemoryHelperTests
     {
         var buckets = new[]
         {
-            Bucket(1, 20, samples: 8, util: 20, interf: 10, txRetry: 5),
-            Bucket(6, 20, samples: 8, util: 20, interf: 10, txRetry: 5)
+            Bucket(1, 20, samples: 5, util: 20, interf: 10, txRetry: 5),
+            Bucket(6, 20, samples: 5, util: 20, interf: 10, txRetry: 5)
         };
 
         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
@@ -473,8 +503,8 @@ public class ChannelMemoryHelperTests
         var recent = new Dictionary<int, (double, double, double)> { [153] = (99, 99, 99) };
         var buckets = new[]
         {
-            Bucket(149, 80, samples: 8, util: 20, interf: 10, txRetry: 5),
-            Bucket(157, 80, samples: 8, util: 20, interf: 10, txRetry: 5)
+            Bucket(149, 80, samples: 5, util: 20, interf: 10, txRetry: 5),
+            Bucket(157, 80, samples: 5, util: 20, interf: 10, txRetry: 5)
         };
 
         var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
@@ -520,7 +550,7 @@ public class ChannelMemoryHelperTests
         trusted![1].Utilization.Should().BeApproximately(50, 0.001);
 
         var discounted = ChannelMemoryHelper.MergeLongTermOutcomes(
-            null, buckets, currentWidthMhz: 20, Now, band: RadioBand.Band2_4GHz, historyConfidence: 0.4);
+            null, buckets, currentWidthMhz: 20, Now, band: RadioBand.Band2_4GHz, historyConfidence: 0.2);
         discounted.Should().BeNull("the same evidence must clear a higher bar on a churning band");
     }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelMemoryHelperTests.cs
@@ -407,4 +407,120 @@ public class ChannelMemoryHelperTests
         merged.Should().HaveCount(1);
         merged[0].Neighbors.Should().BeEmpty();
     }
+
+    // --- Span-aware pooling (5/6 GHz bonding groups) ---
+
+    [Fact]
+    public void MergeLongTermOutcomes_5GHz_PoolsSameBondingGroup()
+    {
+        // 149/153/157/161 is one 80 MHz block. Apart, each bucket decays under the floor;
+        // pooled they clear it - which is the whole point of keying on occupied spectrum.
+        var buckets = new[]
+        {
+            Bucket(149, 80, samples: 8, util: 20, interf: 10, txRetry: 5),
+            Bucket(157, 80, samples: 8, util: 20, interf: 10, txRetry: 5)
+        };
+
+        var apart = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 80, Now, band: RadioBand.Unknown);
+        apart.Should().BeNull("neither bucket clears the floor on its own");
+
+        var pooled = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 80, Now, band: RadioBand.Band5GHz);
+        pooled.Should().NotBeNull();
+        pooled!.Keys.Should().Contain(new[] { 149, 153, 157, 161 },
+            "pooled stats must be written back to every control channel the span answers for");
+        pooled[153].Utilization.Should().BeApproximately(20, 0.001);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_5GHz_KeepsDifferentBondingGroupsApart()
+    {
+        var buckets = new[]
+        {
+            Bucket(100, 80, samples: 30, util: 10, interf: 5, txRetry: 2),
+            Bucket(116, 80, samples: 30, util: 60, interf: 40, txRetry: 20)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 80, Now, band: RadioBand.Band5GHz);
+
+        merged.Should().NotBeNull();
+        merged![100].Utilization.Should().BeApproximately(10, 0.001);
+        merged[112].Utilization.Should().BeApproximately(10, 0.001);
+        merged[116].Utilization.Should().BeApproximately(60, 0.001);
+        merged[128].Utilization.Should().BeApproximately(60, 0.001);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_2_4GHz_DoesNotPool()
+    {
+        var buckets = new[]
+        {
+            Bucket(1, 20, samples: 8, util: 20, interf: 10, txRetry: 5),
+            Bucket(6, 20, samples: 8, util: 20, interf: 10, txRetry: 5)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 20, Now, band: RadioBand.Band2_4GHz);
+
+        merged.Should().BeNull("2.4 GHz keys on control channel, so neither clears the floor");
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_RecentStillWinsPerChannelWithinAPooledSpan()
+    {
+        var recent = new Dictionary<int, (double, double, double)> { [153] = (99, 99, 99) };
+        var buckets = new[]
+        {
+            Bucket(149, 80, samples: 8, util: 20, interf: 10, txRetry: 5),
+            Bucket(157, 80, samples: 8, util: 20, interf: 10, txRetry: 5)
+        };
+
+        var merged = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null!, buckets, currentWidthMhz: 80, Now, band: RadioBand.Band5GHz);
+        merged.Should().NotBeNull();
+
+        var withRecent = ChannelMemoryHelper.MergeLongTermOutcomes(
+            recent, buckets, currentWidthMhz: 80, Now, band: RadioBand.Band5GHz);
+        withRecent![153].Should().Be((99d, 99d, 99d), "live data outranks memory on the channel it covers");
+        withRecent[149].Utilization.Should().BeApproximately(20, 0.001);
+    }
+
+    // --- Neighbor-weighted history confidence ---
+
+    [Fact]
+    public void HistoryConfidence_QuietBandTrustsHistoryFully()
+    {
+        ChannelMemoryHelper.HistoryConfidenceFromNeighbors(0).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void HistoryConfidence_FallsAsNeighborLoadRises_AndNeverBelowFloor()
+    {
+        var quiet = ChannelMemoryHelper.HistoryConfidenceFromNeighbors(1);
+        var suburban = ChannelMemoryHelper.HistoryConfidenceFromNeighbors(20);
+        var dense = ChannelMemoryHelper.HistoryConfidenceFromNeighbors(130);
+
+        quiet.Should().BeGreaterThan(suburban);
+        suburban.Should().BeGreaterThan(dense);
+        dense.Should().BeGreaterThan(ChannelMemoryHelper.MinHistoryConfidence);
+        ChannelMemoryHelper.HistoryConfidenceFromNeighbors(100000)
+            .Should().BeApproximately(ChannelMemoryHelper.MinHistoryConfidence, 0.01);
+    }
+
+    [Fact]
+    public void MergeLongTermOutcomes_LowConfidenceRaisesTheEvidenceBar()
+    {
+        var buckets = new[] { Bucket(1, 20, samples: 16, util: 50, interf: 40, txRetry: 15) };
+
+        var trusted = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 20, Now, band: RadioBand.Band2_4GHz, historyConfidence: 1.0);
+        trusted.Should().NotBeNull();
+        trusted![1].Utilization.Should().BeApproximately(50, 0.001);
+
+        var discounted = ChannelMemoryHelper.MergeLongTermOutcomes(
+            null, buckets, currentWidthMhz: 20, Now, band: RadioBand.Band2_4GHz, historyConfidence: 0.4);
+        discounted.Should().BeNull("the same evidence must clear a higher bar on a churning band");
+    }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ChannelRecommendationServiceTests.cs
@@ -2495,4 +2495,30 @@ public class ChannelRecommendationServiceTests
         plan.Recommendations[0].IsSoaking.Should().BeFalse();
         plan.Recommendations[0].SoakEndsAt.Should().BeNull();
     }
+
+    [Fact]
+    public void ScoreAssignment_PooledSpanChargedOnce()
+    {
+        // Span pooling writes one measurement to every control channel in the bonding group, and
+        // they all carry the identical span. The stress penalty sums over overlapping spans, so
+        // without de-duplication the same 80 MHz measurement would be charged four times.
+        var graph = BuildSubjectGraph();
+        var assignment = new[] { (149, 80), (100, 80) };
+        var stress = (40.0, 30.0, 20.0);
+
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, stress }
+        };
+        var single = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        graph.Nodes[0].HistoricalStress = new Dictionary<int, (double, double, double)>
+        {
+            { 149, stress }, { 153, stress }, { 157, stress }, { 161, stress }
+        };
+        var pooled = _service.ScoreAssignment(graph, assignment, RadioBand.Band5GHz);
+
+        pooled.Should().BeApproximately(single, 0.0001,
+            "pooled entries describe one measurement of one span, not four measurements");
+    }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
@@ -9,11 +9,11 @@ public class ClientOutcomeHelperTests
 {
     private static readonly DateTime Day0 = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
 
-    /// <summary>Windows in one signal band, spread across the given number of distinct days.</summary>
+    /// <summary>Windows in one width/signal bucket, spread across the given number of days.</summary>
     private static IEnumerable<ClientRateSample> Band(
-        int channel, int signalBand, int days, int windowsPerDay, double meanMbps) =>
+        int channel, int signalBand, int days, int windowsPerDay, double meanMbps, int width = 80) =>
         Enumerable.Range(0, days).Select(d =>
-            new ClientRateSample(channel, signalBand, Day0.AddDays(d), windowsPerDay, meanMbps));
+            new ClientRateSample(channel, width, signalBand, Day0.AddDays(d), windowsPerDay, meanMbps));
 
     [Fact]
     public void NoSamples_LeavesThresholdAlone()
@@ -98,7 +98,7 @@ public class ClientOutcomeHelperTests
             .ToList();
 
         ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
-        reason.Should().Contain("no overlapping signal bands");
+        reason.Should().Contain("no overlapping width/signal buckets");
     }
 
     [Fact]
@@ -109,6 +109,33 @@ public class ClientOutcomeHelperTests
         var samples = Band(1, -50, days: 5, windowsPerDay: 12, meanMbps: 100)
             .Concat(Band(6, -50, days: 5, windowsPerDay: 12, meanMbps: 130))
             .Concat(Band(6, -85, days: 5, windowsPerDay: 40, meanMbps: 10))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)
+            .Should().Be(ClientOutcomeHelper.ImpetusFactor);
+    }
+
+    [Fact]
+    public void DifferentWidths_AreNotComparedAcross()
+    {
+        // Same signal, but the radio ran 80 MHz on one channel and 40 on the other. Doubling the
+        // width roughly doubles the rate, which would clear the impetus ratio on its own and argue
+        // for a move the spectrum does not justify.
+        var samples = Band(1, -60, days: 5, windowsPerDay: 12, meanMbps: 100, width: 40)
+            .Concat(Band(6, -60, days: 5, windowsPerDay: 12, meanMbps: 200, width: 80))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().Contain("no overlapping width/signal buckets");
+    }
+
+    [Fact]
+    public void SameWidthStillCompares()
+    {
+        // Clients commonly run narrower than the AP, so a narrow bucket is normal data, not noise -
+        // it just has to be compared against the same width on the other channel.
+        var samples = Band(1, -60, days: 5, windowsPerDay: 12, meanMbps: 100, width: 20)
+            .Concat(Band(6, -60, days: 5, windowsPerDay: 12, meanMbps: 130, width: 20))
             .ToList();
 
         ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)

--- a/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
@@ -1,0 +1,110 @@
+using FluentAssertions;
+using NetworkOptimizer.WiFi.Helpers;
+using NetworkOptimizer.WiFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.WiFi.Tests;
+
+public class ClientOutcomeHelperTests
+{
+    /// <summary>One signal band's worth of samples, split across the given number of clients.</summary>
+    private static IEnumerable<ClientRateSample> Band(
+        int channel, int signalBand, int clients, int samplesEach, double meanMbps) =>
+        Enumerable.Range(0, clients).Select(i =>
+            new ClientRateSample(channel, $"aa:bb:cc:00:00:{i:x2}", signalBand, samplesEach, meanMbps));
+
+    [Fact]
+    public void NoSamples_LeavesThresholdAlone()
+    {
+        ClientOutcomeHelper.MoveThresholdFactor(null, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().BeNull();
+    }
+
+    [Fact]
+    public void SameChannel_LeavesThresholdAlone()
+    {
+        var samples = Band(1, -60, clients: 3, samplesEach: 400, meanMbps: 100).ToList();
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 1, out _).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void CandidateOnlyOneChannelKnown_LeavesThresholdAlone()
+    {
+        var samples = Band(1, -60, clients: 3, samplesEach: 400, meanMbps: 100).ToList();
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void CandidateClearlyBetter_LowersTheBar()
+    {
+        var samples = Band(1, -60, clients: 2, samplesEach: 300, meanMbps: 100)
+            .Concat(Band(6, -60, clients: 2, samplesEach: 300, meanMbps: 130))
+            .ToList();
+
+        var factor = ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason);
+
+        factor.Should().Be(ClientOutcomeHelper.ImpetusFactor);
+        reason.Should().Contain("ch 6");
+    }
+
+    [Fact]
+    public void CandidateWorse_RaisesTheBar()
+    {
+        var samples = Band(1, -60, clients: 2, samplesEach: 125, meanMbps: 100)
+            .Concat(Band(6, -60, clients: 2, samplesEach: 125, meanMbps: 80))
+            .ToList();
+
+        var factor = ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason);
+
+        factor.Should().Be(ClientOutcomeHelper.VetoFactor);
+        reason.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void ImpetusNeedsMoreEvidenceThanVeto()
+    {
+        // 250 shared samples: enough to block a move, deliberately not enough to originate one.
+        var samples = Band(1, -60, clients: 2, samplesEach: 125, meanMbps: 100)
+            .Concat(Band(6, -60, clients: 2, samplesEach: 125, meanMbps: 140))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void SingleClientPerChannel_LeavesThresholdAlone()
+    {
+        var samples = Band(1, -60, clients: 1, samplesEach: 600, meanMbps: 100)
+            .Concat(Band(6, -60, clients: 1, samplesEach: 600, meanMbps: 140))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)
+            .Should().Be(1.0, "one chatty device must not speak for a channel");
+    }
+
+    [Fact]
+    public void NoOverlappingSignalBands_LeavesThresholdAlone()
+    {
+        // Near clients on one channel, far clients on the other: a rate difference here would
+        // be reporting where the clients were standing, not which channel is better.
+        var samples = Band(1, -50, clients: 3, samplesEach: 400, meanMbps: 200)
+            .Concat(Band(6, -80, clients: 3, samplesEach: 400, meanMbps: 60))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+    }
+
+    [Fact]
+    public void ComparesWithinSignalBands_NotAcrossThem()
+    {
+        // Candidate wins in every shared band, but carries extra far-away samples that would
+        // drag a naive overall mean below the current channel's.
+        var samples = Band(1, -50, clients: 2, samplesEach: 300, meanMbps: 100)
+            .Concat(Band(6, -50, clients: 2, samplesEach: 300, meanMbps: 130))
+            .Concat(Band(6, -85, clients: 2, samplesEach: 900, meanMbps: 10))
+            .ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)
+            .Should().Be(ClientOutcomeHelper.ImpetusFactor);
+    }
+}

--- a/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/ClientOutcomeHelperTests.cs
@@ -7,38 +7,42 @@ namespace NetworkOptimizer.WiFi.Tests;
 
 public class ClientOutcomeHelperTests
 {
-    /// <summary>One signal band's worth of samples, split across the given number of clients.</summary>
+    private static readonly DateTime Day0 = new(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>Windows in one signal band, spread across the given number of distinct days.</summary>
     private static IEnumerable<ClientRateSample> Band(
-        int channel, int signalBand, int clients, int samplesEach, double meanMbps) =>
-        Enumerable.Range(0, clients).Select(i =>
-            new ClientRateSample(channel, $"aa:bb:cc:00:00:{i:x2}", signalBand, samplesEach, meanMbps));
+        int channel, int signalBand, int days, int windowsPerDay, double meanMbps) =>
+        Enumerable.Range(0, days).Select(d =>
+            new ClientRateSample(channel, signalBand, Day0.AddDays(d), windowsPerDay, meanMbps));
 
     [Fact]
     public void NoSamples_LeavesThresholdAlone()
     {
         ClientOutcomeHelper.MoveThresholdFactor(null, 1, 6, out var reason).Should().Be(1.0);
-        reason.Should().BeNull();
+        reason.Should().Contain("no client history");
     }
 
     [Fact]
     public void SameChannel_LeavesThresholdAlone()
     {
-        var samples = Band(1, -60, clients: 3, samplesEach: 400, meanMbps: 100).ToList();
+        var samples = Band(1, -60, days: 5, windowsPerDay: 20, meanMbps: 100).ToList();
         ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 1, out _).Should().Be(1.0);
     }
 
     [Fact]
-    public void CandidateOnlyOneChannelKnown_LeavesThresholdAlone()
+    public void OnlyOneChannelKnown_LeavesThresholdAlone()
     {
-        var samples = Band(1, -60, clients: 3, samplesEach: 400, meanMbps: 100).ToList();
-        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+        var samples = Band(1, -60, days: 5, windowsPerDay: 20, meanMbps: 100).ToList();
+
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().Contain("candidate ch 6");
     }
 
     [Fact]
     public void CandidateClearlyBetter_LowersTheBar()
     {
-        var samples = Band(1, -60, clients: 2, samplesEach: 300, meanMbps: 100)
-            .Concat(Band(6, -60, clients: 2, samplesEach: 300, meanMbps: 130))
+        var samples = Band(1, -60, days: 5, windowsPerDay: 12, meanMbps: 100)
+            .Concat(Band(6, -60, days: 5, windowsPerDay: 12, meanMbps: 130))
             .ToList();
 
         var factor = ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason);
@@ -50,8 +54,8 @@ public class ClientOutcomeHelperTests
     [Fact]
     public void CandidateWorse_RaisesTheBar()
     {
-        var samples = Band(1, -60, clients: 2, samplesEach: 125, meanMbps: 100)
-            .Concat(Band(6, -60, clients: 2, samplesEach: 125, meanMbps: 80))
+        var samples = Band(1, -60, days: 4, windowsPerDay: 6, meanMbps: 100)
+            .Concat(Band(6, -60, days: 4, windowsPerDay: 6, meanMbps: 80))
             .ToList();
 
         var factor = ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason);
@@ -63,23 +67,25 @@ public class ClientOutcomeHelperTests
     [Fact]
     public void ImpetusNeedsMoreEvidenceThanVeto()
     {
-        // 250 shared samples: enough to block a move, deliberately not enough to originate one.
-        var samples = Band(1, -60, clients: 2, samplesEach: 125, meanMbps: 100)
-            .Concat(Band(6, -60, clients: 2, samplesEach: 125, meanMbps: 140))
+        // 24 shared windows: enough to block a move, deliberately not enough to originate one.
+        var samples = Band(1, -60, days: 4, windowsPerDay: 6, meanMbps: 100)
+            .Concat(Band(6, -60, days: 4, windowsPerDay: 6, meanMbps: 140))
             .ToList();
 
-        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().Contain("inconclusive");
     }
 
     [Fact]
-    public void SingleClientPerChannel_LeavesThresholdAlone()
+    public void EvidenceFromTooFewDays_LeavesThresholdAlone()
     {
-        var samples = Band(1, -60, clients: 1, samplesEach: 600, meanMbps: 100)
-            .Concat(Band(6, -60, clients: 1, samplesEach: 600, meanMbps: 140))
+        // Plenty of windows, but all from a single day - one unusual evening must not decide this.
+        var samples = Band(1, -60, days: 1, windowsPerDay: 80, meanMbps: 100)
+            .Concat(Band(6, -60, days: 1, windowsPerDay: 80, meanMbps: 140))
             .ToList();
 
-        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)
-            .Should().Be(1.0, "one chatty device must not speak for a channel");
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().Contain("too few days");
     }
 
     [Fact]
@@ -87,21 +93,22 @@ public class ClientOutcomeHelperTests
     {
         // Near clients on one channel, far clients on the other: a rate difference here would
         // be reporting where the clients were standing, not which channel is better.
-        var samples = Band(1, -50, clients: 3, samplesEach: 400, meanMbps: 200)
-            .Concat(Band(6, -80, clients: 3, samplesEach: 400, meanMbps: 60))
+        var samples = Band(1, -50, days: 5, windowsPerDay: 20, meanMbps: 200)
+            .Concat(Band(6, -80, days: 5, windowsPerDay: 20, meanMbps: 60))
             .ToList();
 
-        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _).Should().Be(1.0);
+        ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out var reason).Should().Be(1.0);
+        reason.Should().Contain("no overlapping signal bands");
     }
 
     [Fact]
     public void ComparesWithinSignalBands_NotAcrossThem()
     {
-        // Candidate wins in every shared band, but carries extra far-away samples that would
-        // drag a naive overall mean below the current channel's.
-        var samples = Band(1, -50, clients: 2, samplesEach: 300, meanMbps: 100)
-            .Concat(Band(6, -50, clients: 2, samplesEach: 300, meanMbps: 130))
-            .Concat(Band(6, -85, clients: 2, samplesEach: 900, meanMbps: 10))
+        // Candidate wins in the shared band, but carries extra far-away windows that would drag a
+        // naive overall mean below the current channel's.
+        var samples = Band(1, -50, days: 5, windowsPerDay: 12, meanMbps: 100)
+            .Concat(Band(6, -50, days: 5, windowsPerDay: 12, meanMbps: 130))
+            .Concat(Band(6, -85, days: 5, windowsPerDay: 40, meanMbps: 10))
             .ToList();
 
         ClientOutcomeHelper.MoveThresholdFactor(samples, 1, 6, out _)


### PR DESCRIPTION
The channel recommender kept a memory of what it had measured on each channel, but three things stopped that memory from being worth much: it filed bonded 5/6 GHz channels apart even when they described the same spectrum, it trusted a crowded band's stale readings as readily as a quiet one's, and it never looked at what clients actually achieved. This addresses all three, and makes the analysis fast enough to cache.

## Wi-Fi Optimizer - Channels

- **History now follows the spectrum, not the control channel** - At 5/6 GHz a radio on ch 149/80 MHz and one on ch 157/80 MHz occupy the identical block, but their measurements were stored separately, so each half could fall under the evidence threshold that together it clears. Bonded channels now pool. On one test radio this recovered four separate spans, one of them worth nine hundred effective samples.

- **A crowded band's memory counts for less** - Neighbors are what churns, so old readings from a busy band describe a neighborhood that has since moved on. Neighbor load now scales how much evidence a channel needs before its history speaks, weighted by the same signal threshold the interference score already uses, so a neighbor too weak to make a radio defer counts for nothing. Quiet bands are unaffected.

- **Thin evidence fades instead of vanishing** - A channel whose record had aged just below the threshold used to be discarded entirely, which made it look like a channel that had never been measured - and an unknown channel is treated more kindly than one known to be mediocre. That could recommend moving onto a radio's worst channel precisely because it had been forgotten. Weak evidence is now kept at reduced weight.

- **What clients actually got can now block or support a move** - Where InfluxDB is available, the PHY rates clients achieved on the current channel and the candidate adjust how much improvement a move has to promise. Evidence that the candidate is better lowers the bar; evidence it is worse raises it. Supporting a move demands more evidence than blocking one, because a needless channel change costs clients a disruption and a soak period. Comparisons are matched on signal strength and channel width, and only count periods where clients were actually moving traffic - an idle client's rate decays and says nothing about the channel. Without InfluxDB, or without enough history, recommendations are exactly as they were.

- **Recommendations are computed once an hour instead of on every visit** - The analysis is cached per site, and the Refresh button rebuilds it. The card title now says whether you are looking at **Channel Analysis - Current** or **Channel Analysis - Recommended**, the button reads **Recompute** on the recommendation view, and a **Last computed** label shows the plan's real age.

## Fixes

- **Channel analysis could report "unavailable" for an hour after a brief console hiccup** - A failed or partial result is no longer cached, so it recovers as soon as the console does.
