### PR TITLE
Cable Modem Stats: handle Technicolor CGA4233VOO firmware variant

### DIFF
--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -11,10 +11,11 @@ using NetworkOptimizer.Web.Services.Monitoring;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for Technicolor CGA-series gateways (CGA437A, CGA4322DE,
-/// CGA6444VF and relatives) shipped by cable ISPs including VOO and Vodafone.
-/// These expose a JSON API behind the single-page web UI, guarded by a
-/// double-PBKDF2 login and a CSRF token.
+/// Cable modem provider for Technicolor CGA-series gateways (CGA437A, CGA4233VOO,
+/// CGA4322DE, CGA6444VF and relatives) shipped by cable ISPs including VOO and
+/// Vodafone. Two firmware families exist: one serves DOCSIS data at
+/// /api/v1/sta_docsis_status, the other at /api/v1/modem/...; both share the same
+/// double-PBKDF2 login but differ in CSRF token delivery and field naming.
 /// </summary>
 public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
 {
@@ -25,9 +26,11 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     public string DisplayName => "Technicolor CGA Series (HTTP)";
 
     private const string DefaultDocsisPath = "/api/v1/sta_docsis_status";
+    private const string ModemDocsisPath = "/api/v1/modem/exUSTbl,exDSTbl,USTbl,DSTbl,ErrTbl";
     private const string LoginPath = "/api/v1/session/login";
     private const string MenuPath = "/api/v1/session/menu";
     private const string DeviceInfoPath = "/api/v1/sta_device_info";
+    private const string ModelNamePath = "/api/v1/system/ModelName";
 
     private const string SaltRequestPassword = "seeksalthash";
     private const int PbkdfIterations = 1000;
@@ -200,7 +203,17 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
             return null;
         }
 
+        // CGA437A firmware returns the CSRF token in the JSON body. CGA4233 (VOO) firmware
+        // returns it as a Set-Cookie: auth=<value> instead.
         var token = GetJsonString(loginResponse.RootElement, "token") ?? "";
+        if (string.IsNullOrEmpty(token))
+        {
+            var authCookie = cookies.GetCookies(new Uri(baseUrl))
+                .FirstOrDefault(c => c.Name == "auth");
+            if (authCookie != null)
+                token = authCookie.Value;
+        }
+
         var session = new CgaSession(token, cookies, "Technicolor CGA");
 
         using var authedClient = CreateClient(cookies, baseUrl, token);
@@ -266,11 +279,27 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         CancellationToken cancellationToken)
     {
         var baseUrl = BuildBaseUrl(context);
-        var path = string.IsNullOrWhiteSpace(context.StatusPagePath) ? DefaultDocsisPath : context.StatusPagePath;
+        var customPath = !string.IsNullOrWhiteSpace(context.StatusPagePath);
+        var path = customPath ? context.StatusPagePath! : DefaultDocsisPath;
 
         using var client = CreateClient(session.Cookies, baseUrl, session.Token);
 
-        // The web UI cache-busts every read; without it some firmware serves a stale payload.
+        var doc = await FetchJsonAsync(client, baseUrl, path, context.Name, cancellationToken);
+
+        // CGA4233 firmware uses /api/v1/modem/... instead of sta_docsis_status.
+        if (doc == null && !customPath)
+            doc = await FetchJsonAsync(client, baseUrl, ModemDocsisPath, context.Name, cancellationToken);
+
+        return doc;
+    }
+
+    private async Task<JsonDocument?> FetchJsonAsync(
+        HttpClient client,
+        string baseUrl,
+        string path,
+        string name,
+        CancellationToken cancellationToken)
+    {
         var separator = path.Contains('?') ? '&' : '?';
         var url = $"{baseUrl}{path}{separator}_={DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture)}";
 
@@ -280,7 +309,8 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
             if (!response.IsSuccessStatusCode)
             {
                 _logger.LogDebug(
-                    "Technicolor CGA {Name}: DOCSIS request returned {Status}", context.Name, response.StatusCode);
+                    "Technicolor CGA {Name}: DOCSIS request to {Path} returned {Status}",
+                    name, path, response.StatusCode);
                 return null;
             }
 
@@ -292,7 +322,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
             var error = GetJsonString(document.RootElement, "error");
             if (!string.IsNullOrEmpty(error) && !error.Equals("ok", StringComparison.OrdinalIgnoreCase))
             {
-                _logger.LogDebug("Technicolor CGA {Name}: DOCSIS request returned error {Error}", context.Name, error);
+                _logger.LogDebug("Technicolor CGA {Name}: DOCSIS request returned error {Error}", name, error);
                 document.Dispose();
                 return null;
             }
@@ -301,7 +331,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         }
         catch (HttpRequestException ex)
         {
-            _logger.LogDebug(ex, "Technicolor CGA {Name}: DOCSIS request failed", context.Name);
+            _logger.LogDebug(ex, "Technicolor CGA {Name}: DOCSIS request to {Path} failed", name, path);
             return null;
         }
     }
@@ -312,23 +342,32 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         string fallback,
         CancellationToken cancellationToken)
     {
+        var model = await TryReadModelFromPath(client, baseUrl + DeviceInfoPath, cancellationToken)
+                    ?? await TryReadModelFromPath(client, baseUrl + ModelNamePath, cancellationToken);
+
+        if (string.IsNullOrWhiteSpace(model))
+            return fallback;
+
+        return model.StartsWith("Technicolor", StringComparison.OrdinalIgnoreCase) ? model : $"Technicolor {model}";
+    }
+
+    private static async Task<string?> TryReadModelFromPath(
+        HttpClient client, string url, CancellationToken cancellationToken)
+    {
         try
         {
-            var body = await client.GetStringAsync(baseUrl + DeviceInfoPath, cancellationToken);
+            var body = await client.GetStringAsync(url, cancellationToken);
             using var document = TryParseJson(body);
             if (document == null)
-                return fallback;
+                return null;
 
             var root = document.RootElement.TryGetProperty("data", out var data) ? data : document.RootElement;
-            var model = GetJsonString(root, "modelName") ?? GetJsonString(root, "model");
-            if (string.IsNullOrWhiteSpace(model))
-                return fallback;
-
-            return model.StartsWith("Technicolor", StringComparison.OrdinalIgnoreCase) ? model : $"Technicolor {model}";
+            return GetJsonString(root, "modelName") ?? GetJsonString(root, "model")
+                ?? GetJsonString(root, "ModelName");
         }
         catch (HttpRequestException)
         {
-            return fallback;
+            return null;
         }
     }
 
@@ -345,43 +384,45 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         // Channel arrays live under "data" on current firmware and at the root on older builds.
         var data = root.TryGetProperty("data", out var wrapped) ? wrapped : root;
 
-        foreach (var channel in EnumerateArray(data, "downstream"))
+        // CGA437A uses downstream/ofdm_downstream/upstream/ofdma_upstream.
+        // CGA4233 (VOO) uses DSTbl/exDSTbl/USTbl/exUSTbl.
+        foreach (var channel in EnumerateFirstArray(data, "downstream", "DSTbl"))
         {
             stats.DownstreamChannels.Add(new DsChannel
             {
-                ChannelId = (int)GetNumber(channel, "channelid"),
+                ChannelId = (int)GetNumber(channel, "channelid", "ChannelID"),
                 LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
                 Modulation = GetString(channel, "FFT", "Modulation"),
-                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
-                Power = ParseLevel(GetString(channel, "power")),
-                Snr = ParseSnr(GetString(channel, "SNR")),
+                Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency", "Frequency")),
+                Power = ParseLevel(GetString(channel, "power", "PowerLevel")),
+                Snr = ParseSnr(GetString(channel, "SNR", "SNRLevel")),
                 Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
                 Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
             });
         }
 
-        foreach (var channel in EnumerateArray(data, "ofdm_downstream"))
+        foreach (var channel in EnumerateFirstArray(data, "ofdm_downstream", "exDSTbl"))
         {
             var modulation = GetString(channel, "FFT_ofdm", "FFT");
             stats.DownstreamChannels.Add(new DsChannel
             {
-                ChannelId = (int)GetNumber(channel, "channelid_ofdm", "channelid"),
+                ChannelId = (int)GetNumber(channel, "channelid_ofdm", "channelid", "ChannelID"),
                 LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
                 Modulation = string.IsNullOrWhiteSpace(modulation) ? "OFDM" : modulation,
                 Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency_ofdm", "CentralFrequency")),
-                Power = ParseLevel(GetString(channel, "power_ofdm", "power")),
-                Snr = ParseSnr(GetString(channel, "SNR_ofdm", "SNR")),
+                Power = ParseLevel(GetString(channel, "power_ofdm", "power", "PowerLevel")),
+                Snr = ParseSnr(GetString(channel, "SNR_ofdm", "SNR", "SNRLevel")),
                 Correctables = (long)GetNumber(channel, "CorrectableCodewords", "Correcteds", "corrError"),
                 Uncorrectables = (long)GetNumber(channel, "UncorrectableCodewords", "Uncorrectables", "nonCorrError"),
             });
         }
 
-        foreach (var channel in EnumerateArray(data, "upstream"))
+        foreach (var channel in EnumerateFirstArray(data, "upstream", "USTbl"))
         {
             stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: null));
         }
 
-        foreach (var channel in EnumerateArray(data, "ofdma_upstream"))
+        foreach (var channel in EnumerateFirstArray(data, "ofdma_upstream", "exUSTbl"))
         {
             stats.UpstreamChannels.Add(BuildUpstream(channel, defaultType: "OFDMA"));
         }
@@ -397,28 +438,31 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
 
         return new UsChannel
         {
-            ChannelId = (int)GetNumber(channel, "channelidup", "channelid"),
+            ChannelId = (int)GetNumber(channel, "channelidup", "channelid", "ChannelID"),
             LockStatus = NormalizeLockStatus(GetString(channel, "locked", "LockStatus")),
             ChannelType = type,
-            Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency")),
-            Power = ParseLevel(GetString(channel, "power")),
+            Frequency = ParseFrequencyHz(GetString(channel, "CentralFrequency", "Frequency")),
+            Power = ParseLevel(GetString(channel, "power", "PowerLevel")),
             SymbolRate = (long)GetNumber(channel, "SymbolRate", "symbolrate"),
         };
     }
 
-    private static IEnumerable<JsonElement> EnumerateArray(JsonElement parent, string name)
+    private static IEnumerable<JsonElement> EnumerateFirstArray(JsonElement parent, params string[] names)
     {
-        if (parent.ValueKind != JsonValueKind.Object ||
-            !parent.TryGetProperty(name, out var array) ||
-            array.ValueKind != JsonValueKind.Array)
-        {
+        if (parent.ValueKind != JsonValueKind.Object)
             yield break;
-        }
 
-        foreach (var element in array.EnumerateArray())
+        foreach (var name in names)
         {
-            if (element.ValueKind == JsonValueKind.Object)
-                yield return element;
+            if (parent.TryGetProperty(name, out var array) && array.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in array.EnumerateArray())
+                {
+                    if (element.ValueKind == JsonValueKind.Object)
+                        yield return element;
+                }
+                yield break;
+            }
         }
     }
 

--- a/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/TechnicolorCgaProviderTests.cs
@@ -193,4 +193,96 @@ public class TechnicolorCgaProviderTests
         stats.DeviceName.Should().Be("Cable Modem");
         stats.DeviceModel.Should().Be("Technicolor CGA437A");
     }
+
+    // --- CGA4233 VOO firmware shape: /api/v1/modem/exUSTbl,exDSTbl,USTbl,DSTbl,ErrTbl ---
+
+    // Reproduces the actual response from a CGA4233VOO captured in a HAR trace. Uses
+    // DSTbl/exDSTbl/USTbl/exUSTbl array names and ChannelID/Frequency/PowerLevel/SNRLevel
+    // field names with unit suffixes.
+    private const string Cga4233Payload = """
+        {
+          "error": "ok",
+          "data": {
+            "exUSTbl": [],
+            "exDSTbl": [
+              {"__id":"1","ChannelID":"162","CentralFrequency":"190.487503 MHz","PowerLevel":"6.6 dBmV","SNRLevel":"41.3 dB","FFT":"","LockStatus":"Locked","ChannelType":"OFDM"}
+            ],
+            "USTbl": [
+              {"__id":"1","ChannelID":"1","Frequency":"50.7 MHz","PowerLevel":"42.3 dBmV","ChannelType":"SC-QAM","SymbolRate":"5120000","Modulation":"32-qam","LockStatus":"Locked"},
+              {"__id":"2","ChannelID":"2","Frequency":"57.2 MHz","PowerLevel":"42.3 dBmV","ChannelType":"SC-QAM","SymbolRate":"5120000","Modulation":"32-qam","LockStatus":"Locked"}
+            ],
+            "DSTbl": [
+              {"__id":"1","ChannelID":"4","Frequency":"474 MHz","PowerLevel":"2.1 dBmV","SNRLevel":"37.1 dB","Modulation":"256-QAM","Correcteds":"507162","Uncorrectables":"13099","LockStatus":"Locked","ChannelType":"SC-QAM"},
+              {"__id":"2","ChannelID":"1","Frequency":"450 MHz","PowerLevel":"2.5 dBmV","SNRLevel":"36.9 dB","Modulation":"256-QAM","Correcteds":"547780","Uncorrectables":"5943","LockStatus":"Locked","ChannelType":"SC-QAM"}
+            ],
+            "ErrTbl": []
+          }
+        }
+        """;
+
+    [Fact]
+    public void ParseDocsis_Cga4233_ParsesDownstreamFromDSTbl()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(Cga4233Payload), Context(), "Technicolor CGA4233VOO");
+
+        stats.DownstreamChannels.Should().HaveCount(3);
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(4);
+        first.LockStatus.Should().Be("Locked");
+        first.Modulation.Should().Be("256-QAM");
+        first.Frequency.Should().Be(474_000_000);
+        first.Power.Should().Be(2.1);
+        first.Snr.Should().Be(37.1);
+        first.Correctables.Should().Be(507162);
+        first.Uncorrectables.Should().Be(13099);
+    }
+
+    [Fact]
+    public void ParseDocsis_Cga4233_ParsesOfdmFromExDSTbl()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(Cga4233Payload), Context(), "Technicolor CGA4233VOO");
+
+        var ofdm = stats.DownstreamChannels[2];
+        ofdm.ChannelId.Should().Be(162);
+        ofdm.Modulation.Should().Be("OFDM");
+        ofdm.Frequency.Should().Be(190_487_503);
+        ofdm.Power.Should().Be(6.6);
+        ofdm.Snr.Should().Be(41.3);
+    }
+
+    [Fact]
+    public void ParseDocsis_Cga4233_ParsesUpstreamFromUSTbl()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(Cga4233Payload), Context(), "Technicolor CGA4233VOO");
+
+        stats.UpstreamChannels.Should().HaveCount(2);
+
+        var first = stats.UpstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.ChannelType.Should().Be("SC-QAM");
+        first.Frequency.Should().Be(50_700_000);
+        first.Power.Should().Be(42.3);
+        first.SymbolRate.Should().Be(5_120_000);
+    }
+
+    [Fact]
+    public void ParseDocsis_Cga4233_PopulatesAggregates()
+    {
+        var stats = TechnicolorCgaProvider.ParseDocsis(Payload(Cga4233Payload), Context(), "Technicolor CGA4233VOO");
+
+        stats.LockedDsChannels.Should().Be(3);
+        stats.LockedUsChannels.Should().Be(2);
+        stats.DownstreamPowerAvgDbmv.Should().BeApproximately(3.733, 0.001);
+        stats.UpstreamPowerAvgDbmv.Should().Be(42.3);
+    }
+
+    [Theory]
+    [InlineData("474 MHz", 474_000_000)]
+    [InlineData("50.7 MHz", 50_700_000)]
+    [InlineData("190.487503 MHz", 190_487_503)]
+    public void ParseFrequencyHz_HandlesUnitSuffix(string raw, long expected)
+    {
+        TechnicolorCgaProvider.ParseFrequencyHz(raw).Should().Be(expected);
+    }
 }


### PR DESCRIPTION
## Summary

The Technicolor CGA provider was built against the CGA437A firmware's API shape (`/api/v1/sta_docsis_status`). The CGA4233VOO (shipped by VOO in Belgium) uses a different firmware family with a different DOCSIS endpoint, field naming, CSRF token delivery, and model name API. The provider now handles both transparently.

## Cable Modem Stats

- **CGA4233VOO DOCSIS endpoint** - tries the existing `sta_docsis_status` path first, falls back to `/api/v1/modem/exUSTbl,exDSTbl,USTbl,DSTbl,ErrTbl` when the primary returns nothing
- **Alternate field names** - the CGA4233 firmware uses `ChannelID`/`Frequency`/`PowerLevel`/`SNRLevel` (with unit suffixes like `"474 MHz"`) instead of `channelid`/`CentralFrequency`/`power`/`SNR`; added as fallbacks throughout the parser
- **CSRF token from cookie** - CGA437A returns the token in the login JSON body; CGA4233 returns it as a `Set-Cookie: auth=<value>` instead. Falls back to reading the auth cookie when the JSON field is absent
- **Model name endpoint** - falls back to `/api/v1/system/ModelName` when `sta_device_info` is unavailable

## Test plan

- [x] Existing 23 Technicolor CGA tests pass (CGA437A payload shape)
- [x] 7 new tests covering CGA4233VOO payload shape (DSTbl, exDSTbl, USTbl, aggregates, frequency unit suffixes)
- [x] 0 build warnings
- [ ] Requester verifies on their CGA4233VOO