### PR TITLE
Never redirect to HTTPS while the agent tunnel is listening

### DIFF
--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -3,7 +3,10 @@
 
 param(
     [string]$Configuration = "Release",
-    [string]$OutputDir = "$PSScriptRoot\..\publish"
+    [string]$OutputDir = "$PSScriptRoot\..\publish",
+    # Stamps the build explicitly instead of deriving it from the nearest tag. Needed to rebuild an
+    # already-released version without moving its tag, which would retrigger the release pipeline.
+    [string]$Version
 )
 
 $ErrorActionPreference = "Stop"
@@ -13,21 +16,23 @@ $WebProject = Join-Path $RepoRoot "src\NetworkOptimizer.Web\NetworkOptimizer.Web
 $InstallerProject = Join-Path $RepoRoot "src\NetworkOptimizer.Installer\NetworkOptimizer.Installer.wixproj"
 $PublishDir = Join-Path $RepoRoot "src\NetworkOptimizer.Web\bin\Release\net10.0\win-x64\publish"
 
-# Get version from git tags (MinVer style)
-Push-Location $RepoRoot
-try {
-    $gitDescribe = git describe --tags --abbrev=0 2>$null
-    if ($gitDescribe) {
-        $Version = $gitDescribe -replace '^v', ''
-    } else {
-        # Fallback: count commits for version
-        $commitCount = git rev-list --count HEAD 2>$null
-        $Version = "0.0.$commitCount"
+# Get version from git tags (MinVer style) unless one was passed in
+if (-not $Version) {
+    Push-Location $RepoRoot
+    try {
+        $gitDescribe = git describe --tags --abbrev=0 2>$null
+        if ($gitDescribe) {
+            $Version = $gitDescribe -replace '^v', ''
+        } else {
+            # Fallback: count commits for version
+            $commitCount = git rev-list --count HEAD 2>$null
+            $Version = "0.0.$commitCount"
+        }
+    } catch {
+        $Version = "0.0.0"
     }
-} catch {
-    $Version = "0.0.0"
+    Pop-Location
 }
-Pop-Location
 
 Write-Host "=== Building Network Optimizer Windows Installer ===" -ForegroundColor Cyan
 Write-Host ""

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -688,7 +688,7 @@
                     else if (_recentWanTests.Count == 0)
                     {
                         <div class="empty-state">
-                            <p>No WAN speed tests yet</p>
+                            <p>No recent WAN speed tests</p>
                         </div>
                     }
                     else
@@ -725,7 +725,7 @@
                     else if (_recentSpeedTests.Count == 0)
                     {
                         <div class="empty-state">
-                            <p>No speed tests yet</p>
+                            <p>No recent speed tests</p>
                         </div>
                     }
                     else

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3591,7 +3591,8 @@
                                                                                 <button class="btn btn-sm btn-secondary"
                                                                                         @onclick="() => ToggleUpgradeCommand(agent.Id)"
                                                                                         data-tooltip="Show the upgrade one-liner">
-                                                                                    @(_upgradeCommandAgentId == agent.Id ? "Hide command" : "Upgrade command")
+                                                                                    <span class="btn-label-full">@(_upgradeCommandAgentId == agent.Id ? "Hide command" : "Upgrade command")</span>
+                                                                                    <span class="btn-label-compact">@(_upgradeCommandAgentId == agent.Id ? "Hide" : "Upgrade")</span>
                                                                                 </button>
                                                                             }
                                                                         }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3493,7 +3493,7 @@
                                             }
                                             else if (!site.Enabled)
                                             {
-                                                <span class="status-badge">Disabled</span>
+                                                <span class="status-badge badge-muted">Disabled</span>
                                             }
                                             else
                                             {

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -75,7 +75,7 @@ else
                     <h3 class="site-card-name">@site.Name</h3>
                     @if (isCurrent)
                     {
-                        <span class="status-badge status-connected">Current</span>
+                        <span class="status-badge status-info">Current</span>
                     }
                 </div>
                 @if (ConsoleHost(site.Id) is { Length: > 0 } host)

--- a/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sites.razor
@@ -88,7 +88,7 @@ else
                     {
                         <span class="status-badge">Default</span>
                     }
-                    @if (LicenseState.GetStatus(site.Slug) is { } licenseStatus)
+                    @if (LicenseState.GetStatus(site.Slug) is { State: not SiteLicenseState.FreeTier } licenseStatus)
                     {
                         <span class="status-badge @LicenseBadgeClass(licenseStatus)" data-tooltip="@LicenseBadgeTooltip(licenseStatus)">@LicenseBadgeLabel(licenseStatus)</span>
                     }

--- a/src/NetworkOptimizer.Web/Endpoints/ApLocationEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/ApLocationEndpoints.cs
@@ -1,29 +1,6 @@
-using ApexCharts;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.EntityFrameworkCore;
-using NetworkOptimizer.Audit;
-using NetworkOptimizer.Audit.Analyzers;
-using NetworkOptimizer.Audit.Services;
-using NetworkOptimizer.Core.Helpers;
-using NetworkOptimizer.Monitoring.Providers;
-using NetworkOptimizer.Storage.Models;
-using NetworkOptimizer.UniFi;
-using NetworkOptimizer.Web;
-using NetworkOptimizer.Web.Endpoints;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Authorization;
-using NetworkOptimizer.Web.Services.Gates;
-using NetworkOptimizer.Web.Services.Identity;
-using NetworkOptimizer.Web.Services.CableModemProviders;
-using NetworkOptimizer.Web.Services.Licensing;
-using NetworkOptimizer.Web.Services.OntProviders;
-using NetworkOptimizer.Web.Services.Ssh;
-using NetworkOptimizer.WiFi.Models;
-using Serilog;
-using Serilog.Events;
 
 namespace NetworkOptimizer.Web.Endpoints;
 
@@ -50,9 +27,8 @@ public static class ApLocationEndpoints
             return Results.Ok(locations);
         });
 
-        // Through the gated service, not the DbContext: it carries the Site Operator gate the
-        // Signal Map's own editing uses, and it resolves the SITE's database - injecting the
-        // context here wrote a managed site's placements into the main install's.
+        // Through the gated service, not the DbContext: the service carries the Site Operator
+        // gate, the same one the Signal Map's editing uses.
         admin.MapPut("/api/ap-locations/{mac}", async (string mac, HttpContext context, IApMapAdminService apMap) =>
         {
             var request = await context.Request.ReadFromJsonAsync<ApLocationRequest>();

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1282,7 +1282,13 @@ if (!string.IsNullOrEmpty(canonicalHost))
 // Only use HTTPS redirection if not in Docker/container (check for DOTNET_RUNNING_IN_CONTAINER)
 if (!string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), "true", StringComparison.OrdinalIgnoreCase))
 {
-    app.UseHttpsRedirection();
+    // Not while the agent tunnel is up. Its TLS listener is the only HTTPS endpoint on the server,
+    // so the redirect middleware adopts that port and sends every request to an HTTP/2-only gRPC
+    // listener holding a self-signed cert. The tunnel binds only when the app itself is HTTP-only
+    // (ResolveHttpBindings rejects an https URL), so there is never a correct port to redirect to.
+    if (!agentTunnelEnabled)
+        app.UseHttpsRedirection();
+
     app.UseHsts();
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3012,6 +3012,12 @@ select.form-control {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
+    z-index: 1;
+    /* The pre this sits over is an async-scrolled composited layer on iOS, which paints across an
+       unpromoted sibling whatever the paint order says. Never drop the transform: on a phone the
+       button then renders invisible - present, hit-testable, and not drawn. */
+    will-change: transform;
+    transform: translateZ(0);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -19395,6 +19401,17 @@ body.kiosk-mode .status-indicators {
     /* Square along the top so the panel reads as an extension of the row that opened it, rather
        than a separate card floating below it. */
     border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
+}
+
+/* .data-table holds a 500px floor, so on a phone this row runs past the wrapper's visible width
+   into its scroll overflow, taking anything at its right edge - the command copy buttons - with
+   it. Capped to the scroller's own inline size instead. */
+.table-responsive:has(> .sites-table) {
+    container-type: inline-size;
+}
+
+.site-config-row .site-config-panel {
+    max-width: 100cqw;
 }
 
 .site-config-section {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19400,8 +19400,10 @@ body.kiosk-mode .status-indicators {
         border-bottom: 0;
     }
 
-    .sites-table > tbody > tr:not(.site-config-row) > td:first-child {
-        flex: 1;
+    .sites-table > tbody > tr:not(.site-config-row) > td:not(:last-child) {
+        flex: 1 1 0;
+        min-width: 0;
+        overflow-wrap: anywhere;
     }
 
     .sites-table > tbody > tr:not(.site-config-row) > td:last-child {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19406,6 +19406,12 @@ body.kiosk-mode .status-indicators {
         overflow-wrap: anywhere;
     }
 
+    /* Status is a badge or a dot and a word, so it takes what it needs and the name and site ID
+       split the rest. */
+    .sites-table > tbody > tr:not(.site-config-row) > td:nth-last-child(2) {
+        flex: 0 0 auto;
+    }
+
     .sites-table > tbody > tr:not(.site-config-row) > td:last-child {
         flex-basis: 100%;
         padding-top: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19367,6 +19367,49 @@ body.kiosk-mode .status-indicators {
 .sites-table th:nth-child(4) { width: 8%; }
 .sites-table th:nth-child(5) { width: 41%; }
 
+@media (max-width: 768px) {
+    .table-responsive:has(> .sites-table) {
+        margin: 0 -0.25rem;
+    }
+
+    /* Each site reads as two lines on a phone - its columns, then its buttons across the full
+       width - so the cells size to their content and the header, the fixed layout and the 500px
+       floor all stop applying. One row still means one bottom border, so the two lines read as a
+       single record. */
+    .sites-table,
+    .sites-table > tbody,
+    .sites-table > tbody > tr.site-config-row,
+    .sites-table > tbody > tr.site-config-row > td {
+        display: block;
+        min-width: 0;
+    }
+
+    .sites-table > thead {
+        display: none;
+    }
+
+    .sites-table > tbody > tr:not(.site-config-row) {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .sites-table > tbody > tr:not(.site-config-row) > td {
+        padding: 0.75rem 0.5rem;
+        border-bottom: 0;
+    }
+
+    .sites-table > tbody > tr:not(.site-config-row) > td:first-child {
+        flex: 1;
+    }
+
+    .sites-table > tbody > tr:not(.site-config-row) > td:last-child {
+        flex-basis: 100%;
+        padding-top: 0;
+    }
+}
+
 /* Created is hidden below 768px, so its share is redistributed rather than left as a gap. */
 @media (max-width: 768px) {
     .sites-table th:nth-child(1) { width: 28%; }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3012,7 +3012,6 @@ select.form-control {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
-    z-index: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -19396,18 +19395,6 @@ body.kiosk-mode .status-indicators {
     /* Square along the top so the panel reads as an extension of the row that opened it, rather
        than a separate card floating below it. */
     border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
-}
-
-/* The table holds a 500px floor, so on a phone the panel row extends into the wrapper's scroll
-   overflow and carries anything at its right edge - the command copy buttons - off screen. */
-.table-responsive:has(> .sites-table) {
-    container-type: inline-size;
-}
-
-.site-config-row .site-config-panel {
-    position: sticky;
-    left: 0;
-    max-width: 100cqw;
 }
 
 .site-config-section {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2311,6 +2311,10 @@ a.stat-card-link:active {
     color: var(--info-color);
 }
 
+.status-badge.badge-muted {
+    color: var(--text-muted);
+}
+
 .status-badge.badge-agent {
     background: rgba(100, 116, 139, 0.2);
     color: var(--text-secondary);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19141,6 +19141,7 @@ body.kiosk-mode .status-indicators {
     font-family: monospace;
     font-size: 0.8rem;
     color: var(--text-muted);
+    margin-right: auto;
 }
 
 .site-card-footer {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2277,6 +2277,7 @@ a.stat-card-link:active {
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
+    background-color: var(--bg-elevated);
     padding: 0.25rem 0.75rem;
     border-radius: var(--border-radius-lg);
     font-size: 0.75rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3012,6 +3012,7 @@ select.form-control {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
+    z-index: 1;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -3034,14 +3035,6 @@ select.form-control {
 .code-copy-btn svg {
     width: 0.95rem;
     height: 0.95rem;
-}
-
-/* Capped on a phone: the block sits inside containers that size to their content, and without a
-   cap it grows past the viewport, taking the copy button off-screen with it. */
-@media (max-width: 768px) {
-    .code-copy-block {
-        max-width: 78vw;
-    }
 }
 
 .account-copy-btn {
@@ -19403,6 +19396,18 @@ body.kiosk-mode .status-indicators {
     /* Square along the top so the panel reads as an extension of the row that opened it, rather
        than a separate card floating below it. */
     border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
+}
+
+/* The table holds a 500px floor, so on a phone the panel row extends into the wrapper's scroll
+   overflow and carries anything at its right edge - the command copy buttons - off screen. */
+.table-responsive:has(> .sites-table) {
+    container-type: inline-size;
+}
+
+.site-config-row .site-config-panel {
+    position: sticky;
+    left: 0;
+    max-width: 100cqw;
 }
 
 .site-config-section {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -3036,6 +3036,14 @@ select.form-control {
     height: 0.95rem;
 }
 
+/* Capped on a phone: the block sits inside containers that size to their content, and without a
+   cap it grows past the viewport, taking the copy button off-screen with it. */
+@media (max-width: 768px) {
+    .code-copy-block {
+        max-width: 78vw;
+    }
+}
+
 .account-copy-btn {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
## UniFi Console Connection

- **Multi-site no longer makes the app unreachable on native installs** - enabling multi-site brought up the agent tunnel's TLS listener, which on a native install is the only HTTPS endpoint the server has. ASP.NET's HTTPS redirection takes its target port from the server's own addresses when exactly one is HTTPS, so it adopted the tunnel port and sent every request to an HTTP/2-only gRPC listener behind a self-signed cert. Reverse-proxied installs were hit too, not just direct access: forwarded headers are only honoured when `TRUSTED_PROXIES` is set, so without it the app sees `http` and redirects regardless of what the proxy terminated. Docker and Proxmox were never affected - the container check already skipped redirection - and single-site installs never bind the tunnel.

  Redirection is now skipped whenever the tunnel is listening. That is exact rather than defensive: the tunnel only binds when the app's own bindings are HTTP-only, so a listening tunnel guarantees there was never a correct port to redirect to. HSTS is untouched, and canonical host enforcement is a separate middleware that was never involved.

## Multi-Site

- **Site rows read as two lines on a phone** - the actions cell carries up to three buttons and was squeezing the columns beside it. Below 768px each row lays out as a flex container with the buttons on their own full-width line, as a row rather than a stack. Name, Site ID and status share the line above, with status taking only what it needs. Desktop is unchanged.
- **Badges sit to the right on each site card**, and **Current** takes the blue rather than the green - it marks which site you are on, not a health state.
- **Disabled** is muted in the sites table, and the **Free tier** badge is gone from the site cards - it marked the ordinary case on every card and said nothing.
- **The Upgrade command button fits on a phone** - it shows **Upgrade** / **Hide** below 768px and keeps its full wording on desktop.

## Dashboard

- **The speed test cards say no recent tests, not none yet** - both cards list a recent window rather than all history, so an install with older results was being told it had never run one.

## Fixes

- **The copy button on command blocks is visible on a phone** - the sites table holds a 500px floor inside a horizontal scroller, so the expanded config row ran past the screen and took the button into the scroll overflow with it. On iOS it was then painted underneath the command block's own composited scroll layer. Capping the panel to the scroller's width and promoting the button to its own layer fixes both; confirmed on-device.
- **Plain status badges have a surface** - badges with no colour variant (Default, Disabled, Free tier, SSH Required, schedule run status) were rendering as bare text next to the coloured ones.


## Build

- `scripts/build-installer.ps1` takes an optional `-Version` so an already-released MSI can be rebuilt without moving its tag. Omitted, it behaves exactly as before.
