### PR TITLE
Per-WAN Agent vantages for WAN speed tests

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2420,6 +2420,10 @@
             _agentVantages = _wanTestViaAgent
                 ? await AgentVantages.ListVantagesAsync(SiteContext.Slug)
                 : new List<AgentWanVantage>();
+            // First entry is a WAN, so a schedule made without touching the field measures one
+            // rather than the unpinned path.
+            if (_agentVantages.Count > 0 && string.IsNullOrEmpty(_newAgentVantage))
+                _newAgentVantage = _agentVantages[0].ContextId?.ToString() ?? "";
         }
         catch
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1996,7 +1996,7 @@
                     @if (_newWanTestType == "server" && _agentVantages.Count > 0)
                     {
                         <div class="form-group schedule-field">
-                            <label>WAN</label>
+                            <label>WAN / Path</label>
                             <select class="form-control" @bind="_newAgentVantage">
                                 @foreach (var vantage in _agentVantages)
                                 {
@@ -3212,8 +3212,8 @@
                     config["wanName"] = vantage.Label;
                 }
                 // The WAN goes in the name the way the gateway test does, so the row reads the same
-                // whichever runs it. Unnamed means the primary WAN, which is what a single-WAN site
-                // and every schedule made before this always meant.
+                // whichever runs it. Unnamed means the default path, which is what a single-WAN
+                // site and every schedule made before this always meant.
                 var wanLabel = vantage?.ContextId != null ? $", {vantage.Label}" : "";
                 var loadLabel = _newWanMaxMode ? ", Max Load" : "";
                 taskName = $"WAN Speed Test (Server{wanLabel}{loadLabel})";
@@ -3456,8 +3456,8 @@
                     config["wanName"] = vantage.Label;
                 }
                 // The WAN goes in the name the way the gateway test does, so the row reads the same
-                // whichever runs it. Unnamed means the primary WAN, which is what a single-WAN site
-                // and every schedule made before this always meant.
+                // whichever runs it. Unnamed means the default path, which is what a single-WAN
+                // site and every schedule made before this always meant.
                 var wanLabel = vantage?.ContextId != null ? $", {vantage.Label}" : "";
                 var loadLabel = _newWanMaxMode ? ", Max Load" : "";
                 taskName = $"WAN Speed Test (Server{wanLabel}{loadLabel})";

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1757,7 +1757,7 @@
                 <div>
                     <h4 class="event-type-group-header">On-Site Agent</h4>
                     <div class="event-type-key-list">
-                        <div @onclick='() => SelectEventType("agent.offline")'><code>agent.offline</code> <span>Site agent offline past the grace period</span></div>
+                        <div @onclick='() => SelectEventType("agent.offline")'><code>agent.offline</code> <span>Site Agent offline past the grace period</span></div>
                         <div @onclick='() => SelectEventType("agent.reconnected")'><code>agent.reconnected</code> <span>Site agent came back online</span></div>
                     </div>
                 </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -3385,7 +3385,13 @@
             ? UtcToLocalTimeOnly(task.CustomMorningHour.Value, task.CustomMorningMinute ?? 0)
             : new TimeOnly(6, 0);
 
-        _newAgentVantage = GetConfigValue(config, "wanContextId") ?? "";
+        // A schedule whose WAN was deleted falls back to the default path here rather than holding an
+        // id no option carries: the select would show the first option while the field still held
+        // the dead one, so what was displayed and what would be saved disagreed until it was touched.
+        var storedVantage = GetConfigValue(config, "wanContextId") ?? "";
+        _newAgentVantage = _agentVantages.Any(v => (v.ContextId?.ToString() ?? "") == storedVantage)
+            ? storedVantage
+            : "";
 
         // Try to match WAN selection from config
         if (_newWanTestType == "gateway")

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2421,8 +2421,9 @@
                 ? await AgentVantages.ListVantagesAsync(SiteContext.Slug)
                 : new List<AgentWanVantage>();
             // First entry is a WAN, so a schedule made without touching the field measures one
-            // rather than the unpinned path.
-            if (_agentVantages.Count > 0 && string.IsNullOrEmpty(_newAgentVantage))
+            // rather than the unpinned path. Never while editing: an existing schedule's choice is
+            // its own, including the default path a deleted WAN falls back to.
+            if (_editingWanScheduleId == null && _agentVantages.Count > 0 && string.IsNullOrEmpty(_newAgentVantage))
                 _newAgentVantage = _agentVantages[0].ContextId?.ToString() ?? "";
         }
         catch

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -27,6 +27,7 @@
 @inject IGatewaySshService GatewaySshService
 @inject AgentOnGatewayDetector OnGatewayDetector
 @inject SiteAgentCoverage AgentCoverage
+@inject AgentWanTestVantageResolver AgentVantages
 @inject NetworkOptimizer.Web.Services.Monitoring.ProbeExecutorFactory ProbeExecutors
 @inject SiteTunnelRouting TunnelRouting
 @inject WanDataUsageService DataUsageService
@@ -1894,10 +1895,15 @@
     // so the Server WAN test can never succeed - hidden for new schedules. An
     // existing legacy Server schedule keeps its option while being edited so the
     // bound selection stays coherent.
-    private bool _agentOnGateway;
     private bool _wanTestViaAgent;
+
+    // Whether a "server" WAN test can be scheduled here at all: this server runs it, or an agent
+    // that can. A gateway agent carries no speed test binary, so it offers nothing to schedule.
+    private bool _serverTestOffered;
     private string _newWanTestType = "gateway";
     private string _newWanSelection = "0";
+    private List<AgentWanVantage> _agentVantages = new();
+    private string _newAgentVantage = "";
     private bool _newWanMaxMode;
     private TimeOnly _newWanStartTime = new(6, 0);
     private string? _newLanDevice;
@@ -1958,7 +1964,7 @@
     private int? _editingLanScheduleId;
     private string? _scheduleMessage;
     private string _scheduleMessageClass = "info";
-    private bool CanCreateWanSchedule => (_newWanTestType == "server" && !_agentOnGateway) || (_gatewayAvailable && _wanSelectorOptions.Count > 0);
+    private bool CanCreateWanSchedule => (_newWanTestType == "server" && _serverTestOffered) || (_gatewayAvailable && _wanSelectorOptions.Count > 0);
     private readonly string _serverTzAbbrev = GetServerTimezoneAbbrev();
 
     private RenderFragment WanScheduleForm => __builder =>
@@ -1981,12 +1987,24 @@
                             {
                                 <option value="gateway">Gateway (Direct)</option>
                             }
-                            @if (!_agentOnGateway || _newWanTestType == "server")
+                            @if (_serverTestOffered || _newWanTestType == "server")
                             {
                                 <option value="server">@ServerVantageLabel</option>
                             }
                         </select>
                     </div>
+                    @if (_newWanTestType == "server" && _agentVantages.Count > 0)
+                    {
+                        <div class="form-group schedule-field">
+                            <label>WAN</label>
+                            <select class="form-control" @bind="_newAgentVantage">
+                                @foreach (var vantage in _agentVantages)
+                                {
+                                    <option value="@(vantage.ContextId?.ToString() ?? "")">@vantage.Label</option>
+                                }
+                            </select>
+                        </div>
+                    }
                     @if (_newWanTestType == "gateway" && _wanSelectorOptions.Count > 0)
                     {
                         <div class="form-group schedule-field">
@@ -2396,15 +2414,21 @@
 
         try
         {
-            _agentOnGateway = await OnGatewayDetector.IsAgentOnGatewayAsync(SiteContext.Slug);
-            _wanTestViaAgent = !_agentOnGateway && AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
+            _serverTestOffered = await AgentVantages.HasCapableAgentAsync(SiteContext.Slug)
+                || !AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
+            _wanTestViaAgent = _serverTestOffered && AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
+            _agentVantages = _wanTestViaAgent
+                ? await AgentVantages.ListVantagesAsync(SiteContext.Slug)
+                : new List<AgentWanVantage>();
         }
         catch
         {
-            _agentOnGateway = false;
+            // Keep offering it rather than removing the option on a transient read failure: a run
+            // that cannot happen says so with a specific reason, a missing option says nothing.
+            _serverTestOffered = true;
         }
 
-        if (!_gatewayAvailable && !_agentOnGateway)
+        if (!_gatewayAvailable && _serverTestOffered)
             _newWanTestType = "server";
 
         BuildWanSelectorOptions();
@@ -3178,7 +3202,21 @@
 
             if (_newWanTestType == "server")
             {
-                taskName = _newWanMaxMode ? "WAN Speed Test (Server, Max Load)" : "WAN Speed Test (Server)";
+                var vantage = _agentVantages.FirstOrDefault(v => (v.ContextId?.ToString() ?? "") == _newAgentVantage);
+                if (vantage?.ContextId != null)
+                {
+                    config["wanContextId"] = vantage.ContextId.Value;
+                    // Display only, so the schedule row shows its WAN the same way a gateway row
+                    // does. The executor reconciles wanName against the console for gateway tests
+                    // only, so this is never read back as a target.
+                    config["wanName"] = vantage.Label;
+                }
+                // The WAN goes in the name the way the gateway test does, so the row reads the same
+                // whichever runs it. Unnamed means the primary WAN, which is what a single-WAN site
+                // and every schedule made before this always meant.
+                var wanLabel = vantage?.ContextId != null ? $", {vantage.Label}" : "";
+                var loadLabel = _newWanMaxMode ? ", Max Load" : "";
+                taskName = $"WAN Speed Test (Server{wanLabel}{loadLabel})";
             }
             else
             {
@@ -3235,6 +3273,7 @@
 
             await AlertConfig.CreateScheduleAsync(task);
             _newWanSelection = "0";
+            _newAgentVantage = "";
             _newWanMaxMode = false;
             _newWanFrequency = 1440;
             _newWanStartTime = new(6, 0);
@@ -3346,6 +3385,8 @@
             ? UtcToLocalTimeOnly(task.CustomMorningHour.Value, task.CustomMorningMinute ?? 0)
             : new TimeOnly(6, 0);
 
+        _newAgentVantage = GetConfigValue(config, "wanContextId") ?? "";
+
         // Try to match WAN selection from config
         if (_newWanTestType == "gateway")
         {
@@ -3379,6 +3420,7 @@
         _editingWanScheduleId = null;
         _newWanTestType = "gateway";
         _newWanSelection = "0";
+        _newAgentVantage = "";
         _newWanMaxMode = false;
         _newWanFrequency = 1440;
         _newWanStartTime = new(6, 0);
@@ -3404,7 +3446,21 @@
 
             if (_newWanTestType == "server")
             {
-                taskName = _newWanMaxMode ? "WAN Speed Test (Server, Max Load)" : "WAN Speed Test (Server)";
+                var vantage = _agentVantages.FirstOrDefault(v => (v.ContextId?.ToString() ?? "") == _newAgentVantage);
+                if (vantage?.ContextId != null)
+                {
+                    config["wanContextId"] = vantage.ContextId.Value;
+                    // Display only, so the schedule row shows its WAN the same way a gateway row
+                    // does. The executor reconciles wanName against the console for gateway tests
+                    // only, so this is never read back as a target.
+                    config["wanName"] = vantage.Label;
+                }
+                // The WAN goes in the name the way the gateway test does, so the row reads the same
+                // whichever runs it. Unnamed means the primary WAN, which is what a single-WAN site
+                // and every schedule made before this always meant.
+                var wanLabel = vantage?.ContextId != null ? $", {vantage.Label}" : "";
+                var loadLabel = _newWanMaxMode ? ", Max Load" : "";
+                taskName = $"WAN Speed Test (Server{wanLabel}{loadLabel})";
             }
             else
             {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -3211,10 +3211,12 @@
                 if (vantage?.ContextId != null)
                 {
                     config["wanContextId"] = vantage.ContextId.Value;
-                    // Display only, so the schedule row shows its WAN the same way a gateway row
-                    // does. The executor reconciles wanName against the console for gateway tests
-                    // only, so this is never read back as a target.
+                    // wanName for the row, wanGroup so anything asking which WANs have a schedule
+                    // finds this one. The executor reconciles both against the console for gateway
+                    // tests only, so neither is read back as a target here.
                     config["wanName"] = vantage.Label;
+                    if (!string.IsNullOrEmpty(vantage.WanKey))
+                        config["wanGroup"] = NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(vantage.WanKey!);
                 }
                 // The WAN goes in the name the way the gateway test does, so the row reads the same
                 // whichever runs it. Unnamed means the default path, which is what a single-WAN
@@ -3461,10 +3463,12 @@
                 if (vantage?.ContextId != null)
                 {
                     config["wanContextId"] = vantage.ContextId.Value;
-                    // Display only, so the schedule row shows its WAN the same way a gateway row
-                    // does. The executor reconciles wanName against the console for gateway tests
-                    // only, so this is never read back as a target.
+                    // wanName for the row, wanGroup so anything asking which WANs have a schedule
+                    // finds this one. The executor reconciles both against the console for gateway
+                    // tests only, so neither is read back as a target here.
                     config["wanName"] = vantage.Label;
+                    if (!string.IsNullOrEmpty(vantage.WanKey))
+                        config["wanGroup"] = NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(vantage.WanKey!);
                 }
                 // The WAN goes in the name the way the gateway test does, so the row reads the same
                 // whichever runs it. Unnamed means the default path, which is what a single-WAN
@@ -3692,7 +3696,9 @@
         var idx = name.IndexOf(marker);
         if (idx < 0) return (name, null);
         var baseName = name[..(idx + 4)]; // "... Test"
-        var detail = name[(idx + marker.Length)..].TrimEnd(')');
+        // One paren closes the name; a WAN label can carry its own, and TrimEnd would eat those too.
+        var detail = name[(idx + marker.Length)..];
+        if (detail.EndsWith(')')) detail = detail[..^1];
         return (baseName, detail);
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -2317,7 +2317,7 @@
         {
             var newTab = ResolveTab(TabParam);
             if (newTab != _activeTab)
-                _ = SetActiveTab(newTab, pushHistory: false);
+                _ = InvokeAsync(() => SetActiveTab(newTab, pushHistory: false));
         }
         _lastTabParam = TabParam;
     }
@@ -2373,6 +2373,10 @@
         }
 
         _loading = false;
+        // Arriving from the nav rather than the tab strip runs this detached from OnParametersSet,
+        // where no event follows to redraw. Without this the finished load sat unrendered and the
+        // tab spun until the 30s timer happened to paint it.
+        StateHasChanged();
     }
 
     // ========== Data Loading ==========
@@ -3784,15 +3788,13 @@
     {
         try
         {
-            // Load WAN networks from console. OnConnectionChanged handles the
-            // case where the console isn't ready yet at page load.
+            // OnConnectionChanged reloads this if the console is not ready yet.
             if (ConnectionService.IsConnected)
             {
                 try
                 {
                     var networks = await ConnectionService.GetNetworksAsync();
                     _dataUsageWanNetworks = networks.Where(n => n.IsWan && n.Enabled).ToList();
-                    _wanNetworksFetched = true;
                 }
                 catch (Exception ex)
                 {
@@ -3800,10 +3802,9 @@
                 }
             }
 
-            // The spinner means "not looked yet", so the look counts however it went. Setting this
-            // only on success left a disconnected console - or a call that threw - spinning on
-            // "Connecting to UniFi Console..." with nothing to end it. The empty state says the
-            // same thing and stops, and OnConnectionChanged reloads the tab if the console returns.
+            // The spinner means "not looked yet", so the look counts however it went: a disconnected
+            // console or a call that threw lands on the empty state, which says the same thing and
+            // stops. Never inside the branch above, which is what left it spinning.
             _wanNetworksFetched = true;
 
             // Load live WAN up/down status from device API

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -51,7 +51,7 @@
             {
                 <div class="alert alert-info">
                     <strong>On-site agent:</strong> Speed tests for this site run against its on-site agent at <code>@serverHost</code>, so they measure this site's own network rather than the central server.
-                    <a href="/settings#multi-site" class="tooltip-icon settings-link" data-tooltip="You can reconfigure this site's speed test URL if needed" data-tooltip-hover-only>
+                    <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")" class="tooltip-icon settings-link" data-tooltip="You can reconfigure this site's speed test URL if needed" data-tooltip-hover-only>
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
                     </a>
                 </div>
@@ -59,7 +59,7 @@
             else if (agentOnGateway)
             {
                 <div class="alert alert-info">
-                    <strong>Agent on gateway:</strong> This site's agent runs on the UniFi gateway itself, which doesn't host the LAN speed test. To enable client speed tests here, deploy a Docker or bare-metal agent on a separate box at the site (Settings &gt; Multi-Site).
+                    <strong>Agent on gateway:</strong> This site's agent runs on the UniFi gateway itself, which doesn't host the LAN speed test. To enable client speed tests here, deploy a Docker or bare-metal agent on a separate box at the site (<a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>).
                 </div>
             }
             else if (agentSiteOffline)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -59,13 +59,13 @@
             else if (agentOnGateway)
             {
                 <div class="alert alert-info">
-                    <strong>Agent on gateway:</strong> This site's agent runs on the UniFi gateway itself, which doesn't host the LAN speed test. To enable client speed tests here, deploy a Docker or bare-metal agent on a separate box at the site (<a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>).
+                    <strong>Agent on Gateway:</strong> This site's Agent runs on the UniFi Gateway itself, which doesn't host the LAN speed test. To enable client speed tests here, deploy a Docker or bare-metal Agent on a separate box at the site (<a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>).
                 </div>
             }
             else if (agentSiteOffline)
             {
                 <div class="alert alert-warning">
-                    <strong>On-Site Agent offline:</strong> This site's agent isn't reporting in, so the targets below point at the central server and may be unreachable from the site's network. Start the site's agent to test against the site directly.
+                    <strong>On-Site Agent offline:</strong> This site's Agent isn't reporting in, so the targets below point at the central server and may be unreachable from the site's network. Start the site's Agent to test against the site directly.
                 </div>
             }
             @if (!agentOnGateway)

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientSpeedTest.razor
@@ -50,7 +50,7 @@
             @if (siteUsesAgent)
             {
                 <div class="alert alert-info">
-                    <strong>On-site agent:</strong> Speed tests for this site run against its on-site agent at <code>@serverHost</code>, so they measure this site's own network rather than the central server.
+                    <strong>On-Site Agent:</strong> Speed tests for this site run against its On-Site Agent at <code>@serverHost</code>, so they measure this site's own network rather than the central server.
                     <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")" class="tooltip-icon settings-link" data-tooltip="You can reconfigure this site's speed test URL if needed" data-tooltip-hover-only>
                         <img src="/images/gear.svg" alt="" style="width:16px;height:16px;" />
                     </a>
@@ -65,7 +65,7 @@
             else if (agentSiteOffline)
             {
                 <div class="alert alert-warning">
-                    <strong>On-site agent offline:</strong> This site's agent isn't reporting in, so the targets below point at the central server and may be unreachable from the site's network. Start the site's agent to test against the site directly.
+                    <strong>On-Site Agent offline:</strong> This site's agent isn't reporting in, so the targets below point at the central server and may be unreachable from the site's network. Start the site's agent to test against the site directly.
                 </div>
             }
             @if (!agentOnGateway)
@@ -435,7 +435,7 @@
                 </ol>
 
                 <p class="form-help">
-                    <strong>Note:</strong> This tests the LAN speed between client devices and @(siteUsesAgent ? "the on-site agent" : "the Network Optimizer server").
+                    <strong>Note:</strong> This tests the LAN speed between client devices and @(siteUsesAgent ? "the On-Site Agent" : "the Network Optimizer server").
                     It's useful for identifying wireless bottlenecks, cable issues, switch problems, or network congestion.
                 </p>
             </div>
@@ -883,7 +883,7 @@
         agentSiteOffline = !SiteContext.IsDefault && siteTarget.AgentOffline;
         agentOnGateway = siteTarget.AgentOnGateway;
         siteUsesAgent = siteTarget.UsesAgent;
-        targetLabel = siteUsesAgent ? "the on-site agent" : "this server";
+        targetLabel = siteUsesAgent ? "the On-Site Agent" : "this server";
 
         if (siteUsesAgent)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -97,7 +97,7 @@
                         {
                             <div class="alert alert-warning">
                                 <strong>This site's agent is offline.</strong> WAN speed test results for this site
-                                are attributed through the on-site agent, which isn't connected right now. Wait for
+                                are attributed through the On-Site Agent, which isn't connected right now. Wait for
                                 the agent to come back online (or check it under
                                 <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>), then
                                 reload this page. Running the test without the agent would record the result

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -87,18 +87,18 @@
                         @if (AgentOnGateway)
                         {
                             <div class="alert alert-info">
-                                <strong>Agent on gateway:</strong> This site's agent runs on the UniFi gateway itself,
+                                <strong>Agent on Gateway:</strong> This site's Agent runs on the UniFi Gateway itself,
                                 which doesn't host the speed-test pages that relay client WAN results back to this
-                                server. To enable client WAN tests here, deploy a Docker or bare-metal agent on a
+                                server. To enable client WAN tests here, deploy a Docker or bare-metal Agent on a
                                 separate box at the site (<a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>).
                             </div>
                         }
                         else if (AgentRequiredButOffline)
                         {
                             <div class="alert alert-warning">
-                                <strong>This site's agent is offline.</strong> WAN speed test results for this site
+                                <strong>This site's Agent is offline.</strong> WAN speed test results for this site
                                 are attributed through the On-Site Agent, which isn't connected right now. Wait for
-                                the agent to come back online (or check it under
+                                the Agent to come back online (or check it under
                                 <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>), then
                                 reload this page. Running the test without the agent would record the result
                                 against the wrong site.

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientWanSpeedTest.razor
@@ -90,7 +90,7 @@
                                 <strong>Agent on gateway:</strong> This site's agent runs on the UniFi gateway itself,
                                 which doesn't host the speed-test pages that relay client WAN results back to this
                                 server. To enable client WAN tests here, deploy a Docker or bare-metal agent on a
-                                separate box at the site (Settings &gt; Multi-Site).
+                                separate box at the site (<a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>).
                             </div>
                         }
                         else if (AgentRequiredButOffline)
@@ -98,7 +98,8 @@
                             <div class="alert alert-warning">
                                 <strong>This site's agent is offline.</strong> WAN speed test results for this site
                                 are attributed through the on-site agent, which isn't connected right now. Wait for
-                                the agent to come back online (or check it under Settings &gt; Multi-Site), then
+                                the agent to come back online (or check it under
+                                <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a>), then
                                 reload this page. Running the test without the agent would record the result
                                 against the wrong site.
                             </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1777,7 +1777,7 @@
                                 {
                                     <div class="form-value-line">
                                         <span class="status-indicator @(_siteAgent is not null && TunnelRegistry.IsAgentLive(_siteAgent) ? "status-active" : "status-danger")"></span>
-                                        <span>On-site agent: @AgentCollectionState</span>
+                                        <span>On-Site Agent: @AgentCollectionState</span>
                                     </div>
                                 }
                             }
@@ -3648,7 +3648,7 @@
             <span class="banner-icon">!</span>
             <div class="banner-text" style="flex: 1;">
                 <strong>No agent for this site</strong>
-                Probe-based monitoring needs an on-site agent. SNMP collection is unaffected.
+                Probe-based monitoring needs an On-Site Agent. SNMP collection is unaffected.
             </div>
             <div class="banner-actions">
                 <button class="btn btn-sm btn-primary" @onclick='() => NavigationManager.NavigateTo($"/settings?tab=multisite&configure={SiteCtx.Slug}")'>Set Up an Agent</button>

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -48,7 +48,7 @@
 @if (_siteAgentOffline)
 {
     <div class="alert alert-warning">
-        This site's probes run through its on-site agent, which isn't connected right now.
+        This site's probes run through its On-Site Agent, which isn't connected right now.
         Ping, traceroute, and reading a gateway interface can resume when the agent reconnects.
     </div>
 }
@@ -72,7 +72,7 @@
                 }
                 else
                 {
-                    <option value="server" selected="@(_fromKey == "server")">@(ExecutorFactory.ServerVantageIsAgent ? "On-site agent" : "Network Optimizer server")</option>
+                    <option value="server" selected="@(_fromKey == "server")">@(ExecutorFactory.ServerVantageIsAgent ? "On-Site Agent" : "Network Optimizer server")</option>
                 }
                 @foreach (var d in _devices)
                 {
@@ -92,7 +92,7 @@
                 <p class="page-description" style="margin-top: 0.5rem;">
                     @if (ExecutorFactory.ServerVantageIsAgent)
                     {
-                        @:Probes run from this site's on-site agent (on the site's own network), not the central server.
+                        @:Probes run from this site's On-Site Agent (on the site's own network), not the central server.
                     }
                     else
                     {
@@ -1551,7 +1551,7 @@ else if (_diagResult != null && !string.IsNullOrEmpty(_diagResult.InterfaceError
         if (vantageId.StartsWith("agent:"))
             return _probeVantages.FirstOrDefault(v => v.Key == vantageId)?.Label ?? vantageId;
         if (vantageId == "server")
-            return ExecutorFactory.ServerVantageIsAgent ? "On-site agent" : "Network Optimizer server";
+            return ExecutorFactory.ServerVantageIsAgent ? "On-Site Agent" : "Network Optimizer server";
         return vantageId;
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/MonitoringTools.razor
@@ -49,7 +49,7 @@
 {
     <div class="alert alert-warning">
         This site's probes run through its On-Site Agent, which isn't connected right now.
-        Ping, traceroute, and reading a gateway interface can resume when the agent reconnects.
+        Ping, traceroute, and reading a Gateway interface can resume when the Agent reconnects.
     </div>
 }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -5064,7 +5064,8 @@
                 // scrolls, so the sides and bottom get cut whichever element it is put on.
                 // Ringed rather than tinted - the panel paints its own background over the row.
                 await Task.Delay(300);
-                await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center");
+                await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center",
+                    "0 0 var(--border-radius-lg) var(--border-radius-lg)");
             }
         }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3553,9 +3553,9 @@
                                     @if (_expandedSiteId == site.Id)
                                     {
                                         var agents = AgentsFor(site.Id).ToList();
-                                        <tr id="site-config-@site.Id" class="history-details-row site-config-row">
+                                        <tr class="history-details-row site-config-row">
                                             <td colspan="5">
-                                                <div class="expand-wrapper @(_panelExpanded ? "expanded" : "")">
+                                                <div id="site-config-@site.Id" class="expand-wrapper @(_panelExpanded ? "expanded" : "")">
                                                     <div class="expand-content">
                                                 <div class="site-config-panel">
                                                                                                         <div class="site-config-section">
@@ -5059,11 +5059,10 @@
             if (target is not null)
             {
                 await ToggleAgents(target.Id);
-                // The details row, not the panel inside it: the panel sits in a wrapper that hides
-                // overflow for the expand animation, and an outline is painted outside the border
-                // box at every offset, so a ring on the panel is clipped wherever it is put. The
-                // row is outside that wrapper. Ringed, not tinted - the panel paints its own
-                // background over the row, so a tint lands behind it and is never seen.
+                // The expand wrapper, not the panel inside it and not the row around it. An
+                // element's own overflow never clips its own outline, so ringing the wrapper draws
+                // outside the area it hides - which a ring on the panel cannot do, and which a
+                // table row does not paint reliably.
                 await Task.Delay(300);
                 await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center");
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -5060,12 +5060,11 @@
             {
                 await ToggleAgents(target.Id);
                 // The panel rather than its row: the panel paints its own background over the
-                // whole row, so a row tint lands behind it and is never seen. Ringed with an
-                // explicit radius, which is what noHighlightTarget takes for a target that is
-                // not card-shaped.
+                // whole row, so a row tint lands behind it and is never seen. No radius passed -
+                // the panel keeps its own shape and ring offset in CSS, because its wrapper clips
+                // overflow and an offset ring would be cut off.
                 await Task.Delay(300);
-                await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}",
-                    "center", "var(--border-radius)");
+                await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center");
             }
         }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3555,9 +3555,9 @@
                                         var agents = AgentsFor(site.Id).ToList();
                                         <tr class="history-details-row site-config-row">
                                             <td colspan="5">
-                                                <div id="site-config-@site.Id" class="expand-wrapper @(_panelExpanded ? "expanded" : "")">
+                                                <div class="expand-wrapper @(_panelExpanded ? "expanded" : "")">
                                                     <div class="expand-content">
-                                                <div class="site-config-panel">
+                                                <div id="site-config-@site.Id" class="site-config-panel">
                                                                                                         <div class="site-config-section">
                                                         <div class="site-config-section-title">Agent</div>
                                                         @if (agents.Count > 0)
@@ -5059,10 +5059,10 @@
             if (target is not null)
             {
                 await ToggleAgents(target.Id);
-                // The expand wrapper, not the panel inside it and not the row around it. An
-                // element's own overflow never clips its own outline, so ringing the wrapper draws
-                // outside the area it hides - which a ring on the panel cannot do, and which a
-                // table row does not paint reliably.
+                // The panel, ringed on its inside edge (CSS). An outset ring cannot work anywhere
+                // here: .expand-content hides overflow for the animation and .table-responsive
+                // scrolls, so the sides and bottom get cut whichever element it is put on.
+                // Ringed rather than tinted - the panel paints its own background over the row.
                 await Task.Delay(300);
                 await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center");
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -153,7 +153,7 @@
             <div class="card-header-badges">
                 @if (_currentSiteConsoleViaAgent)
                 {
-                    <span class="status-badge badge-agent" data-tooltip="This site's console is reached through its on-site agent tunnel, not a direct connection from this server">Via Site Agent</span>
+                    <span class="status-badge badge-agent" data-tooltip="This site's console is reached through its On-Site Agent tunnel, not a direct connection from this server">Via Site Agent</span>
                 }
                 <span class="status-badge status-@controllerStatus.ToLower()">@controllerStatus</span>
             </div>
@@ -448,7 +448,7 @@
             <div class="card-header-badges">
                 @if (_currentSiteSshViaAgent)
                 {
-                    <span class="status-badge badge-agent" data-tooltip="This site's SSH connections are made through its on-site agent tunnel, not directly from this server">Via Site Agent</span>
+                    <span class="status-badge badge-agent" data-tooltip="This site's SSH connections are made through its On-Site Agent tunnel, not directly from this server">Via Site Agent</span>
                 }
                 <span class="status-badge status-@(gatewaySettings?.Enabled == true ? "connected" : "disconnected")">
                     @(gatewaySettings?.Enabled == true ? "Configured" : "Not Configured")
@@ -624,7 +624,7 @@
             <div class="card-header-badges">
                 @if (_currentSiteSshViaAgent)
                 {
-                    <span class="status-badge badge-agent" data-tooltip="This site's SSH connections are made through its on-site agent tunnel, not directly from this server">Via Site Agent</span>
+                    <span class="status-badge badge-agent" data-tooltip="This site's SSH connections are made through its On-Site Agent tunnel, not directly from this server">Via Site Agent</span>
                 }
                 <span class="status-badge status-@(sshSettings?.Enabled == true ? "connected" : "disconnected")">
                     @(sshSettings?.Enabled == true ? "Configured" : "Not Configured")
@@ -3648,7 +3648,7 @@
                                                             <p class="site-config-empty">
                                                                 @(site.IsDefault
                                                                     ? "This site is monitored directly by this server. Add an agent only if this server runs off-site."
-                                                                    : "No on-site agent for this site yet. Set one up to reach it without a VPN.")
+                                                                    : "No On-Site Agent for this site yet. Set one up to reach it without a VPN.")
                                                             </p>
                                                             <div class="site-agent-actions">
                                                                 @if (!site.IsDefault)

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3553,11 +3553,11 @@
                                     @if (_expandedSiteId == site.Id)
                                     {
                                         var agents = AgentsFor(site.Id).ToList();
-                                        <tr class="history-details-row site-config-row">
+                                        <tr id="site-config-@site.Id" class="history-details-row site-config-row">
                                             <td colspan="5">
                                                 <div class="expand-wrapper @(_panelExpanded ? "expanded" : "")">
                                                     <div class="expand-content">
-                                                <div id="site-config-@site.Id" class="site-config-panel">
+                                                <div class="site-config-panel">
                                                                                                         <div class="site-config-section">
                                                         <div class="site-config-section-title">Agent</div>
                                                         @if (agents.Count > 0)
@@ -5059,10 +5059,11 @@
             if (target is not null)
             {
                 await ToggleAgents(target.Id);
-                // The panel rather than its row: the panel paints its own background over the
-                // whole row, so a row tint lands behind it and is never seen. No radius passed -
-                // the panel keeps its own shape and ring offset in CSS, because its wrapper clips
-                // overflow and an offset ring would be cut off.
+                // The details row, not the panel inside it: the panel sits in a wrapper that hides
+                // overflow for the expand animation, and an outline is painted outside the border
+                // box at every offset, so a ring on the panel is clipped wherever it is put. The
+                // row is outside that wrapper. Ringed, not tinted - the panel paints its own
+                // background over the row, so a tint lands behind it and is never seen.
                 await Task.Delay(300);
                 await JS.InvokeVoidAsync("noHighlightTarget", $"site-config-{target.Id}", "center");
             }

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -104,7 +104,7 @@
                     <strong>Site Agent Offline</strong>
                     <p>
                         This site's LAN speed tests run through its On-Site Agent, which isn't
-                        connected right now. Tests can resume when the agent reconnects.
+                        connected right now. Tests can resume when the Agent reconnects.
                     </p>
                 }
                 else
@@ -112,7 +112,7 @@
                     <strong>No Site Agent</strong>
                     <p>
                         LAN speed tests on a managed site run from its On-Site Agent, and this
-                        site has none online. Set up the site's agent under
+                        site has none online. Set up the site's Agent under
                         <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a> to enable them.
                     </p>
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -103,7 +103,7 @@
                 {
                     <strong>Site Agent Offline</strong>
                     <p>
-                        This site's LAN speed tests run through its on-site agent, which isn't
+                        This site's LAN speed tests run through its On-Site Agent, which isn't
                         connected right now. Tests can resume when the agent reconnects.
                     </p>
                 }
@@ -111,7 +111,7 @@
                 {
                     <strong>No Site Agent</strong>
                     <p>
-                        LAN speed tests on a managed site run from its on-site agent, and this
+                        LAN speed tests on a managed site run from its On-Site Agent, and this
                         site has none online. Set up the site's agent under
                         <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a> to enable them.
                     </p>

--- a/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/SpeedTest.razor
@@ -113,7 +113,7 @@
                     <p>
                         LAN speed tests on a managed site run from its on-site agent, and this
                         site has none online. Set up the site's agent under
-                        <a href="/settings#multi-site">Settings</a> to enable them.
+                        <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a> to enable them.
                     </p>
                 }
             </div>
@@ -361,7 +361,7 @@
                 <div class="alert alert-info">
                     <strong>Agent on gateway:</strong> Device speed tests reach the site's devices over SSH through
                     the agent tunnel, which isn't enabled for this site. Turn on <strong>Reach this site's devices
-                    through the agent tunnel</strong> under Settings &gt; Multi-Site to run them.
+                    through the agent tunnel</strong> under <a href="@($"/settings?tab=multisite&configure={SiteContext.Slug}")">Settings &gt; Multi-Site</a> to run them.
                 </div>
             }
             else

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -148,18 +148,16 @@
                     </div>
                     @if (!_gatewayAvailable && !_isRunning && !string.IsNullOrEmpty(_gatewayUnavailableReason))
                     {
-                        var reason = _gatewayUnavailableReason!;
-                        var linkIdx = string.IsNullOrEmpty(_gatewaySettingsHref)
-                            ? -1
-                            : reason.IndexOf("Settings", StringComparison.Ordinal);
+                        var linked = MessageLinker.Split(
+                            _gatewayUnavailableReason, _gatewaySettingsLinkText, _gatewaySettingsHref);
                         <div class="alert alert-warning">
-                            @if (linkIdx >= 0)
+                            @if (linked.HasLink)
                             {
-                                @reason.Substring(0, linkIdx)<a href="@_gatewaySettingsHref">Settings</a>@reason.Substring(linkIdx + "Settings".Length)
+                                @linked.Before<a href="@linked.Href">@linked.LinkText</a>@linked.After
                             }
                             else
                             {
-                                @reason
+                                @linked.Before
                             }
                         </div>
                     }
@@ -695,7 +693,8 @@
     private string? _gatewayUnavailableReason;
     private bool _gatewaySshConfigured;      // gateway SSH host+creds present and enabled
     private string? _gatewaySshUnavailableReason;
-    private string? _gatewaySettingsHref;    // deep link for the "Settings" word in the unavailable reason, when applicable
+    private string? _gatewaySettingsHref;     // where the unavailable reason's link goes, when it has one
+    private string? _gatewaySettingsLinkText; // the phrase in that reason to turn into the link
     private bool _consoleDataLoaded;         // WAN list/interfaces loaded from a connected console
 
     // Agent-backed secondary site whose on-site agent isn't currently connected.
@@ -1021,13 +1020,17 @@
             _gatewayUnavailableReason = agentReason;
             // Only the "no agent set up" reason points at a settings page; the
             // "agent offline, resumes when it reconnects" reason is not actionable.
-            _gatewaySettingsHref = _siteAgentOffline ? null : "/settings#multi-site";
+            _gatewaySettingsHref = _siteAgentOffline
+                ? null
+                : $"/settings?tab=multisite&configure={SiteContext.Slug}";
+            _gatewaySettingsLinkText = _siteAgentOffline ? null : "Settings > Multi-Site";
         }
         else
         {
             _gatewayAvailable = _gatewaySshConfigured;
             _gatewayUnavailableReason = _gatewaySshConfigured ? null : _gatewaySshUnavailableReason;
             _gatewaySettingsHref = "/settings#gateway-ssh";
+            _gatewaySettingsLinkText = "Settings, under the Connection tab";
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -712,6 +712,10 @@
     private List<AgentWanVantage> _agentVantages = new();
     private string _selectedAgentVantage = "";
 
+    // Availability the site as a whole allows, which the chosen WAN can only narrow.
+    private bool _serverAvailableForSite = true;
+    private string? _serverUnavailableReasonForSite;
+
     /// <summary>
     /// Whether the non-gateway run happens on the site's agent rather than on this server, which is
     /// what the option is called and described as. Matches the actual execution path
@@ -987,24 +991,29 @@
             && await TunnelRouting.IsViaAgentAsync(SiteContext.Slug)
             && !agentOnline;
 
-        // An agent on the gateway itself (monitoring-only) has no WAN test binary,
-        // and a "from the server through the LAN" run makes no sense when the agent
-        // IS the gateway - the Server option is hidden and the Gateway test is the
-        // one to use. When speed-test-capable gateway installs arrive, key this off
-        // the agent's capability instead of its location.
+        // An agent on the gateway itself (monitoring-only) has no WAN test binary, and a "from the
+        // server through the LAN" run makes no sense when the agent IS the gateway - the Server
+        // option is hidden and the Gateway test is the one to use. Keyed off whether any agent here
+        // CAN run the test rather than where one sits, so a site pairing a gateway agent with a
+        // bare-metal one keeps the option the bare-metal agent can serve.
         _hasCapableAgent = agentOnline && await AgentVantages.HasCapableAgentAsync(SiteContext.Slug);
         _runsOnAgent = _hasCapableAgent
             && AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
         // The option stays visible for a site this server tests itself; it is only the agent-run
         // case that needs an agent able to run it.
         _serverOptionVisible = _hasCapableAgent || !AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
-        await LoadAgentVantagesAsync();
+        // Before the vantage list, which reads RunsOnAgent - and that answers from a fallback until
+        // this is set, so loading ahead of it asks the wrong question on a covered default site.
         _vantageResolved = true;
+        await LoadAgentVantagesAsync();
         var agentRequired = !SiteContext.IsDefault && !agentOnline;
         var agentReason = _siteAgentOffline ? AgentOfflineReason : NoAgentReason;
 
-        _serverAvailable = !agentRequired;
-        _serverUnavailableReason = agentRequired ? agentReason : null;
+        // What the SITE allows, before the chosen WAN narrows it. Kept apart because changing the
+        // selector re-derives availability without re-running any of the above.
+        _serverAvailableForSite = !agentRequired;
+        _serverUnavailableReasonForSite = agentRequired ? agentReason : null;
+        ApplyAgentVantageAvailability();
 
         if (agentRequired)
         {
@@ -1040,17 +1049,19 @@
         }
         if (!_agentVantages.Any(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage))
             _selectedAgentVantage = _agentVantages[0].ContextId?.ToString() ?? "";
-        ApplyAgentVantageAvailability();
     }
 
     /// <summary>
     /// Reports up front whether the chosen WAN can be tested, rather than leaving the operator to
-    /// press the button and read a failure. Only narrows: an option already unavailable for the
-    /// site as a whole (no agent, offline agent) keeps that reason.
+    /// press the button and read a failure. Always derived from what the site allows, so it only
+    /// ever narrows: a site already unavailable (no agent, offline agent) keeps its own reason.
     /// </summary>
     private void ApplyAgentVantageAvailability()
     {
+        _serverAvailable = _serverAvailableForSite;
+        _serverUnavailableReason = _serverUnavailableReasonForSite;
         if (!_serverAvailable) return;
+
         var selected = _agentVantages.FirstOrDefault(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage);
         if (selected is { Runnable: false })
         {
@@ -1059,12 +1070,7 @@
         }
     }
 
-    private void OnAgentVantageChanged()
-    {
-        _serverAvailable = true;
-        _serverUnavailableReason = null;
-        ApplyAgentVantageAvailability();
-    }
+    private void OnAgentVantageChanged() => ApplyAgentVantageAvailability();
 
     /// <summary>The WAN context the agent run measures, or null for the site's default path.</summary>
     private int? SelectedWanContextId =>

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -709,7 +709,10 @@
     // Selectable WAN vantages for the agent run. Empty on a site with no WAN contexts, which is
     // every single-WAN site: nothing to choose between, so no selector.
     private List<AgentWanVantage> _agentVantages = new();
-    private string _selectedAgentVantage = "";
+
+    // Null until something is chosen. Not "", because that is Default path's own value - starting
+    // there made the keep-the-selection check below match it and never reach the first WAN.
+    private string? _selectedAgentVantage;
 
     // Availability the site as a whole allows, which the chosen WAN can only narrow.
     private bool _serverAvailableForSite = true;
@@ -1047,10 +1050,11 @@
 
         if (_agentVantages.Count == 0)
         {
-            _selectedAgentVantage = "";
+            _selectedAgentVantage = null;
             return;
         }
-        if (!_agentVantages.Any(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage))
+        if (_selectedAgentVantage == null
+            || !_agentVantages.Any(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage))
             _selectedAgentVantage = _agentVantages[0].ContextId?.ToString() ?? "";
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -22,6 +22,7 @@
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject SiteTunnelRouting TunnelRouting
 @inject AgentOnGatewayDetector OnGatewayDetector
+@inject AgentWanTestVantageResolver AgentVantages
 @inject UniFiConnectionService ConnectionService
 @inject IJSRuntime JS
 @inject SystemSettingsService SettingsService
@@ -142,7 +143,7 @@
                         }
                     </div>
                     <div class="wan-test-option-hint">
-                        Deploys a speed test binary to the gateway and runs it directly. Most accurate WAN measurement - no LAN overhead.@if (!_agentOnGateway)
+                        Deploys a speed test binary to the gateway and runs it directly. Most accurate WAN measurement - no LAN overhead.@if (_serverOptionVisible)
                         {<text> For multi-gig connections, @(RunsOnAgent ? "an Agent-based" : "a Server-based") test may be best.</text>}
                     </div>
                     @if (!_gatewayAvailable && !_isRunning && !string.IsNullOrEmpty(_gatewayUnavailableReason))
@@ -164,10 +165,10 @@
                     }
                 </div>
 
-                @* Server Option - Secondary. Hidden entirely when the site's agent runs
-                   on the gateway itself: the run would happen ON the gateway, which is
+                @* Server Option - Secondary. Hidden entirely when no agent at the site can run
+                   the test - on a gateway agent the run would happen ON the gateway, which is
                    what the Gateway option already does properly. *@
-                @if (!_agentOnGateway)
+                @if (_serverOptionVisible)
                 {
                 <div class="wan-test-option @(_serverAvailable ? "" : "wan-test-option-unavailable")">
                     <div class="wan-test-option-header">
@@ -178,6 +179,20 @@
                         }
                     </div>
                     <div class="wan-test-option-controls">
+                        @if (_agentVantages.Count > 0)
+                        {
+                            <div class="wan-selector">
+                                <select class="form-control wan-select"
+                                        @bind="_selectedAgentVantage"
+                                        @bind:after="OnAgentVantageChanged"
+                                        disabled="@(_isRunning)">
+                                    @foreach (var vantage in _agentVantages)
+                                    {
+                                        <option value="@(vantage.ContextId?.ToString() ?? "")">@vantage.Label</option>
+                                    }
+                                </select>
+                            </div>
+                        }
                         <label class="toggle-switch" data-tooltip="Normal: 4 servers, 20 connections, 8 s. Max Load: up to 12 servers, 48 connections, 8 s for saturating high-bandwidth or congested links." data-tooltip-hover-only>
                             <input type="checkbox" @bind="_maxMode" disabled="@_isRunning" />
                             <span class="toggle-slider"></span>
@@ -686,7 +701,16 @@
     // Agent-backed secondary site whose on-site agent isn't currently connected.
     // Both WAN tests run through that agent, so they can't run until it reconnects.
     private bool _siteAgentOffline;
-    private bool _agentOnGateway;
+
+    // Whether any connected agent at this site can run the test. A gateway agent cannot (it carries
+    // no speed test binary), which is why the option hides rather than offering a run that fails.
+    private bool _hasCapableAgent;
+    private bool _serverOptionVisible = true;
+
+    // Selectable WAN vantages for the agent run. Empty on a site with no WAN contexts, which is
+    // every single-WAN site: nothing to choose between, so no selector.
+    private List<AgentWanVantage> _agentVantages = new();
+    private string _selectedAgentVantage = "";
 
     /// <summary>
     /// Whether the non-gateway run happens on the site's agent rather than on this server, which is
@@ -968,9 +992,13 @@
         // IS the gateway - the Server option is hidden and the Gateway test is the
         // one to use. When speed-test-capable gateway installs arrive, key this off
         // the agent's capability instead of its location.
-        _agentOnGateway = agentOnline && await OnGatewayDetector.IsAgentOnGatewayAsync(SiteContext.Slug);
-        _runsOnAgent = !_agentOnGateway
+        _hasCapableAgent = agentOnline && await AgentVantages.HasCapableAgentAsync(SiteContext.Slug);
+        _runsOnAgent = _hasCapableAgent
             && AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
+        // The option stays visible for a site this server tests itself; it is only the agent-run
+        // case that needs an agent able to run it.
+        _serverOptionVisible = _hasCapableAgent || !AgentCoverage.AgentOwnsPathMeasurement(SiteContext.Slug);
+        await LoadAgentVantagesAsync();
         _vantageResolved = true;
         var agentRequired = !SiteContext.IsDefault && !agentOnline;
         var agentReason = _siteAgentOffline ? AgentOfflineReason : NoAgentReason;
@@ -995,6 +1023,54 @@
     }
 
     /// <summary>
+    /// Loads the WAN vantages the agent run can be pointed at, keeping the current selection when
+    /// it survives the refresh. A run on this server has no vantage to choose, so the list is
+    /// dropped entirely there rather than offering a choice that would not be honored.
+    /// </summary>
+    private async Task LoadAgentVantagesAsync()
+    {
+        _agentVantages = RunsOnAgent
+            ? await AgentVantages.ListVantagesAsync(SiteContext.Slug)
+            : new List<AgentWanVantage>();
+
+        if (_agentVantages.Count == 0)
+        {
+            _selectedAgentVantage = "";
+            return;
+        }
+        if (!_agentVantages.Any(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage))
+            _selectedAgentVantage = _agentVantages[0].ContextId?.ToString() ?? "";
+        ApplyAgentVantageAvailability();
+    }
+
+    /// <summary>
+    /// Reports up front whether the chosen WAN can be tested, rather than leaving the operator to
+    /// press the button and read a failure. Only narrows: an option already unavailable for the
+    /// site as a whole (no agent, offline agent) keeps that reason.
+    /// </summary>
+    private void ApplyAgentVantageAvailability()
+    {
+        if (!_serverAvailable) return;
+        var selected = _agentVantages.FirstOrDefault(v => (v.ContextId?.ToString() ?? "") == _selectedAgentVantage);
+        if (selected is { Runnable: false })
+        {
+            _serverAvailable = false;
+            _serverUnavailableReason = selected.Reason;
+        }
+    }
+
+    private void OnAgentVantageChanged()
+    {
+        _serverAvailable = true;
+        _serverUnavailableReason = null;
+        ApplyAgentVantageAvailability();
+    }
+
+    /// <summary>The WAN context the agent run measures, or null for the site's primary WAN.</summary>
+    private int? SelectedWanContextId =>
+        int.TryParse(_selectedAgentVantage, out var id) ? id : null;
+
+    /// <summary>
     /// Polls the site's agent tunnel status so the WAN test options re-enable on
     /// their own once the agent reconnects. Only agent-backed secondary sites can
     /// go offline, so the default site skips the timer entirely.
@@ -1011,9 +1087,9 @@
                     // Compare on the rendered availability, not just the offline flag:
                     // a site with no via-agent flag that gains its first agent flips
                     // _serverAvailable without ever changing _siteAgentOffline.
-                    var before = (_siteAgentOffline, _serverAvailable, _gatewayAvailable, _agentOnGateway);
+                    var before = (_siteAgentOffline, _serverAvailable, _gatewayAvailable, _serverOptionVisible);
                     await RefreshAgentAvailabilityAsync();
-                    var changed = before != (_siteAgentOffline, _serverAvailable, _gatewayAvailable, _agentOnGateway);
+                    var changed = before != (_siteAgentOffline, _serverAvailable, _gatewayAvailable, _serverOptionVisible);
 
                     // The console comes back a moment after the agent tunnel does; once it's
                     // connected, load the WAN data the Gateway (Direct) test needs so the
@@ -2086,7 +2162,8 @@
                 // arriving up to one poll late is not visible.
                 InvokeAsync(StateHasChanged);
             },
-            maxMode: _maxMode);
+            maxMode: _maxMode,
+            wanContextId: SelectedWanContextId);
 
         StopPolling();
         _isRunning = false;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -740,7 +740,7 @@
 
     private const string NoAgentReason =
         "WAN speed tests on a managed site run from its On-Site Agent, and this site has none online. " +
-        "Set up the site's agent under Settings > Multi-Site to enable them.";
+        "Set up the site's Agent under Settings > Multi-Site to enable them.";
 
     // Progress interpolation for smooth bar during long phases
     private DateTime _interpStart;
@@ -2059,7 +2059,7 @@
         if (_wanInterfaces.Count == 0)
         {
             _errorMessage = ConnectionService.IsAwaitingAgent
-                ? "Waiting for the On-Site Agent to connect. The gateway test needs the WAN interface list from this site's UniFi Console, which is reached through its agent."
+                ? "Waiting for the On-Site Agent to connect. The Gateway test needs the WAN interface list from this site's UniFi Console, which is reached through its Agent."
                 : "The UniFi Console is unreachable, so the WAN interface list isn't available for a gateway test.";
             StateHasChanged();
             return;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -1066,7 +1066,7 @@
         ApplyAgentVantageAvailability();
     }
 
-    /// <summary>The WAN context the agent run measures, or null for the site's primary WAN.</summary>
+    /// <summary>The WAN context the agent run measures, or null for the site's default path.</summary>
     private int? SelectedWanContextId =>
         int.TryParse(_selectedAgentVantage, out var id) ? id : null;
 

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSpeedTest.razor
@@ -170,7 +170,7 @@
                 {
                 <div class="wan-test-option @(_serverAvailable ? "" : "wan-test-option-unavailable")">
                     <div class="wan-test-option-header">
-                        <span class="wan-test-option-label">@(RunsOnAgent ? "On-site agent" : "Server")</span>
+                        <span class="wan-test-option-label">@(RunsOnAgent ? "On-Site Agent" : "Server")</span>
                         @if (!_serverAvailable && !_isRunning)
                         {
                             <span class="wan-test-option-badge" data-tooltip="@_serverUnavailableReason">Unavailable</span>
@@ -221,11 +221,11 @@
                     <div class="wan-test-option-hint">
                         @if (_hasMultipleWans)
                         {
-                            <text>Tests from @(RunsOnAgent ? "the on-site agent" : "this server") through the LAN. Traffic may be load-balanced across WAN interfaces.</text>
+                            <text>Tests from @(RunsOnAgent ? "the On-Site Agent" : "this server") through the LAN. Traffic may be load-balanced across WAN interfaces.</text>
                         }
                         else
                         {
-                            <text>Tests from @(RunsOnAgent ? "the on-site agent" : "this server") through the LAN. Includes LAN traversal overhead.</text>
+                            <text>Tests from @(RunsOnAgent ? "the On-Site Agent" : "this server") through the LAN. Includes LAN traversal overhead.</text>
                         }
                     </div>
                 </div>
@@ -736,10 +736,10 @@
     private System.Threading.Timer? _agentStatusTimer;
 
     private const string AgentOfflineReason =
-        "This site connects through its on-site agent, which isn't online. WAN speed tests can resume when it reconnects.";
+        "This site connects through its On-Site Agent, which isn't online. WAN speed tests can resume when it reconnects.";
 
     private const string NoAgentReason =
-        "WAN speed tests on a managed site run from its on-site agent, and this site has none online. " +
+        "WAN speed tests on a managed site run from its On-Site Agent, and this site has none online. " +
         "Set up the site's agent under Settings > Multi-Site to enable them.";
 
     // Progress interpolation for smooth bar during long phases
@@ -2059,7 +2059,7 @@
         if (_wanInterfaces.Count == 0)
         {
             _errorMessage = ConnectionService.IsAwaitingAgent
-                ? "Waiting for the on-site agent to connect. The gateway test needs the WAN interface list from this site's UniFi Console, which is reached through its agent."
+                ? "Waiting for the On-Site Agent to connect. The gateway test needs the WAN interface list from this site's UniFi Console, which is reached through its agent."
                 : "The UniFi Console is unreachable, so the WAN interface list isn't available for a gateway test.";
             StateHasChanged();
             return;

--- a/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WanSteering.razor
@@ -302,7 +302,7 @@
         @if (_siteAgentOffline)
         {
             <div class="alert alert-warning">
-                This site deploys through its on-site agent, which isn't connected right now.
+                This site deploys through its On-Site Agent, which isn't connected right now.
                 Deploy actions can resume when the agent reconnects.
             </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -293,7 +293,7 @@
         @if (!CanAddTargets)
         {
             <p class="page-description" style="margin-top: 0.75rem;">
-                <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Deploy an on-site agent</a> to
+                <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Deploy an On-Site Agent</a> to
                 this site to add latency targets - the agent probes them from inside the site's
                 network.
             </p>

--- a/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/LatencyTargetsCard.razor
@@ -293,7 +293,7 @@
         @if (!CanAddTargets)
         {
             <p class="page-description" style="margin-top: 0.75rem;">
-                <a href="/settings?tab=multisite#multi-site">Deploy an on-site agent</a> to
+                <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Deploy an on-site agent</a> to
                 this site to add latency targets - the agent probes them from inside the site's
                 network.
             </p>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1252,12 +1252,14 @@ else
         try
         {
             using var doc = System.Text.Json.JsonDocument.Parse(targetConfig);
+            // A vantage that still exists answers outright; one since deleted falls through to the
+            // WAN group the schedule also records, rather than reading as uncovered.
             if (doc.RootElement.TryGetProperty("wanContextId", out var ctx)
-                && ctx.TryGetInt32(out var contextId))
+                && ctx.TryGetInt32(out var contextId)
+                && contextWans.TryGetValue(contextId, out var contextWan))
             {
-                return contextWans.TryGetValue(contextId, out var contextWan)
-                    && string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(contextWan),
-                        wanGroup, StringComparison.OrdinalIgnoreCase);
+                return string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(contextWan),
+                    wanGroup, StringComparison.OrdinalIgnoreCase);
             }
             if (!doc.RootElement.TryGetProperty("wanGroup", out var g) || g.ValueKind != System.Text.Json.JsonValueKind.String)
                 return wanIsPrimary;

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1231,7 +1231,13 @@ else
                     System.Linq.Queryable.Where(db.ScheduledTasks,
                         t => t.Enabled && t.TaskType == "wan_speedtest"),
                     t => t.TargetConfig));
-            _wanHasSpeedTestSchedule = configs.Any(c => ScheduleCoversWan(c, wanGroup, isPrimary));
+            // An Agent-run schedule names its WAN by context id, so those are resolved to a WAN key
+            // here. Schedules made before that field existed carry neither, and still fall back to
+            // "the primary is what an unnamed test measures".
+            var contextWans = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToDictionaryAsync(
+                System.Linq.Queryable.Where(db.WanContexts, c => c.WanInterface != null && c.WanInterface != ""),
+                c => c.Id, c => c.WanInterface!);
+            _wanHasSpeedTestSchedule = configs.Any(c => ScheduleCoversWan(c, wanGroup, isPrimary, contextWans));
         }
         catch
         {
@@ -1239,12 +1245,20 @@ else
         }
     }
 
-    private static bool ScheduleCoversWan(string? targetConfig, string wanGroup, bool wanIsPrimary)
+    private static bool ScheduleCoversWan(
+        string? targetConfig, string wanGroup, bool wanIsPrimary, IReadOnlyDictionary<int, string> contextWans)
     {
         if (string.IsNullOrEmpty(targetConfig)) return wanIsPrimary;
         try
         {
             using var doc = System.Text.Json.JsonDocument.Parse(targetConfig);
+            if (doc.RootElement.TryGetProperty("wanContextId", out var ctx)
+                && ctx.TryGetInt32(out var contextId))
+            {
+                return contextWans.TryGetValue(contextId, out var contextWan)
+                    && string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanNetworkGroupFromKey(contextWan),
+                        wanGroup, StringComparison.OrdinalIgnoreCase);
+            }
             if (!doc.RootElement.TryGetProperty("wanGroup", out var g) || g.ValueKind != System.Text.Json.JsonValueKind.String)
                 return wanIsPrimary;
             return (g.GetString() ?? "").Split('+')

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -183,7 +183,7 @@
     }
     else if (_step == 3 && _site != null)
     {
-        <h3 class="site-wizard-title">On-site agent for @_site.Name</h3>
+        <h3 class="site-wizard-title">On-Site Agent for @_site.Name</h3>
         @if (!_wantAgent && _agentToken == null)
         {
             <p class="section-description">

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -59,7 +59,7 @@
             <div class="alert alert-info" style="margin-bottom: 0;">
                 <strong>Deploy an On-Site Agent first.</strong>
                 Upstream discovery traces the path from inside this site's network, so it needs a
-                connected agent at the site. Enroll one from <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings &gt; Multi-Site</a>, then
+                connected Agent at the site. Enroll one from <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings &gt; Multi-Site</a>, then
                 run discovery here.
             </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -57,7 +57,7 @@
         @if (!CanDiscover)
         {
             <div class="alert alert-info" style="margin-bottom: 0;">
-                <strong>Deploy an on-site agent first.</strong>
+                <strong>Deploy an On-Site Agent first.</strong>
                 Upstream discovery traces the path from inside this site's network, so it needs a
                 connected agent at the site. Enroll one from <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings &gt; Multi-Site</a>, then
                 run discovery here.

--- a/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/UpstreamTracerPanel.razor
@@ -59,7 +59,7 @@
             <div class="alert alert-info" style="margin-bottom: 0;">
                 <strong>Deploy an on-site agent first.</strong>
                 Upstream discovery traces the path from inside this site's network, so it needs a
-                connected agent at the site. Enroll one from <a href="/settings?tab=multisite#multi-site">Settings</a>, then
+                connected agent at the site. Enroll one from <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings &gt; Multi-Site</a>, then
                 run discovery here.
             </div>
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -112,7 +112,7 @@
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
                                 else if (PinMatches(wc))
                                 {
-                                    <span class="text-muted" data-tooltip="@PinTooltip(wc)">Policy route</span>
+                                    <span class="text-muted wc-probe-source" data-tooltip="@PinTooltip(wc)">Policy route</span>
                                 }
                                 else
                                 {
@@ -400,6 +400,11 @@
     .wc-orphan-warn {
         color: var(--warning-color);
         margin-right: 0.35rem;
+        cursor: pointer;
+    }
+
+    .wc-probe-source {
+        cursor: pointer;
     }
 
     .wc-targets-none {

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -110,7 +110,15 @@
                                           data-tooltip="This site is probed by its agent, so assign one to this WAN.">&#9888;</span>
                                 }
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
-                                else { <span class="text-muted">Default NIC</span> }
+                                else
+                                {
+                                    @if (BindsNothing(wc))
+                                    {
+                                        <span class="wc-note"
+                                              data-tooltip="Nothing is bound, so probes leave by the agent's default interface - not this WAN. Edit to set the interface.">&#8505;</span>
+                                    }
+                                    <span class="text-muted">Default interface</span>
+                                }
                             </td>
                             <td>
                                 @if (wc.AgentId is int rowAgentId)
@@ -386,6 +394,11 @@
         margin-right: 0.35rem;
     }
 
+    .wc-note {
+        color: var(--info-color);
+        margin-right: 0.35rem;
+    }
+
     .wc-targets-none {
         color: var(--warning-color);
         font-weight: 600;
@@ -503,6 +516,19 @@
     /// WAN that is simply quiet.
     /// </summary>
     private bool IsOrphaned(WanContext context) => context.AgentId == null && !ServerProbesThisSite;
+
+    /// <summary>
+    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
+    /// agent's default interface and are filed under this WAN regardless. Reachable without
+    /// anything going wrong: save the vantage while the agent is too old to offer a binding, then
+    /// update the agent - the capability arrives, the empty configuration does not change, and
+    /// nothing says so.
+    /// </summary>
+    private bool BindsNothing(WanContext context) =>
+        context.AgentId is int id
+        && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
+        && string.IsNullOrEmpty(context.InterfaceName)
+        && string.IsNullOrEmpty(context.ProbeSourceIp);
 
     /// <summary>
     /// Whether the selected agent reports a version older than the release currently expected of

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -110,9 +110,17 @@
                                           data-tooltip="This site is probed by its agent, so assign one to this WAN.">&#9888;</span>
                                 }
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
+                                else if (PinMatches(wc))
+                                {
+                                    <span class="text-muted" data-tooltip="@PinTooltip(wc)">Policy route</span>
+                                }
                                 else
                                 {
-                                    @if (BindsNothing(wc))
+                                    @if (PinFor(wc) is RoutePin misrouted)
+                                    {
+                                        <span class="wc-orphan-warn" data-tooltip="@MisroutedWarning(misrouted)">&#9888;</span>
+                                    }
+                                    else if (BindsNothing(wc))
                                     {
                                         <span class="wc-orphan-warn" data-tooltip="@UnboundWarning(wc)">&#9888;</span>
                                     }
@@ -466,6 +474,12 @@
     // bind, and one that cannot bind at all would fail every probe in the context.
     private HashSet<int> _bindCapableAgents = new();
     private HashSet<int> _sourceBindAgents = new();
+
+    /// <summary>What a policy route pins each agent's traffic to, keyed by agent id.</summary>
+    private Dictionary<int, RoutePin> _routePins = new();
+
+    /// <summary>A policy route steering one agent, in the terms this card shows.</summary>
+    private sealed record RoutePin(string WanKey, string? Description, bool KillSwitchEnabled);
     private HashSet<int> _connectedAgents = new();
     private Dictionary<int, int> _targetCounts = new();
     private bool _gatewayAgentHintAllowed;
@@ -565,6 +579,7 @@
         await LoadWansAsync();
         LoadConnectedAgents();
         await LoadBindCapableAgentsAsync();
+        await LoadRoutePinsAsync();
         _gatewayAgentHintAllowed = await UiHints.ShouldShowAsync(UiHintKeys.MultiWanVantageSetup);
     }
 
@@ -705,6 +720,7 @@
         await LoadAgentsAsync();
         await LoadWansAsync();
         await LoadBindCapableAgentsAsync();
+        await LoadRoutePinsAsync();
     }
 
     /// <summary>
@@ -769,6 +785,85 @@
     /// interface, so it binds one of its own addresses instead and the gateway policy-routes that
     /// address out the WAN.
     /// </summary>
+    /// <summary>
+    /// Which WAN a policy route steers each of this site's agents onto. Resolved once per load
+    /// rather than per row, since it costs a console round trip. A gateway-resident agent is
+    /// skipped: it binds its own probe source, so a route naming it steers nothing extra.
+    /// </summary>
+    private async Task LoadRoutePinsAsync()
+    {
+        var pins = new Dictionary<int, RoutePin>();
+        try
+        {
+            var api = Connection.Client;
+            if (api != null && _agents.Count > 0)
+            {
+                var routes = await api.GetTrafficRoutesAsync();
+                if (routes.Count > 0)
+                {
+                    var clients = await api.GetClientsAsync();
+                    var networks = await Connection.GetNetworksAsync();
+                    foreach (var agent in _agents.Where(a => !_bindCapableAgents.Contains(a.Id)))
+                    {
+                        var mac = NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder
+                            .MacForAddress(clients, agent.LanIp);
+                        var pin = TrafficRouteWanPinning.ResolvePin(routes, mac);
+                        if (pin == null) continue;
+                        var network = networks.FirstOrDefault(n =>
+                            string.Equals(n.Id, pin.NetworkId, StringComparison.OrdinalIgnoreCase));
+                        if (network is not { IsWan: true } || string.IsNullOrEmpty(network.WanNetworkgroup)) continue;
+                        pins[agent.Id] = new RoutePin(
+                            GatewayWanHelper.WanInterfaceKeyFromKey(network.WanNetworkgroup),
+                            pin.Description,
+                            pin.KillSwitchEnabled);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // Best effort: with no answer every vantage reads as unrouted, which is what this card
+            // showed before it asked at all.
+            Log.LogDebug(ex, "Could not read policy routes for the vantage list");
+        }
+        _routePins = pins;
+    }
+
+    /// <summary>
+    /// What the route does for this vantage. The kill-switch sentence appears only when it is off,
+    /// which is most of the time and rightly so: a box that also does real work must not have its
+    /// traffic blackholed when a WAN drops. It is a consequence to know, not a fault to fix.
+    /// </summary>
+    private string PinTooltip(WanContext context)
+    {
+        var pin = PinFor(context);
+        var named = string.IsNullOrWhiteSpace(pin?.Description)
+            ? "Steered by a policy route."
+            : $"Steered by the policy route \"{pin!.Description}\".";
+        return pin is { KillSwitchEnabled: false }
+            ? named + " No kill switch, a WAN failover will send probe traffic over another WAN."
+            : named;
+    }
+
+    /// <summary>
+    /// A route steering this agent somewhere other than the WAN its vantage names. Every reading
+    /// here would carry this WAN's name and another WAN's numbers, which no binding can correct.
+    /// </summary>
+    private string MisroutedWarning(RoutePin pin) =>
+        $"A policy route sends this agent's traffic out {WanLabelFor(pin.WanKey)}, so probes take that WAN "
+        + "while readings are recorded against this one. Point the route at this WAN, or change the vantage.";
+
+    /// <summary>The policy route steering this vantage's agent, if one does.</summary>
+    private RoutePin? PinFor(WanContext context) =>
+        context.AgentId is int id && _routePins.TryGetValue(id, out var pin) ? pin : null;
+
+    /// <summary>Whether a policy route steers this vantage's agent onto the WAN the vantage names.</summary>
+    private bool PinMatches(WanContext context) =>
+        PinFor(context) is RoutePin pin
+        && !string.IsNullOrEmpty(context.WanInterface)
+        && string.Equals(pin.WanKey, GatewayWanHelper.WanInterfaceKeyFromKey(context.WanInterface),
+                         StringComparison.OrdinalIgnoreCase);
+
     private async Task LoadBindCapableAgentsAsync()
     {
         var byInterface = new HashSet<int>();

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -67,7 +67,7 @@
                             The easiest way to monitor your other WANs is to deploy the agent on your
                             UniFi gateway. It reaches each WAN by that WAN's own interface, so there is
                             no routing policy to build. Set one up in
-                            <a href="/settings?tab=multisite#multi-site">Settings - Multi-Site</a>.
+                            <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings - Multi-Site</a>.
                         </p>
                     </div>
                     <button class="btn btn-sm btn-tertiary" @onclick="DismissGatewayAgentHintAsync">Dismiss</button>
@@ -193,11 +193,11 @@
                             Assigned agent
                             @* Hover-only because the icon navigates - see App.razor's tooltip init. *@
                             <span class="tooltip-wrapper">
-                                <a href="/settings?tab=multisite#multi-site"
+                                <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")"
                                    class="tooltip-icon tooltip-icon-sm tooltip-icon-contrast"
                                    data-tooltip-hover-only>?</a>
                                 <span class="tooltip-content">
-                                    Agents enroll under <a href="/settings?tab=multisite#multi-site">Settings - Multi-Site</a>; the ones connected to this site appear here.
+                                    Agents enroll under <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings - Multi-Site</a>; the ones connected to this site appear here.
                                 </span>
                             </span>
                         </label>
@@ -260,7 +260,7 @@
                             No agent on the gateway yet. That is the shortest path to probing another
                             WAN: an agent on the UniFi gateway reaches every WAN by its own interface,
                             with no source address to pick and no routing policy to build. The install
-                            command is in <a href="/settings?tab=multisite#multi-site">Settings -
+                            command is in <a href="@($"/settings?tab=multisite&configure={SiteCtx.Slug}")">Settings -
                             Multi-Site</a>. Everything below relies on the gateway routing the probe
                             out the WAN instead.
                         </p>

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -112,7 +112,7 @@
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
                                 else if (PinMatches(wc))
                                 {
-                                    <span class="text-muted wc-probe-source" data-tooltip="@PinTooltip(wc)">Policy route</span>
+                                    <span class="text-muted wc-probe-source" data-tooltip="@PinTooltip(wc)">Policy-Based Route</span>
                                 }
                                 else
                                 {
@@ -473,6 +473,9 @@
     // Null until a connected compute has recorded the site's WAN roles: neither sentence below is
     // shown on a guess, because they prescribe opposite things.
     private bool? _siteLoadBalances;
+
+    /// <summary>The site's primary WAN key, for the vantages that need no binding to reach it.</summary>
+    private string? _primaryWanKey;
     private string? _primaryWanLabel;
     // Agents that both run on the gateway and told us they can bind a probe source. Interface
     // binding is only offered for those: an agent elsewhere on the network has no WAN interface to
@@ -552,7 +555,19 @@
         context.AgentId is int id
         && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
         && string.IsNullOrEmpty(context.InterfaceName)
-        && string.IsNullOrEmpty(context.ProbeSourceIp);
+        && string.IsNullOrEmpty(context.ProbeSourceIp)
+        && !PrimaryPathIsEnough(context);
+
+    /// <summary>
+    /// A primary-WAN vantage on a site that fails over needs nothing bound: the agent's default
+    /// route already is that WAN, and there is no policy route to find because none is wanted.
+    /// Where the site load balances it does need one, because there the balancer picks per flow and
+    /// only a route or a bind says which WAN a probe took. An unknown answer reads as failover, the
+    /// shape of nearly every site.
+    /// </summary>
+    private bool PrimaryPathIsEnough(WanContext context) =>
+        _siteLoadBalances != true
+        && AgentProbeResultSink.IsPrimaryWanContext(context, _primaryWanKey);
 
     /// <summary>
     /// Whether the selected agent reports a version older than the release currently expected of
@@ -677,10 +692,25 @@
         // After the render that created it, not before - there is no element to scroll to until
         // the form is actually in the DOM. Scroll only, no ring: the user pressed the button that
         // opened this, so nothing needs pointing out to them.
-        if (!_revealForm) return;
-        _revealForm = false;
-        await JS.InvokeVoidAsync("noScrollTo", "wan-vantage-form", "center");
+        if (_revealForm)
+        {
+            _revealForm = false;
+            await JS.InvokeVoidAsync("noScrollTo", "wan-vantage-form", "center");
+        }
+
+        if (!firstRender) return;
+        // Both answers below are resolved once and then persist, but the FIRST resolve for an agent
+        // has nothing to fall back on - a card opened just after an agent connects renders before
+        // its answer exists, and nothing here re-asks. One late re-read rather than a poll: by then
+        // the verdict is recorded and every later load reads it directly.
+        await Task.Delay(RowStateSettleDelay);
+        await LoadBindCapableAgentsAsync();
+        await LoadRoutePinsAsync();
+        StateHasChanged();
     }
+
+    /// <summary>How long to wait before re-reading the row state that is unresolved on a cold ask.</summary>
+    private static readonly TimeSpan RowStateSettleDelay = TimeSpan.FromSeconds(3);
 
     private async Task EditContextAsync(WanContext context)
     {
@@ -772,6 +802,9 @@
             await using var db = SiteDb.CreateForSite(SiteCtx.Slug, SiteCtx.IsDefault);
             var primary = await db.WanProfiles.AsNoTracking().FirstOrDefaultAsync(w => w.IsPrimary == true);
             _siteLoadBalances = primary?.SiteLoadBalances;
+            _primaryWanKey = string.IsNullOrEmpty(primary?.WanNetworkgroup)
+                ? null
+                : GatewayWanHelper.WanInterfaceKeyFromKey(primary!.WanNetworkgroup);
             if (_primaryWanLabel == null && primary != null)
             {
                 var key = GatewayWanHelper.WanInterfaceKeyFromKey(primary.WanNetworkgroup);
@@ -779,7 +812,7 @@
                     WanLabelFor(key), GatewayWanHelper.WanIndexFromKey(key));
             }
         }
-        catch { _siteLoadBalances = null; }
+        catch { _siteLoadBalances = null; _primaryWanKey = null; }
     }
 
     /// <summary>
@@ -852,9 +885,11 @@
     private string PinTooltip(WanContext context)
     {
         var pin = PinFor(context);
+        // Tooltips render HTML, and the name comes from the console, so it is encoded before it
+        // goes anywhere near the markup that bolds it.
         var named = string.IsNullOrWhiteSpace(pin?.Description)
-            ? "Steered by a policy route."
-            : $"Steered by the policy route \"{pin!.Description}\".";
+            ? "Steered by a Policy-Based Route."
+            : $"Steered by the Policy-Based Route <strong>{System.Net.WebUtility.HtmlEncode(pin!.Description)}</strong>.";
         return pin is { KillSwitchEnabled: false }
             ? named + " No kill switch, a WAN failover will send probe traffic over another WAN."
             : named;
@@ -865,7 +900,7 @@
     /// here would carry this WAN's name and another WAN's numbers, which no binding can correct.
     /// </summary>
     private string MisroutedWarning(RoutePin pin) =>
-        $"A policy route sends this agent's traffic out {WanLabelFor(pin.WanKey)}, so probes take that WAN "
+        $"A Policy-Based Route sends this agent's traffic out {WanLabelFor(pin.WanKey)}, so probes take that WAN "
         + "while readings are recorded against this one. Point the route at this WAN, or change the vantage.";
 
     /// <summary>The policy route steering this vantage's agent, if one does.</summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -112,8 +112,10 @@
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
                                 else
                                 {
-                                    <span class="wc-note"
-                                          data-tooltip="Nothing is bound, so probes leave by the agent's default interface - not this WAN. Edit to set the interface.">&#8505;</span>
+                                    @if (BindsNothing(wc))
+                                    {
+                                        <span class="wc-orphan-warn" data-tooltip="@UnboundWarning(wc)">&#9888;</span>
+                                    }
                                     <span class="text-muted">Default interface</span>
                                 }
                             </td>
@@ -294,23 +296,24 @@
                     else if (!string.IsNullOrEmpty(_newAgentId))
                     {
                         <p>
-                            This agent reaches @WanLabelFor(_newWanInterface) only if the gateway routes it there. In UniFi
-                            Network, go to Settings - Policy Table and add a Policy-Based Route with
-                            this WAN as the interface, this agent's Client Device as the source, and
-                            Any as the destination. The source is matched by MAC, so the agent needs an
-                            interface and MAC of its own - an LXC has one already, a VM or Docker
-                            container can be given one - not a second address on a host that's already
-                            on the network.
+                            Probes reach @WanLabelFor(_newWanInterface) only when the gateway routes them there. In
+                            UniFi Network, go to Settings - Policy Table and add a Policy-Based Route
+                            with this WAN as the interface, this agent's Client Device as the source,
+                            and Any as the destination. The source is matched by MAC, so the agent
+                            needs a MAC of its own: an LXC or VM has one, and a Docker container can
+                            be given one with macvlan. A second address on a host already on the
+                            network will not work.
                         </p>
                     }
                     else if (!string.IsNullOrWhiteSpace(_newSourceIp))
                     {
                         <p>
-                            This server reaches @WanLabelFor(_newWanInterface) only if the gateway routes it there. In
+                            Probes reach @WanLabelFor(_newWanInterface) only when the gateway routes them there. In
                             UniFi Network, go to Settings - Policy Table and add a Policy-Based Route
                             with this WAN as the interface, this server as the source, and Any as the
-                            destination. The source is matched by MAC, so the address has to sit on a
-                            NIC of its own - not a second address on the NIC this server already uses.
+                            destination. The source is matched by MAC, so the address needs a MAC of
+                            its own, which a macvlan interface provides. A plain second address, or a
+                            VLAN sub-interface that inherits the parent's MAC, will not work.
                         </p>
                     }
                 </div>
@@ -388,11 +391,6 @@
 
     .wc-orphan-warn {
         color: var(--warning-color);
-        margin-right: 0.35rem;
-    }
-
-    .wc-note {
-        color: var(--info-color);
         margin-right: 0.35rem;
     }
 
@@ -513,6 +511,29 @@
     /// WAN that is simply quiet.
     /// </summary>
     private bool IsOrphaned(WanContext context) => context.AgentId == null && !ServerProbesThisSite;
+
+    /// <summary>
+    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
+    /// agent's own interface and are filed under this WAN regardless. Gated on the capability
+    /// because an agent that cannot bind has nothing to fix. Reachable without anything going
+    /// wrong: save the vantage while the agent is too old to offer a binding, then update the agent
+    /// - the capability arrives, the empty configuration does not change, and nothing says so.
+    /// </summary>
+    /// <summary>
+    /// What an unbound vantage costs, in the terms of the binding its agent actually offers: a
+    /// gateway agent leaves by an interface, anything else by a source address the gateway
+    /// policy-routes. Both record against this WAN either way, which is the part worth saying.
+    /// </summary>
+    private string UnboundWarning(WanContext context) =>
+        context.AgentId is int id && _bindCapableAgents.Contains(id)
+            ? "No interface bound. Probes follow the default route and are still recorded against this WAN. Bind the WAN's interface."
+            : "No source address bound. The gateway cannot policy-route the probes, so they follow the default route and are still recorded against this WAN. Bind a source address.";
+
+    private bool BindsNothing(WanContext context) =>
+        context.AgentId is int id
+        && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
+        && string.IsNullOrEmpty(context.InterfaceName)
+        && string.IsNullOrEmpty(context.ProbeSourceIp);
 
     /// <summary>
     /// Whether the selected agent reports a version older than the release currently expected of

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -532,13 +532,6 @@
     private bool IsOrphaned(WanContext context) => context.AgentId == null && !ServerProbesThisSite;
 
     /// <summary>
-    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
-    /// agent's own interface and are filed under this WAN regardless. Gated on the capability
-    /// because an agent that cannot bind has nothing to fix. Reachable without anything going
-    /// wrong: save the vantage while the agent is too old to offer a binding, then update the agent
-    /// - the capability arrives, the empty configuration does not change, and nothing says so.
-    /// </summary>
-    /// <summary>
     /// What an unbound vantage costs, in the terms of the binding its agent actually offers: a
     /// gateway agent leaves by an interface, anything else by a source address the gateway
     /// policy-routes. Both record against this WAN either way, which is the part worth saying.
@@ -548,6 +541,13 @@
             ? "No interface bound. Probes follow the default route and are still recorded against this WAN. Bind the WAN's interface."
             : "No source address bound. The gateway cannot policy-route the probes, so they follow the default route and are still recorded against this WAN. Bind a source address.";
 
+    /// <summary>
+    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
+    /// agent's own interface and are filed under this WAN regardless. Gated on the capability
+    /// because an agent that cannot bind has nothing to fix. Reachable without anything going
+    /// wrong: save the vantage while the agent is too old to offer a binding, then update the agent
+    /// - the capability arrives, the empty configuration does not change, and nothing says so.
+    /// </summary>
     private bool BindsNothing(WanContext context) =>
         context.AgentId is int id
         && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
@@ -793,7 +793,9 @@
     /// <summary>
     /// Which WAN a policy route steers each of this site's agents onto. Resolved once per load
     /// rather than per row, since it costs a console round trip. A gateway-resident agent is
-    /// skipped: it binds its own probe source, so a route naming it steers nothing extra.
+    /// skipped: it binds its own probe source, so a route naming it steers nothing extra. Asked of
+    /// the durable per-agent verdict rather than the bind-capability set, which also requires the
+    /// agent to report source-bind support and so misses a gateway agent too old to say.
     /// </summary>
     private async Task LoadRoutePinsAsync()
     {
@@ -808,8 +810,16 @@
                 {
                     var clients = await api.GetClientsAsync();
                     var networks = await Connection.GetNetworksAsync();
-                    foreach (var agent in _agents.Where(a => !_bindCapableAgents.Contains(a.Id)))
+                    var connections = TunnelRegistry.GetForSite(SiteCtx.Slug);
+                    foreach (var agent in _agents)
                     {
+                        var candidates = connections.FirstOrDefault(c => c.AgentId == agent.Id)?.HostAddresses;
+                        if (candidates is not { Count: > 0 })
+                            candidates = string.IsNullOrEmpty(agent.LanIp)
+                                ? Array.Empty<string>()
+                                : new[] { agent.LanIp! };
+                        if (await OnGatewayDetector.IsAgentOnGatewayAsync(SiteCtx.Slug, agent.Id, candidates)) continue;
+
                         var mac = NetworkOptimizer.Web.Services.Monitoring.PinnedProbeContextBuilder
                             .MacForAddress(clients, agent.LanIp);
                         var pin = TrafficRouteWanPinning.ResolvePin(routes, mac);
@@ -878,12 +888,14 @@
             foreach (var connection in TunnelRegistry.GetForSite(SiteCtx.Slug))
             {
                 if (connection.SupportsSourceBind != true) continue;
-                // TODO(#1106): use the durable per-agent overload
-                // IsAgentOnGatewayAsync(slug, agentId, candidates) instead. This resolves live and
-                // has no persisted verdict, so a console that is not up yet - the norm on an agent
-                // site, where it reconnects through the agent's own tunnel - reads as "not on the
-                // gateway" and offers source-address binding where interface binding belongs.
-                if (await OnGatewayDetector.MatchGatewayAddressAsync(SiteCtx.Slug, connection.HostAddresses) != null)
+                // #1106 fixed HERE, as the pattern for the rest: the durable per-agent overload
+                // seeds from a persisted verdict and keeps the last answer when the console cannot
+                // be reached. The live MatchGatewayAddressAsync this replaced answered "not on the
+                // gateway" whenever the console was not up yet - the norm on an agent site, where
+                // it reconnects through the agent's own tunnel - so the card offered source-address
+                // binding where interface binding belongs, and settled only on a second load.
+                if (await OnGatewayDetector.IsAgentOnGatewayAsync(
+                        SiteCtx.Slug, connection.AgentId, connection.HostAddresses))
                     byInterface.Add(connection.AgentId);
                 else
                     byAddress.Add(connection.AgentId);

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -112,11 +112,8 @@
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
                                 else
                                 {
-                                    @if (BindsNothing(wc))
-                                    {
-                                        <span class="wc-note"
-                                              data-tooltip="Nothing is bound, so probes leave by the agent's default interface - not this WAN. Edit to set the interface.">&#8505;</span>
-                                    }
+                                    <span class="wc-note"
+                                          data-tooltip="Nothing is bound, so probes leave by the agent's default interface - not this WAN. Edit to set the interface.">&#8505;</span>
                                     <span class="text-muted">Default interface</span>
                                 }
                             </td>
@@ -516,19 +513,6 @@
     /// WAN that is simply quiet.
     /// </summary>
     private bool IsOrphaned(WanContext context) => context.AgentId == null && !ServerProbesThisSite;
-
-    /// <summary>
-    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
-    /// agent's default interface and are filed under this WAN regardless. Reachable without
-    /// anything going wrong: save the vantage while the agent is too old to offer a binding, then
-    /// update the agent - the capability arrives, the empty configuration does not change, and
-    /// nothing says so.
-    /// </summary>
-    private bool BindsNothing(WanContext context) =>
-        context.AgentId is int id
-        && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
-        && string.IsNullOrEmpty(context.InterfaceName)
-        && string.IsNullOrEmpty(context.ProbeSourceIp);
 
     /// <summary>
     /// Whether the selected agent reports a version older than the release currently expected of

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -305,10 +305,10 @@
                     else if (!string.IsNullOrEmpty(_newAgentId))
                     {
                         <p>
-                            Probes reach @WanLabelFor(_newWanInterface) only when the gateway routes them there. In
+                            Probes reach @WanLabelFor(_newWanInterface) only when the Gateway routes them there. In
                             UniFi Network, go to Settings - Policy Table and add a Policy-Based Route
-                            with this WAN as the interface, this agent's Client Device as the source,
-                            and Any as the destination. The source is matched by MAC, so the agent
+                            with this WAN as the interface, this Agent's Client Device as the source,
+                            and Any as the destination. The source is matched by MAC, so the Agent
                             needs a MAC of its own: an LXC or VM has one, and a Docker container can
                             be given one with macvlan. A second address on a host already on the
                             network will not work.
@@ -317,7 +317,7 @@
                     else if (!string.IsNullOrWhiteSpace(_newSourceIp))
                     {
                         <p>
-                            Probes reach @WanLabelFor(_newWanInterface) only when the gateway routes them there. In
+                            Probes reach @WanLabelFor(_newWanInterface) only when the Gateway routes them there. In
                             UniFi Network, go to Settings - Policy Table and add a Policy-Based Route
                             with this WAN as the interface, this server as the source, and Any as the
                             destination. The source is matched by MAC, so the address needs a MAC of
@@ -543,7 +543,7 @@
     private string UnboundWarning(WanContext context) =>
         context.AgentId is int id && _bindCapableAgents.Contains(id)
             ? "No interface bound. Probes follow the default route and are still recorded against this WAN. Bind the WAN's interface."
-            : "No source address bound. The gateway cannot policy-route the probes, so they follow the default route and are still recorded against this WAN. Bind a source address.";
+            : "No source address bound. The Gateway cannot policy-route the probes, so they follow the default route and are still recorded against this WAN. Bind a source address.";
 
     /// <summary>
     /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
@@ -901,7 +901,7 @@
     /// here would carry this WAN's name and another WAN's numbers, which no binding can correct.
     /// </summary>
     private string MisroutedWarning(RoutePin pin) =>
-        $"A Policy-Based Route sends this agent's traffic out {WanLabelFor(pin.WanKey)}, so probes take that WAN "
+        $"A Policy-Based Route sends this Agent's traffic out {WanLabelFor(pin.WanKey)}, so probes take that WAN "
         + "while readings are recorded against this one. Point the route at this WAN, or change the vantage.";
 
     /// <summary>The policy route steering this vantage's agent, if one does.</summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -34,9 +34,10 @@
         <div class="expand-content">
     <div class="card-body">
         <p class="section-description">
-            Monitor another WAN by giving its targets their own vantage. A vantage names the WAN
-            and what probes it: an agent on the gateway reaches any WAN directly, or a separate
-            agent can be routed out that WAN in UniFi Network.
+            Monitor additional WAN connections by giving each one a Vantage. A Vantage pairs the WAN
+            connection with the box that probes it: an Agent on the Gateway reaches every WAN via
+            that WAN's own interface, with nothing else to set up. Any other kind of Agent needs a
+            Policy-Based Route in UniFi Network.
         </p>
 
         @if (_siteLoadBalances == true)

--- a/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WanContextsCard.razor
@@ -110,13 +110,7 @@
                                           data-tooltip="This site is probed by its agent, so assign one to this WAN.">&#9888;</span>
                                 }
                                 @if (ProbeSourceOf(wc) is string source) { <code>@source</code> }
-                                else if (BindsNothing(wc))
-                                {
-                                    <span class="wc-orphan-warn"
-                                          data-tooltip="Nothing is bound, so probes leave by the default route - not this WAN. Edit to set the interface.">&#9888;</span>
-                                    <span class="text-muted">default route</span>
-                                }
-                                else { <span class="text-muted">default route</span> }
+                                else { <span class="text-muted">Default NIC</span> }
                             </td>
                             <td>
                                 @if (wc.AgentId is int rowAgentId)
@@ -509,18 +503,6 @@
     /// WAN that is simply quiet.
     /// </summary>
     private bool IsOrphaned(WanContext context) => context.AgentId == null && !ServerProbesThisSite;
-
-    /// <summary>
-    /// A vantage whose agent CAN bind but which has nothing to bind to, so its probes leave by the
-    /// agent's default route and are filed under this WAN regardless. Reachable without anything
-    /// going wrong: save the vantage while the agent is too old to offer a binding, then update the
-    /// agent - the capability arrives, the empty configuration does not change, and nothing says so.
-    /// </summary>
-    private bool BindsNothing(WanContext context) =>
-        context.AgentId is int id
-        && (_bindCapableAgents.Contains(id) || _sourceBindAgents.Contains(id))
-        && string.IsNullOrEmpty(context.InterfaceName)
-        && string.IsNullOrEmpty(context.ProbeSourceIp);
 
     /// <summary>
     /// Whether the selected agent reports a version older than the release currently expected of

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -248,6 +248,7 @@ builder.Services.AddSingleton<AgentProbeResultSink>();
 builder.Services.AddSingleton<AgentTunnelProxyService>();
 builder.Services.AddSingleton<AgentIperf3Service>();
 builder.Services.AddSingleton<AgentUwnService>();
+builder.Services.AddSingleton<AgentWanTestVantageResolver>();
 builder.Services.AddSingleton<AgentProbeService>();
 builder.Services.AddSingleton<AgentSnmpQueryService>();
 builder.Services.AddSingleton<CanonicalBaseUrlProvider>();

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -662,6 +662,16 @@ public class AgentProbeResultSink
     internal static bool ShouldPushSiteCollectionConfig(bool agentIsSteeredToWan) => !agentIsSteeredToWan;
 
     /// <summary>
+    /// Whether this agent should poll SNMP. Steered agents stand down so the site's collector does
+    /// it once, but only when there IS another one to do it: on a site where every agent sits
+    /// behind its own WAN, the collector is necessarily a steered agent, and standing it down too
+    /// leaves the site with no poller at all. <see cref="SelectCollectorAgentId"/> already falls
+    /// back to one for that reason; this is what lets its answer reach the agent.
+    /// </summary>
+    internal static bool ShouldPushSnmpConfig(bool agentIsSteeredToWan, bool agentIsCollector) =>
+        !agentIsSteeredToWan || agentIsCollector;
+
+    /// <summary>
     /// Whether this agent sits ENTIRELY behind one WAN: a context names it and gives no interface
     /// to bind, so the box itself is policy-routed out that WAN. An agent whose contexts all name
     /// an interface binds per probe and still routes normally, so it is not steered. Answers false
@@ -777,7 +787,9 @@ public class AgentProbeResultSink
     {
         var isDefault = connection.SiteSlug == SiteManagementService.DefaultSiteSlug;
         if (isDefault && !await _agentCoverage.CoversAsync(connection.SiteSlug)) return;
-        if (!ShouldPushSiteCollectionConfig(await IsSteeredToWanAgentAsync(connection, ct)))
+        var steered = await IsSteeredToWanAgentAsync(connection, ct);
+        var isCollector = steered && await GetCollectorAgentIdAsync(connection.SiteSlug, ct) == connection.AgentId;
+        if (!ShouldPushSnmpConfig(steered, isCollector))
         {
             // Disabled rather than absent: an agent that polled before being assigned a context
             // keeps polling on its last config until a new one tells it to stop.

--- a/src/NetworkOptimizer.Web/Services/AgentUwnService.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentUwnService.cs
@@ -35,11 +35,13 @@ public class AgentUwnService
     /// uwnspeedtest JSON stdout on success, or an error message otherwise.
     /// </summary>
     public async Task<(bool success, string output)> RunAsync(
-        string siteSlug, int streams, int servers, int durationSeconds, int timeoutSeconds, CancellationToken ct)
+        string siteSlug, int agentId, int streams, int servers, int durationSeconds, int timeoutSeconds, CancellationToken ct)
     {
-        var agent = _registry.GetForSite(siteSlug).FirstOrDefault();
+        // The caller has already chosen which agent measures which WAN, so this never falls back to
+        // another one: a substitute would measure a different WAN under the chosen WAN's name.
+        var agent = _registry.GetForSite(siteSlug).FirstOrDefault(c => c.AgentId == agentId);
         if (agent == null)
-            return (false, $"No agent is online for site '{siteSlug}' to run the WAN speed test");
+            return (false, $"The agent chosen to run the WAN speed test for site '{siteSlug}' is no longer connected");
 
         var id = Interlocked.Increment(ref _nextRequestId);
         var pending = new PendingRun(agent.AgentId);

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -74,12 +74,18 @@ public class AgentWanTestVantageResolver
 
     /// <summary>
     /// The vantages offered on the site's WAN speed test surfaces: the default path, then one entry
-    /// per WAN context. Empty when the site has no contexts - a single-WAN site has nothing to
-    /// choose between and gets no selector at all.
+    /// per WAN context that could run a test. Empty when that leaves nothing to choose between,
+    /// which covers a site with no contexts and a site whose contexts are all served by a gateway
+    /// agent - one possibility is not a choice, so no selector is drawn at all.
     /// <para>
-    /// Deliberately the same list, in the same order, that Latency Targets offers when a target
-    /// picks its WAN: by WAN index so it reads WAN1, WAN2, ... rather than alphabetically, with
-    /// ties broken by name. Choosing a WAN should look the same wherever it is chosen.
+    /// Ordered the way Latency Targets orders the same list: by WAN index so it reads WAN1, WAN2,
+    /// ... rather than alphabetically, with ties broken by name.
+    /// </para>
+    /// <para>
+    /// The filter is about what CAN run, never about what happens to be up. A context whose agent
+    /// is merely offline stays listed and carries its reason, because it comes back; one bound to a
+    /// gateway agent or to no agent at all is dropped, because no amount of waiting makes it
+    /// runnable and the Gateway test already covers that WAN.
     /// </para>
     /// </summary>
     public async Task<List<AgentWanVantage>> ListVantagesAsync(string siteSlug, CancellationToken ct = default)
@@ -87,17 +93,35 @@ public class AgentWanTestVantageResolver
         var contexts = await LoadContextsAsync(siteSlug, ct);
         if (contexts.Count == 0) return new List<AgentWanVantage>();
 
+        var capable = new HashSet<int>();
+        foreach (var agentId in contexts.Where(c => c.AgentId != null).Select(c => c.AgentId!.Value).Distinct())
+            if (await CanRunAsync(siteSlug, agentId, ct))
+                capable.Add(agentId);
+
+        var runnable = SelectableContexts(contexts, capable).ToList();
+        if (runnable.Count == 0) return new List<AgentWanVantage>();
+
         var vantages = new List<AgentWanVantage>();
         var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
         vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
 
-        foreach (var context in OrderForDisplay(contexts))
+        foreach (var context in runnable)
         {
             var (_, refusal) = await ResolveAsync(siteSlug, context.Id, ct);
             vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
         }
         return vantages;
     }
+
+    /// <summary>
+    /// The contexts a WAN speed test could be pointed at, in display order. Drops what can never
+    /// run - a context with no agent, or one whose agent is on the gateway - rather than listing a
+    /// WAN that will refuse every time it is picked. An agent that is simply offline is NOT dropped:
+    /// it comes back, and its entry carries the reason meanwhile.
+    /// </summary>
+    internal static IEnumerable<WanContext> SelectableContexts(
+        IEnumerable<WanContext> contexts, IReadOnlyCollection<int> capableAgentIds) =>
+        OrderForDisplay(contexts.Where(c => c.AgentId != null && capableAgentIds.Contains(c.AgentId.Value)));
 
     /// <summary>
     /// WAN contexts in the order every selector shows them: by WAN index, then by name. Shared with

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -1,0 +1,223 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>One selectable vantage for an agent-run WAN speed test: the primary WAN, or a WAN context.</summary>
+/// <param name="ContextId">Null for the primary WAN, which has no context row.</param>
+/// <param name="Label">Display name for the selector.</param>
+/// <param name="Runnable">Whether a test started on this vantage right now would run.</param>
+/// <param name="Reason">Why it would not, when <paramref name="Runnable"/> is false.</param>
+public sealed record AgentWanVantage(int? ContextId, string Label, bool Runnable, string? Reason);
+
+/// <summary>The agent an agent-run WAN speed test will execute on, and the WAN it measures.</summary>
+/// <param name="AgentId">Agent to dispatch the run to.</param>
+/// <param name="Context">The chosen WAN context, or null when the run is on the primary WAN.</param>
+public sealed record AgentWanTestVantage(int AgentId, WanContext? Context);
+
+/// <summary>
+/// Chooses which of a site's agents runs its WAN speed test, and which WAN that measures.
+///
+/// A site can have several agents - one per WAN behind separate uplinks, or a bare-metal agent for
+/// speed testing alongside a gateway agent for monitoring. Picking whichever answered first sends
+/// the run to an arbitrary box and, on a mixed site, to one that cannot run it at all.
+/// </summary>
+public class AgentWanTestVantageResolver
+{
+    private readonly AgentTunnelRegistry _tunnels;
+    private readonly AgentOnGatewayDetector _onGateway;
+    private readonly AgentProbeResultSink _probeSink;
+    private readonly SiteDbContextFactory _siteDbFactory;
+    private readonly IDbContextFactory<NetworkOptimizerDbContext> _mainDbFactory;
+    private readonly ILogger<AgentWanTestVantageResolver> _logger;
+
+    public AgentWanTestVantageResolver(
+        AgentTunnelRegistry tunnels,
+        AgentOnGatewayDetector onGateway,
+        AgentProbeResultSink probeSink,
+        SiteDbContextFactory siteDbFactory,
+        IDbContextFactory<NetworkOptimizerDbContext> mainDbFactory,
+        ILogger<AgentWanTestVantageResolver> logger)
+    {
+        _tunnels = tunnels;
+        _onGateway = onGateway;
+        _probeSink = probeSink;
+        _siteDbFactory = siteDbFactory;
+        _mainDbFactory = mainDbFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Whether an agent can run the WAN test, which today means it is not on the gateway: the
+    /// on-gateway installer ships no uwnspeedtest ("no speed-test machinery"), and the agent
+    /// resolves the binary next to itself.
+    /// <para>
+    /// A proxy for a capability the agent does not report. Not <c>ServesSpeedTest</c> from the
+    /// hello - that is the LAN speed test page, which is opt-in at install while uwnspeedtest is
+    /// always fetched, so a no there says nothing about this. When gateway installs gain the
+    /// binary, replace this with a reported capability rather than widening the proxy.
+    /// </para>
+    /// </summary>
+    public async Task<bool> CanRunAsync(string siteSlug, int agentId, CancellationToken ct = default)
+        => !await IsOnGatewayAsync(siteSlug, agentId, ct);
+
+    /// <summary>Whether any connected agent for the site could run a WAN speed test.</summary>
+    public async Task<bool> HasCapableAgentAsync(string siteSlug, CancellationToken ct = default)
+        => await FirstCapableAgentAsync(siteSlug, ct) != null;
+
+    /// <summary>
+    /// The vantages offered on the site's WAN speed test surfaces: the primary WAN, then one entry
+    /// per WAN context. Empty when the site has no contexts - a single-WAN site has nothing to
+    /// choose between and gets no selector at all.
+    /// </summary>
+    public async Task<List<AgentWanVantage>> ListVantagesAsync(string siteSlug, CancellationToken ct = default)
+    {
+        var contexts = await LoadContextsAsync(siteSlug, ct);
+        if (contexts.Count == 0) return new List<AgentWanVantage>();
+
+        var vantages = new List<AgentWanVantage>();
+        var (_, primaryRefusal) = await ResolveAsync(siteSlug, null, ct);
+        vantages.Add(new AgentWanVantage(null, "Primary", primaryRefusal == null, primaryRefusal));
+
+        foreach (var context in contexts.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
+        {
+            var (_, refusal) = await ResolveAsync(siteSlug, context.Id, ct);
+            vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
+        }
+        return vantages;
+    }
+
+    /// <summary>
+    /// The agent that runs the test, or the reason none will. Exactly one of the two is non-null.
+    /// <para>
+    /// A named context is honored or refused, never redirected: running on a different agent would
+    /// measure a different WAN and file the number under the name the caller chose, which is worse
+    /// than returning nothing. Same rule <see cref="Monitoring.ProbeExecutorFactory.ForAgent"/>
+    /// holds for probes.
+    /// </para>
+    /// </summary>
+    /// <param name="siteSlug">Site whose agents are candidates.</param>
+    /// <param name="wanContextId">Chosen WAN context, or null for the site's primary WAN.</param>
+    public async Task<(AgentWanTestVantage? Vantage, string? Refusal)> ResolveAsync(
+        string siteSlug, int? wanContextId, CancellationToken ct = default)
+    {
+        var connected = _tunnels.GetForSite(siteSlug).Select(c => c.AgentId).ToList();
+        var capable = new HashSet<int>();
+        foreach (var agentId in connected)
+            if (await CanRunAsync(siteSlug, agentId, ct))
+                capable.Add(agentId);
+
+        var contexts = wanContextId == null ? new List<WanContext>() : await LoadContextsAsync(siteSlug, ct);
+        var collector = wanContextId == null ? await _probeSink.GetCollectorAgentIdAsync(siteSlug, ct) : null;
+
+        return Decide(wanContextId, contexts, connected, capable, collector);
+    }
+
+    /// <summary>
+    /// Picks the agent, or says why none will run. Pure, so the rules can be tested without a
+    /// tunnel, a console or a database - the same reason
+    /// <see cref="AgentProbeResultSink.SelectCollectorAgentId"/> is shaped this way.
+    /// <para>
+    /// For the primary WAN: the collector when it can run the test, otherwise the lowest-id
+    /// connected agent that can. The two rules diverge on purpose - a gateway agent is deliberately
+    /// eligible to collect, because it binds each probe to a WAN and one of them can serve a whole
+    /// site, and is equally deliberately unable to run this test. On a site pairing a gateway agent
+    /// with a bare-metal one, that fallback is what finds the box that can.
+    /// </para>
+    /// </summary>
+    /// <param name="wanContextId">Chosen context, or null for the primary WAN.</param>
+    /// <param name="contexts">The site's WAN contexts. Only read when one was chosen.</param>
+    /// <param name="connectedAgentIds">Agents with an open tunnel.</param>
+    /// <param name="capableAgentIds">Of those, the ones that can run the test.</param>
+    /// <param name="collectorAgentId">The site's collector, or null when none owns it.</param>
+    internal static (AgentWanTestVantage? Vantage, string? Refusal) Decide(
+        int? wanContextId,
+        IReadOnlyCollection<WanContext> contexts,
+        IReadOnlyCollection<int> connectedAgentIds,
+        IReadOnlyCollection<int> capableAgentIds,
+        int? collectorAgentId)
+    {
+        if (wanContextId == null)
+        {
+            if (collectorAgentId != null && capableAgentIds.Contains(collectorAgentId.Value))
+                return (new AgentWanTestVantage(collectorAgentId.Value, null), null);
+
+            var fallback = connectedAgentIds.Where(capableAgentIds.Contains).OrderBy(id => id).ToList();
+            return fallback.Count == 0
+                ? (null, "No connected agent at this site can run a WAN speed test.")
+                : (new AgentWanTestVantage(fallback[0], null), null);
+        }
+
+        var context = contexts.FirstOrDefault(c => c.Id == wanContextId);
+        if (context == null)
+            return (null, "The WAN this test was set up for no longer exists. Pick a WAN and save it again.");
+
+        if (context.AgentId == null)
+            return (null, $"'{context.Name}' is measured by this server over a bound source address, not by an agent, so it has no agent to run a speed test on.");
+
+        if (!connectedAgentIds.Contains(context.AgentId.Value))
+            return (null, $"The agent for '{context.Name}' is not connected. WAN speed tests on that WAN resume when it reconnects.");
+
+        if (!capableAgentIds.Contains(context.AgentId.Value))
+            return (null, $"The agent for '{context.Name}' runs on the gateway, which carries no speed test binary. Use the Gateway test for that WAN.");
+
+        return (new AgentWanTestVantage(context.AgentId.Value, context), null);
+    }
+
+    /// <summary>Lowest-id connected agent that can run the test, so the choice does not move between runs.</summary>
+    private async Task<int?> FirstCapableAgentAsync(string siteSlug, CancellationToken ct)
+    {
+        foreach (var agentId in _tunnels.GetForSite(siteSlug).Select(c => c.AgentId).OrderBy(id => id))
+            if (await CanRunAsync(siteSlug, agentId, ct))
+                return agentId;
+        return null;
+    }
+
+    /// <summary>
+    /// Resolves one agent against its site's gateway addresses. The live tunnel reports every
+    /// address its host holds; an agent with no open tunnel falls back to its last known LAN IP.
+    /// </summary>
+    private async Task<bool> IsOnGatewayAsync(string siteSlug, int agentId, CancellationToken ct)
+    {
+        var candidates = _tunnels.GetForSite(siteSlug).FirstOrDefault(c => c.AgentId == agentId)?.HostAddresses;
+        if (candidates is not { Count: > 0 })
+        {
+            var lanIp = await LookupLanIpAsync(agentId, ct);
+            candidates = string.IsNullOrEmpty(lanIp) ? Array.Empty<string>() : new[] { lanIp };
+        }
+        return await _onGateway.IsAgentOnGatewayAsync(siteSlug, agentId, candidates, ct);
+    }
+
+    private async Task<string?> LookupLanIpAsync(int agentId, CancellationToken ct)
+    {
+        try
+        {
+            await using var db = await _mainDbFactory.CreateDbContextAsync(ct);
+            return await db.SiteAgents.AsNoTracking()
+                .Where(a => a.Id == agentId).Select(a => a.LanIp).FirstOrDefaultAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the LAN IP for agent {AgentId}", agentId);
+            return null;
+        }
+    }
+
+    private async Task<List<WanContext>> LoadContextsAsync(string siteSlug, CancellationToken ct)
+    {
+        try
+        {
+            await using var db = _siteDbFactory.CreateForSite(
+                siteSlug, siteSlug == SiteManagementService.DefaultSiteSlug);
+            return await db.WanContexts.AsNoTracking().ToListAsync(ct);
+        }
+        catch (Exception ex)
+        {
+            // A site mid-creation or mid-removal reads as "no contexts", which is the single-WAN
+            // path every install takes today.
+            _logger.LogDebug(ex, "Could not read WAN contexts for site {Slug}", siteSlug);
+            return new List<WanContext>();
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -315,6 +315,10 @@ public class AgentWanTestVantageResolver
         return await _onGateway.IsAgentOnGatewayAsync(siteSlug, agentId, candidates, ct);
     }
 
+    /// <summary>The LAN address an agent is known by, for callers that resolved the agent already.</summary>
+    public Task<string?> AgentLanIpAsync(int agentId, CancellationToken ct = default) =>
+        LookupLanIpAsync(agentId, ct);
+
     private async Task<string?> LookupLanIpAsync(int agentId, CancellationToken ct)
     {
         try

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -114,14 +114,33 @@ public class AgentWanTestVantageResolver
     }
 
     /// <summary>
+    /// Whether a speed test run on this context's agent actually leaves by this context's WAN.
+    /// <para>
+    /// Only true for a ROUTE-steered agent, which is what an empty <see cref="WanContext.InterfaceName"/>
+    /// means: the gateway sends everything that box emits out this WAN, the speed test included.
+    /// An interface-bound context is the opposite - the agent binds each PROBE to that interface,
+    /// and everything else it sends, an unbound uwnspeedtest run included, takes whatever route the
+    /// table prefers. Offering one would measure a different WAN and label it with this one's name.
+    /// </para>
+    /// <para>
+    /// It is the same property <see cref="AgentProbeResultSink.SelectCollectorAgentId"/> tests to
+    /// decide an agent must NOT collect, for the same reason read the other way: everything it
+    /// sends leaves by its own WAN.
+    /// </para>
+    /// </summary>
+    internal static bool MeasuresItsOwnWan(WanContext context) =>
+        context.AgentId != null && string.IsNullOrEmpty(context.InterfaceName);
+
+    /// <summary>
     /// The contexts a WAN speed test could be pointed at, in display order. Drops what can never
-    /// run - a context with no agent, or one whose agent is on the gateway - rather than listing a
-    /// WAN that will refuse every time it is picked. An agent that is simply offline is NOT dropped:
-    /// it comes back, and its entry carries the reason meanwhile.
+    /// produce a true reading - no agent, an interface-bound agent whose traffic does not follow
+    /// the WAN, or an agent that cannot run the binary - rather than listing a WAN that refuses
+    /// every time it is picked, or worse, answers with another WAN's number. An agent that is
+    /// simply offline is NOT dropped: it comes back, and its entry carries the reason meanwhile.
     /// </summary>
     internal static IEnumerable<WanContext> SelectableContexts(
         IEnumerable<WanContext> contexts, IReadOnlyCollection<int> capableAgentIds) =>
-        OrderForDisplay(contexts.Where(c => c.AgentId != null && capableAgentIds.Contains(c.AgentId.Value)));
+        OrderForDisplay(contexts.Where(c => MeasuresItsOwnWan(c) && capableAgentIds.Contains(c.AgentId!.Value)));
 
     /// <summary>
     /// WAN contexts in the order every selector shows them: by WAN index, then by name. Shared with
@@ -201,6 +220,9 @@ public class AgentWanTestVantageResolver
 
         if (context.AgentId == null)
             return (null, $"'{context.Name}' is measured by this server over a bound source address, not by an agent, so it has no agent to run a speed test on.");
+
+        if (!MeasuresItsOwnWan(context))
+            return (null, $"The agent for '{context.Name}' binds each probe to that WAN's interface rather than routing over it, so a speed test from it would measure whichever WAN its own route takes. Use the Gateway test for that WAN.");
 
         if (!connectedAgentIds.Contains(context.AgentId.Value))
             return (null, $"The agent for '{context.Name}' is not connected. WAN speed tests on that WAN resume when it reconnects.");

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -102,14 +102,17 @@ public class AgentWanTestVantageResolver
         if (runnable.Count == 0) return new List<AgentWanVantage>();
 
         var vantages = new List<AgentWanVantage>();
-        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
-        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
-
         foreach (var context in runnable)
         {
             var (_, refusal) = await ResolveAsync(siteSlug, context.Id, ct);
             vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
         }
+
+        // Last, and so not the one selected by default. It is the only way to reach a WAN with no
+        // vantage yet, but a named WAN gives an attributed result where this gives an inferred one,
+        // so it is the fallback rather than the offer.
+        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
+        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
         return vantages;
     }
 

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -108,12 +108,49 @@ public class AgentWanTestVantageResolver
             vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
         }
 
-        // Last, and so not the one selected by default. It is the only way to reach a WAN with no
-        // vantage yet, but a named WAN gives an attributed result where this gives an inferred one,
-        // so it is the fallback rather than the offer.
-        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
-        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
+        // Last, and so not the one selected by default. It reaches a WAN that has no vantage yet,
+        // which is the only thing it is for - a named WAN gives an attributed result where this
+        // gives an inferred one. Once every WAN is covered it offers nothing but that ambiguity, so
+        // it is dropped rather than left as a way to file one WAN's numbers under a guess.
+        if (!await EveryWanIsCoveredAsync(siteSlug, runnable, ct))
+        {
+            var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
+            vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
+        }
         return vantages;
+    }
+
+    /// <summary>
+    /// Whether the runnable vantages between them account for every WAN the site has. Answers false
+    /// on any doubt - an unreadable site database, or a site with no WAN profiles recorded yet - so
+    /// the fallback stays offered rather than being removed on a gap.
+    /// </summary>
+    private async Task<bool> EveryWanIsCoveredAsync(
+        string siteSlug, IReadOnlyCollection<WanContext> runnable, CancellationToken ct)
+    {
+        try
+        {
+            await using var db = _siteDbFactory.CreateForSite(
+                siteSlug, siteSlug == SiteManagementService.DefaultSiteSlug);
+            var wanKeys = await db.WanProfiles.AsNoTracking()
+                .Select(w => w.WanNetworkgroup).ToListAsync(ct);
+            var known = wanKeys
+                .Where(k => !string.IsNullOrEmpty(k))
+                .Select(k => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(k!))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (known.Count == 0) return false;
+
+            var covered = runnable
+                .Where(c => !string.IsNullOrEmpty(c.WanInterface))
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return known.All(covered.Contains);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the WAN list for site {Slug}; keeping the default path option", siteSlug);
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -35,6 +35,7 @@ public class AgentWanTestVantageResolver
     private readonly AgentTunnelRegistry _tunnels;
     private readonly AgentOnGatewayDetector _onGateway;
     private readonly AgentProbeResultSink _probeSink;
+    private readonly SiteConnectionRegistry _siteConnections;
     private readonly SiteDbContextFactory _siteDbFactory;
     private readonly IDbContextFactory<NetworkOptimizerDbContext> _mainDbFactory;
     private readonly ILogger<AgentWanTestVantageResolver> _logger;
@@ -43,6 +44,7 @@ public class AgentWanTestVantageResolver
         AgentTunnelRegistry tunnels,
         AgentOnGatewayDetector onGateway,
         AgentProbeResultSink probeSink,
+        SiteConnectionRegistry siteConnections,
         SiteDbContextFactory siteDbFactory,
         IDbContextFactory<NetworkOptimizerDbContext> mainDbFactory,
         ILogger<AgentWanTestVantageResolver> logger)
@@ -50,6 +52,7 @@ public class AgentWanTestVantageResolver
         _tunnels = tunnels;
         _onGateway = onGateway;
         _probeSink = probeSink;
+        _siteConnections = siteConnections;
         _siteDbFactory = siteDbFactory;
         _mainDbFactory = mainDbFactory;
         _logger = logger;
@@ -113,9 +116,47 @@ public class AgentWanTestVantageResolver
         // where this gives an inferred one. Kept even when every vantage looks covered, because
         // nothing here knows the site's full WAN list - WanProfiles records only the WANs the app
         // has seen, so "all covered" was answerable and wrong.
-        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
-        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
+        // Last, and so not the one selected by default: a named WAN gives an attributed result
+        // where this gives an inferred one. Dropped once every WAN the console reports has a
+        // vantage, because then it can only re-run one of them and file the numbers under a guess.
+        if (!await EveryWanIsCoveredAsync(siteSlug, runnable, ct))
+        {
+            var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
+            vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
+        }
         return vantages;
+    }
+
+    /// <summary>
+    /// Whether the runnable vantages account for every WAN the site actually has. Asked of the
+    /// console, which is the only thing that knows: WanProfiles records only the WANs the app has
+    /// seen so far, and answering from it reported full coverage on a site with WANs it had never
+    /// recorded. Any doubt answers false, so the fallback stays offered rather than being removed
+    /// on a gap.
+    /// </summary>
+    private async Task<bool> EveryWanIsCoveredAsync(
+        string siteSlug, IReadOnlyCollection<WanContext> runnable, CancellationToken ct)
+    {
+        try
+        {
+            var networks = await _siteConnections.GetFor(siteSlug).GetNetworksAsync(ct);
+            var known = networks
+                .Where(n => n.IsWan && n.Enabled && !string.IsNullOrEmpty(n.WanNetworkgroup))
+                .Select(n => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(n.WanNetworkgroup!))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (known.Count == 0) return false;
+
+            var covered = runnable
+                .Where(c => !string.IsNullOrEmpty(c.WanInterface))
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            return known.All(covered.Contains);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the WAN list for site {Slug}; keeping the default path option", siteSlug);
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -4,8 +4,8 @@ using NetworkOptimizer.Storage.Services;
 
 namespace NetworkOptimizer.Web.Services;
 
-/// <summary>One selectable vantage for an agent-run WAN speed test: the primary WAN, or a WAN context.</summary>
-/// <param name="ContextId">Null for the primary WAN, which has no context row.</param>
+/// <summary>One selectable vantage for an agent-run WAN speed test: the default path, or a WAN context.</summary>
+/// <param name="ContextId">Null for the default path, which has no context row.</param>
 /// <param name="Label">Display name for the selector.</param>
 /// <param name="Runnable">Whether a test started on this vantage right now would run.</param>
 /// <param name="Reason">Why it would not, when <paramref name="Runnable"/> is false.</param>
@@ -13,7 +13,7 @@ public sealed record AgentWanVantage(int? ContextId, string Label, bool Runnable
 
 /// <summary>The agent an agent-run WAN speed test will execute on, and the WAN it measures.</summary>
 /// <param name="AgentId">Agent to dispatch the run to.</param>
-/// <param name="Context">The chosen WAN context, or null when the run is on the primary WAN.</param>
+/// <param name="Context">The chosen WAN context, or null when the run takes the default path.</param>
 public sealed record AgentWanTestVantage(int AgentId, WanContext? Context);
 
 /// <summary>
@@ -25,6 +25,12 @@ public sealed record AgentWanTestVantage(int AgentId, WanContext? Context);
 /// </summary>
 public class AgentWanTestVantageResolver
 {
+    /// <summary>
+    /// The unpinned option, named the way the target list already names it in Latency Targets, so
+    /// one WAN choice does not read as two different things across the app.
+    /// </summary>
+    public const string DefaultPathLabel = "Default path";
+
     private readonly AgentTunnelRegistry _tunnels;
     private readonly AgentOnGatewayDetector _onGateway;
     private readonly AgentProbeResultSink _probeSink;
@@ -67,9 +73,14 @@ public class AgentWanTestVantageResolver
         => await FirstCapableAgentAsync(siteSlug, ct) != null;
 
     /// <summary>
-    /// The vantages offered on the site's WAN speed test surfaces: the primary WAN, then one entry
+    /// The vantages offered on the site's WAN speed test surfaces: the default path, then one entry
     /// per WAN context. Empty when the site has no contexts - a single-WAN site has nothing to
     /// choose between and gets no selector at all.
+    /// <para>
+    /// Deliberately the same list, in the same order, that Latency Targets offers when a target
+    /// picks its WAN: by WAN index so it reads WAN1, WAN2, ... rather than alphabetically, with
+    /// ties broken by name. Choosing a WAN should look the same wherever it is chosen.
+    /// </para>
     /// </summary>
     public async Task<List<AgentWanVantage>> ListVantagesAsync(string siteSlug, CancellationToken ct = default)
     {
@@ -77,16 +88,27 @@ public class AgentWanTestVantageResolver
         if (contexts.Count == 0) return new List<AgentWanVantage>();
 
         var vantages = new List<AgentWanVantage>();
-        var (_, primaryRefusal) = await ResolveAsync(siteSlug, null, ct);
-        vantages.Add(new AgentWanVantage(null, "Primary", primaryRefusal == null, primaryRefusal));
+        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
+        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
 
-        foreach (var context in contexts.OrderBy(c => c.Name, StringComparer.OrdinalIgnoreCase))
+        foreach (var context in OrderForDisplay(contexts))
         {
             var (_, refusal) = await ResolveAsync(siteSlug, context.Id, ct);
             vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
         }
         return vantages;
     }
+
+    /// <summary>
+    /// WAN contexts in the order every selector shows them: by WAN index, then by name. Shared with
+    /// <see cref="Components.Shared.LatencyTargetsCard"/>'s ordering so the two lists match.
+    /// </summary>
+    internal static IEnumerable<WanContext> OrderForDisplay(IEnumerable<WanContext> contexts) =>
+        contexts
+            .OrderBy(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(c.WanInterface) is var i && i >= 1
+                ? i
+                : int.MaxValue)
+            .ThenBy(c => c.Name, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// The agent that runs the test, or the reason none will. Exactly one of the two is non-null.
@@ -98,7 +120,7 @@ public class AgentWanTestVantageResolver
     /// </para>
     /// </summary>
     /// <param name="siteSlug">Site whose agents are candidates.</param>
-    /// <param name="wanContextId">Chosen WAN context, or null for the site's primary WAN.</param>
+    /// <param name="wanContextId">Chosen WAN context, or null to take the site's default path.</param>
     public async Task<(AgentWanTestVantage? Vantage, string? Refusal)> ResolveAsync(
         string siteSlug, int? wanContextId, CancellationToken ct = default)
     {
@@ -119,14 +141,14 @@ public class AgentWanTestVantageResolver
     /// tunnel, a console or a database - the same reason
     /// <see cref="AgentProbeResultSink.SelectCollectorAgentId"/> is shaped this way.
     /// <para>
-    /// For the primary WAN: the collector when it can run the test, otherwise the lowest-id
+    /// On the default path: the collector when it can run the test, otherwise the lowest-id
     /// connected agent that can. The two rules diverge on purpose - a gateway agent is deliberately
     /// eligible to collect, because it binds each probe to a WAN and one of them can serve a whole
     /// site, and is equally deliberately unable to run this test. On a site pairing a gateway agent
     /// with a bare-metal one, that fallback is what finds the box that can.
     /// </para>
     /// </summary>
-    /// <param name="wanContextId">Chosen context, or null for the primary WAN.</param>
+    /// <param name="wanContextId">Chosen context, or null for the default path.</param>
     /// <param name="contexts">The site's WAN contexts. Only read when one was chosen.</param>
     /// <param name="connectedAgentIds">Agents with an open tunnel.</param>
     /// <param name="capableAgentIds">Of those, the ones that can run the test.</param>

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -177,9 +177,21 @@ public class AgentWanTestVantageResolver
     /// <summary>
     /// Resolves one agent against its site's gateway addresses. The live tunnel reports every
     /// address its host holds; an agent with no open tunnel falls back to its last known LAN IP.
+    /// <para>
+    /// A site with one connected agent asks the SITE-level verdict instead, which is the question
+    /// every WAN test surface asked before there was a per-agent one, and is unambiguous when there
+    /// is only one agent to be about. That is not a preference: the two verdicts persist under
+    /// different keys, so an agent enrolled before the per-agent key existed has nothing stored to
+    /// fall back on, and a cold read with the console still down answers "not on the gateway"
+    /// (TODO(#1106) in AgentOnGatewayDetector). Routing single-agent sites through the site-level
+    /// answer means the only installs that exist today cannot behave differently than they did.
+    /// </para>
     /// </summary>
     private async Task<bool> IsOnGatewayAsync(string siteSlug, int agentId, CancellationToken ct)
     {
+        if (_tunnels.GetForSite(siteSlug).Count <= 1)
+            return await _onGateway.IsAgentOnGatewayAsync(siteSlug, ct);
+
         var candidates = _tunnels.GetForSite(siteSlug).FirstOrDefault(c => c.AgentId == agentId)?.HostAddresses;
         if (candidates is not { Count: > 0 })
         {

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -9,7 +9,8 @@ namespace NetworkOptimizer.Web.Services;
 /// <param name="Label">Display name for the selector.</param>
 /// <param name="Runnable">Whether a test started on this vantage right now would run.</param>
 /// <param name="Reason">Why it would not, when <paramref name="Runnable"/> is false.</param>
-public sealed record AgentWanVantage(int? ContextId, string Label, bool Runnable, string? Reason);
+/// <param name="WanKey">UniFi WAN key this measures, so a schedule can record which WAN it covers.</param>
+public sealed record AgentWanVantage(int? ContextId, string Label, bool Runnable, string? Reason, string? WanKey = null);
 
 /// <summary>The agent an agent-run WAN speed test will execute on, and the WAN it measures.</summary>
 /// <param name="AgentId">Agent to dispatch the run to.</param>
@@ -105,7 +106,7 @@ public class AgentWanTestVantageResolver
         foreach (var context in runnable)
         {
             var (_, refusal) = await ResolveAsync(siteSlug, context.Id, ct);
-            vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal));
+            vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal, context.WanInterface));
         }
 
         // Last, and so not the one selected by default. It reaches a WAN that has no vantage yet,

--- a/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentWanTestVantageResolver.cs
@@ -109,49 +109,13 @@ public class AgentWanTestVantageResolver
             vantages.Add(new AgentWanVantage(context.Id, context.Name, refusal == null, refusal, context.WanInterface));
         }
 
-        // Last, and so not the one selected by default. It reaches a WAN that has no vantage yet,
-        // which is the only thing it is for - a named WAN gives an attributed result where this
-        // gives an inferred one. Once every WAN is covered it offers nothing but that ambiguity, so
-        // it is dropped rather than left as a way to file one WAN's numbers under a guess.
-        if (!await EveryWanIsCoveredAsync(siteSlug, runnable, ct))
-        {
-            var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
-            vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
-        }
+        // Last, and so not the one selected by default: a named WAN gives an attributed result
+        // where this gives an inferred one. Kept even when every vantage looks covered, because
+        // nothing here knows the site's full WAN list - WanProfiles records only the WANs the app
+        // has seen, so "all covered" was answerable and wrong.
+        var (_, defaultPathRefusal) = await ResolveAsync(siteSlug, null, ct);
+        vantages.Add(new AgentWanVantage(null, DefaultPathLabel, defaultPathRefusal == null, defaultPathRefusal));
         return vantages;
-    }
-
-    /// <summary>
-    /// Whether the runnable vantages between them account for every WAN the site has. Answers false
-    /// on any doubt - an unreadable site database, or a site with no WAN profiles recorded yet - so
-    /// the fallback stays offered rather than being removed on a gap.
-    /// </summary>
-    private async Task<bool> EveryWanIsCoveredAsync(
-        string siteSlug, IReadOnlyCollection<WanContext> runnable, CancellationToken ct)
-    {
-        try
-        {
-            await using var db = _siteDbFactory.CreateForSite(
-                siteSlug, siteSlug == SiteManagementService.DefaultSiteSlug);
-            var wanKeys = await db.WanProfiles.AsNoTracking()
-                .Select(w => w.WanNetworkgroup).ToListAsync(ct);
-            var known = wanKeys
-                .Where(k => !string.IsNullOrEmpty(k))
-                .Select(k => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(k!))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            if (known.Count == 0) return false;
-
-            var covered = runnable
-                .Where(c => !string.IsNullOrEmpty(c.WanInterface))
-                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            return known.All(covered.Contains);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Could not read the WAN list for site {Slug}; keeping the default path option", siteSlug);
-            return false;
-        }
     }
 
     /// <summary>
@@ -251,7 +215,7 @@ public class AgentWanTestVantageResolver
 
             var fallback = connectedAgentIds.Where(capableAgentIds.Contains).OrderBy(id => id).ToList();
             return fallback.Count == 0
-                ? (null, "No connected agent at this site can run a WAN speed test.")
+                ? (null, "No connected Agent at this site can run a WAN speed test.")
                 : (new AgentWanTestVantage(fallback[0], null), null);
         }
 
@@ -260,16 +224,16 @@ public class AgentWanTestVantageResolver
             return (null, "The WAN this test was set up for no longer exists. Pick a WAN and save it again.");
 
         if (context.AgentId == null)
-            return (null, $"'{context.Name}' is measured by this server over a bound source address, not by an agent, so it has no agent to run a speed test on.");
+            return (null, $"'{context.Name}' is measured by this server over a bound source address, not by an Agent, so it has no Agent to run a speed test on.");
 
         if (!MeasuresItsOwnWan(context))
-            return (null, $"The agent for '{context.Name}' binds each probe to that WAN's interface rather than routing over it, so a speed test from it would measure whichever WAN its own route takes. Use the Gateway test for that WAN.");
+            return (null, $"The Agent for '{context.Name}' binds each probe to that WAN's interface rather than routing over it, so a speed test from it would measure whichever WAN its own route takes. Use the Gateway test for that WAN.");
 
         if (!connectedAgentIds.Contains(context.AgentId.Value))
-            return (null, $"The agent for '{context.Name}' is not connected. WAN speed tests on that WAN resume when it reconnects.");
+            return (null, $"The Agent for '{context.Name}' is not connected. WAN speed tests on that WAN resume when it reconnects.");
 
         if (!capableAgentIds.Contains(context.AgentId.Value))
-            return (null, $"The agent for '{context.Name}' runs on the gateway, which carries no speed test binary. Use the Gateway test for that WAN.");
+            return (null, $"The Agent for '{context.Name}' runs on the Gateway, which carries no speed test binary. Use the Gateway test for that WAN.");
 
         return (new AgentWanTestVantage(context.AgentId.Value, context), null);
     }

--- a/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
+++ b/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
@@ -44,8 +44,8 @@ public interface IUwnSpeedTestService
     /// site's measurements.
     /// </summary>
     /// <param name="wanContextId">
-    /// WAN context the agent run should measure, or null for the site's primary WAN. Ignored by a
-    /// local run, which measures whatever this host's route takes.
+    /// WAN context the agent run should measure, or null for the site's default path. Ignored by a
+    /// local run, which measures whatever this host routes over.
     /// </param>
     [RequireRole(Roles.Operator)]
     [AuditAction(AuditActions.SpeedTestRun, TargetType = "wan_speedtest")]

--- a/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
+++ b/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
@@ -39,12 +39,20 @@ public interface IUwnSpeedTestService
     /// <summary>Raised with the result id once the post-test path analysis finishes.</summary>
     event Action<int>? OnPathAnalysisComplete;
 
-    /// <summary>Runs a WAN speed test from this server.</summary>
+    /// <summary>
+    /// Runs a WAN speed test from this server, or from the site's agent when the agent owns the
+    /// site's measurements.
+    /// </summary>
+    /// <param name="wanContextId">
+    /// WAN context the agent run should measure, or null for the site's primary WAN. Ignored by a
+    /// local run, which measures whatever this host's route takes.
+    /// </param>
     [RequireRole(Roles.Operator)]
     [AuditAction(AuditActions.SpeedTestRun, TargetType = "wan_speedtest")]
     Task<Iperf3Result?> RunTestAsync(
         Action<(string Phase, int Percent, string? Status)>? onProgress = null,
         bool maxMode = false,
+        int? wanContextId = null,
         CancellationToken cancellationToken = default);
 
     /// <summary>Stored WAN speed test results for this site.</summary>

--- a/src/NetworkOptimizer.Web/Services/LinkedMessage.cs
+++ b/src/NetworkOptimizer.Web/Services/LinkedMessage.cs
@@ -1,0 +1,41 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// A message with one phrase inside it turned into a link, split ready to render.
+/// </summary>
+/// <param name="Before">Text before the link.</param>
+/// <param name="LinkText">The linked phrase, or null when there is no link.</param>
+/// <param name="Href">Where it goes, or null when there is no link.</param>
+/// <param name="After">Text after the link.</param>
+public readonly record struct LinkedMessage(string? Before, string? LinkText, string? Href, string? After)
+{
+    /// <summary>Whether the caller should render an anchor at all.</summary>
+    public bool HasLink => !string.IsNullOrEmpty(Href) && !string.IsNullOrEmpty(LinkText);
+}
+
+/// <summary>
+/// Turns a phrase inside a message into a link. The caller names the phrase, which is what lets a
+/// whole breadcrumb ("Settings &gt; Multi-Site") be the link rather than the bare word "Settings",
+/// and lets two messages on one surface link different phrases to different places.
+/// </summary>
+public static class MessageLinker
+{
+    /// <summary>
+    /// Splits <paramref name="message"/> around <paramref name="linkText"/>. Falls back to the
+    /// whole message unlinked whenever a link cannot be made - no href, no phrase named, or the
+    /// phrase is not in the message. The text is never dropped or altered, only divided, so a
+    /// caller that gets its phrase wrong loses the link and nothing else.
+    /// </summary>
+    public static LinkedMessage Split(string? message, string? linkText, string? href)
+    {
+        if (string.IsNullOrEmpty(message)) return new LinkedMessage(message, null, null, null);
+        if (string.IsNullOrEmpty(linkText) || string.IsNullOrEmpty(href))
+            return new LinkedMessage(message, null, null, null);
+
+        var index = message.IndexOf(linkText, StringComparison.Ordinal);
+        if (index < 0) return new LinkedMessage(message, null, null, null);
+
+        return new LinkedMessage(
+            message[..index], linkText, href, message[(index + linkText.Length)..]);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
+++ b/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
@@ -85,7 +85,7 @@ public static class ScheduleExecutorRegistration
     /// <summary>
     /// A WAN speed test schedule's stored config. Every field is absent-tolerant: a schedule made
     /// before a field existed keeps the meaning it had when it was created, which for
-    /// <c>wanContextId</c> is the site's primary WAN.
+    /// <c>wanContextId</c> is the site's default path.
     /// </summary>
     internal static (string TestType, bool MaxMode, string? WanGroup, string? WanName, int? WanContextId, string[]? MultiInterfaces)
         ParseWanTestConfig(string? targetConfig)

--- a/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
+++ b/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
@@ -82,6 +82,42 @@ public static class ScheduleExecutorRegistration
         return scope;
     }
 
+    /// <summary>
+    /// A WAN speed test schedule's stored config. Every field is absent-tolerant: a schedule made
+    /// before a field existed keeps the meaning it had when it was created, which for
+    /// <c>wanContextId</c> is the site's primary WAN.
+    /// </summary>
+    internal static (string TestType, bool MaxMode, string? WanGroup, string? WanName, int? WanContextId, string[]? MultiInterfaces)
+        ParseWanTestConfig(string? targetConfig)
+    {
+        var testType = "gateway";
+        var maxMode = false;
+        string? wanGroup = null;
+        string? wanName = null;
+        int? wanContextId = null;
+        string[]? multiInterfaces = null;
+
+        if (!string.IsNullOrEmpty(targetConfig))
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(targetConfig);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("testType", out var tt))
+                testType = tt.GetString() ?? "gateway";
+            if (root.TryGetProperty("maxMode", out var mm))
+                maxMode = mm.GetBoolean();
+            if (root.TryGetProperty("wanContextId", out var wc) && wc.TryGetInt32(out var contextId))
+                wanContextId = contextId;
+            if (root.TryGetProperty("wanGroup", out var wg))
+                wanGroup = wg.GetString();
+            if (root.TryGetProperty("wanName", out var wn))
+                wanName = wn.GetString();
+            if (root.TryGetProperty("interfaces", out var ifaces) && ifaces.ValueKind == System.Text.Json.JsonValueKind.Array)
+                multiInterfaces = ifaces.EnumerateArray().Select(e => e.GetString()!).ToArray();
+        }
+
+        return (testType, maxMode, wanGroup, wanName, wanContextId, multiInterfaces);
+    }
+
     private static async Task<(bool Success, string? Summary, string? Error)> ExecuteWanSpeedTestAsync(
         IServiceProvider services, string siteKey, int taskId, string? targetId, string? targetConfig, CancellationToken ct)
     {
@@ -96,33 +132,8 @@ public static class ScheduleExecutorRegistration
 
         try
         {
-            // Parse config for test type, max mode, multi-WAN
-            var testType = "gateway";
-            var maxMode = false;
-            string? wanGroup = null;
-            string? wanName = null;
-            // Which WAN an agent-run test measures. Null is the site's primary WAN, which is what
-            // every schedule made before this meant and what a single-WAN site always means.
-            int? wanContextId = null;
-            string[]? multiInterfaces = null;
-
-            if (!string.IsNullOrEmpty(targetConfig))
-            {
-                using var doc = System.Text.Json.JsonDocument.Parse(targetConfig);
-                var root = doc.RootElement;
-                if (root.TryGetProperty("testType", out var tt))
-                    testType = tt.GetString() ?? "gateway";
-                if (root.TryGetProperty("maxMode", out var mm))
-                    maxMode = mm.GetBoolean();
-                if (root.TryGetProperty("wanContextId", out var wc) && wc.TryGetInt32(out var wanContextIdValue))
-                wanContextId = wanContextIdValue;
-            if (root.TryGetProperty("wanGroup", out var wg))
-                    wanGroup = wg.GetString();
-                if (root.TryGetProperty("wanName", out var wn))
-                    wanName = wn.GetString();
-                if (root.TryGetProperty("interfaces", out var ifaces) && ifaces.ValueKind == System.Text.Json.JsonValueKind.Array)
-                    multiInterfaces = ifaces.EnumerateArray().Select(e => e.GetString()!).ToArray();
-            }
+            var (testType, maxMode, wanGroup, wanName, wanContextId, multiInterfaces) =
+                ParseWanTestConfig(targetConfig);
 
             // Reconcile WAN metadata against live controller data before running the test.
             // Scheduled configs bake interface, group, and name at creation time; these go stale

--- a/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
+++ b/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
@@ -101,6 +101,9 @@ public static class ScheduleExecutorRegistration
             var maxMode = false;
             string? wanGroup = null;
             string? wanName = null;
+            // Which WAN an agent-run test measures. Null is the site's primary WAN, which is what
+            // every schedule made before this meant and what a single-WAN site always means.
+            int? wanContextId = null;
             string[]? multiInterfaces = null;
 
             if (!string.IsNullOrEmpty(targetConfig))
@@ -111,7 +114,9 @@ public static class ScheduleExecutorRegistration
                     testType = tt.GetString() ?? "gateway";
                 if (root.TryGetProperty("maxMode", out var mm))
                     maxMode = mm.GetBoolean();
-                if (root.TryGetProperty("wanGroup", out var wg))
+                if (root.TryGetProperty("wanContextId", out var wc) && wc.TryGetInt32(out var wanContextIdValue))
+                wanContextId = wanContextIdValue;
+            if (root.TryGetProperty("wanGroup", out var wg))
                     wanGroup = wg.GetString();
                 if (root.TryGetProperty("wanName", out var wn))
                     wanName = wn.GetString();
@@ -153,7 +158,8 @@ public static class ScheduleExecutorRegistration
                 var serverService = scope.ServiceProvider.GetRequiredService<IUwnSpeedTestService>();
                 if (await serverService.IsRunningAsync())
                     return (false, null, "WAN speed test is already running");
-                result = await serverService.RunTestAsync(maxMode: maxMode, cancellationToken: ct);
+                result = await serverService.RunTestAsync(
+                    maxMode: maxMode, wanContextId: wanContextId, cancellationToken: ct);
             }
             else
             {

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -143,7 +143,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
 
         Logger.LogInformation(
             "Dispatching UWN WAN speed test to site {Slug}'s agent {AgentId} ({Wan}, {Streams} streams, {Servers} servers)",
-            SiteSlug, vantage.AgentId, vantage.Context?.Name ?? "primary WAN", Streams, ServerCount);
+            SiteSlug, vantage.AgentId, vantage.Context?.Name ?? "default path", Streams, ServerCount);
         // The agent returns only the final JSON over the tunnel, so there's no live progress to
         // stream. Report the SAME phase boundaries the local run does and let the page interpolate
         // download (20->55) and upload (60->95) between them, so the bar climbs smoothly. Reporting

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -32,6 +32,10 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
     // agent path only; a local run measures whatever this host's route takes, whatever was asked
     // for. Runs serialize per site instance, so one field is enough.
     private WanContext? _runContext;
+
+    // The agent the in-flight run was dispatched to. The trace source must be THAT agent, not
+    // whichever one reported in last.
+    private int? _runAgentId;
     private readonly AgentEnrollmentService _agentEnrollment;
 
     protected override SpeedTestDirection Direction => SpeedTestDirection.UwnWan;
@@ -121,6 +125,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
             return await RunViaAgentAsync(report, cancellationToken);
 
         _runContext = null;
+        _runAgentId = null;
         return await RunLocalAsync(report, cancellationToken);
     }
 
@@ -140,6 +145,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         if (vantage == null)
             throw new InvalidOperationException(refusal ?? "No agent is available to run this WAN speed test.");
         _runContext = vantage.Context;
+        _runAgentId = vantage.AgentId;
 
         Logger.LogInformation(
             "Dispatching UWN WAN speed test to site {Slug}'s agent {AgentId} ({Wan}, {Streams} streams, {Servers} servers)",
@@ -326,11 +332,13 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
             Location: finalIsp ?? "",
             WanIp: finalWanIp));
 
-        // Local endpoint the test ran from, for path analysis. An agent run measures
-        // from the on-site agent, so the trace source is the agent's LAN IP on that
-        // site's topology; a local run uses this server's HOST_IP.
+        // Local endpoint the test ran from, for path analysis. An agent run measures from the agent
+        // it was DISPATCHED to, so the trace starts at that agent's LAN IP - asking the site for
+        // its most recently seen agent traced one WAN's test from another WAN's box.
         var serverIp = viaAgent
-            ? await _agentEnrollment.GetOnlineAgentLanIpAsync(SiteSlug)
+            ? (_runAgentId is int ranOn
+                ? await _vantageResolver.AgentLanIpAsync(ranOn, cancellationToken)
+                : await _agentEnrollment.GetOnlineAgentLanIpAsync(SiteSlug))
             : _configuration["HOST_IP"];
 
         var result = new Iperf3Result

--- a/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/UwnSpeedTestService.cs
@@ -26,6 +26,12 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
     private readonly SiteTunnelRouting _tunnelRouting;
     private readonly SiteAgentCoverage _agentCoverage;
     private readonly AgentUwnService _agentUwn;
+    private readonly AgentWanTestVantageResolver _vantageResolver;
+
+    // WAN context the in-flight agent run was pointed at, for attributing the result. Set by the
+    // agent path only; a local run measures whatever this host's route takes, whatever was asked
+    // for. Runs serialize per site instance, so one field is enough.
+    private WanContext? _runContext;
     private readonly AgentEnrollmentService _agentEnrollment;
 
     protected override SpeedTestDirection Direction => SpeedTestDirection.UwnWan;
@@ -54,6 +60,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         SiteTunnelRouting tunnelRouting,
         SiteAgentCoverage agentCoverage,
         AgentUwnService agentUwn,
+        AgentWanTestVantageResolver vantageResolver,
         AgentEnrollmentService agentEnrollment,
         NetworkOptimizer.Storage.Services.SiteDbContextFactory siteDbFactory,
         Licensing.LicenseStateService licenseState,
@@ -68,6 +75,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         _tunnelRouting = tunnelRouting;
         _agentCoverage = agentCoverage;
         _agentUwn = agentUwn;
+        _vantageResolver = vantageResolver;
         _agentEnrollment = agentEnrollment;
     }
 
@@ -112,6 +120,7 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         if (RunsOnAgent)
             return await RunViaAgentAsync(report, cancellationToken);
 
+        _runContext = null;
         return await RunLocalAsync(report, cancellationToken);
     }
 
@@ -124,16 +133,24 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
         Action<string, int, string?> report,
         CancellationToken cancellationToken)
     {
+        // Which agent, and which WAN it measures. A refusal here is the answer - it is never
+        // retried on another agent, because that agent is on another WAN and the result would be
+        // filed under the WAN the caller asked for.
+        var (vantage, refusal) = await _vantageResolver.ResolveAsync(SiteSlug, WanContextId, cancellationToken);
+        if (vantage == null)
+            throw new InvalidOperationException(refusal ?? "No agent is available to run this WAN speed test.");
+        _runContext = vantage.Context;
+
         Logger.LogInformation(
-            "Dispatching UWN WAN speed test to site {Slug}'s agent ({Streams} streams, {Servers} servers)",
-            SiteSlug, Streams, ServerCount);
+            "Dispatching UWN WAN speed test to site {Slug}'s agent {AgentId} ({Wan}, {Streams} streams, {Servers} servers)",
+            SiteSlug, vantage.AgentId, vantage.Context?.Name ?? "primary WAN", Streams, ServerCount);
         // The agent returns only the final JSON over the tunnel, so there's no live progress to
         // stream. Report the SAME phase boundaries the local run does and let the page interpolate
         // download (20->55) and upload (60->95) between them, so the bar climbs smoothly. Reporting
         // fine-grained steps here fights that interpolation and makes the bar jump. The local
         // (this-server) run keeps its accurate per-line stdout progress in RunLocalAsync.
         var agentTask = _agentUwn.RunAsync(
-            SiteSlug, Streams, ServerCount, UwnDurationSeconds, UwnTimeoutSeconds, cancellationToken);
+            SiteSlug, vantage.AgentId, Streams, ServerCount, UwnDurationSeconds, UwnTimeoutSeconds, cancellationToken);
         await WanSpeedTestProgressAnimator.AnimatePhasesAsync(agentTask, report, UwnDurationSeconds, cancellationToken);
         var (success, output) = await agentTask;
         if (!success)
@@ -511,11 +528,15 @@ public class UwnSpeedTestService : WanSpeedTestServiceBase, IUwnSpeedTestService
             // A vantage names the WAN its box probes over, which is the same box and the same
             // path this test took. Scoped to whoever ran it: a vantage bound to an agent says
             // nothing about a test this server ran, or the other way round. Only one candidate
-            // may answer - two agent-bound vantages are two boxes on two WANs, and we cannot
-            // tell from here which of them ran the test, so guessing would name a WAN at random.
+            // may answer - two agent-bound vantages are two boxes on two WANs, and without a
+            // chosen one we cannot tell which ran the test, so guessing would name a WAN at random.
             var vantages = await EntityFrameworkQueryableExtensions.ToListAsync(
                 db.WanContexts.AsNoTracking().Where(c => c.WanInterface != null && c.WanInterface != ""), ct);
-            var candidates = vantages.Where(c => viaAgent ? c.AgentId != null : c.AgentId == null).ToList();
+            // A run pointed at a context needs no inference: that context IS the answer, and
+            // narrowing to it rather than short-circuiting keeps one naming path for both cases.
+            var candidates = _runContext != null
+                ? vantages.Where(c => c.Id == _runContext.Id).ToList()
+                : vantages.Where(c => viaAgent ? c.AgentId != null : c.AgentId == null).ToList();
             if (candidates.Count > 1)
             {
                 Logger.LogDebug(

--- a/src/NetworkOptimizer.Web/Services/WanSpeedTestServiceBase.cs
+++ b/src/NetworkOptimizer.Web/Services/WanSpeedTestServiceBase.cs
@@ -49,8 +49,8 @@ public abstract class WanSpeedTestServiceBase
     protected bool MaxMode { get; private set; }
 
     /// <summary>
-    /// WAN context the current test measures, or null for the site's primary WAN. Only agent-run
-    /// tests can be pointed at one; the local run measures whatever this host's route takes.
+    /// WAN context the current test measures, or null to take the site's default path. Only
+    /// agent-run tests can be pointed at one; the local run measures whatever this host routes over.
     /// </summary>
     protected int? WanContextId { get; private set; }
 
@@ -144,7 +144,7 @@ public abstract class WanSpeedTestServiceBase
     /// Pauses the iperf3 server during the test to free pipe handles.
     /// </summary>
     /// <param name="maxMode">When true, uses more servers and connections for maximum throughput.</param>
-    /// <param name="wanContextId">WAN context to measure, or null for the site's primary WAN.</param>
+    /// <param name="wanContextId">WAN context to measure, or null for the site's default path.</param>
     public async Task<Iperf3Result?> RunTestAsync(
         Action<(string Phase, int Percent, string? Status)>? onProgress = null,
         bool maxMode = false,

--- a/src/NetworkOptimizer.Web/Services/WanSpeedTestServiceBase.cs
+++ b/src/NetworkOptimizer.Web/Services/WanSpeedTestServiceBase.cs
@@ -48,6 +48,12 @@ public abstract class WanSpeedTestServiceBase
     /// <summary>Whether the current test is running in max mode (more servers and connections).</summary>
     protected bool MaxMode { get; private set; }
 
+    /// <summary>
+    /// WAN context the current test measures, or null for the site's primary WAN. Only agent-run
+    /// tests can be pointed at one; the local run measures whatever this host's route takes.
+    /// </summary>
+    protected int? WanContextId { get; private set; }
+
     /// <summary>The SpeedTestDirection for results created by this service.</summary>
     protected abstract SpeedTestDirection Direction { get; }
 
@@ -138,9 +144,11 @@ public abstract class WanSpeedTestServiceBase
     /// Pauses the iperf3 server during the test to free pipe handles.
     /// </summary>
     /// <param name="maxMode">When true, uses more servers and connections for maximum throughput.</param>
+    /// <param name="wanContextId">WAN context to measure, or null for the site's primary WAN.</param>
     public async Task<Iperf3Result?> RunTestAsync(
         Action<(string Phase, int Percent, string? Status)>? onProgress = null,
         bool maxMode = false,
+        int? wanContextId = null,
         CancellationToken cancellationToken = default)
     {
         if (!IsSiteLicenseOperational)
@@ -178,6 +186,7 @@ public abstract class WanSpeedTestServiceBase
         try
         {
             MaxMode = maxMode;
+            WanContextId = wanContextId;
 
             // Pause iperf3 server during WAN speed test to free pipe handles.
             if (Iperf3Server.IsRunning)

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19467,6 +19467,13 @@ body.kiosk-mode .status-indicators {
     container-type: inline-size;
 }
 
+/* Its wrapper clips overflow for the expand animation, so an offset ring is cut off. Sits on the
+   panel edge instead, keeping the panel's own bottom-only corners. */
+.site-config-panel.nav-highlight {
+    outline-offset: 0;
+    border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
+}
+
 .site-config-row .site-config-panel {
     max-width: 100cqw;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19467,14 +19467,6 @@ body.kiosk-mode .status-indicators {
     container-type: inline-size;
 }
 
-/* Its wrapper clips overflow for the expand animation, and an outline is painted outside the
-   border box at any offset from 0 up - so the ring is drawn INSIDE the panel instead, where
-   nothing can cut it off. Keeps the panel's own bottom-only corners. */
-.site-config-panel.nav-highlight {
-    outline-offset: -2px;
-    border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
-}
-
 .site-config-row .site-config-panel {
     max-width: 100cqw;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19467,10 +19467,11 @@ body.kiosk-mode .status-indicators {
     container-type: inline-size;
 }
 
-/* Its wrapper clips overflow for the expand animation, so an offset ring is cut off. Sits on the
-   panel edge instead, keeping the panel's own bottom-only corners. */
+/* Its wrapper clips overflow for the expand animation, and an outline is painted outside the
+   border box at any offset from 0 up - so the ring is drawn INSIDE the panel instead, where
+   nothing can cut it off. Keeps the panel's own bottom-only corners. */
 .site-config-panel.nav-highlight {
-    outline-offset: 0;
+    outline-offset: -2px;
     border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19471,7 +19471,6 @@ body.kiosk-mode .status-indicators {
    .expand-content hides overflow for the expand animation, and .table-responsive scrolls. */
 .site-config-panel.nav-highlight {
     outline-offset: -2px;
-    border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
 }
 
 .site-config-row .site-config-panel {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -19467,6 +19467,13 @@ body.kiosk-mode .status-indicators {
     container-type: inline-size;
 }
 
+/* Drawn on the panel's inside edge. An outset ring is cut off here whichever element carries it:
+   .expand-content hides overflow for the expand animation, and .table-responsive scrolls. */
+.site-config-panel.nav-highlight {
+    outline-offset: -2px;
+    border-radius: 0 0 var(--border-radius-lg) var(--border-radius-lg);
+}
+
 .site-config-row .site-config-panel {
     max-width: 100cqw;
 }

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -79,6 +79,59 @@ public class AgentWanTestVantageTests
         refusal.Should().NotBeNullOrEmpty();
     }
 
+    // ---- The cases that already worked, which must keep working ------------
+
+    [Fact]
+    public void ASingleAgentSiteRunsOnThatAgent()
+    {
+        // The only shape that exists on installs today. It ran on the site's one agent before and
+        // has to keep doing exactly that, whether or not the site has WAN contexts.
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SpeedTestAgent);
+    }
+
+    [Fact]
+    public void ASingleAgentSiteRunsOnThatAgentEvenWithNoCollector()
+    {
+        // A site whose collector cannot be resolved (console down, agent just connected) still has
+        // one obvious answer, and refusing there would take away a test that works today.
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: null);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SpeedTestAgent);
+    }
+
+    [Fact]
+    public void ASingleAgentSiteWithWanContextsStillDefaultsToItsOneAgent()
+    {
+        // Contexts exist for monitoring, but nothing was chosen: still the primary WAN on the one
+        // agent, not a refusal because a context happens to name a different box.
+        var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SpeedTestAgent);
+        vantage.Context.Should().BeNull();
+    }
+
     // ---- A chosen WAN context ---------------------------------------------
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -331,7 +331,7 @@ public class AgentWanTestVantageTests
             collectorAgentId: SpeedTestAgent);
 
         vantage.Should().BeNull();
-        refusal.Should().Contain("Cable").And.Contain("not by an agent");
+        refusal.Should().Contain("Cable").And.Contain("not by an Agent");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -165,6 +165,58 @@ public class AgentWanTestVantageTests
             .Should().Equal("Fiber", "Unkeyed A", "Unkeyed B");
     }
 
+    // ---- What the selector offers ------------------------------------------
+
+    [Fact]
+    public void ContextsServedByAGatewayAgentAreNotOffered()
+    {
+        // The main-site shape: every WAN context bound to the agent on the gateway. None of them
+        // can run this test and none ever will, so the list collapses to the default path alone -
+        // which the callers render as no selector, because one possibility is not a choice.
+        var contexts = new[]
+        {
+            Context(1, "Fiber", GatewayAgent, wan: "wan"),
+            Context(2, "Backup LTE", GatewayAgent, wan: "wan2"),
+        };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SpeedTestAgent })
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AContextWithNoAgentIsNotOffered()
+    {
+        var contexts = new[] { Context(1, "Cable", agentId: null) };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SpeedTestAgent })
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnOfflineAgentsWanIsStillOffered()
+    {
+        // Offline is temporary, so the WAN stays listed and its entry explains itself. Dropping it
+        // would make a WAN disappear from the picker every time its agent blinked.
+        var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SecondaryWanAgent })
+            .Select(c => c.Name).Should().Equal("Starlink");
+    }
+
+    [Fact]
+    public void OnlyTheRunnableWansSurviveOnAMixedSite()
+    {
+        var contexts = new[]
+        {
+            Context(1, "Fiber", GatewayAgent, wan: "wan"),
+            Context(2, "Starlink", SecondaryWanAgent, wan: "wan2"),
+            Context(3, "Cable", agentId: null, wan: "wan3"),
+        };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SpeedTestAgent, SecondaryWanAgent })
+            .Select(c => c.Name).Should().Equal("Starlink");
+    }
+
     // ---- A chosen WAN context ---------------------------------------------
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -1,0 +1,167 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Which of a site's agents runs its WAN speed test, and which WAN that measures.
+/// Mirrors the collector-selection tests: the rules are a pure function, so they are exercised
+/// without a tunnel, a console or a database.
+/// </summary>
+public class AgentWanTestVantageTests
+{
+    private const int SpeedTestAgent = 3;
+    private const int GatewayAgent = 7;
+    private const int SecondaryWanAgent = 9;
+
+    private static WanContext Context(int id, string name, int? agentId, string? wan = "wan2") =>
+        new() { Id = id, Name = name, AgentId = agentId, WanInterface = wan };
+
+    // ---- The primary WAN ---------------------------------------------------
+
+    [Fact]
+    public void ThePrimaryWanRunsOnTheCollector()
+    {
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            capableAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            collectorAgentId: SecondaryWanAgent);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SecondaryWanAgent);
+        vantage.Context.Should().BeNull();
+    }
+
+    [Fact]
+    public void AGatewayCollectorHandsThePrimaryWanToAnAgentThatCanRunTheTest()
+    {
+        // The mixed topology: a gateway agent monitors, a bare-metal agent speed tests. The
+        // gateway agent is a legitimate collector and still cannot run this.
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { SpeedTestAgent, GatewayAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: GatewayAgent);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SpeedTestAgent);
+    }
+
+    [Fact]
+    public void TheFallbackTakesTheLowestIdSoTheChoiceDoesNotMoveBetweenRuns()
+    {
+        var (vantage, _) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { SecondaryWanAgent, SpeedTestAgent },
+            capableAgentIds: new[] { SecondaryWanAgent, SpeedTestAgent },
+            collectorAgentId: null);
+
+        vantage!.AgentId.Should().Be(SpeedTestAgent);
+    }
+
+    [Fact]
+    public void ASiteWhoseOnlyAgentIsOnTheGatewayRefusesRatherThanRunning()
+    {
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: null,
+            contexts: Array.Empty<WanContext>(),
+            connectedAgentIds: new[] { GatewayAgent },
+            capableAgentIds: Array.Empty<int>(),
+            collectorAgentId: GatewayAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().NotBeNullOrEmpty();
+    }
+
+    // ---- A chosen WAN context ---------------------------------------------
+
+    [Fact]
+    public void AChosenContextRunsOnItsOwnAgent()
+    {
+        var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 1,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            capableAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        refusal.Should().BeNull();
+        vantage!.AgentId.Should().Be(SecondaryWanAgent);
+        vantage.Context!.Name.Should().Be("Starlink");
+    }
+
+    [Fact]
+    public void AnOfflineContextAgentIsNeverSubstituted()
+    {
+        // Another agent is connected and capable. Running on it would measure a different WAN and
+        // file the number under this one's name.
+        var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 1,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().Contain("Starlink").And.Contain("not connected");
+    }
+
+    [Fact]
+    public void AContextOnAGatewayAgentPointsAtTheGatewayTest()
+    {
+        var contexts = new[] { Context(1, "Backup LTE", GatewayAgent) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 1,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent, GatewayAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().Contain("Gateway test");
+    }
+
+    [Fact]
+    public void ASourceIpContextHasNoAgentToRunOn()
+    {
+        // Probed by this server over a bound source address, so there is no agent at all.
+        var contexts = new[] { Context(1, "Cable", agentId: null) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 1,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().Contain("Cable").And.Contain("not by an agent");
+    }
+
+    [Fact]
+    public void AScheduleWhoseWanWasDeletedRefusesInsteadOfPickingAnother()
+    {
+        var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 42,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            capableAgentIds: new[] { SpeedTestAgent, SecondaryWanAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().Contain("no longer exists");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -19,10 +19,10 @@ public class AgentWanTestVantageTests
     private static WanContext Context(int id, string name, int? agentId, string? wan = "wan2") =>
         new() { Id = id, Name = name, AgentId = agentId, WanInterface = wan };
 
-    // ---- The primary WAN ---------------------------------------------------
+    // ---- The default path --------------------------------------------------
 
     [Fact]
-    public void ThePrimaryWanRunsOnTheCollector()
+    public void TheDefaultPathRunsOnTheCollector()
     {
         var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
             wanContextId: null,
@@ -37,7 +37,7 @@ public class AgentWanTestVantageTests
     }
 
     [Fact]
-    public void AGatewayCollectorHandsThePrimaryWanToAnAgentThatCanRunTheTest()
+    public void AGatewayCollectorHandsTheDefaultPathToAnAgentThatCanRunTheTest()
     {
         // The mixed topology: a gateway agent monitors, a bare-metal agent speed tests. The
         // gateway agent is a legitimate collector and still cannot run this.
@@ -116,8 +116,8 @@ public class AgentWanTestVantageTests
     [Fact]
     public void ASingleAgentSiteWithWanContextsStillDefaultsToItsOneAgent()
     {
-        // Contexts exist for monitoring, but nothing was chosen: still the primary WAN on the one
-        // agent, not a refusal because a context happens to name a different box.
+        // Contexts exist for monitoring, but nothing was chosen: still the default path on the
+        // one agent, not a refusal because a context happens to name a different box.
         var contexts = new[] { Context(1, "Starlink", SecondaryWanAgent) };
 
         var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
@@ -130,6 +130,39 @@ public class AgentWanTestVantageTests
         refusal.Should().BeNull();
         vantage!.AgentId.Should().Be(SpeedTestAgent);
         vantage.Context.Should().BeNull();
+    }
+
+    // ---- The selector reads like every other WAN selector ------------------
+
+    [Fact]
+    public void WansAreOrderedByWanIndexTheWayLatencyTargetsOrdersThem()
+    {
+        // WAN1, WAN2, WAN3 - not alphabetical. Picking a WAN should look the same wherever it is
+        // picked, and Latency Targets got there first.
+        var contexts = new[]
+        {
+            Context(1, "Zephyr Cable", SecondaryWanAgent, wan: "wan2"),
+            Context(2, "Alpha Fiber", SpeedTestAgent, wan: "wan"),
+            Context(3, "Backup LTE", GatewayAgent, wan: "wan3"),
+        };
+
+        AgentWanTestVantageResolver.OrderForDisplay(contexts).Select(c => c.Name)
+            .Should().Equal("Alpha Fiber", "Zephyr Cable", "Backup LTE");
+    }
+
+    [Fact]
+    public void AContextWithNoWanKeySortsLastByName()
+    {
+        // Rows predating the WanInterface column have no index to sort on.
+        var contexts = new[]
+        {
+            Context(1, "Unkeyed B", SpeedTestAgent, wan: null),
+            Context(2, "Unkeyed A", SpeedTestAgent, wan: null),
+            Context(3, "Fiber", SpeedTestAgent, wan: "wan"),
+        };
+
+        AgentWanTestVantageResolver.OrderForDisplay(contexts).Select(c => c.Name)
+            .Should().Equal("Fiber", "Unkeyed A", "Unkeyed B");
     }
 
     // ---- A chosen WAN context ---------------------------------------------

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AgentWanTestVantageTests.cs
@@ -184,6 +184,53 @@ public class AgentWanTestVantageTests
     }
 
     [Fact]
+    public void AnInterfaceBoundContextIsNotOffered()
+    {
+        // The agent binds each PROBE to eth8; an unbound speed test from it leaves by whatever its
+        // own route prefers. Offering it would measure one WAN and name it another.
+        var contexts = new[]
+        {
+            new WanContext { Id = 1, Name = "Backup LTE", AgentId = SpeedTestAgent, WanInterface = "wan2", InterfaceName = "eth8" },
+        };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SpeedTestAgent })
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ARouteSteeredContextIsOffered()
+    {
+        // No InterfaceName: the gateway sends everything this box emits out that WAN, so the test
+        // measures the WAN the context names.
+        var contexts = new[]
+        {
+            new WanContext { Id = 1, Name = "Starlink", AgentId = SpeedTestAgent, WanInterface = "wan2" },
+        };
+
+        AgentWanTestVantageResolver.SelectableContexts(contexts, new[] { SpeedTestAgent })
+            .Select(c => c.Name).Should().Equal("Starlink");
+    }
+
+    [Fact]
+    public void PickingAnInterfaceBoundWanIsRefusedRatherThanMisattributed()
+    {
+        var contexts = new[]
+        {
+            new WanContext { Id = 1, Name = "Backup LTE", AgentId = SpeedTestAgent, WanInterface = "wan2", InterfaceName = "eth8" },
+        };
+
+        var (vantage, refusal) = AgentWanTestVantageResolver.Decide(
+            wanContextId: 1,
+            contexts: contexts,
+            connectedAgentIds: new[] { SpeedTestAgent },
+            capableAgentIds: new[] { SpeedTestAgent },
+            collectorAgentId: SpeedTestAgent);
+
+        vantage.Should().BeNull();
+        refusal.Should().Contain("binds each probe");
+    }
+
+    [Fact]
     public void AContextWithNoAgentIsNotOffered()
     {
         var contexts = new[] { Context(1, "Cable", agentId: null) };

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/MessageLinkerTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/MessageLinkerTests.cs
@@ -1,0 +1,104 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Turning a phrase inside an unavailable-reason into a link. The three real reasons the WAN Speed
+/// Test page shows are used verbatim, because the point of these is that none of them loses text or
+/// loses its link when the phrase changes.
+/// </summary>
+public class MessageLinkerTests
+{
+    private const string NoAgent =
+        "WAN speed tests on a managed site run from its on-site agent, and this site has none online. " +
+        "Set up the site's agent under Settings > Multi-Site to enable them.";
+
+    private const string AgentOffline =
+        "This site connects through its on-site agent, which isn't online. WAN speed tests can resume when it reconnects.";
+
+    private const string NoGatewaySsh =
+        "Gateway SSH not configured. Set it up in Settings, under the Connection tab.";
+
+    [Fact]
+    public void CaseA_NoAgent_LinksTheWholeBreadcrumbToTheSite()
+    {
+        var linked = MessageLinker.Split(NoAgent, "Settings > Multi-Site", "/settings?tab=multisite&configure=atl-1365");
+
+        linked.HasLink.Should().BeTrue();
+        linked.LinkText.Should().Be("Settings > Multi-Site");
+        linked.Href.Should().Be("/settings?tab=multisite&configure=atl-1365");
+        (linked.Before + linked.LinkText + linked.After).Should().Be(NoAgent);
+    }
+
+    [Fact]
+    public void CaseB_AgentOffline_RendersPlainBecauseThereIsNowhereToGo()
+    {
+        var linked = MessageLinker.Split(AgentOffline, null, null);
+
+        linked.HasLink.Should().BeFalse();
+        linked.Before.Should().Be(AgentOffline);
+    }
+
+    [Fact]
+    public void CaseC_NoGatewaySsh_LinksItsOwnPhraseToItsOwnPage()
+    {
+        var linked = MessageLinker.Split(NoGatewaySsh, "Settings, under the Connection tab", "/settings#gateway-ssh");
+
+        linked.HasLink.Should().BeTrue();
+        linked.LinkText.Should().Be("Settings, under the Connection tab");
+        linked.Href.Should().Be("/settings#gateway-ssh");
+        (linked.Before + linked.LinkText + linked.After).Should().Be(NoGatewaySsh);
+    }
+
+    [Fact]
+    public void APhraseThatIsNotInTheMessageLosesTheLinkAndNothingElse()
+    {
+        // Copy gets edited; the link should fall away rather than the sentence.
+        var linked = MessageLinker.Split(NoAgent, "Settings > Monitoring", "/settings?tab=multisite");
+
+        linked.HasLink.Should().BeFalse();
+        linked.Before.Should().Be(NoAgent);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NoHrefMeansNoLink(string? href)
+    {
+        var linked = MessageLinker.Split(NoAgent, "Settings > Multi-Site", href);
+
+        linked.HasLink.Should().BeFalse();
+        linked.Before.Should().Be(NoAgent);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void AnEmptyMessageStaysEmpty(string? message)
+    {
+        var linked = MessageLinker.Split(message, "Settings > Multi-Site", "/settings?tab=multisite");
+
+        linked.HasLink.Should().BeFalse();
+        linked.Before.Should().Be(message);
+    }
+
+    [Fact]
+    public void TheMessageIsOnlyEverDividedNeverEdited()
+    {
+        // Every branch must reassemble to the original - the renderer emits these three parts and
+        // nothing else, so anything lost here is lost on screen.
+        foreach (var (message, phrase, href) in new[]
+                 {
+                     (NoAgent, "Settings > Multi-Site", "/settings?tab=multisite&configure=x"),
+                     (NoGatewaySsh, "Settings, under the Connection tab", "/settings#gateway-ssh"),
+                     (AgentOffline, "Settings", (string?)null),
+                     (NoAgent, "not present", "/settings"),
+                 })
+        {
+            var linked = MessageLinker.Split(message, phrase, href);
+            (linked.Before + linked.LinkText + linked.After).Should().Be(message);
+        }
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanContextRoutingTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanContextRoutingTests.cs
@@ -190,6 +190,31 @@ public class WanContextRoutingTests
         AgentProbeResultSink.ShouldPushSiteCollectionConfig(agentIsSteeredToWan: true).Should().BeFalse();
     }
 
+    [Fact]
+    public void Snmp_UnsteeredAgent_Polls()
+    {
+        AgentProbeResultSink.ShouldPushSnmpConfig(agentIsSteeredToWan: false, agentIsCollector: false)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void Snmp_SteeredAgent_StandsDownWhenAnotherCollects()
+    {
+        // Unchanged: the site has a collector, so a context agent polling too would double every
+        // sample.
+        AgentProbeResultSink.ShouldPushSnmpConfig(agentIsSteeredToWan: true, agentIsCollector: false)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void Snmp_SteeredCollector_PollsRatherThanLeavingTheSiteDark()
+    {
+        // One agent per WAN: every agent is steered, so the collector is necessarily one of them.
+        // Standing it down too left the site with no poller at all.
+        AgentProbeResultSink.ShouldPushSnmpConfig(agentIsSteeredToWan: true, agentIsCollector: true)
+            .Should().BeTrue();
+    }
+
     // ---- Influx wan tag ---------------------------------------------------
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanScheduleConfigTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanScheduleConfigTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// What a stored WAN speed test schedule means when it runs. Every schedule on an existing install
+/// predates the WAN choice, so the point of these is that adding the field changed none of them.
+/// </summary>
+public class WanScheduleConfigTests
+{
+    [Fact]
+    public void AServerScheduleMadeBeforeWanChoiceRunsOnThePrimaryWan()
+    {
+        var (testType, maxMode, _, _, wanContextId, _) =
+            ScheduleExecutorRegistration.ParseWanTestConfig("""{"testType":"server"}""");
+
+        testType.Should().Be("server");
+        maxMode.Should().BeFalse();
+        wanContextId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AMaxLoadServerScheduleKeepsMaxLoad()
+    {
+        var (testType, maxMode, _, _, wanContextId, _) =
+            ScheduleExecutorRegistration.ParseWanTestConfig("""{"testType":"server","maxMode":true}""");
+
+        testType.Should().Be("server");
+        maxMode.Should().BeTrue();
+        wanContextId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ASingleWanGatewayScheduleIsUnchanged()
+    {
+        var (testType, maxMode, wanGroup, wanName, wanContextId, multiInterfaces) =
+            ScheduleExecutorRegistration.ParseWanTestConfig(
+                """{"testType":"gateway","wanGroup":"WAN","wanName":"Fiber"}""");
+
+        testType.Should().Be("gateway");
+        maxMode.Should().BeFalse();
+        wanGroup.Should().Be("WAN");
+        wanName.Should().Be("Fiber");
+        multiInterfaces.Should().BeNull();
+        // Never read on the gateway branch, but it must not arrive as anything but absent.
+        wanContextId.Should().BeNull();
+    }
+
+    [Fact]
+    public void AMultiWanGatewayScheduleKeepsItsInterfaceList()
+    {
+        var (testType, _, wanGroup, wanName, _, multiInterfaces) =
+            ScheduleExecutorRegistration.ParseWanTestConfig(
+                """{"testType":"gateway","wanGroup":"WAN+WAN2","wanName":"Fiber + LTE","interfaces":["eth4","eth8"]}""");
+
+        testType.Should().Be("gateway");
+        wanGroup.Should().Be("WAN+WAN2");
+        wanName.Should().Be("Fiber + LTE");
+        multiInterfaces.Should().Equal("eth4", "eth8");
+    }
+
+    [Fact]
+    public void AnEmptyConfigStillMeansAGatewayTest()
+    {
+        // The default every caller relied on before any of these fields were written.
+        foreach (var config in new string?[] { null, "", "{}" })
+        {
+            var (testType, maxMode, wanGroup, wanName, wanContextId, multiInterfaces) =
+                ScheduleExecutorRegistration.ParseWanTestConfig(config);
+
+            testType.Should().Be("gateway");
+            maxMode.Should().BeFalse();
+            wanGroup.Should().BeNull();
+            wanName.Should().BeNull();
+            wanContextId.Should().BeNull();
+            multiInterfaces.Should().BeNull();
+        }
+    }
+
+    [Fact]
+    public void AServerScheduleCanNameTheWanItMeasures()
+    {
+        var (testType, _, _, wanName, wanContextId, _) =
+            ScheduleExecutorRegistration.ParseWanTestConfig(
+                """{"testType":"server","wanContextId":4,"wanName":"Starlink"}""");
+
+        testType.Should().Be("server");
+        wanContextId.Should().Be(4);
+        wanName.Should().Be("Starlink");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanScheduleConfigTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanScheduleConfigTests.cs
@@ -11,7 +11,7 @@ namespace NetworkOptimizer.Web.Tests.Monitoring;
 public class WanScheduleConfigTests
 {
     [Fact]
-    public void AServerScheduleMadeBeforeWanChoiceRunsOnThePrimaryWan()
+    public void AServerScheduleMadeBeforeWanChoiceTakesTheDefaultPath()
     {
         var (testType, maxMode, _, _, wanContextId, _) =
             ScheduleExecutorRegistration.ParseWanTestConfig("""{"testType":"server"}""");


### PR DESCRIPTION
Picks which of a site's Agents runs its WAN speed test and which WAN that measures, then makes the Vantages that decide it say what they actually do.

`AgentUwnService` took a site slug and dispatched to `GetForSite(slug).FirstOrDefault()`, tunnel-registry order. On a site with more than one Agent that meant the run went to an arbitrary box, the on-site option appeared and disappeared with heartbeat order, and WAN attribution declined to answer because it could not tell which box ran the test.

## Approach

`WanContext` already models one Agent per WAN, so the selector reads that rather than inventing a parallel notion of a vantage. No new model and no new config UI.

Deliberately **no protocol change**: the Agent runs `uwnspeedtest` on its own default route, so there is nothing to bind. No `UwnRequest` field, no Go change, no Agent redeploy, no `LatestAgentVersion` bump.

## WAN Speed Test

- **WAN selector on the On-Site Agent test** - the same list, in the same order, that Latency Targets offers: **Default path** plus each Vantage, ordered by WAN index, under the same **WAN / Path** label. It only offers WANs a test would actually leave by, so a Vantage bound to an interface or served by a Gateway Agent is not listed - neither would measure the WAN it names.
- **No control when there is nothing to choose** - no Vantages, or none runnable, draws no selector. Default path sits last and drops out entirely once every WAN the console reports has a Vantage.
- **The option hides on capability, not location** - "no Agent here can run this" rather than "the last Agent to phone home was on the Gateway".
- **The chosen WAN reports before you press the button**, with its own reason.

## Alerts & Schedule

- **Scheduled Agent WAN tests take a WAN** - stored as `wanContextId`, written by both the add and edit paths, restored on edit, and shown on the schedule row.

## Monitoring - Network Performance

- **Multi-WAN Monitoring - Vantages reads the Policy-Based Route.** A Vantage whose Agent is already steered onto its WAN shows **Policy-Based Route** with the route named, instead of claiming nothing is bound. One steered somewhere else is a new warning: readings would carry this WAN's name and another WAN's numbers.
- **A Vantage that needs no binding no longer warns** - the primary WAN on a failover site, since the Agent's default route already is that WAN. On a load-balancing site it still warns, because there the balancer picks per flow.
- **Unbound warnings name the mechanism** the Agent actually offers, an interface or a source address, rather than one generic sentence.
- **Policy-Based Route guidance corrected** - the requirement is a MAC of its own, which macvlan provides on an existing NIC. It previously asked for a separate NIC, which is not true.

## Fixes

- **A named WAN is honored or refused, never redirected.** Offline Agent, Gateway Agent, source-IP Vantage, interface-bound Vantage, and a deleted WAN each get their own reason.
- **Default path falls back when the collector cannot run the test**, which is what makes a mixed site work.
- **A steered Agent still polls SNMP when it is the site's collector.** On a site where every Agent sits behind its own WAN the collector is necessarily steered, and standing every one of them down left the site with no poller at all.
- **An Agent WAN test is traced from the Agent that ran it** - the source came from the site's most recently seen Agent, so one WAN's test was traced from another WAN's box.
- **ISP Health sees Agent schedules** - the coverage check read only `wanGroup`, which those schedules do not write, so every non-primary WAN looked unscheduled.
- **Agent setup links deep link to the site** - `/settings?tab=multisite&configure={slug}`, with the whole **Settings - Multi-Site** breadcrumb as the link, across 9 places. Four were plain text.
- **The reason's link is the phrase it names**, not the bare word "Settings", so two messages on one surface can link different phrases to different pages.
- **The site config panel's ring is visible** - its wrapper clips overflow, so an outset outline was cut off.
- **On-Site Agent** capitalized consistently across 27 user-facing strings.

## Regression safety

Single-Agent sites cannot resolve differently than they did: with one connected Agent the capability question asks the **site-level** verdict, exactly as every WAN test surface did before. Only sites with several connected Agents take the new per-Agent path, and those had no routing at all before this branch.

Covered by tests rather than asserted: `ParseWanTestConfig` over every stored schedule shape (server, server + Max Load, single-WAN gateway, multi-WAN gateway, absent config); single-Agent resolution including a site with Vantages it did not choose; which WANs the selector offers, and the can-run vs happens-to-be-up distinction; and `MessageLinker` reassembling every branch to the original text.

Untouched: the local (this-server) run, `IGatewayWanSpeedTestService` in full, and the executor's gateway branch. `RunTestAsync`'s new parameter is optional.

## Notes

Capability is "not on the Gateway", a proxy for something the Agent does not report - not `ServesSpeedTest`, which is the LAN speed test page and opt-in at install.

`#1106` is fixed in `LoadBindCapableAgentsAsync` as the pattern for the rest; six sites still carry the TODO.

Selection rules are pure statics (`Decide`, `SelectableContexts`, `OrderForDisplay`), tested without a tunnel, a console or a database.
