### PR TITLE
Comcast Business cable modem support, and a multi-site provider cache fix

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
+++ b/src/NetworkOptimizer.Core/Helpers/NetworkFormatHelpers.cs
@@ -150,6 +150,23 @@ public static class NetworkFormatHelpers
     };
 
     /// <summary>
+    /// Vendors that arrive in caps but are not branded that way. SFP DDM reports the
+    /// vendor from a fixed-width EEPROM field that modules routinely fill in upper
+    /// case, so the raw string shouts where the brand does not.
+    ///
+    /// An explicit allowlist, never a blanket title-case pass: plenty of vendors ARE
+    /// all caps (ZTE, FS, HPE, TP-LINK), and lower-casing those would be the same
+    /// mistake in the other direction. Add a row when someone spots one.
+    /// </summary>
+    private static readonly Dictionary<string, string> BrandCasing = new(StringComparer.Ordinal)
+    {
+        ["CALIX"] = "Calix",
+        ["NOKIA"] = "Nokia",
+        ["HUAWEI"] = "Huawei",
+        ["UBIQUITI"] = "Ubiquiti",
+    };
+
+    /// <summary>
     /// The storage-time ASN/org-name cleaner: strips industry suffixes (Communications, Telecom,
     /// Broadband, Networks, Services, Parent, Holdings ...) and legal forms (LLC, Inc, AB ...) off
     /// the tail ("Hisense Broadband Technologies Co Ltd" -> "Hisense", "Level 3 Parent, LLC" ->
@@ -178,6 +195,9 @@ public static class NetworkFormatHelpers
             }
         } while (changed && cleaned.Contains(' '));
         cleaned = cleaned.Trim();
-        return OrgAliases.TryGetValue(cleaned, out var alias) ? alias : cleaned;
+        if (OrgAliases.TryGetValue(cleaned, out var alias))
+            cleaned = alias;
+
+        return BrandCasing.TryGetValue(cleaned, out var cased) ? cased : cleaned;
     }
 }

--- a/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
@@ -9,6 +9,13 @@ public sealed record CmPollContext
     /// <summary>Configuration ID for caching keys and diagnostics.</summary>
     public required int Id { get; init; }
 
+    /// <summary>
+    /// Site this configuration belongs to. Providers are singletons shared by
+    /// every site, while <see cref="Id"/> only counts within one site's database,
+    /// so any provider-side cache must key on both.
+    /// </summary>
+    public string SiteSlug { get; init; } = "";
+
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 

--- a/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/CmPollContext.cs
@@ -12,9 +12,16 @@ public sealed record CmPollContext
     /// <summary>
     /// Site this configuration belongs to. Providers are singletons shared by
     /// every site, while <see cref="Id"/> only counts within one site's database,
-    /// so any provider-side cache must key on both.
+    /// so any provider-side cache must key on <see cref="CacheKey"/>, not Id.
     /// </summary>
     public string SiteSlug { get; init; } = "";
+
+    /// <summary>
+    /// Key for provider-side per-device caches (sessions, tokens, discovered
+    /// endpoints, last-seen counters). Never key such a cache on Id alone: the
+    /// first device added at every site has Id 1.
+    /// </summary>
+    public string CacheKey => $"{SiteSlug}/{Id}";
 
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }

--- a/src/NetworkOptimizer.Monitoring/Providers/ModemPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/ModemPollContext.cs
@@ -11,6 +11,20 @@ public sealed record ModemPollContext
     /// <summary>Identifier for diagnostics and caching keys.</summary>
     public required int Id { get; init; }
 
+    /// <summary>
+    /// Site this configuration belongs to. Providers are singletons shared by
+    /// every site, while <see cref="Id"/> only counts within one site's database,
+    /// so any provider-side cache must key on <see cref="CacheKey"/>, not Id.
+    /// </summary>
+    public string SiteSlug { get; init; } = "";
+
+    /// <summary>
+    /// Key for provider-side per-device caches (sessions, tokens, discovered
+    /// endpoints, last-seen counters). Never key such a cache on Id alone: the
+    /// first device added at every site has Id 1.
+    /// </summary>
+    public string CacheKey => $"{SiteSlug}/{Id}";
+
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 

--- a/src/NetworkOptimizer.Monitoring/Providers/OntPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/OntPollContext.cs
@@ -9,6 +9,20 @@ public sealed record OntPollContext
     /// <summary>Configuration ID for caching keys and diagnostics.</summary>
     public required int Id { get; init; }
 
+    /// <summary>
+    /// Site this configuration belongs to. Providers are singletons shared by
+    /// every site, while <see cref="Id"/> only counts within one site's database,
+    /// so any provider-side cache must key on <see cref="CacheKey"/>, not Id.
+    /// </summary>
+    public string SiteSlug { get; init; } = "";
+
+    /// <summary>
+    /// Key for provider-side per-device caches (sessions, tokens, discovered
+    /// endpoints, last-seen counters). Never key such a cache on Id alone: the
+    /// first device added at every site has Id 1.
+    /// </summary>
+    public string CacheKey => $"{SiteSlug}/{Id}";
+
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 

--- a/src/NetworkOptimizer.Monitoring/Providers/StarlinkPollContext.cs
+++ b/src/NetworkOptimizer.Monitoring/Providers/StarlinkPollContext.cs
@@ -9,6 +9,20 @@ public sealed record StarlinkPollContext
     /// <summary>Configuration ID for caching keys and diagnostics.</summary>
     public required int Id { get; init; }
 
+    /// <summary>
+    /// Site this configuration belongs to. Providers are singletons shared by
+    /// every site, while <see cref="Id"/> only counts within one site's database,
+    /// so any provider-side cache must key on <see cref="CacheKey"/>, not Id.
+    /// </summary>
+    public string SiteSlug { get; init; } = "";
+
+    /// <summary>
+    /// Key for provider-side per-device caches (sessions, tokens, discovered
+    /// endpoints, last-seen counters). Never key such a cache on Id alone: the
+    /// first device added at every site has Id 1.
+    /// </summary>
+    public string CacheKey => $"{SiteSlug}/{Id}";
+
     /// <summary>Friendly name for logs and UI.</summary>
     public required string Name { get; init; }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1630,7 +1630,7 @@
                                 <option value="netgear">Netgear / Nighthawk CM (HTTP)</option>
                                 <option value="technicolor-cga">Technicolor CGA Series (HTTP)</option>
                                 <option value="vodafone-station">Vodafone Station (ARRIS TG3442DE)</option>
-                                <option value="xfinity-gateway">Xfinity XB8/XB10, Cox CGM4981 (HTTP)</option>
+                                <option value="xfinity-gateway">Xfinity XB8/XB10, Comcast Business CGA4332, Cox CGM4981 (HTTP)</option>
                             </select>
                         </div>
                     </div>
@@ -7073,7 +7073,7 @@
         "arris-surfboard" => "ARRIS Surfboard (HTTP)",
         "arris-surfboard-hnap" => "ARRIS Surfboard S33/S34 (HNAP)",
         "motorola-hnap" => "Motorola (HNAP)",
-        "xfinity-gateway" => "Xfinity Gateway (HTTP)",
+        "xfinity-gateway" => "Xfinity XB8/XB10, Comcast Business CGA4332, Cox CGM4981 (HTTP)",
         "technicolor-cga" => "Technicolor CGA Series (HTTP)",
         "vodafone-station" => "Vodafone Station (ARRIS TG3442DE)",
         _ => provider,
@@ -7084,7 +7084,7 @@
         "arris-surfboard" => "/cgi-bin/status",
         "arris-surfboard-hnap" => "N/A (uses /HNAP1/)",
         "motorola-hnap" => "N/A (uses /HNAP1/)",
-        "xfinity-gateway" => "/network_setup.jst",
+        "xfinity-gateway" => "Detected automatically",
         "technicolor-cga" => "/api/v1/sta_docsis_status",
         "vodafone-station" => "/php/status_docsis_data.php",
         _ => "/DocsisStatus.htm",

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -284,27 +284,33 @@
 
     /// <summary>
     /// Split a provider's device model into the name users know and the model
-    /// number behind it, so "CBR (CGA4332COM)" stacks as two lines.
+    /// number behind it: "CBR (CGA4332COM)" and "ARRIS SB8200" both stack as two
+    /// lines, whether the provider parenthesized the number or just appended it.
     ///
     /// A bare vendor word means the provider could not read a model off the device
     /// and fell back to naming the maker ("Netgear", "Motorola"). Those take a model
     /// number off the device's own name when it holds one - someone who calls it
     /// "CM600 - MyISP" has already told us what it is - and "CM" when it does not.
-    /// Anything already carrying CM in the name is left alone rather than made to
-    /// say it twice.
+    ///
+    /// A model number standing on its own has no vendor to sit above it, so it stays
+    /// a single line rather than being made to say "CM" underneath itself.
     /// </summary>
     internal static (string Name, string? Number) SplitModel(string model, string? deviceName = null)
     {
         var trimmed = model.Trim();
 
-        var match = ModelWithNumber.Match(trimmed);
-        if (match.Success)
-            return (match.Groups[1].Value, match.Groups[2].Value);
+        var parenthesized = ModelWithNumber.Match(trimmed);
+        if (parenthesized.Success)
+            return (parenthesized.Groups[1].Value, parenthesized.Groups[2].Value);
 
-        var vendorOnly = !trimmed.Contains(' ')
-            && !trimmed.Contains("CM", StringComparison.OrdinalIgnoreCase);
+        var number = ModelNumberInName.Match(trimmed);
+        if (number.Success)
+        {
+            var vendor = trimmed[..number.Index].Trim();
+            return vendor.Length > 0 ? (vendor, number.Value) : (trimmed, null);
+        }
 
-        if (!vendorOnly)
+        if (trimmed.Contains(' '))
             return (trimmed, null);
 
         var fromName = string.IsNullOrWhiteSpace(deviceName)

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -109,7 +109,6 @@
                     var snrPos = SignalGauge.Position(_stats.DownstreamSnrAvgDb.Value, SnrDomainLow, SnrDomainHigh);
                     <div class="signal-gauge" style="background: @SnrTrack">
                         <div class="gauge-shade" style="height: @($"{100 - snrPos:0.#}")%"></div>
-                        <div class="gauge-line" style="bottom: @($"{snrPos:0.#}")%"></div>
                     </div>
                 }
                 <div class="ont-rx-gauge">
@@ -279,15 +278,25 @@
 
     /// <summary>
     /// Split a provider's device model into the name users know and the model
-    /// number behind it, so "CBR (CGA4332COM)" stacks as two lines. Models
-    /// reported as a single string stay on one.
+    /// number behind it, so "CBR (CGA4332COM)" stacks as two lines.
+    ///
+    /// A bare vendor word means the provider could not read a model off the device
+    /// and fell back to naming the maker ("Netgear", "Motorola"). Label those "CM"
+    /// so the second line still says what the thing is. Anything already carrying
+    /// CM in the name is left alone rather than made to say it twice.
     /// </summary>
-    private static (string Name, string? Number) SplitModel(string model)
+    internal static (string Name, string? Number) SplitModel(string model)
     {
-        var match = ModelWithNumber.Match(model.Trim());
-        return match.Success
-            ? (match.Groups[1].Value, match.Groups[2].Value)
-            : (model.Trim(), null);
+        var trimmed = model.Trim();
+
+        var match = ModelWithNumber.Match(trimmed);
+        if (match.Success)
+            return (match.Groups[1].Value, match.Groups[2].Value);
+
+        var vendorOnly = !trimmed.Contains(' ')
+            && !trimmed.Contains("CM", StringComparison.OrdinalIgnoreCase);
+
+        return vendorOnly ? (trimmed, "CM") : (trimmed, null);
     }
 
     // Grade boundaries for downstream SNR, and the visible span around them.

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -20,7 +20,7 @@
             </div>
         </div>
 
-        <div class="signal-quality-section signal-centered">
+        <div class="signal-quality-section signal-with-model">
             <div class="ont-rx-gauge">
                 <span class="rx-power-value">-</span>
                 <span class="rx-power-label">Downstream SNR avg</span>
@@ -101,7 +101,7 @@
             </div>
         </div>
 
-        <div class="signal-quality-section signal-centered">
+        <div class="signal-quality-section signal-with-model">
             <div class="ont-rx-gauge">
                 <span class="rx-power-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">
                     @(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")
@@ -116,6 +116,17 @@
                     <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= _configs.Count - 1)">&#x203A;</button>
                 }
             </div>
+            @if (!string.IsNullOrWhiteSpace(_stats.DeviceModel))
+            {
+                var model = SplitModel(_stats.DeviceModel);
+                <div class="cm-model">
+                    <span class="cm-model-name">@model.Name</span>
+                    @if (model.Number != null)
+                    {
+                        <span class="cm-model-number">@model.Number</span>
+                    }
+                </div>
+            }
         </div>
 
         <div class="cellular-metrics" style="margin-top: 0.75rem;">
@@ -250,6 +261,22 @@
     private async Task Next()
     {
         if (_currentIndex < _configs.Count - 1) { _currentIndex++; await LoadStatsAsync(); }
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex ModelWithNumber =
+        new(@"^(.*?)\s*\((.+)\)$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Split a provider's device model into the name users know and the model
+    /// number behind it, so "CBR (CGA4332COM)" stacks as two lines. Models
+    /// reported as a single string stay on one.
+    /// </summary>
+    private static (string Name, string? Number) SplitModel(string model)
+    {
+        var match = ModelWithNumber.Match(model.Trim());
+        return match.Success
+            ? (match.Groups[1].Value, match.Groups[2].Value)
+            : (model.Trim(), null);
     }
 
     private string GetSnrClass(double? snr)

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -1,6 +1,7 @@
 @using NetworkOptimizer.Web.Services
 @using NetworkOptimizer.Monitoring.Models
 @inject ICableModemService CmService
+@using NetworkOptimizer.Web.Services.Monitoring
 @implements IDisposable
 
 <div class="cellular-stats-panel">
@@ -102,11 +103,21 @@
         </div>
 
         <div class="signal-quality-section signal-with-model">
-            <div class="ont-rx-gauge">
-                <span class="rx-power-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">
-                    @(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")
-                </span>
-                <span class="rx-power-label">Downstream SNR avg</span>
+            <div class="signal-hero">
+                @if (_stats.DownstreamSnrAvgDb.HasValue)
+                {
+                    var snrPos = SignalGauge.Position(_stats.DownstreamSnrAvgDb.Value, SnrDomainLow, SnrDomainHigh);
+                    <div class="signal-gauge" style="background: @SnrTrack">
+                        <div class="gauge-shade" style="height: @($"{100 - snrPos:0.#}")%"></div>
+                        <div class="gauge-line" style="bottom: @($"{snrPos:0.#}")%"></div>
+                    </div>
+                }
+                <div class="ont-rx-gauge">
+                    <span class="rx-power-value @GetSnrClass(_stats.DownstreamSnrAvgDb)">
+                        @(_stats.DownstreamSnrAvgDb.HasValue ? $"{_stats.DownstreamSnrAvgDb.Value:F1} dB" : "-")
+                    </span>
+                    <span class="rx-power-label">Downstream SNR avg</span>
+                </div>
             </div>
             <div class="modem-nav">
                 @if (_configs.Count > 1)
@@ -279,12 +290,22 @@
             : (model.Trim(), null);
     }
 
+    // Grade boundaries for downstream SNR, and the visible span around them.
+    private const double SnrFair = 30;
+    private const double SnrGood = 33;
+    private const double SnrExcellent = 36;
+    private const double SnrDomainLow = 25;
+    private const double SnrDomainHigh = 45;
+
+    private static readonly string SnrTrack =
+        SignalGauge.SnrTrack(SnrDomainLow, SnrDomainHigh, SnrFair, SnrGood, SnrExcellent);
+
     private string GetSnrClass(double? snr)
     {
         if (!snr.HasValue) return "";
-        if (snr >= 36) return "signal-excellent";
-        if (snr >= 33) return "signal-good";
-        if (snr >= 30) return "signal-fair";
+        if (snr >= SnrExcellent) return "signal-excellent";
+        if (snr >= SnrGood) return "signal-good";
+        if (snr >= SnrFair) return "signal-fair";
         return "signal-poor";
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CmStatsPanel.razor
@@ -128,7 +128,7 @@
             </div>
             @if (!string.IsNullOrWhiteSpace(_stats.DeviceModel))
             {
-                var model = SplitModel(_stats.DeviceModel);
+                var model = SplitModel(_stats.DeviceModel, _stats.DeviceName);
                 <div class="cm-model">
                     <span class="cm-model-name">@model.Name</span>
                     @if (model.Number != null)
@@ -276,16 +276,24 @@
     private static readonly System.Text.RegularExpressions.Regex ModelWithNumber =
         new(@"^(.*?)\s*\((.+)\)$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
+    // A model number shape: a short prefix, digits, and sometimes a suffix -
+    // CM600, SB8200, MB8611, CGA4332COM. Two digits minimum so ordinary words
+    // with a number after them ("Rack 4B", "Modem 2") are not mistaken for one.
+    private static readonly System.Text.RegularExpressions.Regex ModelNumberInName =
+        new(@"\b[A-Za-z]{1,5}\d{2,}[A-Za-z]{0,4}\b", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     /// <summary>
     /// Split a provider's device model into the name users know and the model
     /// number behind it, so "CBR (CGA4332COM)" stacks as two lines.
     ///
     /// A bare vendor word means the provider could not read a model off the device
-    /// and fell back to naming the maker ("Netgear", "Motorola"). Label those "CM"
-    /// so the second line still says what the thing is. Anything already carrying
-    /// CM in the name is left alone rather than made to say it twice.
+    /// and fell back to naming the maker ("Netgear", "Motorola"). Those take a model
+    /// number off the device's own name when it holds one - someone who calls it
+    /// "CM600 - MyISP" has already told us what it is - and "CM" when it does not.
+    /// Anything already carrying CM in the name is left alone rather than made to
+    /// say it twice.
     /// </summary>
-    internal static (string Name, string? Number) SplitModel(string model)
+    internal static (string Name, string? Number) SplitModel(string model, string? deviceName = null)
     {
         var trimmed = model.Trim();
 
@@ -296,7 +304,14 @@
         var vendorOnly = !trimmed.Contains(' ')
             && !trimmed.Contains("CM", StringComparison.OrdinalIgnoreCase);
 
-        return vendorOnly ? (trimmed, "CM") : (trimmed, null);
+        if (!vendorOnly)
+            return (trimmed, null);
+
+        var fromName = string.IsNullOrWhiteSpace(deviceName)
+            ? null
+            : ModelNumberInName.Match(deviceName).Value;
+
+        return (trimmed, string.IsNullOrEmpty(fromName) ? "CM" : fromName);
     }
 
     // Grade boundaries for downstream SNR, and the visible span around them.

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -1,6 +1,7 @@
 @using Microsoft.EntityFrameworkCore
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Monitoring.Models
+@using NetworkOptimizer.Web.Services.Monitoring
 @using NetworkOptimizer.Web.Services
 @implements IDisposable
 @inject MonitoringLiveStats LiveStats
@@ -31,12 +32,15 @@ else if (IsShowingExternal && _externalOntStats != null)
         }
     </div>
 
-    <div class="signal-quality-section signal-centered">
-        <div class="ont-rx-gauge">
-            <span class="rx-power-value @ExternalRxClass()">
-                @(_externalOntStats.RxPowerDbm.HasValue ? $"{_externalOntStats.RxPowerDbm.Value:0.0#} dBm" : "-")
-            </span>
-            <span class="rx-power-label">RX optical power</span>
+    <div class="signal-quality-section signal-with-model">
+        <div class="signal-hero">
+            @RxGauge(_externalOntStats.RxPowerDbm, OpticalBands.ExternalOnt)
+            <div class="ont-rx-gauge">
+                <span class="rx-power-value @ExternalRxClass()">
+                    @(_externalOntStats.RxPowerDbm.HasValue ? $"{_externalOntStats.RxPowerDbm.Value:0.0#} dBm" : "-")
+                </span>
+                <span class="rx-power-label">RX optical power</span>
+            </div>
         </div>
         <div class="modem-nav">
             @if (TotalCount > 1)
@@ -46,20 +50,13 @@ else if (IsShowingExternal && _externalOntStats != null)
                 <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= TotalCount - 1)">&#x203A;</button>
             }
         </div>
+        @ModelBlock(_externalOntStats.VendorName, _externalOntStats.VendorPn)
     </div>
 
     <div class="cellular-metrics" style="margin-top: 0.75rem;">
         <div class="metric-box">
             <div class="metric-header">Connection</div>
             <div class="metric-content">
-                @{ var extModel = SfpModelLabel(_externalOntStats.VendorName, _externalOntStats.VendorPn); }
-                @if (!string.IsNullOrEmpty(extModel))
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Model:</span>
-                        <span class="metric-value ont-model-value">@extModel</span>
-                    </div>
-                }
                 @if (!string.IsNullOrEmpty(_externalOntStats.PonType))
                 {
                     <div class="metric-row">
@@ -132,10 +129,12 @@ else if (IsShowingExternal)
         </div>
     </div>
 
-    <div class="signal-quality-section signal-centered">
-        <div class="ont-rx-gauge">
-            <span class="rx-power-value">-</span>
-            <span class="rx-power-label">RX optical power</span>
+    <div class="signal-quality-section signal-with-model">
+        <div class="signal-hero">
+            <div class="ont-rx-gauge">
+                <span class="rx-power-value">-</span>
+                <span class="rx-power-label">RX optical power</span>
+            </div>
         </div>
         <div class="modem-nav">
             @if (TotalCount > 1)
@@ -228,12 +227,15 @@ else
         }
     </div>
 
-    <div class="signal-quality-section signal-centered">
-        <div class="ont-rx-gauge">
-            <span class="rx-power-value @rxClass">
-                @(stats?.RxPowerDbm.HasValue == true ? $"{stats.RxPowerDbm.Value:0.0#} dBm" : "-")
-            </span>
-            <span class="rx-power-label">RX optical power</span>
+    <div class="signal-quality-section signal-with-model">
+        <div class="signal-hero">
+            @RxGauge(stats?.RxPowerDbm, BandsFor(current.Category))
+            <div class="ont-rx-gauge">
+                <span class="rx-power-value @rxClass">
+                    @(stats?.RxPowerDbm.HasValue == true ? $"{stats.RxPowerDbm.Value:0.0#} dBm" : "-")
+                </span>
+                <span class="rx-power-label">RX optical power</span>
+            </div>
         </div>
         <div class="modem-nav">
             @if (TotalCount > 1)
@@ -243,6 +245,7 @@ else
                 <button class="nav-btn" @onclick="Next" @onclick:stopPropagation disabled="@(_currentIndex >= TotalCount - 1)">›</button>
             }
         </div>
+        @ModelBlock(current.SfpVendor, current.SfpPart)
     </div>
 
     var sfpPonState = PonLinkStateExtensions.ParsePonLinkState(stats?.PonLinkStatus);
@@ -259,14 +262,6 @@ else
         <div class="metric-box">
             <div class="metric-header">Connection</div>
             <div class="metric-content">
-                @{ var model = SfpModelLabel(current.SfpVendor, current.SfpPart); }
-                @if (!string.IsNullOrEmpty(model))
-                {
-                    <div class="metric-row">
-                        <span class="metric-label">Model:</span>
-                        <span class="metric-value ont-model-value">@model</span>
-                    </div>
-                }
                 <div class="metric-row">
                     <span class="metric-label">Link Type:</span>
                     <span class="metric-value @(current.IsActiveEthernet ? "ont-ae-value" : "")">@LinkTypeLabel(current)</span>
@@ -369,9 +364,6 @@ else
         padding-top: 0.5rem;
     }
 
-    .metric-value.ont-model-value {
-        font-size: 0.95rem;
-    }
     .metric-value.ont-ae-value {
         font-size: 1.1rem;
     }
@@ -573,22 +565,52 @@ else
         return ponType;
     }
 
-    private static string OpticalHealthClass(double? rxDbm, SfpCategory category)
+    private static OpticalBands BandsFor(SfpCategory category) =>
+        category == SfpCategory.ActiveEthernet ? OpticalBands.ActiveEthernet : OpticalBands.Pon;
+
+    private static string OpticalHealthClass(double? rxDbm, SfpCategory category) =>
+        BandsFor(category).ClassFor(rxDbm);
+
+    /// <summary>
+    /// Rx power against its grading band. The track runs back to red above the band
+    /// as well as below it: a receiver getting too much light is a fault, not a good
+    /// reading, and a rising bar would say the opposite.
+    /// </summary>
+    private RenderFragment RxGauge(double? rxDbm, OpticalBands bands) => __builder =>
     {
-        if (!rxDbm.HasValue) return "";
-        var v = rxDbm.Value;
-        if (category == SfpCategory.ActiveEthernet)
+        if (rxDbm.HasValue)
         {
-            if (v >= -8 && v <= -1) return "signal-excellent";
-            if (v >= -10 && v <= 0) return "signal-good";
-            if (v >= -14 && v <= 1) return "signal-fair";
-            return "signal-poor";
+            var pos = SignalGauge.Position(rxDbm.Value, bands.DomainLow, bands.DomainHigh);
+            <div class="signal-gauge" style="background: @SignalGauge.OpticalTrack(bands)">
+                <div class="gauge-shade" style="height: @($"{100 - pos:0.#}")%"></div>
+                <div class="gauge-line" style="bottom: @($"{pos:0.#}")%"></div>
+            </div>
         }
-        if (v >= -22 && v <= -8) return "signal-excellent";
-        if (v >= -25 && v <= -6) return "signal-good";
-        if (v >= -28 && v <= -4) return "signal-fair";
-        return "signal-poor";
-    }
+    };
+
+    /// <summary>Vendor over part number, in the slot the Cellular card gives the device icon.</summary>
+    private RenderFragment ModelBlock(string? vendor, string? part) => __builder =>
+    {
+        var name = NetworkOptimizer.Core.Helpers.NetworkFormatHelpers.CleanOrgName(vendor);
+        var number = part?.Trim();
+
+        if (string.IsNullOrEmpty(name))
+        {
+            name = number;
+            number = null;
+        }
+
+        if (!string.IsNullOrEmpty(name))
+        {
+            <div class="cm-model">
+                <span class="cm-model-name">@name</span>
+                @if (!string.IsNullOrEmpty(number))
+                {
+                    <span class="cm-model-number">@number</span>
+                }
+            </div>
+        }
+    };
 
     private static string SfpModelLabel(string? vendor, string? part)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -583,7 +583,6 @@ else
             var pos = SignalGauge.Position(rxDbm.Value, bands.DomainLow, bands.DomainHigh);
             <div class="signal-gauge" style="background: @SignalGauge.OpticalTrack(bands)">
                 <div class="gauge-shade" style="height: @($"{100 - pos:0.#}")%"></div>
-                <div class="gauge-line" style="bottom: @($"{pos:0.#}")%"></div>
             </div>
         }
     };

--- a/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/OntStatsPanel.razor
@@ -581,8 +581,10 @@ else
         if (rxDbm.HasValue)
         {
             var pos = SignalGauge.Position(rxDbm.Value, bands.DomainLow, bands.DomainHigh);
+            var (above, below) = SignalGauge.WindowEdges(pos);
             <div class="signal-gauge" style="background: @SignalGauge.OpticalTrack(bands)">
-                <div class="gauge-shade" style="height: @($"{100 - pos:0.#}")%"></div>
+                <div class="gauge-shade" style="height: @($"{above:0.#}")%"></div>
+                <div class="gauge-shade gauge-shade-low" style="height: @($"{below:0.#}")%"></div>
             </div>
         }
     };

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -122,18 +122,19 @@
 
         @if (stats != null)
         {
-            @if (stats.ActiveAlerts.Count > 0)
+            var notices = GetNotices();
+            @if (stats.ActiveAlerts.Count > 0 || notices.Count > 0)
             {
                 <div class="starlink-alerts">
                     @foreach (var alert in stats.ActiveAlerts)
                     {
-                        <span class="starlink-badge starlink-badge-warning">@HumanizeToken(alert)</span>
+                        <span class="starlink-badge starlink-badge-warning">@AlertLabel(alert)</span>
+                    }
+                    @foreach (var notice in notices)
+                    {
+                        <span class="starlink-notice">@notice</span>
                     }
                 </div>
-            }
-            @foreach (var notice in GetNotices())
-            {
-                <div class="starlink-notice">@notice</div>
             }
         }
 
@@ -257,7 +258,8 @@
     .starlink-alerts {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.35rem;
+        align-items: center;
+        gap: 0.35rem 0.6rem;
     }
 
     .starlink-badge {
@@ -565,6 +567,20 @@
     }
 
     /// <summary>"thermal_throttle" or "ThermalThrottle" -> "Thermal throttle".</summary>
+    /// <summary>
+    /// Alert names whose humanized form is not what the dish is actually telling
+    /// you. InstallPending reads as though something is waiting to be installed on
+    /// site; it means a software update is waiting. Add a row when another reads
+    /// wrong.
+    /// </summary>
+    private static readonly Dictionary<string, string> AlertLabels = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["InstallPending"] = "Update pending",
+    };
+
+    private static string AlertLabel(string token) =>
+        AlertLabels.TryGetValue(token, out var label) ? label : HumanizeToken(token);
+
     private static string HumanizeToken(string token)
     {
         if (string.IsNullOrEmpty(token)) return token;

--- a/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemMonitorService.cs
@@ -320,6 +320,7 @@ public sealed class CableModemMonitorService : ICableModemService, IDisposable
         return new CmPollContext
         {
             Id = config.Id,
+            SiteSlug = _siteSlug,
             Name = config.Name,
             Host = host,
             ConfiguredHost = config.Host,

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
@@ -36,7 +36,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
     private const int TimeoutSeconds = 15;
 
     private readonly ILogger<ArrisSurfboardHnapProvider> _logger;
-    private readonly ConcurrentDictionary<int, HnapSession> _sessions = new();
+    private readonly ConcurrentDictionary<string, HnapSession> _sessions = new();
     private readonly ConditionalWeakTable<HttpClient, CookieContainer> _cookieContainers = new();
 
     public ArrisSurfboardHnapProvider(ILogger<ArrisSurfboardHnapProvider> logger)
@@ -51,7 +51,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("ARRIS Surfboard HNAP poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("ARRIS Surfboard HNAP poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
@@ -75,7 +75,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogWarning(ex, "Error polling ARRIS Surfboard HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
@@ -137,7 +137,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
 
             if (channelResponse == null)
             {
-                _sessions.TryRemove(context.Id, out _);
+                _sessions.TryRemove(context.CacheKey, out _);
                 return null;
             }
 
@@ -149,7 +149,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogDebug(ex, "ARRIS Surfboard HNAP request failed for {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return null;
         }
@@ -161,7 +161,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
         CmPollContext context,
         CancellationToken cancellationToken)
     {
-        if (_sessions.TryGetValue(context.Id, out var cached))
+        if (_sessions.TryGetValue(context.CacheKey, out var cached))
         {
             ApplySession(client, endpoint[..^HnapPath.Length], cached);
 
@@ -175,12 +175,12 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
             if (testResponse != null)
                 return cached;
 
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
         }
 
         var session = await LoginAsync(client, endpoint, context, cancellationToken);
         if (session != null)
-            _sessions[context.Id] = session;
+            _sessions[context.CacheKey] = session;
 
         return session;
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHnapProvider.cs
@@ -51,7 +51,7 @@ public sealed class ArrisSurfboardHnapProvider : ICableModemProvider, IDisposabl
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("ARRIS Surfboard HNAP poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("ARRIS Surfboard HNAP poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
@@ -33,7 +33,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
     /// Cached auth tokens keyed by CmConfiguration.Id.
     /// SB8200 requires token-based auth; tokens are cached until they expire.
     /// </summary>
-    private readonly ConcurrentDictionary<int, string> _tokenCache = new();
+    private readonly ConcurrentDictionary<string, string> _tokenCache = new();
 
     public ArrisSurfboardHttpProvider(ILogger<ArrisSurfboardHttpProvider> logger)
     {
@@ -47,7 +47,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("ARRIS Surfboard poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("ARRIS Surfboard poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
@@ -144,14 +144,14 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         using var client = CreateHttpClient(ignoreSslErrors: true);
 
         // Try with cached token first
-        if (_tokenCache.TryGetValue(context.Id, out var cachedToken))
+        if (_tokenCache.TryGetValue(context.CacheKey, out var cachedToken))
         {
             var html = await FetchWithTokenAsync(client, statusUrl, cachedToken, cancellationToken);
             if (html != null && !IsAuthPage(html))
                 return html;
 
             // Cached token expired
-            _tokenCache.TryRemove(context.Id, out _);
+            _tokenCache.TryRemove(context.CacheKey, out _);
             _logger.LogDebug("ARRIS SB8200 cached token expired for {Name}, re-authenticating", context.Name);
         }
 
@@ -160,7 +160,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
         if (token == null)
             return null;
 
-        _tokenCache[context.Id] = token;
+        _tokenCache[context.CacheKey] = token;
 
         // Fetch with new token
         var result = await FetchWithTokenAsync(client, statusUrl, token, cancellationToken);
@@ -168,7 +168,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
             return result;
 
         // Auth failed completely
-        _tokenCache.TryRemove(context.Id, out _);
+        _tokenCache.TryRemove(context.CacheKey, out _);
         return null;
     }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/ArrisSurfboardHttpProvider.cs
@@ -47,7 +47,7 @@ public sealed class ArrisSurfboardHttpProvider : ICableModemProvider, IDisposabl
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("ARRIS Surfboard poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("ARRIS Surfboard poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -46,20 +46,20 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     /// Cached HNAP sessions keyed by CmConfiguration.Id.
     /// Each session holds the derived private key and cookies for reuse across polls.
     /// </summary>
-    private readonly ConcurrentDictionary<int, HnapSession> _sessions = new();
+    private readonly ConcurrentDictionary<string, HnapSession> _sessions = new();
 
     /// <summary>
     /// Per-config timestamps until which automatic login attempts are suspended
     /// after a login failure, to avoid tripping the modem's 3-strike lockout.
     /// </summary>
-    private readonly ConcurrentDictionary<int, DateTime> _loginBackoffUntil = new();
+    private readonly ConcurrentDictionary<string, DateTime> _loginBackoffUntil = new();
 
     /// <summary>
     /// Per-config detected transport scheme: true = HTTPS, false = HTTP. Determined on
     /// first successful contact (a Test press or the first poll) and reused so later
     /// polls skip protocol detection. Re-detected after a process restart.
     /// </summary>
-    private readonly ConcurrentDictionary<int, bool> _useHttps = new();
+    private readonly ConcurrentDictionary<string, bool> _useHttps = new();
 
     public MotorolaHnapProvider(ILogger<MotorolaHnapProvider> logger)
     {
@@ -73,11 +73,11 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
-        if (_loginBackoffUntil.TryGetValue(context.Id, out var backoffUntil))
+        if (_loginBackoffUntil.TryGetValue(context.CacheKey, out var backoffUntil))
         {
             if (DateTime.UtcNow < backoffUntil)
             {
@@ -87,7 +87,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
                 return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
 
-            _loginBackoffUntil.TryRemove(context.Id, out _);
+            _loginBackoffUntil.TryRemove(context.CacheKey, out _);
         }
 
         try
@@ -113,7 +113,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 
             if (response == null)
             {
-                _sessions.TryRemove(context.Id, out _);
+                _sessions.TryRemove(context.CacheKey, out _);
                 _logger.LogWarning("Motorola HNAP {Name} at {Host}: GetMultipleHNAPs failed", context.Name, context.ConfiguredHost ?? context.Host);
                 return PollResult<CableModemStats>.Failed($"No stats could be read from {(context.ConfiguredHost ?? context.Host)}.");
             }
@@ -132,7 +132,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogWarning(ex, "Error polling Motorola HNAP {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, (context.ConfiguredHost ?? context.Host)));
         }
@@ -193,8 +193,8 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         HttpClient client, CmPollContext context, CancellationToken cancellationToken)
     {
         // Fast path: reuse a cached session over the scheme we already detected.
-        if (_useHttps.TryGetValue(context.Id, out var knownScheme) &&
-            _sessions.TryGetValue(context.Id, out var cached))
+        if (_useHttps.TryGetValue(context.CacheKey, out var knownScheme) &&
+            _sessions.TryGetValue(context.CacheKey, out var cached))
         {
             var cachedUrl = BuildBaseUrl(context, knownScheme);
             using var testResponse = await CallMultipleHnapsAsync(
@@ -205,7 +205,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             if (testResponse != null)
                 return new SessionInfo(cached, cachedUrl);
 
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogDebug("Motorola HNAP session expired for {Name}, re-authenticating", context.Name);
         }
 
@@ -213,7 +213,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         // modems already working over TLS keep the exact same path they use today; HTTP
         // is the fallback for modems whose HTTPS handshake .NET can't complete (it stalls
         // until timeout, e.g. on macOS) - those modems also serve /HNAP1/ over plain HTTP.
-        foreach (var useHttps in SchemesToTry(context.Id))
+        foreach (var useHttps in SchemesToTry(context.CacheKey))
         {
             var baseUrl = BuildBaseUrl(context, useHttps);
 
@@ -233,17 +233,17 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 
             if (session != null)
             {
-                _sessions[context.Id] = session;
-                _useHttps[context.Id] = useHttps;
+                _sessions[context.CacheKey] = session;
+                _useHttps[context.CacheKey] = useHttps;
                 return new SessionInfo(session, baseUrl);
             }
 
             // The endpoint answered on this scheme but auth failed (lockout backoff is
             // now set). The scheme is correct, so remember it and stop - retrying the
             // other scheme would just burn another failed login against the lockout.
-            if (_loginBackoffUntil.ContainsKey(context.Id))
+            if (_loginBackoffUntil.ContainsKey(context.CacheKey))
             {
-                _useHttps[context.Id] = useHttps;
+                _useHttps[context.CacheKey] = useHttps;
                 return null;
             }
 
@@ -253,7 +253,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
 
         // Nothing worked and no scheme was confirmed - drop any stale cached scheme so
         // the next attempt probes both again.
-        _useHttps.TryRemove(context.Id, out _);
+        _useHttps.TryRemove(context.CacheKey, out _);
         return null;
     }
 
@@ -261,8 +261,8 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     /// Schemes to attempt for this config: the cached one if known, otherwise HTTPS
     /// first (so modems already working over TLS are unchanged) then HTTP.
     /// </summary>
-    private bool[] SchemesToTry(int id) =>
-        _useHttps.TryGetValue(id, out var scheme) ? [scheme] : [true, false];
+    private bool[] SchemesToTry(string cacheKey) =>
+        _useHttps.TryGetValue(cacheKey, out var scheme) ? [scheme] : [true, false];
 
     /// <summary>
     /// Two-phase HNAP login: request challenge, derive keys, authenticate.
@@ -303,7 +303,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var result = loginResp.GetProperty("LoginResult").GetString();
         if (result == "FAILED")
         {
-            _loginBackoffUntil[context.Id] = DateTime.UtcNow + LoginFailureBackoff;
+            _loginBackoffUntil[context.CacheKey] = DateTime.UtcNow + LoginFailureBackoff;
             _logger.LogWarning(
                 "Motorola HNAP {Name}: login locked out. Wait 5 minutes before retrying", context.Name);
             return null;
@@ -357,7 +357,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
         var authResult = authResp.GetProperty("LoginResult").GetString();
         if (authResult != "OK" && authResult != "OK_CHANGED")
         {
-            _loginBackoffUntil[context.Id] = DateTime.UtcNow + LoginFailureBackoff;
+            _loginBackoffUntil[context.CacheKey] = DateTime.UtcNow + LoginFailureBackoff;
             _logger.LogWarning(
                 "Motorola HNAP {Name}: login authentication failed (result: {Result}). " +
                 "Suspending retries for {Minutes} minutes to avoid the modem's failed-login lockout",
@@ -365,7 +365,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
             return null;
         }
 
-        _loginBackoffUntil.TryRemove(context.Id, out _);
+        _loginBackoffUntil.TryRemove(context.CacheKey, out _);
         _logger.LogDebug("Motorola HNAP {Name}: logged in successfully", context.Name);
         return session;
     }

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/MotorolaHnapProvider.cs
@@ -73,7 +73,7 @@ public sealed class MotorolaHnapProvider : ICableModemProvider, IDisposable
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("Motorola HNAP poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -103,7 +103,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
     /// CmConfiguration.Id so later polls go straight to it instead of re-probing the dead
     /// extension or wrong auth style every interval.
     /// </summary>
-    private readonly ConcurrentDictionary<int, (string Path, bool FormLogin)> _attemptCache = new();
+    private readonly ConcurrentDictionary<string, (string Path, bool FormLogin)> _attemptCache = new();
 
     public NetgearCmProvider(ILogger<NetgearCmProvider> logger)
     {
@@ -117,7 +117,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Netgear CM poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("Netgear CM poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
@@ -253,7 +253,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
                 if (IsStatusPage(html))
                 {
                     if (context.Id > 0)
-                        _attemptCache[context.Id] = (path, formLogin);
+                        _attemptCache[context.CacheKey] = (path, formLogin);
                     return html;
                 }
 
@@ -296,7 +296,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
         // (and logging a 404 or connection error for) the wrong extension/auth. The poll loop
         // forces the full matrix on its final retry, so a combo that has genuinely stopped working
         // is still re-discovered.
-        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var cached))
+        if (!fullMatrix && context.Id > 0 && _attemptCache.TryGetValue(context.CacheKey, out var cached))
             return new List<(string Path, bool FormLogin)> { cached };
 
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath)
@@ -320,7 +320,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
                 attempts.Add((htmPath, true));
         }
 
-        if (context.Id > 0 && _attemptCache.TryGetValue(context.Id, out var lastGood))
+        if (context.Id > 0 && _attemptCache.TryGetValue(context.CacheKey, out var lastGood))
         {
             var idx = attempts.FindIndex(a => a.Path == lastGood.Path && a.FormLogin == lastGood.FormLogin);
             if (idx > 0)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/NetgearCmProvider.cs
@@ -117,7 +117,7 @@ public sealed class NetgearCmProvider : ICableModemProvider
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Netgear CM poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("Netgear CM poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -52,7 +52,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/TechnicolorCgaProvider.cs
@@ -38,7 +38,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     private const int TimeoutSeconds = 15;
 
     private readonly ILogger<TechnicolorCgaProvider> _logger;
-    private readonly ConcurrentDictionary<int, CgaSession> _sessions = new();
+    private readonly ConcurrentDictionary<string, CgaSession> _sessions = new();
 
     public TechnicolorCgaProvider(ILogger<TechnicolorCgaProvider> logger)
     {
@@ -52,7 +52,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("Technicolor CGA poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
@@ -76,7 +76,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogWarning(ex, "Error polling Technicolor CGA {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
@@ -125,7 +125,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         {
             // A token only stays valid for one signed-in session, so anything else signing in
             // invalidates ours. Re-authenticate once before giving up.
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             session = await LoginAsync(context, cancellationToken);
             if (session == null)
                 return null;
@@ -143,7 +143,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
 
     private async Task<CgaSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
     {
-        if (_sessions.TryGetValue(context.Id, out var cached))
+        if (_sessions.TryGetValue(context.CacheKey, out var cached))
             return cached;
 
         return await LoginAsync(context, cancellationToken);
@@ -230,7 +230,7 @@ public sealed class TechnicolorCgaProvider : ICableModemProvider, IDisposable
         }
 
         session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
-        _sessions[context.Id] = session;
+        _sessions[context.CacheKey] = session;
 
         _logger.LogDebug("Technicolor CGA {Name}: authenticated", context.Name);
         return session;

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -58,7 +58,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/VodafoneStationProvider.cs
@@ -44,7 +44,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
     private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
 
     private readonly ILogger<VodafoneStationProvider> _logger;
-    private readonly ConcurrentDictionary<int, TgSession> _sessions = new();
+    private readonly ConcurrentDictionary<string, TgSession> _sessions = new();
 
     public VodafoneStationProvider(ILogger<VodafoneStationProvider> logger)
     {
@@ -58,7 +58,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("Vodafone Station poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<CableModemStats>.Failed("No address is configured for this device.");
         }
 
@@ -82,7 +82,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         }
         catch (Exception ex)
         {
-            _sessions.TryRemove(context.Id, out _);
+            _sessions.TryRemove(context.CacheKey, out _);
             _logger.LogWarning(ex, "Error polling Vodafone Station {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
             return PollResult<CableModemStats>.Failed(HttpFailureSummary.Describe(ex, context.ConfiguredHost ?? context.Host));
         }
@@ -146,7 +146,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
 
     private async Task<TgSession?> EnsureSessionAsync(CmPollContext context, CancellationToken cancellationToken)
     {
-        if (_sessions.TryGetValue(context.Id, out var cached))
+        if (_sessions.TryGetValue(context.CacheKey, out var cached))
             return cached;
 
         return await LoginAsync(context, cancellationToken);
@@ -279,7 +279,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
         await ApplyCredentialCookieAsync(authedClient, cookies, baseUrl, context, cancellationToken);
 
         session = session with { DeviceModel = await ReadDeviceModelAsync(authedClient, baseUrl, session.DeviceModel, cancellationToken) };
-        _sessions[context.Id] = session;
+        _sessions[context.CacheKey] = session;
 
         _logger.LogDebug("Vodafone Station {Name}: authenticated (p_status={Status})", context.Name, status);
         return session;
@@ -322,7 +322,7 @@ public sealed partial class VodafoneStationProvider : ICableModemProvider, IDisp
 
     private async Task InvalidateSessionAsync(CmPollContext context, CancellationToken cancellationToken)
     {
-        if (!_sessions.TryRemove(context.Id, out var session))
+        if (!_sessions.TryRemove(context.CacheKey, out var session))
             return;
 
         var baseUrl = BuildBaseUrl(context);

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -574,14 +574,23 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Name the gateway from the Device Information section. Product Type is the
-    /// name users know ("XB10", "CBR"), with the model number as a fallback for
-    /// firmware that omits it.
+    /// Name the gateway from the Device Information section, pairing the name
+    /// users know with the model number behind it: "XB10 (SG417DBCT)",
+    /// "CBR (CGA4332COM)". Product Type alone is too coarse on business firmware,
+    /// where every gateway in the line reports "CBR", and the model number alone
+    /// is unrecognizable on residential firmware.
     /// </summary>
     private static string? ExtractProductType(HtmlDocument doc)
     {
-        return ExtractDeviceInfoValue(doc, "Product Type")
-            ?? ExtractDeviceInfoValue(doc, "Model");
+        var productType = ExtractDeviceInfoValue(doc, "Product Type");
+        var model = ExtractDeviceInfoValue(doc, "Model");
+
+        if (productType == null || model == null)
+            return productType ?? model;
+
+        return string.Equals(productType, model, StringComparison.OrdinalIgnoreCase)
+            ? productType
+            : $"{productType} ({model})";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -230,6 +230,9 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     /// <summary>
     /// GET one candidate path. A 404 or a bounce back to the login page is an
     /// ordinary "not this one" answer here, not a failure worth surfacing.
+    /// Connection-level failures are left to throw: they are path-independent,
+    /// so swallowing them per candidate would trade the caller's specific
+    /// message ("connection refused") for a generic "no stats could be read".
     /// </summary>
     private async Task<string?> TryGetPageAsync(
         HttpClient client,
@@ -238,19 +241,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         CmPollContext context,
         CancellationToken cancellationToken)
     {
-        HttpResponseMessage response;
-        try
-        {
-            response = await client.GetAsync($"{baseUrl}{path}", cancellationToken);
-        }
-        catch (HttpRequestException ex)
-        {
-            _logger.LogDebug(ex, "Xfinity Gateway at {Host}: {Path} could not be fetched",
-                context.ConfiguredHost ?? context.Host, path);
-            return null;
-        }
-
-        using (response)
+        using (var response = await client.GetAsync($"{baseUrl}{path}", cancellationToken))
         {
             if (!response.IsSuccessStatusCode)
             {

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using HtmlAgilityPack;
 using NetworkOptimizer.Monitoring.Models;
@@ -7,10 +8,21 @@ using NetworkOptimizer.Web.Services.Monitoring;
 namespace NetworkOptimizer.Web.Services.CableModemProviders;
 
 /// <summary>
-/// Cable modem provider for gateways sharing the Xfinity/Technicolor web UI (Xfinity XB8/XB10, Cox CGM4981).
-/// Authenticates via form POST to /check.jst, then scrapes DOCSIS channel
-/// tables from /network_setup.jst. The tables use a transposed layout where
-/// each row is a metric and each column is a channel.
+/// Cable modem provider for gateways sharing the Comcast-derived .jst web UI,
+/// whatever the OEM: Xfinity XB8/XB10 (Sercomm), Comcast Business CGA4332
+/// (Technicolor), Cox CGM4981 (Technicolor). Authenticates via form POST to
+/// /check.jst, then scrapes DOCSIS channel tables that use a transposed layout
+/// where each row is a metric and each column is a channel.
+///
+/// Firmware families differ in two ways this provider absorbs rather than
+/// exposing as separate providers, because a user cannot tell them apart from
+/// the outside: residential builds serve the tables from /network_setup.jst and
+/// label the channel row "Channel ID", while Comcast Business builds serve
+/// /comcast_network.jst and label it "Index".
+///
+/// Not to be confused with <see cref="TechnicolorCgaProvider"/>. That one talks
+/// to Technicolor's own firmware over its JSON API; the CGA hardware here runs
+/// Comcast's UI instead and shares none of that transport.
 /// </summary>
 public sealed class XfinityGatewayProvider : ICableModemProvider
 {
@@ -18,15 +30,39 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     public string ProviderKey => "xfinity-gateway";
 
     /// <inheritdoc/>
-    public string DisplayName => "Xfinity Gateway (HTTP)";
+    public string DisplayName => "Xfinity XB8/XB10, Comcast Business CGA4332, Cox CGM4981 (HTTP)";
 
-    private const string DefaultStatusPath = "/network_setup.jst";
+    /// <summary>
+    /// Status page candidates in discovery order. Residential firmware first:
+    /// it is the larger population, so most sites settle on one request.
+    /// </summary>
+    private static readonly string[] DefaultStatusPaths =
+    {
+        "/network_setup.jst",
+        "/comcast_network.jst",
+    };
+
     private const string LoginPath = "/check.jst";
     private const int TimeoutSeconds = 15;
     private const int MaxRetries = 3;
     private static readonly TimeSpan RetryDelay = TimeSpan.FromSeconds(1);
 
     private readonly ILogger<XfinityGatewayProvider> _logger;
+
+    /// <summary>
+    /// Status page path discovered per configured modem, so only the first poll
+    /// pays for probing. Keyed by site and configuration ID together: this
+    /// provider is a singleton shared by every site, and configuration IDs only
+    /// count within one site's database.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, DiscoveredPath> _discoveredPaths = new();
+
+    /// <summary>
+    /// A remembered discovery. <paramref name="ConfiguredPath"/> is the override
+    /// in force when it was made, so editing that setting re-discovers instead of
+    /// serving a stale answer.
+    /// </summary>
+    private sealed record DiscoveredPath(string? ConfiguredPath, string Path);
 
     public XfinityGatewayProvider(ILogger<XfinityGatewayProvider> logger)
     {
@@ -128,18 +164,15 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Authenticate via form POST and fetch the status page in one session.
-    /// Uses CookieContainer to carry the session cookie from login to page fetch.
+    /// Authenticate via form POST, then fetch the first status page that yields
+    /// DOCSIS channels. The winning path is remembered for this modem, so the
+    /// probing cost is paid once rather than on every poll.
     /// </summary>
     private async Task<string?> FetchStatusPageAsync(CmPollContext context, CancellationToken cancellationToken)
     {
         var port = context.Port > 0 ? context.Port : 80;
         var portSuffix = port == 80 ? "" : $":{port}";
         var baseUrl = $"http://{context.Host}{portSuffix}";
-
-        var statusPath = string.IsNullOrWhiteSpace(context.StatusPagePath)
-            ? DefaultStatusPath
-            : context.StatusPagePath;
 
         using var handler = new HttpClientHandler
         {
@@ -169,26 +202,131 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
             return null;
         }
 
-        var response = await client.GetAsync($"{baseUrl}{statusPath}", cancellationToken);
-        if (!response.IsSuccessStatusCode)
+        // Keep the first page that authenticated but had no tables: if no
+        // candidate parses, returning it lets the caller say "connected, wrong
+        // page" instead of the indistinguishable "no response".
+        string? readableButUnparsed = null;
+
+        foreach (var path in CandidatePaths(context))
         {
-            _logger.LogDebug("Xfinity Gateway status page returned {Status} for {Host}",
-                response.StatusCode, context.ConfiguredHost ?? context.Host);
+            var html = await TryGetPageAsync(client, baseUrl, path, context, cancellationToken);
+            if (html == null)
+                continue;
+
+            readableButUnparsed ??= html;
+
+            if (!HasChannelData(html))
+            {
+                _logger.LogDebug("Xfinity Gateway at {Host}: {Path} has no DOCSIS channel tables",
+                    context.ConfiguredHost ?? context.Host, path);
+                continue;
+            }
+
+            Remember(context, path);
+            return html;
+        }
+
+        return readableButUnparsed;
+    }
+
+    /// <summary>
+    /// GET one candidate path. A 404 or a bounce back to the login page is an
+    /// ordinary "not this one" answer here, not a failure worth surfacing.
+    /// </summary>
+    private async Task<string?> TryGetPageAsync(
+        HttpClient client,
+        string baseUrl,
+        string path,
+        CmPollContext context,
+        CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.GetAsync($"{baseUrl}{path}", cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Xfinity Gateway at {Host}: {Path} could not be fetched",
+                context.ConfiguredHost ?? context.Host, path);
             return null;
         }
 
-        var html = await response.Content.ReadAsStringAsync(cancellationToken);
-        if (string.IsNullOrWhiteSpace(html))
-            return null;
-
-        if (IsLoginPage(html))
+        using (response)
         {
-            _logger.LogDebug("Xfinity Gateway at {Host}: login failed, got redirected back to login page",
-                context.ConfiguredHost ?? context.Host);
-            return null;
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Xfinity Gateway at {Host}: {Path} returned {Status}",
+                    context.ConfiguredHost ?? context.Host, path, response.StatusCode);
+                return null;
+            }
+
+            var html = await response.Content.ReadAsStringAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(html))
+                return null;
+
+            if (IsLoginPage(html))
+            {
+                _logger.LogDebug("Xfinity Gateway at {Host}: login failed, got redirected back to login page",
+                    context.ConfiguredHost ?? context.Host);
+                return null;
+            }
+
+            return html;
+        }
+    }
+
+    /// <summary>
+    /// Paths to try, best guess first: what worked last time, then any explicit
+    /// override, then the built-in candidates.
+    /// </summary>
+    internal IEnumerable<string> CandidatePaths(CmPollContext context)
+    {
+        var configured = string.IsNullOrWhiteSpace(context.StatusPagePath) ? null : context.StatusPagePath;
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (_discoveredPaths.TryGetValue(CacheKey(context), out var remembered)
+            && string.Equals(remembered.ConfiguredPath, configured, StringComparison.OrdinalIgnoreCase)
+            && seen.Add(remembered.Path))
+        {
+            yield return remembered.Path;
         }
 
-        return html;
+        if (configured != null && seen.Add(configured))
+            yield return configured;
+
+        foreach (var path in DefaultStatusPaths)
+        {
+            if (seen.Add(path))
+                yield return path;
+        }
+    }
+
+    internal void Remember(CmPollContext context, string path)
+    {
+        var configured = string.IsNullOrWhiteSpace(context.StatusPagePath) ? null : context.StatusPagePath;
+        var entry = new DiscoveredPath(configured, path);
+        var key = CacheKey(context);
+
+        if (_discoveredPaths.TryGetValue(key, out var previous) && previous == entry)
+            return;
+
+        _discoveredPaths[key] = entry;
+        _logger.LogDebug("Xfinity Gateway {Name} at {Host}: serving DOCSIS stats from {Path}",
+            context.Name, context.ConfiguredHost ?? context.Host, path);
+    }
+
+    private static string CacheKey(CmPollContext context) => $"{context.SiteSlug}/{context.Id}";
+
+    /// <summary>Whether a page carries a channel table this provider can read.</summary>
+    private static bool HasChannelData(string html)
+    {
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var tables = FindChannelTables(doc);
+        return CountChannelsInTransposedTable(tables.Downstream) > 0
+            || CountChannelsInTransposedTable(tables.Upstream) > 0;
     }
 
     /// <summary>
@@ -201,7 +339,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
             || html.Contains("action='/check.jst'", StringComparison.OrdinalIgnoreCase);
     }
 
-    private CableModemStats ParseNetworkSetup(string html, CmPollContext context)
+    internal CableModemStats ParseNetworkSetup(string html, CmPollContext context)
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
@@ -271,7 +409,8 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     private void ParseTransposedDownstreamTable(HtmlNode table, CableModemStats stats)
     {
         var metricRows = ExtractMetricRows(table);
-        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+        var channelIds = FindChannelIdRow(metricRows);
+        if (channelIds == null)
             return;
 
         metricRows.TryGetValue("lockstatus", out var lockStatuses);
@@ -303,7 +442,8 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     private void ParseTransposedUpstreamTable(HtmlNode table, CableModemStats stats)
     {
         var metricRows = ExtractMetricRows(table);
-        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
+        var channelIds = FindChannelIdRow(metricRows);
+        if (channelIds == null)
             return;
 
         metricRows.TryGetValue("lockstatus", out var lockStatuses);
@@ -330,30 +470,70 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Merge error codewords from the separate table into existing DS channels by channel ID.
+    /// Merge error codewords from the separate table into existing DS channels.
+    /// Matches by channel ID where the table carries one; Comcast Business
+    /// firmware omits that row entirely, so there the columns are positional and
+    /// line up with the downstream table read moments earlier.
     /// </summary>
     private void MergeErrorCodewords(HtmlNode table, CableModemStats stats)
     {
         var metricRows = ExtractMetricRows(table);
-        if (!metricRows.TryGetValue("channelid", out var channelIds) || channelIds.Count == 0)
-            return;
 
         metricRows.TryGetValue("correctablecodewords", out var correctables);
         metricRows.TryGetValue("uncorrectablecodewords", out var uncorrectables);
+        if (correctables == null && uncorrectables == null)
+            return;
 
-        var dsLookup = new Dictionary<int, DsChannel>();
-        foreach (var ch in stats.DownstreamChannels)
-            dsLookup.TryAdd(ch.ChannelId, ch);
-
-        for (int i = 0; i < channelIds.Count; i++)
+        if (metricRows.TryGetValue("channelid", out var channelIds) && channelIds.Count > 0)
         {
-            var chId = ParseInt(GetAt(channelIds, i));
-            if (chId > 0 && dsLookup.TryGetValue(chId, out var channel))
+            var dsLookup = new Dictionary<int, DsChannel>();
+            foreach (var ch in stats.DownstreamChannels)
+                dsLookup.TryAdd(ch.ChannelId, ch);
+
+            for (int i = 0; i < channelIds.Count; i++)
             {
-                channel.Correctables = ParseLong(GetAt(correctables, i));
-                channel.Uncorrectables = ParseLong(GetAt(uncorrectables, i));
+                var chId = ParseInt(GetAt(channelIds, i));
+                if (chId > 0 && dsLookup.TryGetValue(chId, out var channel))
+                {
+                    channel.Correctables = ParseLong(GetAt(correctables, i));
+                    channel.Uncorrectables = ParseLong(GetAt(uncorrectables, i));
+                }
             }
+
+            return;
         }
+
+        var columns = Math.Max(correctables?.Count ?? 0, uncorrectables?.Count ?? 0);
+        if (columns != stats.DownstreamChannels.Count)
+        {
+            _logger.LogDebug(
+                "Xfinity Gateway: codeword table has {Columns} columns for {Channels} downstream channels, skipping merge",
+                columns, stats.DownstreamChannels.Count);
+            return;
+        }
+
+        for (int i = 0; i < stats.DownstreamChannels.Count; i++)
+        {
+            stats.DownstreamChannels[i].Correctables = ParseLong(GetAt(correctables, i));
+            stats.DownstreamChannels[i].Uncorrectables = ParseLong(GetAt(uncorrectables, i));
+        }
+    }
+
+    /// <summary>
+    /// The row identifying each channel column. Residential firmware labels it
+    /// "Channel ID" and gives the real DOCSIS ID; Comcast Business labels it
+    /// "Index" and gives a 1-based position instead, which is all that firmware
+    /// exposes.
+    /// </summary>
+    private static List<string>? FindChannelIdRow(Dictionary<string, List<string>> metricRows)
+    {
+        if (metricRows.TryGetValue("channelid", out var ids) && ids.Count > 0)
+            return ids;
+
+        if (metricRows.TryGetValue("index", out var indexes) && indexes.Count > 0)
+            return indexes;
+
+        return null;
     }
 
     /// <summary>
@@ -394,16 +574,27 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     }
 
     /// <summary>
-    /// Extract the Product Type from the Device Information section (e.g. "XB10").
+    /// Name the gateway from the Device Information section. Product Type is the
+    /// name users know ("XB10", "CBR"), with the model number as a fallback for
+    /// firmware that omits it.
     /// </summary>
     private static string? ExtractProductType(HtmlDocument doc)
+    {
+        return ExtractDeviceInfoValue(doc, "Product Type")
+            ?? ExtractDeviceInfoValue(doc, "Model");
+    }
+
+    /// <summary>
+    /// Read one label/value pair out of the Device Information section.
+    /// </summary>
+    private static string? ExtractDeviceInfoValue(HtmlDocument doc, string labelText)
     {
         var labels = doc.DocumentNode.SelectNodes("//span[contains(@class,'readonlyLabel')]");
         if (labels == null) return null;
 
         foreach (var label in labels)
         {
-            if (!label.InnerText.Contains("Product Type", StringComparison.OrdinalIgnoreCase))
+            if (!label.InnerText.Contains(labelText, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             var value = label.ParentNode?.SelectSingleNode(".//span[contains(@class,'value')]");
@@ -421,8 +612,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     private static int CountChannelsInTransposedTable(HtmlNode? table)
     {
         if (table == null) return 0;
-        var metricRows = ExtractMetricRows(table);
-        return metricRows.TryGetValue("channelid", out var ids) ? ids.Count : 0;
+        return FindChannelIdRow(ExtractMetricRows(table))?.Count ?? 0;
     }
 
     private static string? GetAt(List<string>? list, int index)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -51,9 +51,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
 
     /// <summary>
     /// Status page path discovered per configured modem, so only the first poll
-    /// pays for probing. Keyed by site and configuration ID together: this
-    /// provider is a singleton shared by every site, and configuration IDs only
-    /// count within one site's database.
+    /// pays for probing.
     /// </summary>
     private readonly ConcurrentDictionary<string, DiscoveredPath> _discoveredPaths = new();
 
@@ -285,7 +283,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath) ? null : context.StatusPagePath;
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        if (_discoveredPaths.TryGetValue(CacheKey(context), out var remembered)
+        if (_discoveredPaths.TryGetValue(context.CacheKey, out var remembered)
             && string.Equals(remembered.ConfiguredPath, configured, StringComparison.OrdinalIgnoreCase)
             && seen.Add(remembered.Path))
         {
@@ -306,7 +304,7 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
     {
         var configured = string.IsNullOrWhiteSpace(context.StatusPagePath) ? null : context.StatusPagePath;
         var entry = new DiscoveredPath(configured, path);
-        var key = CacheKey(context);
+        var key = context.CacheKey;
 
         if (_discoveredPaths.TryGetValue(key, out var previous) && previous == entry)
             return;
@@ -315,8 +313,6 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
         _logger.LogDebug("Xfinity Gateway {Name} at {Host}: serving DOCSIS stats from {Path}",
             context.Name, context.ConfiguredHost ?? context.Host, path);
     }
-
-    private static string CacheKey(CmPollContext context) => $"{context.SiteSlug}/{context.Id}";
 
     /// <summary>Whether a page carries a channel table this provider can read.</summary>
     private static bool HasChannelData(string html)

--- a/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CableModemProviders/XfinityGatewayProvider.cs
@@ -150,10 +150,12 @@ public sealed class XfinityGatewayProvider : ICableModemProvider
             var dsCount = CountChannelsInTransposedTable(tables.Downstream);
             var usCount = CountChannelsInTransposedTable(tables.Upstream);
 
+            // "to {model}" rather than "({model})": the model is itself parenthesized
+            // ("CBR (CGA4332COM)"), and this matches the other providers' phrasing.
             var model = ExtractProductType(doc);
-            var modelSuffix = string.IsNullOrEmpty(model) ? "" : $" ({model})";
+            var target = string.IsNullOrEmpty(model) ? "" : $" to {model}";
 
-            return (true, $"Connected{modelSuffix} - {dsCount} downstream, {usCount} upstream channels detected");
+            return (true, $"Connected{target} - {dsCount} downstream, {usCount} upstream channels detected");
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/NetgearNighthawkHotspotProvider.cs
@@ -134,7 +134,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
             _logger.LogInformation(
                 "Netgear session for {Host} expired (302 to /sess_cd_tmp), rebuilding",
                 context.ConfiguredHost ?? context.Host);
-            InvalidateSession(context.Host);
+            InvalidateSession(context.CacheKey);
 
             session = await GetOrCreateSessionAsync(context, requireAuth, cancellationToken);
             if (session == null) return null;
@@ -198,14 +198,14 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         CancellationToken cancellationToken)
     {
         // Fast path: existing session that's still authenticated to the right level
-        if (_sessions.TryGetValue(context.Host, out var existing))
+        if (_sessions.TryGetValue(context.CacheKey, out var existing))
         {
             if (!requireAuth || existing.IsAuthenticated)
             {
                 return existing;
             }
             // We need auth but have an unauthenticated session - tear it down
-            InvalidateSession(context.Host);
+            InvalidateSession(context.CacheKey);
         }
 
         var session = CreateSession(context.Host);
@@ -231,7 +231,7 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
             }
         }
 
-        _sessions[context.Host] = session;
+        _sessions[context.CacheKey] = session;
         return session;
     }
 
@@ -366,9 +366,9 @@ public sealed class NetgearNighthawkHotspotProvider : ICellularModemProvider, ID
         };
     }
 
-    private void InvalidateSession(string host)
+    private void InvalidateSession(string cacheKey)
     {
-        if (_sessions.TryRemove(host, out var session))
+        if (_sessions.TryRemove(cacheKey, out var session))
         {
             session.Dispose();
         }

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -224,6 +224,7 @@ public class CellularModemService : ICellularModemService
         return new ModemPollContext
         {
             Id = modem.Id,
+            SiteSlug = _siteSlug,
             Name = modem.Name,
             Host = host,
             ConfiguredHost = modem.Host,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -18,6 +18,23 @@ public static class SignalGauge
     private const string Good = "var(--signal-good)";
     private const string Excellent = "var(--signal-excellent)";
 
+    /// <summary>
+    /// How much of a band track to dim above and below the reading, leaving a lit
+    /// window on it.
+    ///
+    /// A band track cannot be lit from the bottom the way the rising one is. Doing
+    /// that lights everything the reading has passed, so a perfectly good -22 dBm
+    /// shows a bar full of the red and orange below it, and an overdriven -5 shows
+    /// a bar full of green. Only the reading's own stretch of the track says
+    /// anything true about the reading.
+    /// </summary>
+    public static (double Above, double Below) WindowEdges(double position, double halfHeight = 9)
+    {
+        var above = Math.Clamp(100 - position - halfHeight, 0, 100);
+        var below = Math.Clamp(position - halfHeight, 0, 100);
+        return (above, below);
+    }
+
     /// <summary>Where a reading sits on its track, 0 (bottom) to 100 (top).</summary>
     public static double Position(double value, double domainLow, double domainHigh)
     {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -1,0 +1,105 @@
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Gradient tracks for the dashboard signal gauges. The gradient stops and the
+/// health thresholds come from one place here so a threshold change cannot leave
+/// the bar showing green where the reading is called poor.
+///
+/// Two shapes, because the two readings are not the same kind of scale. DOCSIS
+/// SNR only rises: more is better, all the way up. Optical Rx power is a band -
+/// a receiver above the top of it is overloaded, which is a fault, so the track
+/// has to run back to red at BOTH ends. Never reuse the rising track for optical.
+/// </summary>
+public static class SignalGauge
+{
+    private const string Poor = "var(--signal-poor)";
+    private const string Weak = "var(--signal-weak)";
+    private const string Fair = "var(--signal-fair)";
+    private const string Good = "var(--signal-good)";
+    private const string Excellent = "var(--signal-excellent)";
+
+    /// <summary>Where a reading sits on its track, 0 (bottom) to 100 (top).</summary>
+    public static double Position(double value, double domainLow, double domainHigh)
+    {
+        if (domainHigh <= domainLow) return 0;
+        var pct = (value - domainLow) / (domainHigh - domainLow) * 100.0;
+        return Math.Clamp(pct, 0, 100);
+    }
+
+    /// <summary>
+    /// Rising track for DOCSIS downstream SNR: red at the bottom through to green
+    /// at the top. Thresholds are the lower bounds for each grade.
+    /// </summary>
+    public static string SnrTrack(double domainLow, double domainHigh, double fair, double good, double excellent)
+    {
+        var f = Position(fair, domainLow, domainHigh);
+        var g = Position(good, domainLow, domainHigh);
+        var e = Position(excellent, domainLow, domainHigh);
+
+        return "linear-gradient(to top, " +
+               $"{Poor} 0%, {Weak} {f / 2:0.#}%, {Fair} {f:0.#}%, {Good} {g:0.#}%, {Excellent} {e:0.#}%, {Excellent} 100%)";
+    }
+
+    /// <summary>
+    /// Band track for optical Rx power: red at both ends, green through the good
+    /// band. The upper red is the point of the whole thing - it is what tells a
+    /// user their receiver is being overdriven rather than that it is doing well.
+    /// </summary>
+    public static string OpticalTrack(OpticalBands bands)
+    {
+        var lo = bands.DomainLow;
+        var hi = bands.DomainHigh;
+
+        double P(double v) => Position(v, lo, hi);
+
+        return "linear-gradient(to top, " +
+               $"{Poor} 0%, " +
+               $"{Weak} {P(bands.FairLow):0.#}%, " +
+               $"{Fair} {P(bands.GoodLow):0.#}%, " +
+               $"{Excellent} {P(bands.ExcellentLow):0.#}%, " +
+               $"{Excellent} {P(bands.ExcellentHigh):0.#}%, " +
+               $"{Good} {P(bands.GoodHigh):0.#}%, " +
+               $"{Fair} {P(bands.FairHigh):0.#}%, " +
+               $"{Poor} 100%)";
+    }
+}
+
+/// <summary>
+/// Optical Rx power grading bounds, in dBm. Every grade is a range with a floor
+/// and a ceiling: too much light is a fault in its own right.
+/// </summary>
+public readonly record struct OpticalBands(
+    double ExcellentLow, double ExcellentHigh,
+    double GoodLow, double GoodHigh,
+    double FairLow, double FairHigh)
+{
+    /// <summary>PON and generic optics.</summary>
+    public static readonly OpticalBands Pon = new(-22, -8, -25, -6, -28, -4);
+
+    /// <summary>Active Ethernet optics, which run far hotter than PON.</summary>
+    public static readonly OpticalBands ActiveEthernet = new(-8, -1, -10, 0, -14, 1);
+
+    /// <summary>
+    /// External ONT devices, which report against slightly tighter bounds than the
+    /// gateway-attached optics. Kept separate so the track's color boundaries land
+    /// exactly where OntStatsPanel.ExternalRxClass changes grade.
+    /// </summary>
+    public static readonly OpticalBands ExternalOnt = new(-22.5, -8, -25, -6, -27, -4);
+
+    /// <summary>A little headroom past the last graded bound, so the ends are visible.</summary>
+    public double DomainLow => FairLow - 2;
+
+    /// <summary>A little headroom past the last graded bound, so the ends are visible.</summary>
+    public double DomainHigh => FairHigh + 2;
+
+    /// <summary>The signal-* class for a reading, or empty when there is none.</summary>
+    public string ClassFor(double? rxDbm)
+    {
+        if (!rxDbm.HasValue) return "";
+        var v = rxDbm.Value;
+        if (v >= ExcellentLow && v <= ExcellentHigh) return "signal-excellent";
+        if (v >= GoodLow && v <= GoodHigh) return "signal-good";
+        if (v >= FairLow && v <= FairHigh) return "signal-fair";
+        return "signal-poor";
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -41,14 +41,20 @@ public static class SignalGauge
     }
 
     /// <summary>
-    /// Band track for optical Rx power: red at both ends, green through the good
-    /// band. The upper red is the point of the whole thing - it is what tells a
-    /// user their receiver is being overdriven rather than that it is doing well.
+    /// Band track for optical Rx power: red at both ends, peaking green at the
+    /// middle of the excellent band and easing out through good and fair either
+    /// side of it. The upper red is the point of the whole thing - it is what
+    /// tells a user their receiver is being overdriven rather than doing well.
+    ///
+    /// Green peaks at a point rather than holding flat across the whole excellent
+    /// band: the eye reads the taper as "how much room is left", which a plateau
+    /// hides.
     /// </summary>
     public static string OpticalTrack(OpticalBands bands)
     {
         var lo = bands.DomainLow;
         var hi = bands.DomainHigh;
+        var peak = (bands.ExcellentLow + bands.ExcellentHigh) / 2;
 
         double P(double v) => Position(v, lo, hi);
 
@@ -56,10 +62,11 @@ public static class SignalGauge
                $"{Poor} 0%, " +
                $"{Weak} {P(bands.FairLow):0.#}%, " +
                $"{Fair} {P(bands.GoodLow):0.#}%, " +
-               $"{Excellent} {P(bands.ExcellentLow):0.#}%, " +
-               $"{Excellent} {P(bands.ExcellentHigh):0.#}%, " +
-               $"{Good} {P(bands.GoodHigh):0.#}%, " +
-               $"{Fair} {P(bands.FairHigh):0.#}%, " +
+               $"{Good} {P(bands.ExcellentLow):0.#}%, " +
+               $"{Excellent} {P(peak):0.#}%, " +
+               $"{Good} {P(bands.ExcellentHigh):0.#}%, " +
+               $"{Fair} {P(bands.GoodHigh):0.#}%, " +
+               $"{Weak} {P(bands.FairHigh):0.#}%, " +
                $"{Poor} 100%)";
     }
 }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -54,7 +54,6 @@ public static class SignalGauge
     {
         var lo = bands.DomainLow;
         var hi = bands.DomainHigh;
-        var peak = (bands.ExcellentLow + bands.ExcellentHigh) / 2;
 
         double P(double v) => Position(v, lo, hi);
 
@@ -63,7 +62,7 @@ public static class SignalGauge
                $"{Weak} {P(bands.FairLow):0.#}%, " +
                $"{Fair} {P(bands.GoodLow):0.#}%, " +
                $"{Good} {P(bands.ExcellentLow):0.#}%, " +
-               $"{Excellent} {P(peak):0.#}%, " +
+               $"{Excellent} {P(bands.Peak):0.#}%, " +
                $"{Good} {P(bands.ExcellentHigh):0.#}%, " +
                $"{Fair} {P(bands.GoodHigh):0.#}%, " +
                $"{Weak} {P(bands.FairHigh):0.#}%, " +
@@ -75,23 +74,30 @@ public static class SignalGauge
 /// Optical Rx power grading bounds, in dBm. Every grade is a range with a floor
 /// and a ceiling: too much light is a fault in its own right.
 /// </summary>
+/// <param name="Peak">
+/// Where the gauge shows its best reading. Stated outright rather than taken as the
+/// middle of the excellent band: that middle is -15 dBm for PON, which would only be
+/// seen on an unusually low split ratio, so the gauge would have peaked well hotter
+/// than a normal link ever runs.
+/// </param>
 public readonly record struct OpticalBands(
     double ExcellentLow, double ExcellentHigh,
     double GoodLow, double GoodHigh,
-    double FairLow, double FairHigh)
+    double FairLow, double FairHigh,
+    double Peak)
 {
     /// <summary>PON and generic optics.</summary>
-    public static readonly OpticalBands Pon = new(-22, -8, -25, -6, -28, -4);
+    public static readonly OpticalBands Pon = new(-22, -8, -25, -6, -28, -4, Peak: -18);
 
-    /// <summary>Active Ethernet optics, which run far hotter than PON.</summary>
-    public static readonly OpticalBands ActiveEthernet = new(-8, -1, -10, 0, -14, 1);
+    /// <summary>Active Ethernet optics, which run far hotter than PON - no split loss to pay for.</summary>
+    public static readonly OpticalBands ActiveEthernet = new(-8, -1, -10, 0, -14, 1, Peak: -4.5);
 
     /// <summary>
     /// External ONT devices, which report against slightly tighter bounds than the
     /// gateway-attached optics. Kept separate so the track's color boundaries land
     /// exactly where OntStatsPanel.ExternalRxClass changes grade.
     /// </summary>
-    public static readonly OpticalBands ExternalOnt = new(-22.5, -8, -25, -6, -27, -4);
+    public static readonly OpticalBands ExternalOnt = new(-22.5, -8, -25, -6, -27, -4, Peak: -18);
 
     /// <summary>A little headroom past the last graded bound, so the ends are visible.</summary>
     public double DomainLow => FairLow - 2;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -2526,6 +2526,7 @@ public class MonitoringCollectionAgent : BackgroundService
                 var context = new OntPollContext
                 {
                     Id = config.Id,
+                    SiteSlug = _siteSlug,
                     Name = config.Name,
                     Host = host,
                     ConfiguredHost = config.Host,

--- a/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/OntMonitorService.cs
@@ -415,6 +415,7 @@ public class OntMonitorService : IOntMonitorService, IDisposable
         return new OntPollContext
         {
             Id = config.Id,
+            SiteSlug = _siteSlug,
             Name = config.Name,
             Host = host,
             ConfiguredHost = config.Host,

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NetOptCustomPonOntProvider.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
@@ -30,9 +29,16 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
     /// <summary>
     /// Reference endpoints are one-shot listeners (a netcat accept loop) that serve a
     /// single connection at a time and re-gather stats per request, so requests to the
-    /// same endpoint must never overlap. Gated per (host, port) so distinct endpoints -
-    /// different devices, different sites - still poll in parallel (this is a shared
-    /// singleton across all sites).
+    /// same endpoint must never overlap. Gated per site and endpoint, so distinct
+    /// endpoints still poll in parallel.
+    ///
+    /// The site has to be in the key: this is a singleton shared by every site, and
+    /// host:port alone is not unique across them - each site reaches its own gateway at
+    /// the same name ("unifi:10420"), so two sites would serialize against each other
+    /// for no reason, each waiting out the other's 15 s timeout.
+    ///
+    /// Not keyed on the poll context's CacheKey: two configurations on one site may point
+    /// at the same endpoint, and those genuinely must not overlap.
     /// </summary>
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _requestGates = new();
 
@@ -116,7 +122,7 @@ public class NetOptCustomPonOntProvider : ISfpSupplementalOntProvider
         var port = context.Port > 0 ? context.Port : DefaultPort;
         var url = $"http://{context.Host}:{port}/";
 
-        var gate = _requestGates.GetOrAdd($"{context.Host}:{port}", _ => new SemaphoreSlim(1, 1));
+        var gate = _requestGates.GetOrAdd($"{context.SiteSlug}/{context.Host}:{port}", _ => new SemaphoreSlim(1, 1));
         await gate.WaitAsync(cancellationToken);
         try
         {

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -100,7 +100,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.CacheKey);
+            _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.Id);
             return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 

--- a/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/OntProviders/NokiaXs010xOntProvider.cs
@@ -89,7 +89,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     /// later polls go straight to it instead of re-probing the wrong flow (and, for the curl
     /// replay, its extra requests) every interval. Re-detected after a restart.
     /// </summary>
-    private readonly ConcurrentDictionary<int, AuthFlow> _flowCache = new();
+    private readonly ConcurrentDictionary<string, AuthFlow> _flowCache = new();
 
     public NokiaXs010xOntProvider(ILogger<NokiaXs010xOntProvider> logger)
     {
@@ -100,7 +100,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     {
         if (string.IsNullOrWhiteSpace(context.Host))
         {
-            _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.Id);
+            _logger.LogWarning("Nokia XS-010X-Q ONT poll requested but Host is empty (config {Id})", context.CacheKey);
             return PollResult<OntStats>.Failed("No address is configured for this device.");
         }
 
@@ -199,7 +199,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
             if (stats.RxPowerDbm is not null)
             {
                 if (context.Id > 0)
-                    _flowCache[context.Id] = flow;
+                    _flowCache[context.CacheKey] = flow;
                 return stats;
             }
 
@@ -218,7 +218,7 @@ public sealed class NokiaXs010xOntProvider : IOntProvider
     /// </summary>
     private IReadOnlyList<AuthFlow> ResolveFlows(OntPollContext context)
     {
-        if (context.Id > 0 && _flowCache.TryGetValue(context.Id, out var cached))
+        if (context.Id > 0 && _flowCache.TryGetValue(context.CacheKey, out var cached))
             return cached == AuthFlow.CurlReplay
                 ? new[] { AuthFlow.CurlReplay, AuthFlow.Direct }
                 : new[] { AuthFlow.Direct, AuthFlow.CurlReplay };

--- a/src/NetworkOptimizer.Web/Services/Search/SettingsSearchProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/Search/SettingsSearchProvider.cs
@@ -208,7 +208,8 @@ public sealed class SettingsSearchProvider : IAppSearchProvider
             ["Cable Modem", "CM Stats"],
             ["docsis", "snr", "error rates", "signal quality", "provider", "host", "status page path",
              "polling interval", "show the cm stats tab", "arris surfboard", "hnap", "motorola",
-             "netgear nighthawk cm", "technicolor cga", "vodafone station", "xfinity gateway", "cox"]),
+             "netgear nighthawk cm", "technicolor cga", "vodafone station", "xfinity gateway", "cox",
+             "comcast business", "cga4332", "xb8", "xb10", "cgm4981"]),
 
         Entry("monitoring", "Monitoring", "ont-monitoring",
             "ONT Device Monitoring",

--- a/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkMonitorService.cs
@@ -499,6 +499,7 @@ public sealed class StarlinkMonitorService : IStarlinkMonitorService, IDisposabl
         return new StarlinkPollContext
         {
             Id = config.Id,
+            SiteSlug = _siteSlug,
             Name = config.Name,
             Host = host,
             ConfiguredHost = config.Host,

--- a/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
@@ -29,8 +29,8 @@ public class StarlinkGrpcProvider : IStarlinkProvider
     // History ring buffers are 1 Hz with a monotonic sample counter; remember
     // the counter and poll time per config so aggregates cover exactly the
     // samples since the previous poll (the CM correctables-delta pattern).
-    private readonly ConcurrentDictionary<int, ulong> _lastHistoryCounter = new();
-    private readonly ConcurrentDictionary<int, DateTime> _lastPollUtc = new();
+    private readonly ConcurrentDictionary<string, ulong> _lastHistoryCounter = new();
+    private readonly ConcurrentDictionary<string, DateTime> _lastPollUtc = new();
 
     public StarlinkGrpcProvider(ILogger<StarlinkGrpcProvider> logger)
     {
@@ -67,7 +67,7 @@ public class StarlinkGrpcProvider : IStarlinkProvider
             {
                 var historyResp = await CallAsync(client, new Request { GetHistory = new GetHistoryRequest() }, cancellationToken);
                 if (historyResp?.ResponseCase == Response.ResponseOneofCase.DishGetHistory)
-                    ApplyHistory(stats, historyResp.DishGetHistory, context.Id);
+                    ApplyHistory(stats, historyResp.DishGetHistory, context.CacheKey);
             }
             catch (Exception ex)
             {
@@ -85,7 +85,7 @@ public class StarlinkGrpcProvider : IStarlinkProvider
                 _logger.LogDebug(ex, "Starlink {Name}: diagnostics fetch failed; skipping self-test result", context.Name);
             }
 
-            _lastPollUtc[context.Id] = stats.Timestamp;
+            _lastPollUtc[context.CacheKey] = stats.Timestamp;
             return PollResult<StarlinkStats>.Ok(stats);
         }
         catch (Exception ex)
@@ -258,7 +258,7 @@ public class StarlinkGrpcProvider : IStarlinkProvider
         return stats;
     }
 
-    private void ApplyHistory(StarlinkStats stats, DishGetHistoryResponse history, int configId)
+    private void ApplyHistory(StarlinkStats stats, DishGetHistoryResponse history, string configId)
     {
         var counter = history.Current;
         var bufferLen = Math.Max(history.PopPingDropRate.Count, history.PowerIn.Count);

--- a/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/StarlinkProviders/StarlinkGrpcProvider.cs
@@ -258,7 +258,7 @@ public class StarlinkGrpcProvider : IStarlinkProvider
         return stats;
     }
 
-    private void ApplyHistory(StarlinkStats stats, DishGetHistoryResponse history, string configId)
+    private void ApplyHistory(StarlinkStats stats, DishGetHistoryResponse history, string cacheKey)
     {
         var counter = history.Current;
         var bufferLen = Math.Max(history.PopPingDropRate.Count, history.PowerIn.Count);
@@ -268,10 +268,10 @@ public class StarlinkGrpcProvider : IStarlinkProvider
         // ring buffer length. First poll (or counter reset after reboot)
         // aggregates over the full buffer.
         long window = bufferLen;
-        if (_lastHistoryCounter.TryGetValue(configId, out var prev) && counter > prev)
+        if (_lastHistoryCounter.TryGetValue(cacheKey, out var prev) && counter > prev)
             window = Math.Min((long)(counter - prev), bufferLen);
         window = Math.Min(window, (long)counter);
-        _lastHistoryCounter[configId] = counter;
+        _lastHistoryCounter[cacheKey] = counter;
 
         AggregateRing(history.PopPingDropRate, counter, window,
             out var dropAvg, out var dropMax, out _);

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1966,7 +1966,8 @@ a.stat-card-link:active {
     margin-left: 0;
 }
 @media (max-width: 768px) {
-    .signal-centered {
+    .signal-centered,
+    .signal-with-model {
         flex-wrap: wrap;
     }
     .signal-centered .modem-nav {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1964,8 +1964,8 @@ a.stat-card-link:active {
     left: 0;
     right: 0;
     height: 2px;
-    background: var(--bg-primary);
-    opacity: 0.4;
+    background: var(--text-primary);
+    opacity: 0.65;
 }
 
 .signal-with-model .ont-rx-gauge {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1936,7 +1936,7 @@ a.stat-card-link:active {
 .signal-hero {
     display: flex;
     align-items: center;
-    gap: 0.8rem;
+    gap: 1rem;
 }
 
 .signal-gauge {
@@ -1945,6 +1945,7 @@ a.stat-card-link:active {
     border-radius: 7px;
     position: relative;
     flex: none;
+    margin-left: 0.35rem;
     overflow: hidden;
 }
 
@@ -1963,7 +1964,7 @@ a.stat-card-link:active {
     right: 0;
     height: 2px;
     background: var(--bg-primary);
-    opacity: 0.85;
+    opacity: 0.4;
 }
 
 .signal-with-model .ont-rx-gauge {
@@ -2015,6 +2016,12 @@ a.stat-card-link:active {
     }
     .signal-with-model .cm-model {
         margin-left: auto;
+    }
+    .signal-hero {
+        gap: 0.8rem;
+    }
+    .signal-gauge {
+        margin-left: 0.15rem;
     }
     .signal-centered .modem-nav {
         position: static;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1938,7 +1938,7 @@ a.stat-card-link:active {
     display: flex;
     align-items: center;
     gap: 1rem;
-    margin-left: 0.35rem;
+    margin-left: 0.6rem;
 }
 
 .signal-gauge {
@@ -1957,15 +1957,6 @@ a.stat-card-link:active {
     top: 0;
     background: var(--bg-card);
     opacity: 0.72;
-}
-
-.signal-gauge .gauge-line {
-    position: absolute;
-    left: 0;
-    right: 0;
-    height: 2px;
-    background: var(--text-primary);
-    opacity: 0.65;
 }
 
 .signal-with-model .ont-rx-gauge {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17,6 +17,13 @@
     --accent-color: #E56B11;
     --accent-hover: #F08530;
 
+    /* Signal quality - five grades, used by .signal-* and the dashboard gauges */
+    --signal-excellent: #10b981;
+    --signal-good: #22c55e;
+    --signal-fair: #eab308;
+    --signal-weak: #f97316;
+    --signal-poor: #ef4444;
+
     /* Status Colors - refined for dark backgrounds */
     --success-color: #24bc70;
     --warning-color: #e79613;
@@ -1924,6 +1931,39 @@ a.stat-card-link:active {
     align-items: center;
     gap: 0.5rem;
     margin-left: auto;
+}
+
+.signal-hero {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.signal-gauge {
+    width: 14px;
+    height: 52px;
+    border-radius: 7px;
+    position: relative;
+    flex: none;
+    overflow: hidden;
+}
+
+.signal-gauge .gauge-shade {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    background: var(--bg-card);
+    opacity: 0.72;
+}
+
+.signal-gauge .gauge-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: var(--bg-primary);
+    opacity: 0.85;
 }
 
 .signal-with-model .ont-rx-gauge {
@@ -13034,15 +13074,15 @@ a.path-hop.hop-clickable:hover {
 
 /* Signal quality classes */
 .power-stat-card.signal-excellent .power-stat-value,
-.signal-excellent { color: #10b981; }
+.signal-excellent { color: var(--signal-excellent); }
 .power-stat-card.signal-good .power-stat-value,
-.signal-good { color: #22c55e; }
+.signal-good { color: var(--signal-good); }
 .power-stat-card.signal-fair .power-stat-value,
-.signal-fair { color: #eab308; }
+.signal-fair { color: var(--signal-fair); }
 .power-stat-card.signal-weak .power-stat-value,
-.signal-weak { color: #f97316; }
+.signal-weak { color: var(--signal-weak); }
 .power-stat-card.signal-poor .power-stat-value,
-.signal-poor { color: #ef4444; }
+.signal-poor { color: var(--signal-poor); }
 
 /* WiFi Page Sections - Nested Card Colors */
 .wifi-sections .card {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1970,6 +1970,12 @@ a.stat-card-link:active {
     .signal-with-model {
         flex-wrap: wrap;
     }
+    .signal-with-model .modem-nav {
+        margin-left: 0;
+    }
+    .signal-with-model .cm-model {
+        margin-left: auto;
+    }
     .signal-centered .modem-nav {
         position: static;
         margin-left: 0;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1926,6 +1926,33 @@ a.stat-card-link:active {
     margin-left: auto;
 }
 
+.signal-with-model .ont-rx-gauge {
+    align-items: flex-start;
+    flex: initial;
+}
+
+.cm-model {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+    text-align: right;
+    min-width: 0;
+}
+
+.cm-model-name {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.cm-model-number {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    overflow-wrap: anywhere;
+}
+
 .signal-centered {
     position: relative;
     justify-content: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1919,6 +1919,7 @@ a.stat-card-link:active {
 .ont-rx-gauge .rx-power-value {
     font-size: 1.75rem;
     font-weight: 600;
+    line-height: 1.2;
 }
 
 .ont-rx-gauge .rx-power-label {
@@ -1937,6 +1938,7 @@ a.stat-card-link:active {
     display: flex;
     align-items: center;
     gap: 1rem;
+    margin-left: 0.35rem;
 }
 
 .signal-gauge {
@@ -1945,7 +1947,6 @@ a.stat-card-link:active {
     border-radius: 7px;
     position: relative;
     flex: none;
-    margin-left: 0.35rem;
     overflow: hidden;
 }
 
@@ -2019,8 +2020,6 @@ a.stat-card-link:active {
     }
     .signal-hero {
         gap: 0.8rem;
-    }
-    .signal-gauge {
         margin-left: 0.15rem;
     }
     .signal-centered .modem-nav {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1912,7 +1912,7 @@ a.stat-card-link:active {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.1rem;
     flex: 1;
 }
 
@@ -1956,7 +1956,12 @@ a.stat-card-link:active {
     right: 0;
     top: 0;
     background: var(--bg-card);
-    opacity: 0.72;
+    opacity: 0.8;
+}
+
+.signal-gauge .gauge-shade-low {
+    top: auto;
+    bottom: 0;
 }
 
 .signal-with-model .ont-rx-gauge {

--- a/tests/NetworkOptimizer.Core.Tests/BrandCasingTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/BrandCasingTests.cs
@@ -1,0 +1,43 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests;
+
+/// <summary>
+/// SFP DDM fills its vendor field in upper case, so the raw string shouts where
+/// the brand does not. The fix is an allowlist, not a title-case pass.
+/// </summary>
+public class BrandCasingTests
+{
+    [Theory]
+    [InlineData("CALIX", "Calix")]
+    [InlineData("NOKIA", "Nokia")]
+    [InlineData("HUAWEI", "Huawei")]
+    [InlineData("UBIQUITI", "Ubiquiti")]
+    public void CleanOrgName_FixesVendorsThatAreNotBrandedInCaps(string raw, string expected)
+    {
+        NetworkFormatHelpers.CleanOrgName(raw).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ZTE")]
+    [InlineData("FS")]
+    [InlineData("HPE")]
+    public void CleanOrgName_LeavesGenuinelyCapitalizedBrandsAlone(string raw)
+    {
+        NetworkFormatHelpers.CleanOrgName(raw).Should().Be(raw);
+    }
+
+    [Fact]
+    public void CleanOrgName_IsCaseSensitiveSoAProperlyCasedNameIsUntouched()
+    {
+        NetworkFormatHelpers.CleanOrgName("Calix").Should().Be("Calix");
+    }
+
+    [Fact]
+    public void CleanOrgName_StillStripsSuffixesBeforeCasing()
+    {
+        NetworkFormatHelpers.CleanOrgName("CALIX, Inc.").Should().Be("Calix");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Components.Shared;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.CableModem;
+
+/// <summary>
+/// How a modem's model splits across the two lines on the Cable Modem Stats card.
+/// </summary>
+public class CmModelLabelTests
+{
+    [Theory]
+    [InlineData("CBR (CGA4332COM)", "CBR", "CGA4332COM")]
+    [InlineData("XB10 (SG417DBCT)", "XB10", "SG417DBCT")]
+    [InlineData("Motorola (8612)", "Motorola", "8612")]
+    public void ProductTypeAndModelNumberStack(string model, string name, string number)
+    {
+        SplitModel(model).Should().Be((name, number));
+    }
+
+    [Theory]
+    [InlineData("Netgear", "Netgear")]
+    [InlineData("Motorola", "Motorola")]
+    public void ABareVendorGetsLabelledCm(string model, string name)
+    {
+        // The provider could not read a model and named the maker instead, so the
+        // second line has to say what the thing is.
+        SplitModel(model).Should().Be((name, "CM"));
+    }
+
+    [Theory]
+    [InlineData("CM600")]
+    [InlineData("cm1000")]
+    public void AModelAlreadyCarryingCmIsNotMadeToSayItTwice(string model)
+    {
+        SplitModel(model).Should().Be((model, null));
+    }
+
+    [Theory]
+    [InlineData("ARRIS SB8200")]
+    [InlineData("Motorola MB8611")]
+    [InlineData("Xfinity Gateway")]
+    public void AMultiWordModelStaysOnOneLine(string model)
+    {
+        SplitModel(model).Should().Be((model, null));
+    }
+
+    private static (string Name, string? Number) SplitModel(string model) =>
+        CmStatsPanel.SplitModel(model);
+}

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
@@ -52,16 +52,25 @@ public class CmModelLabelTests
     [Theory]
     [InlineData("CM600")]
     [InlineData("cm1000")]
-    public void AModelAlreadyCarryingCmIsNotMadeToSayItTwice(string model)
+    [InlineData("SB8200")]
+    public void AModelNumberOnItsOwnHasNoVendorToStackAboveIt(string model)
     {
         SplitModel(model).Should().Be((model, null));
     }
 
     [Theory]
-    [InlineData("ARRIS SB8200")]
-    [InlineData("Motorola MB8611")]
+    [InlineData("ARRIS SB8200", "ARRIS", "SB8200")]
+    [InlineData("Motorola MB8611", "Motorola", "MB8611")]
+    [InlineData("Netgear CM1000", "Netgear", "CM1000")]
+    public void AnUnparenthesizedModelNumberStacksTheSameWay(string model, string name, string number)
+    {
+        SplitModel(model).Should().Be((name, number));
+    }
+
+    [Theory]
     [InlineData("Xfinity Gateway")]
-    public void AMultiWordModelStaysOnOneLine(string model)
+    [InlineData("ARRIS Surfboard HNAP")]
+    public void AModelWithNoNumberInItStaysOnOneLine(string model)
     {
         SplitModel(model).Should().Be((model, null));
     }

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
@@ -68,6 +68,16 @@ public class CmModelLabelTests
     }
 
     [Theory]
+    [InlineData("Hitron Technologies CODA5810", "Hitron Technologies", "CODA5810")]
+    [InlineData("Technicolor CGA4233VOO", "Technicolor", "CGA4233VOO")]
+    [InlineData("Sercomm Broadband RT2302", "Sercomm Broadband", "RT2302")]
+    public void AVendorNameOfAnyLengthKeepsTheWholeNameOnTheFirstLine(
+        string model, string name, string number)
+    {
+        SplitModel(model).Should().Be((name, number));
+    }
+
+    [Theory]
     [InlineData("Xfinity Gateway")]
     [InlineData("ARRIS Surfboard HNAP")]
     public void AModelWithNoNumberInItStaysOnOneLine(string model)

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/CmModelLabelTests.cs
@@ -29,6 +29,27 @@ public class CmModelLabelTests
     }
 
     [Theory]
+    [InlineData("CM600 - MyISP", "CM600")]
+    [InlineData("Living Room SB8200", "SB8200")]
+    [InlineData("MB8611 Primary", "MB8611")]
+    [InlineData("Basement CGA4332COM", "CGA4332COM")]
+    public void ABareVendorTakesTheModelNumberFromTheDeviceName(string deviceName, string expected)
+    {
+        SplitModel("Netgear", deviceName).Should().Be(("Netgear", expected));
+    }
+
+    [Theory]
+    [InlineData("Modem")]
+    [InlineData("Rack 4B")]
+    [InlineData("Upstairs modem 2")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ANameWithoutAModelNumberFallsBackToCm(string? deviceName)
+    {
+        SplitModel("Netgear", deviceName).Should().Be(("Netgear", "CM"));
+    }
+
+    [Theory]
     [InlineData("CM600")]
     [InlineData("cm1000")]
     public void AModelAlreadyCarryingCmIsNotMadeToSayItTwice(string model)
@@ -45,6 +66,6 @@ public class CmModelLabelTests
         SplitModel(model).Should().Be((model, null));
     }
 
-    private static (string Name, string? Number) SplitModel(string model) =>
-        CmStatsPanel.SplitModel(model);
+    private static (string Name, string? Number) SplitModel(string model, string? deviceName = null) =>
+        CmStatsPanel.SplitModel(model, deviceName);
 }

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/Fixtures/comcast-business-cga4332.html
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/Fixtures/comcast-business-cga4332.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html><head><title>Comcast Network</title></head>
+<body>
+<div class="module">
+<div class="module forms">
+	<h2>Device Information</h2>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">HW Version:</span>
+		<span class="value">2.3</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Vendor:</span>
+		<span class="value">Broadcom.</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">BOOT Version:</span>
+		<span class="value">S1TC-3.77.21.67</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Core Version:</span>
+		<span class="value">1.0</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Model:</span>
+		<span class="value">CGA4332COM</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Product Type:</span>
+		<span class="value">CBR</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Flash Part:</span>
+		<span class="value">4096 MB</span>
+	</div>
+</div>
+</div>
+<div class="module">
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th"><div class="netWidth">Downstream</div></td>
+			<td class="row-label acs-th" colspan="30">Channel Bonding Value</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+			<th class="row-label ">Index</td>
+			<td><div class="netWidth">1</div></td><td><div class="netWidth">2</div></td><td><div class="netWidth">3</div></td><td><div class="netWidth">4</div></td><td><div class="netWidth">5</div></td><td><div class="netWidth">6</div></td><td><div class="netWidth">7</div></td><td><div class="netWidth">8</div></td><td><div class="netWidth">9</div></td><td><div class="netWidth">10</div></td><td><div class="netWidth">11</div></td><td><div class="netWidth">12</div></td><td><div class="netWidth">13</div></td><td><div class="netWidth">14</div></td><td><div class="netWidth">15</div></td><td><div class="netWidth">16</div></td><td><div class="netWidth">17</div></td><td><div class="netWidth">18</div></td><td><div class="netWidth">19</div></td><td><div class="netWidth">20</div></td><td><div class="netWidth">21</div></td><td><div class="netWidth">22</div></td><td><div class="netWidth">23</div></td><td><div class="netWidth">24</div></td><td><div class="netWidth">25</div></td><td><div class="netWidth">26</div></td><td><div class="netWidth">27</div></td><td><div class="netWidth">28</div></td><td><div class="netWidth">29</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Lock Status</td>
+			<td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Frequency</td>
+			<td><div class="netWidth">819 MHz</div></td><td><div class="netWidth">387 MHz</div></td><td><div class="netWidth">393 MHz</div></td><td><div class="netWidth">399 MHz</div></td><td><div class="netWidth">405 MHz</div></td><td><div class="netWidth">411 MHz</div></td><td><div class="netWidth">417 MHz</div></td><td><div class="netWidth">423 MHz</div></td><td><div class="netWidth">429 MHz</div></td><td><div class="netWidth">435 MHz</div></td><td><div class="netWidth">441 MHz</div></td><td><div class="netWidth">447 MHz</div></td><td><div class="netWidth">453 MHz</div></td><td><div class="netWidth">459 MHz</div></td><td><div class="netWidth">465 MHz</div></td><td><div class="netWidth">471 MHz</div></td><td><div class="netWidth">477 MHz</div></td><td><div class="netWidth">483 MHz</div></td><td><div class="netWidth">489 MHz</div></td><td><div class="netWidth">495 MHz</div></td><td><div class="netWidth">765 MHz</div></td><td><div class="netWidth">771 MHz</div></td><td><div class="netWidth">777 MHz</div></td><td><div class="netWidth">783 MHz</div></td><td><div class="netWidth">789 MHz</div></td><td><div class="netWidth">801 MHz</div></td><td><div class="netWidth">807 MHz</div></td><td><div class="netWidth">813 MHz</div></td><td><div class="netWidth">900 MHz</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">SNR</td>
+			<td><div class="netWidth">44.6 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.1 dB</div></td><td><div class="netWidth">43.0 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.1 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.3 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.2 dB</div></td><td><div class="netWidth">43.3 dB</div></td><td><div class="netWidth">43.3 dB</div></td><td><div class="netWidth">43.4 dB</div></td><td><div class="netWidth">43.3 dB</div></td><td><div class="netWidth">43.6 dB</div></td><td><div class="netWidth">43.6 dB</div></td><td><div class="netWidth">43.6 dB</div></td><td><div class="netWidth">44.9 dB</div></td><td><div class="netWidth">44.8 dB</div></td><td><div class="netWidth">44.8 dB</div></td><td><div class="netWidth">44.9 dB</div></td><td><div class="netWidth">44.9 dB</div></td><td><div class="netWidth">45.2 dB</div></td><td><div class="netWidth">45.0 dB</div></td><td><div class="netWidth">45.0 dB</div></td><td><div class="netWidth">44.9 dB</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Power Level</td>
+			<td><div class="netWidth">10.7 dBmV</div></td><td><div class="netWidth">7.9 dBmV</div></td><td><div class="netWidth">7.8 dBmV</div></td><td><div class="netWidth">7.7 dBmV</div></td><td><div class="netWidth">7.7 dBmV</div></td><td><div class="netWidth">7.6 dBmV</div></td><td><div class="netWidth">7.5 dBmV</div></td><td><div class="netWidth">7.5 dBmV</div></td><td><div class="netWidth">7.3 dBmV</div></td><td><div class="netWidth">7.3 dBmV</div></td><td><div class="netWidth">7.2 dBmV</div></td><td><div class="netWidth">7.4 dBmV</div></td><td><div class="netWidth">7.4 dBmV</div></td><td><div class="netWidth">7.4 dBmV</div></td><td><div class="netWidth">7.3 dBmV</div></td><td><div class="netWidth">7.6 dBmV</div></td><td><div class="netWidth">7.6 dBmV</div></td><td><div class="netWidth">7.8 dBmV</div></td><td><div class="netWidth">7.7 dBmV</div></td><td><div class="netWidth">7.8 dBmV</div></td><td><div class="netWidth">9.9 dBmV</div></td><td><div class="netWidth">9.7 dBmV</div></td><td><div class="netWidth">9.8 dBmV</div></td><td><div class="netWidth">9.8 dBmV</div></td><td><div class="netWidth">10.1 dBmV</div></td><td><div class="netWidth">10.6 dBmV</div></td><td><div class="netWidth">10.5 dBmV</div></td><td><div class="netWidth">10.6 dBmV</div></td><td><div class="netWidth">10.4 dBmV</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Modulation</td>
+			<td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">OFDM</div></td>
+		</tr>
+	</tbody>
+	</table>
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th"><div class="netWidth">Upstream</div></td>
+			<td class="row-label acs-th" colspan="6">Channel Bonding Value</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+			<th class="row-label ">Index</td>
+			<td><div class="netWidth">1</div></td><td><div class="netWidth">2</div></td><td><div class="netWidth">3</div></td><td><div class="netWidth">4</div></td><td><div class="netWidth">5</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Lock Status</td>
+			<td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Frequency</td>
+			<td><div class="netWidth">16  MHz</div></td><td><div class="netWidth">22  MHz</div></td><td><div class="netWidth">29  MHz</div></td><td><div class="netWidth">35  MHz</div></td><td><div class="netWidth">36  MHz</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Symbol Rate</td>
+			<td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">0</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Power Level</td>
+			<td><div class="netWidth">41.0 dBmV</div></td><td><div class="netWidth">41.0 dBmV</div></td><td><div class="netWidth">40.0 dBmV</div></td><td><div class="netWidth">41.0 dBmV</div></td><td><div class="netWidth">35.0 dBmV</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Modulation</td>
+			<td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">OFDMA</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Channel Type</td>
+			<td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">TDMA</div></td>
+		</tr>
+	</tbody>
+	</table>
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th" colspan="30">CM Error Codewords</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+			<th class="row-label ">Unerrored Codewords</td>
+			<td><div class="netWidth">4271043715</div></td><td><div class="netWidth">301027572</div></td><td><div class="netWidth">301008255</div></td><td><div class="netWidth">301035404</div></td><td><div class="netWidth">293528189</div></td><td><div class="netWidth">301054034</div></td><td><div class="netWidth">301048990</div></td><td><div class="netWidth">301053295</div></td><td><div class="netWidth">301102449</div></td><td><div class="netWidth">301167948</div></td><td><div class="netWidth">301135554</div></td><td><div class="netWidth">301132741</div></td><td><div class="netWidth">301187580</div></td><td><div class="netWidth">301129719</div></td><td><div class="netWidth">301149581</div></td><td><div class="netWidth">301160550</div></td><td><div class="netWidth">301040110</div></td><td><div class="netWidth">301072700</div></td><td><div class="netWidth">301080517</div></td><td><div class="netWidth">301068041</div></td><td><div class="netWidth">301120884</div></td><td><div class="netWidth">301104954</div></td><td><div class="netWidth">301117302</div></td><td><div class="netWidth">301088839</div></td><td><div class="netWidth">301132449</div></td><td><div class="netWidth">300922057</div></td><td><div class="netWidth">301116675</div></td><td><div class="netWidth">300966549</div></td><td><div class="netWidth">4271043715</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Correctable Codewords</td>
+			<td><div class="netWidth">4256604764</div></td><td><div class="netWidth">312</div></td><td><div class="netWidth">306</div></td><td><div class="netWidth">342</div></td><td><div class="netWidth">138</div></td><td><div class="netWidth">288</div></td><td><div class="netWidth">350</div></td><td><div class="netWidth">303</div></td><td><div class="netWidth">334</div></td><td><div class="netWidth">412</div></td><td><div class="netWidth">324</div></td><td><div class="netWidth">441</div></td><td><div class="netWidth">219</div></td><td><div class="netWidth">315</div></td><td><div class="netWidth">311</div></td><td><div class="netWidth">319</div></td><td><div class="netWidth">333</div></td><td><div class="netWidth">455</div></td><td><div class="netWidth">441</div></td><td><div class="netWidth">339</div></td><td><div class="netWidth">185</div></td><td><div class="netWidth">365</div></td><td><div class="netWidth">375</div></td><td><div class="netWidth">288</div></td><td><div class="netWidth">382</div></td><td><div class="netWidth">214</div></td><td><div class="netWidth">310</div></td><td><div class="netWidth">198</div></td><td><div class="netWidth">4256604764</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Uncorrectable Codewords</td>
+			<td><div class="netWidth">3992</div></td><td><div class="netWidth">1630</div></td><td><div class="netWidth">1615</div></td><td><div class="netWidth">1606</div></td><td><div class="netWidth">579</div></td><td><div class="netWidth">1608</div></td><td><div class="netWidth">1513</div></td><td><div class="netWidth">1586</div></td><td><div class="netWidth">1592</div></td><td><div class="netWidth">2038</div></td><td><div class="netWidth">1649</div></td><td><div class="netWidth">1564</div></td><td><div class="netWidth">1093</div></td><td><div class="netWidth">1594</div></td><td><div class="netWidth">1554</div></td><td><div class="netWidth">1549</div></td><td><div class="netWidth">1615</div></td><td><div class="netWidth">2065</div></td><td><div class="netWidth">2068</div></td><td><div class="netWidth">1526</div></td><td><div class="netWidth">920</div></td><td><div class="netWidth">1898</div></td><td><div class="netWidth">1842</div></td><td><div class="netWidth">1438</div></td><td><div class="netWidth">1904</div></td><td><div class="netWidth">930</div></td><td><div class="netWidth">1418</div></td><td><div class="netWidth">952</div></td><td><div class="netWidth">3992</div></td>
+		</tr>
+	</tbody>
+	</table>
+</div>
+</body></html>

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/Fixtures/xfinity-xb10-network-setup.html
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/Fixtures/xfinity-xb10-network-setup.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html><head><title>Network Setup</title></head>
+<body>
+<div class="module">
+<div class="module forms">
+	<h2>Device Information</h2>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">HW Version:</span>
+		<span class="value">V1.2.B</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Vendor:</span>
+		<span class="value">Sercomm</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Model:</span>
+		<span class="value">SG417DBCT</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Product Type:</span>
+		<span class="value">XB10</span>
+	</div>
+	<div class="form-row">
+		<span class="readonlyLabel networkColor">Flash Part:</span>
+		<span class="value">8192 MB</span>
+	</div>
+</div>
+</div>
+<div class="module">
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th"><div class="netWidth">Downstream</div></td>
+			<td class="row-label acs-th" colspan="9">Channel Bonding Value</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+			<th class="row-label ">Channel ID</td>
+			<td><div class="netWidth">17</div></td><td><div class="netWidth">18</div></td><td><div class="netWidth">19</div></td><td><div class="netWidth">20</div></td><td><div class="netWidth">21</div></td><td><div class="netWidth">22</div></td><td><div class="netWidth">23</div></td><td><div class="netWidth">24</div></td><td><div class="netWidth">193</div></td><td><div class="netWidth">194</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Lock Status</td>
+			<td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Frequency</td>
+			<td><div class="netWidth">957 MHz</div></td><td><div class="netWidth">963 MHz</div></td><td><div class="netWidth">969 MHz</div></td><td><div class="netWidth">975 MHz</div></td><td><div class="netWidth">981 MHz</div></td><td><div class="netWidth">987 MHz</div></td><td><div class="netWidth">993 MHz</div></td><td><div class="netWidth">999 MHz</div></td><td><div class="netWidth">774000000</div></td><td><div class="netWidth">1086000000</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">SNR</td>
+			<td><div class="netWidth">48.7 dB</div></td><td><div class="netWidth">49.3 dB</div></td><td><div class="netWidth">49.3 dB</div></td><td><div class="netWidth">49.2 dB</div></td><td><div class="netWidth">49.2 dB</div></td><td><div class="netWidth">49.2 dB</div></td><td><div class="netWidth">49.2 dB</div></td><td><div class="netWidth">48.3 dB</div></td><td><div class="netWidth">48.5 dB</div></td><td><div class="netWidth">48.7 dB</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Power Level</td>
+			<td><div class="netWidth">8.4 dBmV</div></td><td><div class="netWidth">8.6 dBmV</div></td><td><div class="netWidth">8.4 dBmV</div></td><td><div class="netWidth">8.4 dBmV</div></td><td><div class="netWidth">8.3 dBmV</div></td><td><div class="netWidth">8.3 dBmV</div></td><td><div class="netWidth">8.2 dBmV</div></td><td><div class="netWidth">8.1 dBmV</div></td><td><div class="netWidth">3.5 dBmV</div></td><td><div class="netWidth">-9.3 dBmV</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Modulation</td>
+			<td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">256 QAM</div></td><td><div class="netWidth">OFDM</div></td><td><div class="netWidth">OFDM</div></td>
+		</tr>
+	</tbody>
+	</table>
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th"><div class="netWidth">Upstream</div></td>
+			<td class="row-label acs-th" colspan="9">Channel Bonding Value</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+			<th class="row-label ">Channel ID</td>
+			<td><div class="netWidth">1</div></td><td><div class="netWidth">2</div></td><td><div class="netWidth">3</div></td><td><div class="netWidth">4</div></td><td><div class="netWidth">41</div></td><td><div class="netWidth">50</div></td><td><div class="netWidth">51</div></td><td><div class="netWidth">52</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Lock Status</td>
+			<td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td><td><div class="netWidth">Locked</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Frequency</td>
+			<td><div class="netWidth">16  MHz</div></td><td><div class="netWidth">22  MHz</div></td><td><div class="netWidth">29  MHz</div></td><td><div class="netWidth">35  MHz</div></td><td><div class="netWidth">36  MHz</div></td><td><div class="netWidth">105  MHz</div></td><td><div class="netWidth">200  MHz</div></td><td><div class="netWidth">297  MHz</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Symbol Rate</td>
+			<td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">5120</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Power Level</td>
+			<td><div class="netWidth">36.5 dBmV</div></td><td><div class="netWidth">37.3 dBmV</div></td><td><div class="netWidth">38.0 dBmV</div></td><td><div class="netWidth">38.5 dBmV</div></td><td><div class="netWidth">32.7 dBmV</div></td><td><div class="netWidth">33.2 dBmV</div></td><td><div class="netWidth">35.0 dBmV</div></td><td><div class="netWidth">36.5 dBmV</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Modulation</td>
+			<td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">QAM</div></td><td><div class="netWidth">OFDMA</div></td><td><div class="netWidth">OFDMA</div></td><td><div class="netWidth">OFDMA</div></td><td><div class="netWidth">OFDMA</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Channel Type</td>
+			<td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">ATDMA</div></td><td><div class="netWidth">TDMA</div></td><td><div class="netWidth">TDMA</div></td><td><div class="netWidth">TDMA</div></td><td><div class="netWidth">TDMA</div></td>
+		</tr>
+	</tbody>
+	</table>
+<table class="data" cellspacing="0" cellpadding="0">
+	<thead>
+		<tr>
+			<td class="row-label acs-th" colspan="11">CM Error Codewords</td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr class="">
+	    <th class="row-label ">Channel ID</td>
+	    <td><div class="netWidth">17</div></td><td><div class="netWidth">18</div></td><td><div class="netWidth">19</div></td><td><div class="netWidth">20</div></td><td><div class="netWidth">21</div></td><td><div class="netWidth">22</div></td><td><div class="netWidth">23</div></td><td><div class="netWidth">24</div></td><td><div class="netWidth">193</div></td><td><div class="netWidth">194</div></td>
+	</tr>
+	<tr class="odd">
+			<th class="row-label ">Unerrored Codewords</td>
+			<td><div class="netWidth">549706291</div></td><td><div class="netWidth">1255352781</div></td><td><div class="netWidth">1255371159</div></td><td><div class="netWidth">1255396549</div></td><td><div class="netWidth">1255383647</div></td><td><div class="netWidth">1255396014</div></td><td><div class="netWidth">1255397567</div></td><td><div class="netWidth">1255411057</div></td><td><div class="netWidth">1831737436</div></td><td><div class="netWidth">549706291</div></td>
+		</tr>
+		<tr class="">
+			<th class="row-label ">Correctable Codewords</td>
+			<td><div class="netWidth">509057704</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">234721070</div></td><td><div class="netWidth">509057704</div></td>
+		</tr>
+		<tr class="odd">
+			<th class="row-label ">Uncorrectable Codewords</td>
+			<td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td><td><div class="netWidth">0</div></td>
+		</tr>
+	</tbody>
+	</table>
+</div>
+</body></html>

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/PollContextCacheKeyTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/PollContextCacheKeyTests.cs
@@ -1,0 +1,59 @@
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.CableModem;
+
+/// <summary>
+/// Providers are registered as singletons and shared by every site, while each
+/// site's database numbers its own configurations from 1. Any provider-side
+/// cache - sessions, auth tokens, discovered endpoints, last-seen counters -
+/// must therefore key on CacheKey rather than Id.
+/// </summary>
+public class PollContextCacheKeyTests
+{
+    [Fact]
+    public void CmPollContext_SeparatesTheSameConfigIdOnDifferentSites()
+    {
+        var siteA = new CmPollContext { Id = 1, SiteSlug = "site-a", Name = "CM", Host = "192.0.2.10" };
+        var siteB = new CmPollContext { Id = 1, SiteSlug = "site-b", Name = "CM", Host = "192.0.2.20" };
+
+        siteA.CacheKey.Should().NotBe(siteB.CacheKey);
+    }
+
+    [Fact]
+    public void OntPollContext_SeparatesTheSameConfigIdOnDifferentSites()
+    {
+        var siteA = new OntPollContext { Id = 1, SiteSlug = "site-a", Name = "ONT", Host = "192.0.2.10" };
+        var siteB = new OntPollContext { Id = 1, SiteSlug = "site-b", Name = "ONT", Host = "192.0.2.20" };
+
+        siteA.CacheKey.Should().NotBe(siteB.CacheKey);
+    }
+
+    [Fact]
+    public void StarlinkPollContext_SeparatesTheSameConfigIdOnDifferentSites()
+    {
+        var siteA = new StarlinkPollContext { Id = 1, SiteSlug = "site-a", Name = "Dish", Host = "192.0.2.10" };
+        var siteB = new StarlinkPollContext { Id = 1, SiteSlug = "site-b", Name = "Dish", Host = "192.0.2.20" };
+
+        siteA.CacheKey.Should().NotBe(siteB.CacheKey);
+    }
+
+    [Fact]
+    public void ModemPollContext_SeparatesTheSameConfigIdOnDifferentSites()
+    {
+        var siteA = new ModemPollContext { Id = 1, SiteSlug = "site-a", Name = "Modem", Host = "192.0.2.10" };
+        var siteB = new ModemPollContext { Id = 1, SiteSlug = "site-b", Name = "Modem", Host = "192.0.2.20" };
+
+        siteA.CacheKey.Should().NotBe(siteB.CacheKey);
+    }
+
+    [Fact]
+    public void CacheKey_IsStableForTheSameSiteAndConfig()
+    {
+        var first = new CmPollContext { Id = 3, SiteSlug = "site-a", Name = "CM", Host = "192.0.2.10" };
+        var second = new CmPollContext { Id = 3, SiteSlug = "site-a", Name = "CM", Host = "192.0.2.99" };
+
+        first.CacheKey.Should().Be(second.CacheKey);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/XfinityGatewayProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/XfinityGatewayProviderTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.CableModem;
+
+/// <summary>
+/// Parser coverage for the two .jst firmware families this provider spans,
+/// against DOCSIS tables captured from real gateways.
+/// </summary>
+public class XfinityGatewayProviderTests
+{
+    private static readonly string FixtureDir =
+        Path.Combine(AppContext.BaseDirectory, "CableModem", "Fixtures");
+
+    private static XfinityGatewayProvider CreateProvider() =>
+        new(NullLogger<XfinityGatewayProvider>.Instance);
+
+    private static string Fixture(string name) =>
+        File.ReadAllText(Path.Combine(FixtureDir, name));
+
+    private static CmPollContext Context(
+        string siteSlug = "default",
+        int id = 1,
+        string? statusPagePath = null) => new()
+        {
+            Id = id,
+            SiteSlug = siteSlug,
+            Name = "CM1",
+            Host = "192.0.2.10",
+            StatusPagePath = statusPagePath,
+        };
+
+    [Fact]
+    public void ParseNetworkSetup_ComcastBusiness_ReadsIndexLabelledChannels()
+    {
+        var stats = CreateProvider()
+            .ParseNetworkSetup(Fixture("comcast-business-cga4332.html"), Context());
+
+        stats.DownstreamChannels.Should().HaveCount(29);
+        stats.UpstreamChannels.Should().HaveCount(5);
+
+        var first = stats.DownstreamChannels[0];
+        first.ChannelId.Should().Be(1);
+        first.LockStatus.Should().Be("Locked");
+        first.Frequency.Should().Be(819_000_000);
+        first.Snr.Should().Be(44.6);
+        first.Power.Should().Be(10.7);
+        first.Modulation.Should().Be("256 QAM");
+
+        stats.DownstreamChannels[28].Modulation.Should().Be("OFDM");
+        stats.DownstreamChannels[28].Frequency.Should().Be(900_000_000);
+    }
+
+    [Fact]
+    public void ParseNetworkSetup_ComcastBusiness_ReadsUpstreamIncludingOfdma()
+    {
+        var stats = CreateProvider()
+            .ParseNetworkSetup(Fixture("comcast-business-cga4332.html"), Context());
+
+        var scqam = stats.UpstreamChannels[0];
+        scqam.ChannelId.Should().Be(1);
+        scqam.Frequency.Should().Be(16_000_000);
+        scqam.SymbolRate.Should().Be(5120);
+        scqam.Power.Should().Be(41.0);
+        scqam.ChannelType.Should().Be("ATDMA");
+
+        var ofdma = stats.UpstreamChannels[4];
+        ofdma.Frequency.Should().Be(36_000_000);
+        ofdma.SymbolRate.Should().Be(0);
+        ofdma.Power.Should().Be(35.0);
+    }
+
+    [Fact]
+    public void ParseNetworkSetup_ComcastBusiness_MergesCodewordsByPosition()
+    {
+        var stats = CreateProvider()
+            .ParseNetworkSetup(Fixture("comcast-business-cga4332.html"), Context());
+
+        // This firmware's codeword table carries no Channel ID row, so the
+        // columns line up with the downstream table by position alone.
+        stats.DownstreamChannels[0].Correctables.Should().Be(4256604764);
+        stats.DownstreamChannels[0].Uncorrectables.Should().Be(3992);
+        stats.DownstreamChannels[1].Correctables.Should().Be(312);
+        stats.DownstreamChannels[1].Uncorrectables.Should().Be(1630);
+        stats.DownstreamChannels[28].Uncorrectables.Should().Be(3992);
+    }
+
+    [Fact]
+    public void ParseNetworkSetup_Residential_StillReadsChannelIdLabelledTables()
+    {
+        var stats = CreateProvider()
+            .ParseNetworkSetup(Fixture("xfinity-xb10-network-setup.html"), Context());
+
+        stats.DownstreamChannels.Should().HaveCount(10);
+        stats.UpstreamChannels.Should().HaveCount(8);
+
+        // Residential firmware reports real DOCSIS channel IDs, not positions.
+        stats.DownstreamChannels[0].ChannelId.Should().Be(17);
+        stats.DownstreamChannels[0].Snr.Should().Be(48.7);
+        stats.DownstreamChannels[0].Correctables.Should().Be(509057704);
+        stats.DownstreamChannels[0].Uncorrectables.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("comcast-business-cga4332.html", "CBR")]
+    [InlineData("xfinity-xb10-network-setup.html", "XB10")]
+    public void ParseNetworkSetup_NamesTheGatewayFromProductType(string fixture, string expected)
+    {
+        var stats = CreateProvider().ParseNetworkSetup(Fixture(fixture), Context());
+
+        stats.DeviceModel.Should().Be(expected);
+    }
+
+    [Fact]
+    public void CandidatePaths_TriesResidentialPageBeforeBusinessPage()
+    {
+        CreateProvider().CandidatePaths(Context())
+            .Should().Equal("/network_setup.jst", "/comcast_network.jst");
+    }
+
+    [Fact]
+    public void CandidatePaths_PutsAnExplicitOverrideFirstWithoutDroppingTheDefaults()
+    {
+        CreateProvider().CandidatePaths(Context(statusPagePath: "/custom.jst"))
+            .Should().Equal("/custom.jst", "/network_setup.jst", "/comcast_network.jst");
+    }
+
+    [Fact]
+    public void CandidatePaths_LeadsWithThePathThatWorkedLastTime()
+    {
+        var provider = CreateProvider();
+        var context = Context();
+
+        provider.Remember(context, "/comcast_network.jst");
+
+        provider.CandidatePaths(context)
+            .Should().Equal("/comcast_network.jst", "/network_setup.jst");
+    }
+
+    [Fact]
+    public void CandidatePaths_DoesNotShareDiscoveryAcrossSitesWithTheSameConfigId()
+    {
+        var provider = CreateProvider();
+        provider.Remember(Context(siteSlug: "site-a", id: 1), "/comcast_network.jst");
+
+        provider.CandidatePaths(Context(siteSlug: "site-b", id: 1))
+            .Should().Equal("/network_setup.jst", "/comcast_network.jst");
+    }
+
+    [Fact]
+    public void CandidatePaths_ForgetsDiscoveryWhenTheOverrideChanges()
+    {
+        var provider = CreateProvider();
+        provider.Remember(Context(), "/comcast_network.jst");
+
+        provider.CandidatePaths(Context(statusPagePath: "/custom.jst"))
+            .Should().Equal("/custom.jst", "/network_setup.jst", "/comcast_network.jst");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/CableModem/XfinityGatewayProviderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/CableModem/XfinityGatewayProviderTests.cs
@@ -105,9 +105,9 @@ public class XfinityGatewayProviderTests
     }
 
     [Theory]
-    [InlineData("comcast-business-cga4332.html", "CBR")]
-    [InlineData("xfinity-xb10-network-setup.html", "XB10")]
-    public void ParseNetworkSetup_NamesTheGatewayFromProductType(string fixture, string expected)
+    [InlineData("comcast-business-cga4332.html", "CBR (CGA4332COM)")]
+    [InlineData("xfinity-xb10-network-setup.html", "XB10 (SG417DBCT)")]
+    public void ParseNetworkSetup_PairsProductTypeWithTheModelNumber(string fixture, string expected)
     {
         var stats = CreateProvider().ParseNetworkSetup(Fixture(fixture), Context());
 

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/ProviderCacheKeyArchitectureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/ProviderCacheKeyArchitectureTests.cs
@@ -1,0 +1,84 @@
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Reflection;
+using FluentAssertions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.CableModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Poll providers are registered as singletons and shared by every site, while
+/// each site's database numbers its own configurations from 1. A per-device
+/// cache keyed on the configuration ID therefore collides across sites: the
+/// first modem, ONT or dish added at any site is Id 1.
+///
+/// This net catches a cache keyed on an integer. It cannot catch one keyed on
+/// the wrong string - reviewing a new dictionary key is still a reading job.
+/// </summary>
+public class ProviderCacheKeyArchitectureTests
+{
+    private static readonly Assembly WebAssembly = typeof(XfinityGatewayProvider).Assembly;
+
+    private static readonly Type[] ProviderInterfaces =
+    {
+        typeof(ICableModemProvider),
+        typeof(ICellularModemProvider),
+        typeof(IOntProvider),
+        typeof(IStarlinkProvider),
+    };
+
+    private static IReadOnlyList<Type> ProviderTypes() => WebAssembly.GetTypes()
+        .Where(t => t is { IsClass: true, IsAbstract: false })
+        .Where(t => ProviderInterfaces.Any(i => i.IsAssignableFrom(t)))
+        .OrderBy(t => t.FullName)
+        .ToList();
+
+    public static TheoryData<Type> Providers()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var type in ProviderTypes())
+            data.Add(type);
+
+        return data;
+    }
+
+    [Fact]
+    public void TheNetSeesEveryProvider()
+    {
+        // A silent zero here would make every assertion below vacuous.
+        ProviderTypes().Should().HaveCountGreaterThan(10);
+    }
+
+    [Theory]
+    [MemberData(nameof(Providers))]
+    public void ProviderCachesAreNotKeyedOnAConfigurationId(Type providerType)
+    {
+        var offenders = providerType
+            .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(f => IsKeyedCollection(f.FieldType))
+            .Where(f => KeyType(f.FieldType) == typeof(int))
+            .Select(f => $"{providerType.Name}.{f.Name}")
+            .ToList();
+
+        offenders.Should().BeEmpty(
+            "a provider singleton is shared by every site, so an int-keyed per-device cache " +
+            "collides whenever two sites both have a device with that configuration ID - " +
+            "key on the poll context's CacheKey instead");
+    }
+
+    private static bool IsKeyedCollection(Type type)
+    {
+        if (!type.IsGenericType)
+            return false;
+
+        return typeof(IDictionary).IsAssignableFrom(type)
+            || type.GetGenericTypeDefinition() == typeof(ConcurrentDictionary<,>);
+    }
+
+    private static Type? KeyType(Type type) =>
+        type.IsGenericType && type.GetGenericArguments().Length == 2
+            ? type.GetGenericArguments()[0]
+            : null;
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// The gauges have to agree with the grade the reading is given, and optical Rx
+/// has to run back to red above its band - an overdriven receiver is a fault, not
+/// a good reading.
+/// </summary>
+public class SignalGaugeTests
+{
+    [Theory]
+    [InlineData(25, 0)]
+    [InlineData(35, 50)]
+    [InlineData(45, 100)]
+    [InlineData(10, 0)]    // clamped
+    [InlineData(60, 100)]  // clamped
+    public void Position_MapsOntoTheTrackAndClamps(double value, double expected)
+    {
+        SignalGauge.Position(value, 25, 45).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Position_IsZeroForADegenerateDomain()
+    {
+        SignalGauge.Position(5, 10, 10).Should().Be(0);
+    }
+
+    [Fact]
+    public void OpticalTrack_EndsRedAtBothEnds()
+    {
+        var track = SignalGauge.OpticalTrack(OpticalBands.Pon);
+
+        track.Should().StartWith("linear-gradient(to top, var(--signal-poor) 0%");
+        track.Should().EndWith("var(--signal-poor) 100%)");
+    }
+
+    [Fact]
+    public void SnrTrack_RisesToExcellentAndStaysThere()
+    {
+        var track = SignalGauge.SnrTrack(25, 45, fair: 30, good: 33, excellent: 36);
+
+        track.Should().StartWith("linear-gradient(to top, var(--signal-poor) 0%");
+        track.Should().EndWith("var(--signal-excellent) 100%)");
+    }
+
+    [Theory]
+    [InlineData(-19.5, "signal-excellent")]
+    [InlineData(-24, "signal-good")]
+    [InlineData(-27, "signal-fair")]
+    [InlineData(-31, "signal-poor")]
+    [InlineData(-2, "signal-poor")]   // overdriven, not "great"
+    public void PonBands_GradeBothDirections(double rx, string expected)
+    {
+        OpticalBands.Pon.ClassFor(rx).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(-4.5, "signal-excellent")]
+    [InlineData(-9, "signal-good")]
+    [InlineData(-13, "signal-fair")]
+    [InlineData(3, "signal-poor")]
+    public void ActiveEthernetBands_UseTheirOwnRange(double rx, string expected)
+    {
+        OpticalBands.ActiveEthernet.ClassFor(rx).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ClassFor_IsEmptyWithoutAReading()
+    {
+        OpticalBands.Pon.ClassFor(null).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AnOverdrivenReceiverSitsHighOnTheTrackButInTheRed()
+    {
+        // The whole reason the optical track diverges: -2 dBm is near the top of
+        // the domain, where a rising gauge would paint it green.
+        var bands = OpticalBands.Pon;
+        var pos = SignalGauge.Position(-2, bands.DomainLow, bands.DomainHigh);
+
+        pos.Should().BeGreaterThan(90);
+        bands.ClassFor(-2).Should().Be("signal-poor");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
@@ -79,6 +79,41 @@ public class SignalGaugeTests
     }
 
     [Fact]
+    public void WindowEdges_LeaveALitBandOnTheReading()
+    {
+        var (above, below) = SignalGauge.WindowEdges(50, halfHeight: 9);
+
+        above.Should().Be(41);
+        below.Should().Be(41);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(100)]
+    public void WindowEdges_ClampAtTheEndsOfTheTrack(double position)
+    {
+        var (above, below) = SignalGauge.WindowEdges(position);
+
+        above.Should().BeGreaterThanOrEqualTo(0);
+        below.Should().BeGreaterThanOrEqualTo(0);
+        (above + below).Should().BeLessThan(100);
+    }
+
+    [Fact]
+    public void AGoodButLowReadingDoesNotLightTheBadEndOfTheTrack()
+    {
+        // -22.37 dBm grades good. Lighting from the bottom would show everything
+        // below it - the fair, weak and poor stretches - which reads as alarming.
+        var bands = OpticalBands.Pon;
+        var pos = SignalGauge.Position(-22.37, bands.DomainLow, bands.DomainHigh);
+        var (above, below) = SignalGauge.WindowEdges(pos);
+
+        bands.ClassFor(-22.37).Should().Be("signal-good");
+        below.Should().BeGreaterThan(10, "the poor end stays dimmed");
+        above.Should().BeGreaterThan(10, "the overdriven end stays dimmed too");
+    }
+
+    [Fact]
     public void ClassFor_IsEmptyWithoutAReading()
     {
         OpticalBands.Pon.ClassFor(null).Should().BeEmpty();

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
@@ -68,6 +68,17 @@ public class SignalGaugeTests
     }
 
     [Fact]
+    public void PonPeaksWhereARealLinkRuns_NotAtTheBandMidpoint()
+    {
+        // The midpoint of -22..-8 is -15 dBm, which only shows up on an unusually
+        // low split ratio. The peak is stated so the gauge tops out where a normal
+        // link actually sits.
+        OpticalBands.Pon.Peak.Should().Be(-18);
+        OpticalBands.Pon.Peak.Should()
+            .BeLessThan((OpticalBands.Pon.ExcellentLow + OpticalBands.Pon.ExcellentHigh) / 2);
+    }
+
+    [Fact]
     public void ClassFor_IsEmptyWithoutAReading()
     {
         OpticalBands.Pon.ClassFor(null).Should().BeEmpty();

--- a/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
+++ b/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
@@ -31,6 +31,9 @@
     <Content Include="IspHealth\Fixtures\*.csv">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="CableModem\Fixtures\*.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds Comcast Business gateways to the existing `.jst` cable modem provider, and fixes a multi-site cache collision found while doing it.

## Cable Modem Stats

- **Comcast Business gateways now work** - the CGA4332COM (Technicolor hardware) runs Comcast's own `.jst` web UI rather than Technicolor's firmware, so it belongs to the Xfinity provider, not Technicolor CGA Series, which talks a JSON API the box does not serve.
- **The status page is detected automatically** - this firmware serves DOCSIS on `comcast_network.jst`; `network_setup.jst` does not exist on it. The provider probes candidates after login and keeps the first that yields channels, remembered per modem so only the first poll pays for it. An explicit Status Page Path override still leads, and editing it re-discovers.
- **Both channel-table dialects parse** - business firmware labels the channel row `Index` where residential says `Channel ID`, and drops the ID row from the codeword table entirely. The codeword merge falls back to positional when there is no ID to match on, guarded by a column count check so a mismatched table is skipped rather than misattributed.
- **Gateways are named by product type and model together** - `CBR (CGA4332COM)`, `XB10 (SG417DBCT)`. Product type alone is too coarse on business firmware, where the whole line reports `CBR`; the model number alone is unrecognizable on residential.
- Provider renamed to **Xfinity XB8/XB10, Comcast Business CGA4332, Cox CGM4981 (HTTP)**.

## Dashboard

- **The Cable Modem Stats card shows the modem model** - the signal box lays out like the Cellular Stats card, a left-aligned row rather than a centered gauge, with the model taking the place the cellular card gives the device icon. Where a provider reports both parts they stack.

## Multi-Site

- **Provider caches no longer collide across sites** - every poll provider is registered as a singleton and shared by all sites, but each site has its own database and numbers its configurations from 1, so the first modem, ONT or dish added at any site is Id 1. Ten caches across nine providers keyed on that Id alone.

  Consequences ranged by cache. The session and token caches (ARRIS HNAP and HTTP, Motorola, Technicolor CGA, Vodafone Station, Netgear hotspot) handed one site's authenticated session to another site's device. Starlink's history counter drives how many 1 Hz samples each poll aggregates, so a second dish silently corrupted that window. The endpoint caches (Netgear CM, Nokia) merely probed the wrong path first.

  The four poll contexts now carry `SiteSlug` and expose a `CacheKey` composing it with `Id`. The Netgear hotspot was keyed on `Host` instead, which collided the same way whenever two sites reached devices at the same address - and always on agent sites, where `RouteAsync` rewrites every device to the literal host `127.0.0.1` and the key did not include the port.

  `NetOptCustomPonOntProvider._requestGates` stays keyed on `host:port`: it serializes requests to a physical endpoint rather than caching per configuration.

## Testing

- 11 parser tests over DOCSIS tables captured from a real CGA4332COM and XB10. Fixtures carry the channel data verbatim but none of the capture's device or network identifiers.
- 5 tests asserting the same configuration ID on two sites cannot share a cache key.
- An architecture test reflecting over all 20 provider implementations, failing the build on an int-keyed cache. Verified non-vacuous: re-keying a provider back to `int` makes it fail naming that field. It catches integer keys only - a cache keyed on the wrong string still has to be caught by reading.

Full suite green, zero build warnings.

## Notes for review

- Only 2 of the 9 touched providers have a live device on the test sites (Netgear CM, Starlink). The other seven are covered by the build, the type system, and the parser tests.
- A wrong-key regression would not stop data flowing - the cache would simply miss and the provider re-authenticate each poll. The one place it would bite is Motorola's login backoff, which exists to avoid hammering a modem after a failed login.
- `StarlinkGrpcProvider._lastPollUtc` is written every poll and never read. Pre-existing, left alone.
