### PR TITLE
Upstream Path Discovery: curated Verizon access-ISP endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Network Optimizer - TODO / Future Enhancements
+﻿# Network Optimizer - TODO / Future Enhancements
 
 ## SSH key placement on console gateways (udm-boot)
 
@@ -513,6 +513,29 @@ One follow-up idea remains open (not built):
 - [ ] Confirm whether the same flow works on Nokia's **GPON box siblings** (e.g. G-010G-Q). If yes, either relax the hardcoded XGS-PON label or split into a GPON variant - a GPON unit on this provider would currently be mislabeled XGS-PON.
 - [ ] Confirm whether it works on Nokia's **SFP-form ONTs** (the SFP stick modules), which may expose a different web/telnet interface entirely.
 - [ ] If coverage is broader than one model, revisit the dropdown label ("Nokia XS-010X-Q (HTTP)") and the hardcoded `DeviceModel` so multi-model units aren't misreported.
+
+### Upstream discovery: the access ASN is unlearnable on a CGNAT'd WAN
+
+No `_accessAsn` means `InjectAccessIspFallbackAsync` returns immediately, so the curated access-ISP
+endpoint map never fires. `DetermineAccessAsn` needs either a public WAN IP or one attributable
+non-destination hop on some trace; an ICMP-silent first mile alone is survivable, CGNAT plus a first
+mile that surfaces nothing is not (`ResolveAsync` deliberately returns null for 100.64/10). Hits the
+AS6167 / AS22394 Verizon Wireless keys, which are CGNAT by default.
+
+Three possible closers, cheapest first, none investigated beyond reading the code:
+
+- [ ] **`UniFiSysInfo.public_ip` is parsed and has zero consumers** (`UniFiSysInfo.cs:156`;
+  `WanIpAddress` comes from the `wan1..wan6` descriptors, i.e. the interface address). If it holds
+  the console's externally-observed address it is the real egress, for free. **Settle what it
+  contains on a CGNAT'd site first - it decides whether the other two matter.**
+- [ ] **Widen ASN resolution to IPv6.** `ResolveAsync` gates on `PublicAddressClass.PublicIPv4` and
+  the enum has no v6 member, so v6 classifies as `Unknown` and is dropped before either backend -
+  both of which handle v6 fine. Better signal anyway: a CGNAT'd v4 site usually has native global v6
+  mapping straight to the carrier ASN. Belongs with `feature/ipv6-support`.
+- [ ] **External IP echo (icanhazip) as a last resort.** Strict parse, short timeout, failure means
+  no-signal. The landmine is binding, not availability: the tracer is source-bound via
+  `_binding?.Source`, a plain fetch egresses via the OS routing table, so multi-WAN would stamp
+  WAN2's targets with WAN1's ASN. Needs a source-bound `HttpClient`.
 
 ## Multi-Tenant / Multi-Site Support
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-﻿# Network Optimizer - TODO / Future Enhancements
+# Network Optimizer - TODO / Future Enhancements
 
 ## SSH key placement on console gateways (udm-boot)
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
@@ -1989,6 +1989,23 @@ public class UpstreamTracerService
     // Hosts must answer ICMP (the same gate post-traceroute hops face); non-pingable PoPs are omitted.
     // The label follows the standard convention (stripped ASN name + stripped hostname via
     // FormatTransitHopLabel), e.g. "Deutsche Telekom ffm.wsqm".
+    /// <summary>
+    /// Verizon's *.vzbi.com speedtest PoPs, shared by every Verizon access ASN keyed in
+    /// <see cref="AccessIspFallbackHosts"/>. Listed as hostnames, not the captured addresses: each
+    /// forward-resolves to exactly the address its PTR advertises, so a PoP renumber costs nothing.
+    /// </summary>
+    private static readonly string[] VerizonSpeedtestHosts =
+    {
+        "dllstx97-040205c-inet.vzbi.com",    // Dallas, TX
+        "bstpmall-100207c-inet.vzbi.com",    // Boston, MA
+        "rvdlilbd-0011403f-inet.vzbi.com",   // Chicago, IL (Riverdale)
+        "dnvrco26-091505f-inet.vzbi.com",    // Denver, CO
+        "sccsnj75-010206e-inet.vzbi.com",    // Secaucus, NJ
+        "miauflws-040102d-inet.vzbi.com",    // Miami, FL
+        "sttlwawb-000t08c-inet.vzbi.com",    // Seattle, WA
+        "lsancakv-075715b-inet.vzbi.com",    // Los Angeles, CA
+    };
+
     internal static readonly IReadOnlyDictionary<int, IReadOnlyList<string>> AccessIspFallbackHosts =
         new Dictionary<int, IReadOnlyList<string>>
         {
@@ -2096,6 +2113,15 @@ public class UpstreamTracerService
                 "gdjtco-speedtest-ookla-01.st.charter.com",   // Grand Junction, CO
                 "msslmt-speedtest-ookla-01.st.charter.com",   // Missoula, MT
             },
+
+            // Verizon (AS701 UUNET / Verizon Business) - the *.vzbi.com speedtest PoPs, all verified
+            // ICMP-pingable. The wireless ASNs (AS6167 / AS22394 Cellco) key to the same list: their
+            // traffic rides AS701 regardless, so the nearest vzbi PoP is the closest Verizon anchor.
+            // Never stamp the row with the TARGET's ASN - DetectAccessIspChangeAsync keys on that
+            // stamp, so AS701 on a Cellco site would fire a false provider change on every run.
+            [701] = VerizonSpeedtestHosts,     // UUNET - Verizon Business (Fios and business fiber)
+            [6167] = VerizonSpeedtestHosts,    // CELLCO-PART - Verizon Wireless
+            [22394] = VerizonSpeedtestHosts,   // CELLCO - Verizon Wireless
 
             // Orange S.A. (AS3215, France) - NOT YET ENABLED. These hosts BLOCK ICMP (0/3) but
             // answer TCP:8080, so enabling them needs per-endpoint TCP probe support added to this

--- a/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/UpstreamTracerService.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.RegularExpressions;
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Core.Helpers;
@@ -1982,13 +1982,6 @@ public class UpstreamTracerService
         (3356, "4.2.2.2", "Level 3", "Level 3 DNS (transit witness)")
     };
 
-    // Curated access-ISP endpoints for carriers whose first-mile routers commonly ICMP-deprioritize,
-    // leaving the access cloud with no probed target. When the detected access ASN is in this map and
-    // none of the discovered access hops clear the reachability gate, we resolve + ping these published
-    // hosts and adopt the lowest-RTT reachable one as the access target (InjectAccessIspFallbackAsync).
-    // Hosts must answer ICMP (the same gate post-traceroute hops face); non-pingable PoPs are omitted.
-    // The label follows the standard convention (stripped ASN name + stripped hostname via
-    // FormatTransitHopLabel), e.g. "Deutsche Telekom ffm.wsqm".
     /// <summary>
     /// Verizon's *.vzbi.com speedtest PoPs, shared by every Verizon access ASN keyed in
     /// <see cref="AccessIspFallbackHosts"/>. Listed as hostnames, not the captured addresses: each
@@ -2006,6 +1999,13 @@ public class UpstreamTracerService
         "lsancakv-075715b-inet.vzbi.com",    // Los Angeles, CA
     };
 
+    // Curated access-ISP endpoints for carriers whose first-mile routers commonly ICMP-deprioritize,
+    // leaving the access cloud with no probed target. When the detected access ASN is in this map and
+    // none of the discovered access hops clear the reachability gate, we resolve + ping these published
+    // hosts and adopt the lowest-RTT reachable one as the access target (InjectAccessIspFallbackAsync).
+    // Hosts must answer ICMP (the same gate post-traceroute hops face); non-pingable PoPs are omitted.
+    // The label follows the standard convention (stripped ASN name + stripped hostname via
+    // FormatTransitHopLabel), e.g. "Deutsche Telekom ffm.wsqm".
     internal static readonly IReadOnlyDictionary<int, IReadOnlyList<string>> AccessIspFallbackHosts =
         new Dictionary<int, IReadOnlyList<string>>
         {

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+﻿using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
@@ -1325,6 +1325,16 @@ public class AccessIspFallbackTests
         // dssd-tc.wsqm.telekom-dienste.de does not answer ICMP, so it must stay out of the map.
         UpstreamTracerService.AccessIspFallbackHosts[3320]
             .Should().NotContain(h => h.StartsWith("dssd"));
+    }
+
+    [Fact]
+    public void AccessIspFallbackHosts_shares_one_verizon_pop_list_across_all_three_asns()
+    {
+        // The PoPs all live in AS701; Cellco keys to them because its own first mile answers nothing.
+        var pops = UpstreamTracerService.AccessIspFallbackHosts[701];
+        pops.Should().OnlyContain(h => h.EndsWith("-inet.vzbi.com")).And.HaveCount(8);
+        UpstreamTracerService.AccessIspFallbackHosts[6167].Should().BeEquivalentTo(pops);
+        UpstreamTracerService.AccessIspFallbackHosts[22394].Should().BeEquivalentTo(pops);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UpstreamTracerServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using FluentAssertions;
+using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
@@ -1328,11 +1328,29 @@ public class AccessIspFallbackTests
     }
 
     [Fact]
-    public void AccessIspFallbackHosts_shares_one_verizon_pop_list_across_all_three_asns()
+    public void AccessIspFallbackHosts_AS701_has_the_verified_verizon_pops()
+    {
+        // Spelled out rather than pattern-matched: a mistyped host fails silently at runtime
+        // (NXDOMAIN, skipped with a debug log), so the list itself is what needs pinning.
+        UpstreamTracerService.AccessIspFallbackHosts.Should().ContainKey(701);
+        UpstreamTracerService.AccessIspFallbackHosts[701].Should().BeEquivalentTo(new[]
+        {
+            "dllstx97-040205c-inet.vzbi.com",
+            "bstpmall-100207c-inet.vzbi.com",
+            "rvdlilbd-0011403f-inet.vzbi.com",
+            "dnvrco26-091505f-inet.vzbi.com",
+            "sccsnj75-010206e-inet.vzbi.com",
+            "miauflws-040102d-inet.vzbi.com",
+            "sttlwawb-000t08c-inet.vzbi.com",
+            "lsancakv-075715b-inet.vzbi.com",
+        });
+    }
+
+    [Fact]
+    public void AccessIspFallbackHosts_cellco_asns_share_the_AS701_pops()
     {
         // The PoPs all live in AS701; Cellco keys to them because its own first mile answers nothing.
         var pops = UpstreamTracerService.AccessIspFallbackHosts[701];
-        pops.Should().OnlyContain(h => h.EndsWith("-inet.vzbi.com")).And.HaveCount(8);
         UpstreamTracerService.AccessIspFallbackHosts[6167].Should().BeEquivalentTo(pops);
         UpstreamTracerService.AccessIspFallbackHosts[22394].Should().BeEquivalentTo(pops);
     }


### PR DESCRIPTION
Verizon's first-mile routers deprioritize ICMP, so a Verizon site can finish upstream discovery with nothing in its access cloud to probe. This adds Verizon to the curated endpoint map that already covers Deutsche Telekom, Charter, T-Mobile Polska, T-Mobile Czech Republic and Intrepid Fiber. The mechanism is unchanged; this is data.

## Monitoring - Network Performance

- **Curated Verizon endpoints for Upstream Path Discovery** - When the detected access ASN is Verizon and no discovered first-mile hop answers ICMP, discovery resolves and pings eight `*.vzbi.com` speedtest PoPs (Dallas, Boston, Chicago, Denver, Secaucus, Miami, Seattle, Los Angeles) and adopts the nearest reachable one as the access target. It shows in the review panel as a **Curated** row, exactly like the existing carriers. Sites whose first mile already answers are unaffected, since the fallback only runs when nothing else cleared the gate.
- **Verizon Wireless is covered as well as wireline** - AS701 (Fios and business fiber) plus AS6167 and AS22394 (Cellco), so 5G Home and cellular-backup WANs match too.

## Notes for review

All eight endpoints were verified before being added: each answers ICMP 3/3, each forward-resolves to exactly the address its PTR advertises, and both prefixes originate AS701. They are listed as hostnames rather than addresses on purpose. A renumbered PoP follows its name, and a retired one stops resolving and is skipped cleanly, whereas a stale address would still answer ICMP and be adopted as a PoP it is no longer.

The two Cellco ASNs share AS701's endpoints instead of having their own, which departs from the pattern Charter set of keying each ASN only to hosts inside it. That is required rather than incidental: the injected row is stamped with the detected access ASN and never the target's, because `DetectAccessIspChangeAsync` keys on that stamp and a `ConfiguredFallback` row counts as a baseline. Stamping the target's real AS701 on a Cellco site would read as a provider change on every run and reset that site's targets. The map comment states the prohibition so it does not get tidied away later.

`TODO.md` records a gap this surfaced rather than introduced: on a CGNAT'd WAN whose first mile surfaces no attributable hop, the access ASN can be unlearnable altogether, and the fallback is gated on knowing it. Three candidate closers are noted, cheapest first.
