### PR TITLE
Device Health: normalize millidegree temperature readings

### DIFF
--- a/src/NetworkOptimizer.Core/Helpers/TemperatureScale.cs
+++ b/src/NetworkOptimizer.Core/Helpers/TemperatureScale.cs
@@ -1,0 +1,23 @@
+namespace NetworkOptimizer.Core.Helpers;
+
+/// <summary>
+/// Normalizes device temperature readings to degrees Celsius.
+/// </summary>
+public static class TemperatureScale
+{
+    /// <summary>Above this a reading is millidegrees, not degrees.</summary>
+    private const double PlausibleMaxCelsius = 200.0;
+
+    /// <summary>
+    /// Returns <paramref name="value"/> in degrees Celsius, scaling it down when the device
+    /// reported millidegrees. Scaling varies by model rather than by source - the UXG-Lite
+    /// reports its raw thermal-zone value over the UniFi API where other gateways report
+    /// degrees - so read the scale off the value instead of assuming one.
+    /// </summary>
+    public static double NormalizeCelsius(double value) =>
+        Math.Abs(value) > PlausibleMaxCelsius ? value / 1000.0 : value;
+
+    /// <summary>Null-tolerant <see cref="NormalizeCelsius(double)"/>.</summary>
+    public static double? NormalizeCelsius(double? value) =>
+        value.HasValue ? NormalizeCelsius(value.Value) : null;
+}

--- a/src/NetworkOptimizer.Core/Helpers/TemperatureScale.cs
+++ b/src/NetworkOptimizer.Core/Helpers/TemperatureScale.cs
@@ -6,7 +6,7 @@ namespace NetworkOptimizer.Core.Helpers;
 public static class TemperatureScale
 {
     /// <summary>Above this a reading is millidegrees, not degrees.</summary>
-    private const double PlausibleMaxCelsius = 200.0;
+    public const double PlausibleMaxCelsius = 200.0;
 
     /// <summary>
     /// Returns <paramref name="value"/> in degrees Celsius, scaling it down when the device
@@ -14,8 +14,11 @@ public static class TemperatureScale
     /// reports its raw thermal-zone value over the UniFi API where other gateways report
     /// degrees - so read the scale off the value instead of assuming one.
     /// </summary>
+    /// <summary>Divisor taking a millidegree reading to degrees.</summary>
+    public const double MillidegreesPerDegree = 1000.0;
+
     public static double NormalizeCelsius(double value) =>
-        Math.Abs(value) > PlausibleMaxCelsius ? value / 1000.0 : value;
+        Math.Abs(value) > PlausibleMaxCelsius ? value / MillidegreesPerDegree : value;
 
     /// <summary>Null-tolerant <see cref="NormalizeCelsius(double)"/>.</summary>
     public static double? NormalizeCelsius(double? value) =>

--- a/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
+++ b/src/NetworkOptimizer.Monitoring/SnmpPoller.cs
@@ -5,6 +5,7 @@ using Lextm.SharpSnmpLib;
 using Lextm.SharpSnmpLib.Messaging;
 using Lextm.SharpSnmpLib.Security;
 using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Monitoring.Models;
 
 // SNMP v3 protocol requires supporting legacy authentication/encryption for device compatibility.
@@ -589,7 +590,7 @@ public class SnmpPoller : ISnmpPoller
 
         if (lmTemp > 0)
         {
-            metrics.Temperature = lmTemp / 1000.0;
+            metrics.Temperature = TemperatureScale.NormalizeCelsius(lmTemp);
         }
         else if (unifiTemp > 0 && unifiTemp < 200)
         {

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -5,6 +5,7 @@ using InfluxDB.Client.Writes;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Core.Models;
 using NetworkOptimizer.Storage.Models;
 
@@ -1857,7 +1858,7 @@ from(bucket: ""{_bucket}"")
                 Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
                 CpuPercent = AsDoubleOrNull(record.GetValueByKey("cpu_percent")),
                 MemoryUsedPercent = AsDoubleOrNull(record.GetValueByKey("memory_used_percent")),
-                TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
+                TemperatureC = TemperatureScale.NormalizeCelsius(AsDoubleOrNull(record.GetValueByKey("temperature_c"))),
                 UptimeSeconds = (long?)AsDoubleOrNull(record.GetValueByKey("uptime_seconds")),
                 FanSpeedRpm = (int?)AsDoubleOrNull(record.GetValueByKey("fan_speed_rpm"))
             });
@@ -1954,7 +1955,7 @@ from(bucket: ""{_bucket}"")
             Time = kv.Value,
             CpuPercent = cpu.TryGetValue(kv.Key, out var c) ? c : null,
             MemoryUsedPercent = mem.TryGetValue(kv.Key, out var m) ? m : null,
-            TemperatureC = temp.TryGetValue(kv.Key, out var t) ? t : null,
+            TemperatureC = temp.TryGetValue(kv.Key, out var t) ? TemperatureScale.NormalizeCelsius(t) : null,
             UptimeSeconds = uptime.TryGetValue(kv.Key, out var u) ? (long?)u : null,
             FanSpeedRpm = fan.TryGetValue(kv.Key, out var f) ? (int?)f : null,
         }).OrderBy(p => p.Time).ToList();

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Globalization;
 using InfluxDB.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
@@ -1830,7 +1831,17 @@ from(bucket: ""{_bucket}"")
         public double? UploadBps { get; init; }
     }
 
-    /// <summary>Per-device CPU/memory/temperature trace.</summary>
+    // Flux literals must carry a decimal point or they parse as int and clash with the float
+    // fields in the same map. Sourced from TemperatureScale so the two paths can't drift.
+    private static readonly string FluxMillidegreeThreshold =
+        TemperatureScale.PlausibleMaxCelsius.ToString("F1", CultureInfo.InvariantCulture);
+    private static readonly string FluxMillidegreeDivisor =
+        TemperatureScale.MillidegreesPerDegree.ToString("F1", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Per-device CPU/memory/temperature trace. Temperature is normalized per point before the
+    /// mean: a window straddling the millidegree fix would otherwise average the two scales.
+    /// </summary>
     public async Task<IReadOnlyList<DeviceHealthPoint>> QueryDeviceHealthAsync(
         string deviceMac,
         DateTime from,
@@ -1847,6 +1858,7 @@ from(bucket: ""{_bucket}"")
   |> filter(fn: (r) => r._measurement == ""device_health"")
   |> filter(fn: (r) => r.device_mac == ""{mac}"")
   |> filter(fn: (r) => r._field == ""cpu_percent"" or r._field == ""memory_used_percent"" or r._field == ""temperature_c"" or r._field == ""uptime_seconds"" or r._field == ""fan_speed_rpm"")
+  |> map(fn: (r) => ({{ r with _value: if r._field == ""temperature_c"" and float(v: r._value) > {FluxMillidegreeThreshold} then float(v: r._value) / {FluxMillidegreeDivisor} else float(v: r._value) }}))
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: mean, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
@@ -1858,7 +1870,7 @@ from(bucket: ""{_bucket}"")
                 Time = ToUtc(record.GetTimeInDateTime() ?? DateTime.UtcNow),
                 CpuPercent = AsDoubleOrNull(record.GetValueByKey("cpu_percent")),
                 MemoryUsedPercent = AsDoubleOrNull(record.GetValueByKey("memory_used_percent")),
-                TemperatureC = TemperatureScale.NormalizeCelsius(AsDoubleOrNull(record.GetValueByKey("temperature_c"))),
+                TemperatureC = AsDoubleOrNull(record.GetValueByKey("temperature_c")),
                 UptimeSeconds = (long?)AsDoubleOrNull(record.GetValueByKey("uptime_seconds")),
                 FanSpeedRpm = (int?)AsDoubleOrNull(record.GetValueByKey("fan_speed_rpm"))
             });

--- a/src/NetworkOptimizer.Web/Services/UniFiDeviceHealthReader.cs
+++ b/src/NetworkOptimizer.Web/Services/UniFiDeviceHealthReader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
@@ -45,9 +46,13 @@ public static class UniFiDeviceHealthReader
 
     /// <summary>
     /// Reads a device's temperature from the UniFi API, handling the switch (general_temperature /
-    /// bare integer) and gateway (structured sensor array) shapes.
+    /// bare integer) and gateway (structured sensor array) shapes. Normalized to Celsius: some
+    /// models (UXG-Lite) report millidegrees here.
     /// </summary>
-    public static double? ParseDeviceTemperature(UniFiDeviceResponse device)
+    public static double? ParseDeviceTemperature(UniFiDeviceResponse device) =>
+        TemperatureScale.NormalizeCelsius(ReadDeviceTemperature(device));
+
+    private static double? ReadDeviceTemperature(UniFiDeviceResponse device)
     {
         // general_temperature: simple numeric field on switches (e.g., 72)
         if (device.GeneralTemperature.HasValue && device.GeneralTemperature.Value > 0)

--- a/tests/NetworkOptimizer.Core.Tests/TemperatureScaleTests.cs
+++ b/tests/NetworkOptimizer.Core.Tests/TemperatureScaleTests.cs
@@ -1,0 +1,30 @@
+using FluentAssertions;
+using NetworkOptimizer.Core.Helpers;
+using Xunit;
+
+namespace NetworkOptimizer.Core.Tests;
+
+public class TemperatureScaleTests
+{
+    [Theory]
+    [InlineData(48000, 48)]          // UXG-Lite millidegrees
+    [InlineData(62500, 62.5)]
+    [InlineData(48, 48)]             // already Celsius
+    [InlineData(199.9, 199.9)]
+    [InlineData(200, 200)]           // boundary stays as-is
+    [InlineData(200.1, 0.2001)]
+    [InlineData(0, 0)]
+    [InlineData(-5000, -5)]          // sub-zero millidegrees
+    [InlineData(-5, -5)]
+    public void NormalizeCelsius_ScalesOnlyImplausibleReadings(double input, double expected)
+    {
+        TemperatureScale.NormalizeCelsius(input).Should().BeApproximately(expected, 0.0001);
+    }
+
+    [Fact]
+    public void NormalizeCelsius_PassesNullThrough()
+    {
+        TemperatureScale.NormalizeCelsius((double?)null).Should().BeNull();
+        TemperatureScale.NormalizeCelsius((double?)48000).Should().BeApproximately(48, 0.0001);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/UniFiDeviceHealthReaderTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/UniFiDeviceHealthReaderTests.cs
@@ -1,0 +1,37 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+public class UniFiDeviceHealthReaderTests
+{
+    private static UniFiDeviceResponse WithTemperatures(string json) =>
+        new() { Temperatures = JsonDocument.Parse(json).RootElement };
+
+    [Fact]
+    public void ParseDeviceTemperature_ScalesGatewayMillidegrees()
+    {
+        var device = WithTemperatures("""[{"name":"CPU","type":"cpu","value":48000}]""");
+
+        UniFiDeviceHealthReader.ParseDeviceTemperature(device).Should().BeApproximately(48, 0.001);
+    }
+
+    [Fact]
+    public void ParseDeviceTemperature_LeavesCelsiusAlone()
+    {
+        var device = WithTemperatures("""[{"name":"CPU","type":"cpu","value":62.5}]""");
+
+        UniFiDeviceHealthReader.ParseDeviceTemperature(device).Should().BeApproximately(62.5, 0.001);
+    }
+
+    [Fact]
+    public void ParseDeviceTemperature_ScalesSwitchGeneralTemperature()
+    {
+        var device = new UniFiDeviceResponse { GeneralTemperature = 72000 };
+
+        UniFiDeviceHealthReader.ParseDeviceTemperature(device).Should().BeApproximately(72, 0.001);
+    }
+}


### PR DESCRIPTION
Fixes #1158 - a UXG-Lite showed its CPU temperature as 48000 C.

## Monitoring - Device Stats

- **Temperature scale read off the value, not assumed** - the UXG-Lite reports its thermal sensor in millidegrees where other gateways report Celsius. A new `TemperatureScale.NormalizeCelsius` helper treats anything above 200 as millidegrees and scales it down.
- **Applied to both write paths** - the SNMP lm-sensors read (which previously always divided by 1000, so a device reporting whole degrees would have read 0.048) and the UniFi API read in `UniFiDeviceHealthReader`, which covers the live tiles, the alert evaluator, and what gets written to InfluxDB.
- **Applied to the device_health read path** - history already stored at the wrong scale charts correctly without a backfill. The Device Health chart normalizes per point in Flux ahead of its `aggregateWindow(mean)`, so the one bucket that spans the upgrade doesn't average the two scales together; the raw query normalizes per point in C#.

SFP and ONT temperatures are a separate measurement and are untouched.

## Testing

`dotnet build` clean, full `dotnet test` green. New unit tests cover the helper's boundary cases and the UniFi API gateway/switch shapes.

The Flux was verified against a live InfluxDB. Ten points written to the scratch bucket, five at 48000 and five at 48 inside one aggregation bucket: the old shape returned 24024 (24 C after normalizing), the new shape returns 48 C with `uptime_seconds` and `fan_speed_rpm` intact. The `float(v:)` casts are load-bearing - without them Flux rejects the whole query with `type conflict: float != int` because those two fields are int64 in the same map. Also checked against a device that reports no temperature at all. Scratch points deleted afterward.