### PR TITLE
Center the ONT gauge on its peak reading, and inset the model block

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -123,7 +123,7 @@ public readonly record struct OpticalBands(
     private double HalfSpan => Math.Max(Peak - (FairLow - 2), (FairHigh + 2) - Peak);
 
     /// <summary>
-    /// Bottom of the track. Placed so the peak sits at dead centre: the graded bounds
+    /// Bottom of the track. Placed so the peak sits at dead center: the graded bounds
     /// are not symmetric around it (PON runs -28 to -4 either side of a -18 peak), and
     /// deriving the ends from those bounds alone put the best reading below the middle
     /// of the bar.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SignalGauge.cs
@@ -116,11 +116,22 @@ public readonly record struct OpticalBands(
     /// </summary>
     public static readonly OpticalBands ExternalOnt = new(-22.5, -8, -25, -6, -27, -4, Peak: -18);
 
-    /// <summary>A little headroom past the last graded bound, so the ends are visible.</summary>
-    public double DomainLow => FairLow - 2;
+    /// <summary>
+    /// Half the track's span. Taken as the wider of the two sides so the domain is
+    /// symmetric about <see cref="Peak"/> and neither graded end gets clipped.
+    /// </summary>
+    private double HalfSpan => Math.Max(Peak - (FairLow - 2), (FairHigh + 2) - Peak);
 
-    /// <summary>A little headroom past the last graded bound, so the ends are visible.</summary>
-    public double DomainHigh => FairHigh + 2;
+    /// <summary>
+    /// Bottom of the track. Placed so the peak sits at dead centre: the graded bounds
+    /// are not symmetric around it (PON runs -28 to -4 either side of a -18 peak), and
+    /// deriving the ends from those bounds alone put the best reading below the middle
+    /// of the bar.
+    /// </summary>
+    public double DomainLow => Peak - HalfSpan;
+
+    /// <summary>Top of the track, the same distance past the peak as <see cref="DomainLow"/> is below it.</summary>
+    public double DomainHigh => Peak + HalfSpan;
 
     /// <summary>The signal-* class for a reading, or empty when there is none.</summary>
     public string ClassFor(double? rxDbm)

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2014,7 +2014,7 @@ a.stat-card-link:active {
     }
     .signal-with-model .cm-model {
         margin-left: auto;
-        margin-right: 0;
+        margin-right: 0.25rem;
     }
     .signal-hero {
         gap: 0.8rem;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1975,6 +1975,7 @@ a.stat-card-link:active {
     align-items: flex-end;
     gap: 0.25rem;
     text-align: right;
+    margin-right: 0.4rem;
     min-width: 0;
 }
 
@@ -2013,6 +2014,7 @@ a.stat-card-link:active {
     }
     .signal-with-model .cm-model {
         margin-left: auto;
+        margin-right: 0;
     }
     .signal-hero {
         gap: 0.8rem;

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/SignalGaugeTests.cs
@@ -113,6 +113,31 @@ public class SignalGaugeTests
         above.Should().BeGreaterThan(10, "the overdriven end stays dimmed too");
     }
 
+    [Theory]
+    [InlineData("pon")]
+    [InlineData("ae")]
+    [InlineData("external")]
+    public void ThePeakSitsAtTheCentreOfTheTrack(string which)
+    {
+        var bands = which switch
+        {
+            "ae" => OpticalBands.ActiveEthernet,
+            "external" => OpticalBands.ExternalOnt,
+            _ => OpticalBands.Pon,
+        };
+
+        SignalGauge.Position(bands.Peak, bands.DomainLow, bands.DomainHigh).Should().Be(50);
+    }
+
+    [Fact]
+    public void TheTrackStillCoversEveryGradedBound()
+    {
+        var bands = OpticalBands.Pon;
+
+        bands.DomainLow.Should().BeLessThan(bands.FairLow);
+        bands.DomainHigh.Should().BeGreaterThan(bands.FairHigh);
+    }
+
     [Fact]
     public void ClassFor_IsEmptyWithoutAReading()
     {


### PR DESCRIPTION
Follow-on polish for the dashboard signal gauges, from testing #1161 on the boxes.

## Fiber ONT Stats

- **The gauge centers on its peak reading** - the track ran from `FairLow - 2` to `FairHigh + 2`, whose middle is -16 dBm for PON rather than the -18 peak. The best possible reading therefore sat at 43% of the bar, and a healthy -19.6 dBm showed its green visibly below the middle. The domain is now symmetric about the peak, taking the wider side as the half span so no graded bound gets clipped.

## Dashboard

- **The model block is inset from the card edge** - 0.4rem on desktop, 0.25rem on mobile, where the row is tighter.

## Testing

Three tests added: the peak lands at exactly 50% for all three band sets (PON, Active Ethernet, external ONT), and the track still covers every graded bound after the domain change. 28 passing in `SignalGaugeTests`.

## Note

These three commits were on `feature/cm-comcast-business` after #1161 was squash merged, so they are cherry-picked onto a fresh branch off `dev` rather than rebased. Content is byte-identical to what was tested on the NAS and Mac boxes.
