### PR TITLE
Cellular modem monitoring: reach GL.iNet SoC modems, record device and module versions, and add status tables to every Monitoring tab

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1297,30 +1297,36 @@ the reference doc's "no internet" path for APs/switches.
 - [ ] Investigate per-device-type command selection for the syswrapper path: APs/switches use
   `syswrapper.sh upgrade2 &`, gateways may differ. The reference doc covers both cases.
 
-## Monitored device firmware: fill in SoftwareVersion for the rest
+## Monitored device versions: fill in SoftwareVersion / HostVersion for the rest
 
-`CellularModemStats.SoftwareVersion` is the precedent, populated by the GL.iNet provider from GL's
-`cellular.modem info`. The field is deliberately one field for both words: "software version" and
-"firmware version" are the same thing on this class of device, so the model carries one value and
-the display uses whatever the vendor calls it. `HardwareVersion` stays separate, added only where a
-provider actually reports one (only Starlink does today).
+`CellularModemStats` carries the pair, with the GL.iNet provider populating `SoftwareVersion` from
+GL's `cellular.modem info`. The split is by LAYER, not by vendor wording - firmware is software, so
+there is no separate FirmwareVersion:
 
-Two providers already READ a firmware string and drop it:
+- `SoftwareVersion` - the build of the thing being monitored (the modem, the ONT, the cable modem,
+  the dish). `StarlinkStats.SoftwareVersion` already holds exactly this.
+- `HostVersion` - the device it sits inside, when that is a separate device: the GL router around a
+  Quectel module, the Starlink router in front of a dish. Rarely populated; null is normal.
+
+`HardwareVersion` stays its own concern, added only where a provider reports one (Starlink today).
+
+Two providers already READ a version string and drop it:
 
 - `QuantumQ1000kOntProvider` asks for `SoftwareVersion` and `HardwareVersion` in its query string
   and parses them, with nowhere to put them.
 - The cable modem status pages expose it under varying labels (Arris "Software Version", Netgear
-  "Firmware Version").
+  "Firmware Version") - both are `SoftwareVersion` under the layer rule.
 
-- [ ] Add `SoftwareVersion` to `CableModemStats` and `OntStats`, matching the shape on
-  `CellularModemStats` and `StarlinkStats`.
+- [ ] Add `SoftwareVersion` and `HostVersion` to `CableModemStats` and `OntStats`, and `HostVersion`
+  to `StarlinkStats` (its router, when not in bypass).
 - [ ] Populate from the providers that already have the value in hand, starting with
   `QuantumQ1000kOntProvider`.
-- [ ] Surface it on the Cable Modem Stats, ONT Stats and Cellular Stats cards next to the model.
-  Label per the device's own wording, not the field name - a cable modem owner reads "Firmware
-  Version" on the modem's own page and expects that word on ours. Copy needs sign-off.
+- [ ] Populate `HostVersion` for GL.iNet from the router's own build - one more ubus call in
+  `GlModemTransport`'s discovery.
+- [ ] Surface on the Cable Modem Stats, ONT Stats and Cellular Stats cards next to the model. Label
+  per the device's own wording, not the field name - a cable modem owner reads "Firmware Version"
+  on the modem's own page and expects that word on ours. Copy needs sign-off.
 - [ ] Decide whether the other cellular providers can source it (qmicli has `--dms-get-revision`).
-  Leaving it null where unavailable is fine and expected.
 
-Deliberately NOT written to InfluxDB: it is near-static, so a per-sample string field is waste.
-Revisit only if someone wants to correlate a fleet issue against firmware over time.
+Deliberately NOT written to InfluxDB: near-static, so a per-sample string field is waste. Revisit
+only to correlate a fleet issue against version over time.

--- a/TODO.md
+++ b/TODO.md
@@ -1296,3 +1296,31 @@ the reference doc's "no internet" path for APs/switches.
   `TriggerUpgradeAsync` both fail, or after a device cycles back on the old version.
 - [ ] Investigate per-device-type command selection for the syswrapper path: APs/switches use
   `syswrapper.sh upgrade2 &`, gateways may differ. The reference doc covers both cases.
+
+## Monitored device firmware: fill in SoftwareVersion for the rest
+
+`CellularModemStats.SoftwareVersion` is the precedent, populated by the GL.iNet provider from GL's
+`cellular.modem info`. The field is deliberately one field for both words: "software version" and
+"firmware version" are the same thing on this class of device, so the model carries one value and
+the display uses whatever the vendor calls it. `HardwareVersion` stays separate, added only where a
+provider actually reports one (only Starlink does today).
+
+Two providers already READ a firmware string and drop it:
+
+- `QuantumQ1000kOntProvider` asks for `SoftwareVersion` and `HardwareVersion` in its query string
+  and parses them, with nowhere to put them.
+- The cable modem status pages expose it under varying labels (Arris "Software Version", Netgear
+  "Firmware Version").
+
+- [ ] Add `SoftwareVersion` to `CableModemStats` and `OntStats`, matching the shape on
+  `CellularModemStats` and `StarlinkStats`.
+- [ ] Populate from the providers that already have the value in hand, starting with
+  `QuantumQ1000kOntProvider`.
+- [ ] Surface it on the Cable Modem Stats, ONT Stats and Cellular Stats cards next to the model.
+  Label per the device's own wording, not the field name - a cable modem owner reads "Firmware
+  Version" on the modem's own page and expects that word on ours. Copy needs sign-off.
+- [ ] Decide whether the other cellular providers can source it (qmicli has `--dms-get-revision`).
+  Leaving it null where unavailable is fine and expected.
+
+Deliberately NOT written to InfluxDB: it is near-static, so a per-sample string field is waste.
+Revisit only if someone wants to correlate a fleet issue against firmware over time.

--- a/TODO.md
+++ b/TODO.md
@@ -1326,7 +1326,9 @@ Two providers already READ a version string and drop it:
 - [ ] Surface on the Cable Modem Stats, ONT Stats and Cellular Stats cards next to the model. Label
   per the device's own wording, not the field name - a cable modem owner reads "Firmware Version"
   on the modem's own page and expects that word on ours. Copy needs sign-off.
-- [ ] Decide whether the other cellular providers can source it (qmicli has `--dms-get-revision`).
+- [ ] `HostVersion` for UniFi modems: the U5G-Max / U-LTE / U5G-Backup device's own UniFi firmware,
+  which comes from the console's device record, not from the modem over SSH. `SoftwareVersion` is
+  already populated there from `--dms-get-revision`.
 
 Deliberately NOT written to InfluxDB: near-static, so a per-sample string field is waste. Revisit
 only to correlate a fleet issue against version over time.

--- a/TODO.md
+++ b/TODO.md
@@ -1323,12 +1323,15 @@ Two providers already READ a version string and drop it:
   `QuantumQ1000kOntProvider`.
 - [ ] Populate `HostVersion` for GL.iNet from the router's own build - one more ubus call in
   `GlModemTransport`'s discovery.
-- [ ] Surface on the Cable Modem Stats, ONT Stats and Cellular Stats cards next to the model. Label
-  per the device's own wording, not the field name - a cable modem owner reads "Firmware Version"
-  on the modem's own page and expects that word on ours. Copy needs sign-off.
+- [ ] Surface on the Cable Modem Stats and ONT Stats cards as a tooltip on the make/model badge
+  (`.cm-model`), matching what Cellular Stats does - the versions are reference data, not something
+  worth a permanent row. Label per the device's own wording, not the field name: a cable modem owner
+  reads "Firmware Version" on the modem's own page and expects that word on ours. Copy needs sign-off.
 - [ ] `HostVersion` for UniFi modems: the U5G-Max / U-LTE / U5G-Backup device's own UniFi firmware,
   which comes from the console's device record, not from the modem over SSH. `SoftwareVersion` is
   already populated there from `--dms-get-revision`.
 
-Deliberately NOT written to InfluxDB: near-static, so a per-sample string field is waste. Revisit
-only to correlate a fleet issue against version over time.
+Written to InfluxDB as FIELDS on `cellular` (`software_version`, `host_version`) - correlating
+performance against firmware is the point of collecting them. Never as tags: a tag is part of the
+series key, so it would fork every modem's series the day it upgrades. Do the same for the cable
+modem and ONT measurements when their fields land.

--- a/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
@@ -57,6 +57,15 @@ public class CellularModemStats
     /// </summary>
     public string? HostVersion { get; set; }
 
+    /// <summary>
+    /// Maker of the radio module itself (Quectel, Sierra Wireless), which is not the brand
+    /// the owner bought - that is UniFi or GL.iNet, and comes from the provider.
+    /// </summary>
+    public string? ModuleVendor { get; set; }
+
+    /// <summary>Model of the radio module (RG650V-NA, EM9291). <see cref="SoftwareVersion"/> is its build.</summary>
+    public string? ModuleModel { get; set; }
+
     // Connection status
     public string RegistrationState { get; set; } = "";
     public string Carrier { get; set; } = "";

--- a/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
@@ -45,6 +45,18 @@ public class CellularModemStats
     public string ModemName { get; set; } = "";
     public string ModemModel { get; set; } = "";
 
+    /// <summary>
+    /// The modem's own build, whatever its vendor calls it - "software version" and
+    /// "firmware version" are the same thing on this class of device, so they share one
+    /// field and the display picks the vendor's word. Null when the provider cannot read it.
+    ///
+    /// On a host-plus-module device (a GL.iNet router carrying a Quectel module) this is the
+    /// MODULE's firmware, not the router's: the modem is what is being monitored. Matches
+    /// StarlinkStats.SoftwareVersion, which is where this pair started; a HardwareVersion
+    /// belongs beside it if a provider ever reports one.
+    /// </summary>
+    public string? SoftwareVersion { get; set; }
+
     // Connection status
     public string RegistrationState { get; set; } = "";
     public string Carrier { get; set; } = "";

--- a/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
+++ b/src/NetworkOptimizer.Monitoring/Models/CellularModemStats.cs
@@ -46,16 +46,16 @@ public class CellularModemStats
     public string ModemModel { get; set; } = "";
 
     /// <summary>
-    /// The modem's own build, whatever its vendor calls it - "software version" and
-    /// "firmware version" are the same thing on this class of device, so they share one
-    /// field and the display picks the vendor's word. Null when the provider cannot read it.
-    ///
-    /// On a host-plus-module device (a GL.iNet router carrying a Quectel module) this is the
-    /// MODULE's firmware, not the router's: the modem is what is being monitored. Matches
-    /// StarlinkStats.SoftwareVersion, which is where this pair started; a HardwareVersion
-    /// belongs beside it if a provider ever reports one.
+    /// Build of the thing being monitored, whatever its vendor calls it - firmware is software.
+    /// On a GL.iNet router this is the Quectel module's, not the router's. Null when unreadable.
     /// </summary>
     public string? SoftwareVersion { get; set; }
+
+    /// <summary>
+    /// Build of the device the monitored one sits inside, when that is a separate device -
+    /// the router carrying a cellular module. Usually null.
+    /// </summary>
+    public string? HostVersion { get; set; }
 
     // Connection status
     public string RegistrationState { get; set; } = "";

--- a/src/NetworkOptimizer.Monitoring/QmicliParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QmicliParser.cs
@@ -322,4 +322,39 @@ public static class QmicliParser
 
         return revision.Length > 0 ? revision : null;
     }
+
+    /// <summary>
+    /// Reads a single quoted value out of a qmicli response line
+    /// (<c>Model: 'EM9291'</c> for label "Device model").
+    /// </summary>
+    public static string? ParseQuotedValue(string? output, string label)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        var match = Regex.Match(output, @"'([^']+)'");
+        if (!match.Success)
+            return null;
+
+        var value = match.Groups[1].Value.Trim();
+        return value.Length > 0 ? value : null;
+    }
+
+    /// <summary>
+    /// Module maker from <c>qmicli --dms-get-manufacturer</c>, trimmed to the name people use:
+    /// "Sierra Wireless, Incorporated" is the legal entity, "Sierra Wireless" is the brand.
+    /// </summary>
+    public static string? ParseVendor(string? output)
+    {
+        var value = ParseQuotedValue(output, "Manufacturer");
+        if (value == null)
+            return null;
+
+        var comma = value.IndexOf(',');
+        if (comma > 0)
+            value = value[..comma];
+
+        value = value.Trim();
+        return value.Length > 0 ? value : null;
+    }
 }

--- a/src/NetworkOptimizer.Monitoring/QmicliParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QmicliParser.cs
@@ -300,4 +300,26 @@ public static class QmicliParser
         }
         return false;
     }
+
+    /// <summary>
+    /// Reads the module firmware version out of <c>qmicli --dms-get-revision</c>
+    /// (<c>Revision: 'SWIX65C_03.04.10.01 00b8ca jenkins 2025/06/18 05:56:16'</c>).
+    /// Only the leading token is the version; the rest is the vendor's build metadata.
+    /// </summary>
+    public static string? ParseRevision(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        var match = Regex.Match(output, @"Revision:\s*'([^']+)'");
+        if (!match.Success)
+            return null;
+
+        var revision = match.Groups[1].Value.Trim();
+        var space = revision.IndexOf(' ');
+        if (space > 0)
+            revision = revision[..space];
+
+        return revision.Length > 0 ? revision : null;
+    }
 }

--- a/src/NetworkOptimizer.Monitoring/QmicliParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QmicliParser.cs
@@ -333,11 +333,7 @@ public static class QmicliParser
         if (string.IsNullOrWhiteSpace(output))
             return null;
 
-        var match = Regex.Match(output, @"'([^']+)'");
-        if (!match.Success)
-            return null;
-
-        var value = match.Groups[1].Value.Trim();
+        var value = ExtractQuotedValue(output).Trim();
         return value.Length > 0 ? value : null;
     }
 

--- a/src/NetworkOptimizer.Monitoring/QmicliParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QmicliParser.cs
@@ -324,10 +324,11 @@ public static class QmicliParser
     }
 
     /// <summary>
-    /// Reads a single quoted value out of a qmicli response line
-    /// (<c>Model: 'EM9291'</c> for label "Device model").
+    /// Reads the single quoted value out of a one-value qmicli response
+    /// (<c>Model: 'EM9291'</c>). The device path in the header is bracketed, not quoted,
+    /// so the first quoted run is the value.
     /// </summary>
-    public static string? ParseQuotedValue(string? output, string label)
+    public static string? ParseQuotedValue(string? output)
     {
         if (string.IsNullOrWhiteSpace(output))
             return null;
@@ -346,7 +347,7 @@ public static class QmicliParser
     /// </summary>
     public static string? ParseVendor(string? output)
     {
-        var value = ParseQuotedValue(output, "Manufacturer");
+        var value = ParseQuotedValue(output);
         if (value == null)
             return null;
 

--- a/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
@@ -118,7 +118,7 @@ public static class QuectelAtParser
                 RadioInterface = "5gnr",
                 BandClass = NormalizeBandClass(bandStr, "nr"),
                 Channel = ParseIntField(fields[9]) ?? 0,
-                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[11])),
+                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[11]), "nr"),
             };
         }
     }
@@ -178,7 +178,7 @@ public static class QuectelAtParser
                 RadioInterface = "lte",
                 BandClass = NormalizeBandClass(bandInd, "lte"),
                 Channel = ParseIntField(fields[lteIdx + 1 + 5]) ?? 0,
-                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[lteIdx + 1 + 8])), // DL_bandwidth
+                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[lteIdx + 1 + 8]), "lte"), // DL_bandwidth
             };
         }
     }
@@ -219,7 +219,7 @@ public static class QuectelAtParser
                 RadioInterface = "5gnr",
                 BandClass = NormalizeBandClass(bandStr, "nr"),
                 Channel = ParseIntField(fields[nsaIdx + 7]) ?? 0,
-                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[nsaIdx + 9])),
+                BandwidthMhz = ParseBandwidthMhz(Unquote(fields[nsaIdx + 9]), "nr"),
             };
         }
     }
@@ -296,19 +296,58 @@ public static class QuectelAtParser
         return bandStr;
     }
 
+    /// <summary>LTE DL/UL bandwidth enum from the Quectel AT manual, indexed by the reported value.</summary>
+    private static readonly int[] LteBandwidthMhz = { 1, 3, 5, 10, 15, 20 };
+
+    /// <summary>NR bandwidth enum from the Quectel AT manual, indexed by the reported value.</summary>
+    private static readonly int[] NrBandwidthMhz = { 5, 10, 15, 20, 25, 30, 40, 50, 60, 70, 80, 90, 100, 200, 400 };
+
     /// <summary>
-    /// Parse bandwidth string to MHz. GL-iNet firmware reports the direct MHz value
-    /// (e.g. "5", "10", "20", "100").
+    /// Parse a bandwidth field to MHz. Quectel reports an index into the enum for its
+    /// RAT, not a MHz figure - an RG650V on band n41 at 90 MHz reports 11. Values past
+    /// the end of the enum are taken literally, because firmware that reports MHz
+    /// directly is only distinguishable by being out of range.
     /// </summary>
-    private static int? ParseBandwidthMhz(string? bwStr)
+    private static int? ParseBandwidthMhz(string? bwStr, string rat)
     {
         if (string.IsNullOrEmpty(bwStr))
             return null;
 
         bwStr = bwStr.Replace("MHz", "", StringComparison.OrdinalIgnoreCase).Trim();
 
-        if (int.TryParse(bwStr, out var val) && val > 0)
-            return val;
+        if (!int.TryParse(bwStr, out var val) || val < 0)
+            return null;
+
+        var table = rat == "nr" ? NrBandwidthMhz : LteBandwidthMhz;
+        if (val < table.Length)
+            return table[val];
+
+        return val > 0 ? val : null;
+    }
+
+    /// <summary>
+    /// Read the operator name out of an <c>AT+COPS?</c> response
+    /// (<c>+COPS: 0,0,"T-Mobile",13</c>). Returns null when the modem is not
+    /// registered, which it reports as a bare <c>+COPS: 0</c>.
+    /// </summary>
+    public static string? ParseOperator(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        foreach (var line in output.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!line.StartsWith("+COPS:", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var fields = SplitFields(line.Substring("+COPS:".Length).Trim());
+            if (fields.Length < 3)
+                continue;
+
+            var name = Unquote(fields[2]);
+            if (!string.IsNullOrWhiteSpace(name))
+                return name;
+        }
 
         return null;
     }

--- a/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
@@ -428,10 +428,14 @@ public static class QuectelAtParser
 
         foreach (var line in output.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
         {
+            // A modem that was just upgraded is a modem that just rebooted, so its boot notices
+            // (RDY, +CPIN: READY, +QUSIM) are most likely on exactly the poll this matters on.
+            // Every one of them is either "+"-prefixed or RDY; the bare answer is neither.
             if (line.Equals("OK", StringComparison.OrdinalIgnoreCase) ||
                 line.Equals("ERROR", StringComparison.OrdinalIgnoreCase) ||
+                line.Equals("RDY", StringComparison.OrdinalIgnoreCase) ||
                 line.StartsWith("AT+", StringComparison.OrdinalIgnoreCase) ||
-                line.StartsWith("+CME", StringComparison.OrdinalIgnoreCase))
+                (line.StartsWith('+') && !line.StartsWith("+CGMR:", StringComparison.OrdinalIgnoreCase)))
             {
                 continue;
             }

--- a/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
+++ b/src/NetworkOptimizer.Monitoring/QuectelAtParser.cs
@@ -416,4 +416,35 @@ public static class QuectelAtParser
 
         return int.TryParse(field, out var val) ? val : null;
     }
+
+    /// <summary>
+    /// The firmware revision from <c>AT+CGMR</c>, which answers with the bare version on a line
+    /// of its own. Returns null when the modem echoed nothing usable.
+    /// </summary>
+    public static string? ParseRevisionResponse(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output))
+            return null;
+
+        foreach (var line in output.Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (line.Equals("OK", StringComparison.OrdinalIgnoreCase) ||
+                line.Equals("ERROR", StringComparison.OrdinalIgnoreCase) ||
+                line.StartsWith("AT+", StringComparison.OrdinalIgnoreCase) ||
+                line.StartsWith("+CME", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Some firmware prefixes the value; most answers are bare.
+            var value = line.StartsWith("+CGMR:", StringComparison.OrdinalIgnoreCase)
+                ? line["+CGMR:".Length..].Trim()
+                : line;
+
+            if (value.Length > 0)
+                return value;
+        }
+
+        return null;
+    }
 }

--- a/src/NetworkOptimizer.Storage/Interfaces/IModemRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/IModemRepository.cs
@@ -26,6 +26,10 @@ public interface IModemRepository
     /// LastError, and UpdatedAt - never Enabled. Skips (and returns false) when the config
     /// was disabled meanwhile, so an in-flight poll can neither resurrect a paused modem nor
     /// overwrite its frozen state. Returns true when the result was persisted.
+    ///
+    /// <paramref name="detectedModel"/> fills in ModemType when it still holds the
+    /// provider's generic placeholder, so a model the modem reports about itself replaces
+    /// a stand-in like "GL-iNet". A model the user typed is never overwritten.
     /// </summary>
-    Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default);
+    Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, string? detectedModel = null, CancellationToken cancellationToken = default);
 }

--- a/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/ModemRepository.cs
@@ -178,7 +178,14 @@ public class ModemRepository : IModemRepository
         }
     }
 
-    public async Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Placeholders safe to replace with a model the modem reports about itself. Only the
+    /// GL-iNet one qualifies: its model comes from the router's cellular service, whereas
+    /// a Netgear hotspot reports a user-settable device name in the same field.
+    /// </summary>
+    private static readonly string[] PlaceholderModemTypes = { "GL-iNet" };
+
+    public async Task<bool> UpdateModemPollResultAsync(int id, DateTime? lastPolled, string? lastError, string? detectedModel = null, CancellationToken cancellationToken = default)
     {
         try
         {
@@ -191,6 +198,14 @@ public class ModemRepository : IModemRepository
             if (lastPolled.HasValue)
                 config.LastPolled = lastPolled.Value;
             config.LastError = lastError;
+
+            if (!string.IsNullOrWhiteSpace(detectedModel) &&
+                detectedModel != config.ModemType &&
+                (string.IsNullOrWhiteSpace(config.ModemType) || PlaceholderModemTypes.Contains(config.ModemType)))
+            {
+                config.ModemType = detectedModel;
+            }
+
             config.UpdatedAt = DateTime.UtcNow;
 
             await _context.SaveChangesAsync(cancellationToken);

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -940,7 +940,9 @@ from(bucket: ""{_longtermBucket}"")
         int? neighborCount = null,
         bool? nsaAvailable = null,
         string? softwareVersion = null,
-        string? hostVersion = null)
+        string? hostVersion = null,
+        string? moduleVendor = null,
+        string? moduleModel = null)
     {
         if (!IsConfigured) return Task.CompletedTask;
         var point = PointData.Measurement("cellular")
@@ -977,6 +979,8 @@ from(bucket: ""{_longtermBucket}"")
         // whole point, and a tag would fork every modem's series the day it upgrades.
         if (!string.IsNullOrEmpty(softwareVersion)) point = point.Field("software_version", softwareVersion);
         if (!string.IsNullOrEmpty(hostVersion)) point = point.Field("host_version", hostVersion);
+        if (!string.IsNullOrEmpty(moduleVendor)) point = point.Field("module_vendor", moduleVendor);
+        if (!string.IsNullOrEmpty(moduleModel)) point = point.Field("module_model", moduleModel);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -938,7 +938,9 @@ from(bucket: ""{_longtermBucket}"")
         int? cellId = null,
         int? tac = null,
         int? neighborCount = null,
-        bool? nsaAvailable = null)
+        bool? nsaAvailable = null,
+        string? softwareVersion = null,
+        string? hostVersion = null)
     {
         if (!IsConfigured) return Task.CompletedTask;
         var point = PointData.Measurement("cellular")
@@ -970,6 +972,11 @@ from(bucket: ""{_longtermBucket}"")
         // Whether the serving cell offers EN-DC. Charting it dates the moment the anchor
         // went bad, rather than leaving it to be noticed days later.
         if (nsaAvailable.HasValue) point = point.Field("nsa_available", nsaAvailable.Value);
+
+        // Versions as fields, never tags: correlating performance against firmware is the
+        // whole point, and a tag would fork every modem's series the day it upgrades.
+        if (!string.IsNullOrEmpty(softwareVersion)) point = point.Field("software_version", softwareVersion);
+        if (!string.IsNullOrEmpty(hostVersion)) point = point.Field("host_version", hostVersion);
 
         Enqueue(point, longterm: true);
         return Task.CompletedTask;

--- a/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
+++ b/src/NetworkOptimizer.Storage/Services/MonitoringInfluxClient.cs
@@ -2521,7 +2521,7 @@ from(bucket: ""{_longtermBucket}"")
   |> range(start: {ToFluxInstant(from)}, stop: {ToFluxInstant(to)})
   |> filter(fn: (r) => r._measurement == ""cellular"")
   {modemFilter}
-  |> filter(fn: (r) => r._field == ""rsrp"" or r._field == ""rsrq"" or r._field == ""snr"" or r._field == ""rssi"" or r._field == ""signal_quality"" or r._field == ""band"" or r._field == ""carrier"")
+  |> filter(fn: (r) => r._field == ""rsrp"" or r._field == ""rsrq"" or r._field == ""snr"" or r._field == ""rssi"" or r._field == ""signal_quality"" or r._field == ""band"" or r._field == ""carrier"" or r._field == ""bandwidth_mhz"" or r._field == ""cell_id"" or r._field == ""roaming"" or r._field == ""software_version"" or r._field == ""host_version"" or r._field == ""module_vendor"" or r._field == ""module_model"")
   |> aggregateWindow(every: {ToFluxDuration(window)}, fn: last, createEmpty: false)
   |> pivot(rowKey:[""_time""], columnKey: [""_field""], valueColumn: ""_value"")
 ";
@@ -2548,6 +2548,13 @@ from(bucket: ""{_longtermBucket}"")
                 NetworkMode = mode,
                 Band = record.GetValueByKey("band") as string,
                 Carrier = record.GetValueByKey("carrier") as string,
+                BandwidthMhz = AsIntOrNull(record.GetValueByKey("bandwidth_mhz")),
+                CellId = AsLongOrNull(record.GetValueByKey("cell_id")),
+                IsRoaming = record.GetValueByKey("roaming") as bool?,
+                SoftwareVersion = record.GetValueByKey("software_version") as string,
+                HostVersion = record.GetValueByKey("host_version") as string,
+                ModuleVendor = record.GetValueByKey("module_vendor") as string,
+                ModuleModel = record.GetValueByKey("module_model") as string,
             });
         }
         // Order on assembly: the Flux result is NOT globally ordered. pivot emits a separate table
@@ -3855,6 +3862,13 @@ from(bucket: ""{_longtermBucket}"")
         public string? NetworkMode { get; init; }
         public string? Band { get; init; }
         public string? Carrier { get; init; }
+        public int? BandwidthMhz { get; init; }
+        public long? CellId { get; init; }
+        public bool? IsRoaming { get; init; }
+        public string? SoftwareVersion { get; init; }
+        public string? HostVersion { get; init; }
+        public string? ModuleVendor { get; init; }
+        public string? ModuleModel { get; init; }
     }
 
     public record CmPoint

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1821,11 +1821,11 @@
                 <div>
                     <h4 class="event-type-group-header">Starlink</h4>
                     <div class="event-type-key-list">
-                        <div @onclick='() => SelectEventType("starlink.dish_alert")'><code>starlink.dish_alert</code> <span>Dish reporting a fault or out of service</span></div>
+                        <div @onclick='() => SelectEventType("starlink.dish_alert")'><code>starlink.dish_alert</code> <span>Terminal reporting a fault or out of service</span></div>
                         <div @onclick='() => SelectEventType("starlink.obstructed")'><code>starlink.obstructed</code> <span>Sky view blocked or signal persistently low</span></div>
-                        <div @onclick='() => SelectEventType("starlink.alignment_drift")'><code>starlink.alignment_drift</code> <span>Dish pointing away from where it normally sits</span></div>
+                        <div @onclick='() => SelectEventType("starlink.alignment_drift")'><code>starlink.alignment_drift</code> <span>Terminal pointing away from where it normally sits</span></div>
                         <div @onclick='() => SelectEventType("starlink.eth_speed_degraded")'><code>starlink.eth_speed_degraded</code> <span>Ethernet link negotiated below its usual speed</span></div>
-                        <div @onclick='() => SelectEventType("starlink.outage_burst")'><code>starlink.outage_burst</code> <span>Dish outage seconds piling up over a day</span></div>
+                        <div @onclick='() => SelectEventType("starlink.outage_burst")'><code>starlink.outage_burst</code> <span>Terminal outage seconds piling up over a day</span></div>
                         <div @onclick='() => SelectEventType("starlink.service_restricted")'><code>starlink.service_restricted</code> <span>Service became rate limited</span></div>
                         <div @onclick='() => SelectEventType("starlink.recovered")'><code>starlink.recovered</code> <span>A dish condition cleared</span></div>
                         <div @onclick='() => SelectEventType("starlink.*")'><code>starlink.*</code> <span>All Starlink events</span></div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1121,6 +1121,7 @@
                     <div class="chart-header"><h3 class="chart-title">FEC Errors (per interval)</h3></div>
                     <div class="cm-errors-chart"></div>
                 </div>
+                <div class="cm-details"></div>
                 <div class="cm-stats-table"></div>
             </div>
         </div>
@@ -1422,6 +1423,7 @@
                     <div class="chart-header"><h3 class="chart-title">Signal Quality</h3></div>
                     <div class="cellular-quality-chart"></div>
                 </div>
+                <div class="cellular-details"></div>
                 <div class="cellular-stats-table"></div>
             </div>
         </div>
@@ -1537,6 +1539,7 @@
                     <div class="chart-header"><h3 class="chart-title">Alignment Offset (deg)</h3></div>
                     <div class="starlink-alignment-chart"></div>
                 </div>
+                <div class="starlink-details"></div>
                 <div class="starlink-stats-table"></div>
             </div>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -1520,7 +1520,7 @@
                     <div class="starlink-power-chart"></div>
                 </div>
                 <div class="chart-card">
-                    <div class="chart-header"><h3 class="chart-title">Dish Ping Drop Rate (%)</h3></div>
+                    <div class="chart-header"><h3 class="chart-title">Terminal Ping Drop Rate (%)</h3></div>
                     <div class="starlink-drop-chart"></div>
                 </div>
                 <div class="chart-card">

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -1435,9 +1435,9 @@
                                     <input type="password" class="form-control" @bind="editingModem.Password" autocomplete="new-password" data-1p-ignore data-lpignore="true" data-bwignore />
                                 </div>
                                 <div class="form-group" style="flex: 1;">
-                                    <label class="form-label">USB Bus Path (optional)</label>
+                                    <label class="form-label">Modem Bus (optional)</label>
                                     <input type="text" class="form-control" @bind="editingModem.QmiDevice" placeholder="e.g. 1-1.2" />
-                                    <small class="form-help">Leave empty to auto-detect. Run <code>gl_modem -l</code> on the router to list modem paths.</small>
+                                    <small class="form-help">Leave empty to auto-detect. Set this only if detection fails: <code>cpu</code> for a modem built into the router, or a USB path like 1-1.2 for a plug-in module.</small>
                                 </div>
                             </div>
                         }
@@ -6833,7 +6833,7 @@
             }
         }
 
-        // GL-iNet modems use the TransportPath for USB bus path, not QMI device
+        // GL-iNet modems use the TransportPath for the gl_modem bus, not a QMI device
         if (isQuectelProvider)
         {
             if (string.IsNullOrEmpty(editingModem.ModemType) ||

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -122,8 +122,23 @@
                     <button class="nav-btn" @onclick="NextModem" @onclick:stopPropagation disabled="@(currentModemIndex >= configuredModems.Count - 1)">›</button>
                 }
             </div>
-            <div class="device-icon">
-                <img src="@GetDeviceIconPath()" alt="@(modemStats.ModemModel) icon" class="device-image" onerror="this.style.display='none'" />
+            <div class="modem-identity">
+                @if (DeviceBrand() != null)
+                {
+                    <div class="cm-model" data-tooltip="@DeviceTooltip()">
+                        <span class="cm-model-name">@DeviceBrand()</span>
+                        @if (!string.IsNullOrWhiteSpace(modemStats.ModemModel))
+                        {
+                            <span class="cm-model-number">@modemStats.ModemModel</span>
+                        }
+                    </div>
+                }
+                @if (IsUniFiModem())
+                {
+                    <div class="device-icon">
+                        <img src="@GetDeviceIconPath()" alt="@(modemStats.ModemModel) icon" class="device-image" onerror="this.style.display='none'" />
+                    </div>
+                }
             </div>
         </div>
 
@@ -235,6 +250,13 @@
                         <span class="info-value">@modemStats.ActiveBand.BandClass (@modemStats.ActiveBand.RadioInterface)</span>
                     </div>
                 }
+                @if (ModuleName() != null)
+                {
+                    <div class="info-item">
+                        <span class="info-label">Module:</span>
+                        <span class="info-value" data-tooltip="@ModuleTooltip()">@ModuleName()</span>
+                    </div>
+                }
                 @if (modemStats.ServingCell != null)
                 {
                     <div class="info-item">
@@ -302,6 +324,11 @@
         display: flex;
         flex-direction: column;
         gap: 1rem;
+    }
+
+    .modem-identity {
+        display: flex;
+        align-items: center;
     }
 
     .device-icon {
@@ -747,6 +774,43 @@
             }
         }
     }
+
+    /// <summary>Provider key of the modem being shown, which decides the brand and the icon.</summary>
+    private string? CurrentProvider =>
+        configuredModems.Count > 0 && currentModemIndex < configuredModems.Count
+            ? configuredModems[currentModemIndex].Provider
+            : null;
+
+    private bool IsUniFiModem() => CurrentProvider == "qmicli";
+
+    /// <summary>
+    /// The brand the owner bought, which is not the module maker inside it. Taken from the
+    /// provider rather than the model string, which carries no brand on any of them.
+    /// </summary>
+    private string? DeviceBrand() => CurrentProvider switch
+    {
+        "qmicli" => "UniFi",
+        "quectel-at" => "GL.iNet",
+        "netgear-nighthawk-hotspot" => "Netgear",
+        _ => null,
+    };
+
+    private string? DeviceTooltip() =>
+        string.IsNullOrWhiteSpace(modemStats?.HostVersion) ? null : $"Device firmware {modemStats.HostVersion}";
+
+    private string? ModuleName()
+    {
+        var vendor = modemStats?.ModuleVendor;
+        var model = modemStats?.ModuleModel;
+
+        if (string.IsNullOrWhiteSpace(model))
+            return string.IsNullOrWhiteSpace(vendor) ? null : vendor;
+
+        return string.IsNullOrWhiteSpace(vendor) ? model : $"{vendor} {model}";
+    }
+
+    private string? ModuleTooltip() =>
+        string.IsNullOrWhiteSpace(modemStats?.SoftwareVersion) ? null : $"Module firmware {modemStats.SoftwareVersion}";
 
     private string? GetDeviceIconPath()
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/CellularStatsPanel.razor
@@ -122,10 +122,10 @@
                     <button class="nav-btn" @onclick="NextModem" @onclick:stopPropagation disabled="@(currentModemIndex >= configuredModems.Count - 1)">›</button>
                 }
             </div>
-            <div class="modem-identity">
+            <div class="modem-identity" data-tooltip="@DeviceTooltip()" data-tooltip-wide>
                 @if (DeviceBrand() != null)
                 {
-                    <div class="cm-model" data-tooltip="@DeviceTooltip()">
+                    <div class="cm-model">
                         <span class="cm-model-name">@DeviceBrand()</span>
                         @if (!string.IsNullOrWhiteSpace(modemStats.ModemModel))
                         {
@@ -254,7 +254,7 @@
                 {
                     <div class="info-item">
                         <span class="info-label">Module:</span>
-                        <span class="info-value" data-tooltip="@ModuleTooltip()">@ModuleName()</span>
+                        <span class="info-value" data-tooltip="@ModuleTooltip()" data-tooltip-wide>@ModuleName()</span>
                     </div>
                 }
                 @if (modemStats.ServingCell != null)

--- a/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/StarlinkStatsPanel.razor
@@ -86,7 +86,7 @@
                         </span>
                     </div>
                     <div class="starlink-metric-row">
-                        <span class="starlink-metric-label">Dish loss</span>
+                        <span class="starlink-metric-label">Terminal loss</span>
                         <span class="starlink-metric-value @GetDropRateClass()">@FormatDropRate()</span>
                     </div>
                     <div class="starlink-metric-row">

--- a/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CellularChartEndpoints.cs
@@ -62,12 +62,30 @@ public static class CellularChartEndpoints
                     ? $"{modemName} ({mode})"
                     : modemName;
 
+                // Current state, sent once per modem rather than on every point: these fields
+                // change rarely and the detail table only ever shows the latest.
+                var pts = kvp.Value;
+                string? Latest(Func<MonitoringInfluxClient.CellularPoint, string?> pick) =>
+                    pts.Select(pick).LastOrDefault(v => !string.IsNullOrWhiteSpace(v));
+
                 return new
                 {
                     id = kvp.Key,
                     modemId = rawModemId,
                     label,
                     mode,
+                    current = new
+                    {
+                        carrier = Latest(p => p.Carrier),
+                        band = Latest(p => p.Band),
+                        bandwidthMhz = pts.Select(p => p.BandwidthMhz).LastOrDefault(v => v != null),
+                        cellId = pts.Select(p => p.CellId).LastOrDefault(v => v != null),
+                        roaming = pts.Select(p => p.IsRoaming).LastOrDefault(v => v != null),
+                        moduleVendor = Latest(p => p.ModuleVendor),
+                        moduleModel = Latest(p => p.ModuleModel),
+                        softwareVersion = Latest(p => p.SoftwareVersion),
+                        hostVersion = Latest(p => p.HostVersion),
+                    },
                     data = kvp.Value.Select(p => new
                     {
                         time = p.Time.ToString("o"),

--- a/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/CmChartEndpoints.cs
@@ -53,10 +53,18 @@ public static class CmChartEndpoints
             {
                 var name = nameMap[kvp.Key];
 
+                // Current state for the detail table, sent once per modem rather than per point.
+                var pts = kvp.Value;
+
                 return new
                 {
                     id = kvp.Key,
                     label = name,
+                    current = new
+                    {
+                        lockedDsChannels = pts.Select(p => p.LockedDsChannels).LastOrDefault(v => v != null),
+                        lockedUsChannels = pts.Select(p => p.LockedUsChannels).LastOrDefault(v => v != null),
+                    },
                     data = kvp.Value.Select(p => new
                     {
                         time = p.Time.ToString("o"),

--- a/src/NetworkOptimizer.Web/Endpoints/StarlinkChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/StarlinkChartEndpoints.cs
@@ -54,10 +54,21 @@ public static class StarlinkChartEndpoints
             {
                 var name = nameMap[kvp.Key];
 
+                // Current state for the detail table, sent once per dish rather than per point.
+                var pts = kvp.Value;
+
                 return new
                 {
                     id = kvp.Key,
                     label = name,
+                    current = new
+                    {
+                        uptimeSeconds = pts.Select(p => p.UptimeS).LastOrDefault(v => v != null),
+                        ethSpeedMbps = pts.Select(p => p.EthSpeedMbps).LastOrDefault(v => v != null),
+                        gpsSats = pts.Select(p => p.GpsSats).LastOrDefault(v => v != null),
+                        obstructed = pts.Select(p => p.FractionObstructed).LastOrDefault(v => v != null),
+                        alertCount = pts.Select(p => p.AlertCount).LastOrDefault(v => v != null),
+                    },
                     data = kvp.Value.Select(p => new
                     {
                         time = p.Time.ToString("o"),

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -15,6 +15,7 @@ using NetworkOptimizer.Web.Endpoints;
 using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.Authorization;
 using NetworkOptimizer.Web.Services.CableModemProviders;
+using NetworkOptimizer.Web.Services.CellularModemProviders;
 using NetworkOptimizer.Web.Services.Gates;
 using NetworkOptimizer.Web.Services.Identity;
 using NetworkOptimizer.Web.Services.Licensing;
@@ -330,6 +331,10 @@ builder.Services.AddScoped<SiteSpeedTestTargetResolver>();
 
 // Register SSH client service (singleton - cross-platform SSH.NET wrapper)
 builder.Services.AddSingleton<SshClientService>();
+
+// gl_modem addressing for GL.iNet routers. Singleton so the resolved bus and SIM slot
+// survive the per-site modem provider instances the registry rebuilds.
+builder.Services.AddSingleton<GlModemTransport>();
 
 // Gateway SSH per site: the registry owns one GatewaySshService per site (settings
 // from that site's DB, host fallback from that site's console). Scoped resolution of

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -1,0 +1,333 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using NetworkOptimizer.Monitoring.Providers;
+using NetworkOptimizer.Web.Services.Ssh;
+
+namespace NetworkOptimizer.Web.Services.CellularModemProviders;
+
+/// <summary>
+/// Where a GL.iNet router's modem lives and how <c>gl_modem</c> must be addressed to
+/// reach it, plus the identity its firmware reports.
+/// </summary>
+/// <param name="Bus">Value for gl_modem's <c>-B</c> flag. "cpu" for a modem integrated
+/// into the SoC, a USB path such as "1-1.2" for a plug-in module.</param>
+/// <param name="Sub">Value for gl_modem's <c>-U</c> flag, or null for firmware whose
+/// gl_modem predates the flag.</param>
+public sealed record GlModemEndpoint(
+    string? Bus,
+    int? Sub,
+    string? Model = null,
+    string? Vendor = null,
+    string? Firmware = null)
+{
+    /// <summary>Endpoint used when discovery finds nothing: let gl_modem pick the modem itself.</summary>
+    public static readonly GlModemEndpoint Unknown = new(null, null);
+
+    /// <summary>Human-readable identity for Test Connection, e.g. "Quectel RG650V-NA".</summary>
+    public string? Description =>
+        string.IsNullOrWhiteSpace(Model) ? null
+        : string.IsNullOrWhiteSpace(Vendor) ? Model
+        : $"{Capitalize(Vendor!)} {Model}";
+
+    private static string Capitalize(string s) =>
+        s.Length > 0 && char.IsLower(s[0]) ? char.ToUpperInvariant(s[0]) + s[1..] : s;
+}
+
+/// <summary>
+/// Runs AT commands on a GL.iNet router over SSH, resolving the gl_modem addressing
+/// once per modem and caching it.
+///
+/// Addressing is not guessable from the outside. A 5G unit like the E5800 carries the
+/// modem on the SoC, where the bus is the literal string "cpu" and <c>-U</c> is
+/// mandatory; a plug-in module sits on a USB path, and older firmware has no <c>-U</c>
+/// at all. Getting it wrong is silent: gl_modem prints its usage text and exits, which
+/// reads as "the modem said nothing" rather than as a bad command line.
+/// </summary>
+public sealed class GlModemTransport
+{
+    private readonly ILogger<GlModemTransport> _logger;
+    private readonly SshClientService _sshClient;
+    private readonly ConcurrentDictionary<string, GlModemEndpoint> _endpoints = new();
+
+    private const string UsageMarker = "Usage: gl_modem";
+
+    public GlModemTransport(ILogger<GlModemTransport> logger, SshClientService sshClient)
+    {
+        _logger = logger;
+        _sshClient = sshClient;
+    }
+
+    /// <summary>
+    /// Run one or more AT commands in a single SSH session. Results come back keyed by
+    /// the command that produced them.
+    /// </summary>
+    public async Task<GlModemAtResult> RunAtAsync(
+        ModemPollContext context,
+        SshConnectionInfo connection,
+        IReadOnlyList<string> atCommands,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var at in atCommands)
+        {
+            if (at.Contains('\'') || at.Contains('\n'))
+                throw new ArgumentException($"Unsupported characters in AT command: {at}");
+        }
+
+        var wasCached = _endpoints.TryGetValue(context.CacheKey, out var cached);
+        var endpoint = wasCached
+            ? cached!
+            : await DiscoverAsync(context, connection, cancellationToken);
+
+        var result = await ExecuteAsync(endpoint, connection, atCommands, cancellationToken);
+
+        // gl_modem answering with its usage text means the addressing is stale, not that
+        // the modem is silent. Rediscover once and retry before reporting a failure.
+        if (result.RejectedCommandLine && wasCached)
+        {
+            _logger.LogInformation(
+                "gl_modem rejected the command line on {Name}; rediscovering the modem endpoint", context.Name);
+            _endpoints.TryRemove(context.CacheKey, out _);
+            endpoint = await DiscoverAsync(context, connection, cancellationToken);
+            result = await ExecuteAsync(endpoint, connection, atCommands, cancellationToken);
+        }
+
+        if (result.Success)
+            _endpoints[context.CacheKey] = endpoint;
+
+        return result with { Endpoint = endpoint };
+    }
+
+    private async Task<GlModemAtResult> ExecuteAsync(
+        GlModemEndpoint endpoint,
+        SshConnectionInfo connection,
+        IReadOnlyList<string> atCommands,
+        CancellationToken cancellationToken)
+    {
+        var script = new StringBuilder();
+        for (int i = 0; i < atCommands.Count; i++)
+        {
+            if (i > 0) script.Append("; ");
+            script.Append($"echo '{SectionMarker(i)}'; ");
+            script.Append(BuildAtCommand(endpoint, atCommands[i]));
+        }
+
+        var result = await _sshClient.ExecuteCommandAsync(
+            connection, script.ToString(), cancellationToken: cancellationToken);
+
+        var combined = result.CombinedOutput ?? "";
+        if (combined.Contains(UsageMarker, StringComparison.OrdinalIgnoreCase))
+        {
+            return new GlModemAtResult
+            {
+                Success = false,
+                RejectedCommandLine = true,
+                Error = "gl_modem did not accept the command line for this modem.",
+            };
+        }
+
+        if (!result.Success)
+            return new GlModemAtResult { Success = false, Error = SshFailureSummary.Describe(combined, connection.Host) };
+
+        return new GlModemAtResult
+        {
+            Success = true,
+            Sections = SplitAtSections(result.Output ?? "", atCommands),
+        };
+    }
+
+    /// <summary>
+    /// Build the gl_modem invocation for one AT command. Both flags are omitted when
+    /// unknown, which is the form older firmware accepts.
+    /// </summary>
+    internal static string BuildAtCommand(GlModemEndpoint endpoint, string atCommand)
+    {
+        var sb = new StringBuilder("gl_modem");
+
+        if (!string.IsNullOrWhiteSpace(endpoint.Bus))
+        {
+            if (!Regex.IsMatch(endpoint.Bus, @"^[0-9A-Za-z._:-]+$"))
+                throw new ArgumentException($"Invalid modem bus: {endpoint.Bus}");
+            sb.Append($" -B {endpoint.Bus}");
+        }
+
+        if (endpoint.Sub.HasValue)
+            sb.Append($" -U {endpoint.Sub.Value}");
+
+        sb.Append($" AT '{atCommand}'");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Find the modem's addressing. GL.iNet's own cellular ubus service answers for the
+    /// integrated modems and carries the identity with it; USB enumeration covers the
+    /// plug-in modules, where the configured bus wins if the user set one.
+    /// </summary>
+    public async Task<GlModemEndpoint> DiscoverAsync(
+        ModemPollContext context,
+        SshConnectionInfo connection,
+        CancellationToken cancellationToken = default)
+    {
+        const string command =
+            "echo '===INFO==='; ubus call cellular.modem info '{\"bus\":\"cpu\"}' 2>/dev/null; " +
+            "echo '===STATUS==='; ubus call cellular.modem status '{\"bus\":\"cpu\"}' 2>/dev/null; " +
+            "echo '===USB==='; ls /sys/bus/usb/devices 2>/dev/null";
+
+        try
+        {
+            var result = await _sshClient.ExecuteCommandAsync(
+                connection, command, cancellationToken: cancellationToken);
+
+            if (result.Success)
+            {
+                var endpoint = ParseDiscovery(result.Output ?? "", context.TransportPath);
+                _logger.LogInformation(
+                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model})",
+                    context.Name, endpoint.Bus ?? "auto", endpoint.Sub?.ToString() ?? "none",
+                    endpoint.Description ?? "unidentified");
+                return endpoint;
+            }
+
+            _logger.LogDebug("Modem discovery command failed on {Name}", context.Name);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Modem discovery failed on {Name}", context.Name);
+        }
+
+        return FallbackEndpoint(context.TransportPath);
+    }
+
+    /// <summary>Parse the discovery script's sections. Internal for tests.</summary>
+    internal static GlModemEndpoint ParseDiscovery(string output, string? configuredBus)
+    {
+        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "USB" });
+
+        sections.TryGetValue("INFO", out var info);
+        sections.TryGetValue("STATUS", out var status);
+        sections.TryGetValue("USB", out var usb);
+
+        string? bus = null, model = null, vendor = null, firmware = null;
+        int? sub = null;
+
+        if (TryParseJson(info, out var infoDoc))
+        {
+            using (infoDoc)
+            {
+                var root = infoDoc.RootElement;
+                bus = GetString(root, "bus");
+                model = GetString(root, "name");
+                vendor = GetString(root, "vendor");
+                firmware = GetString(root, "version");
+            }
+        }
+
+        // The AT subscription follows the SIM slot the modem is actually using.
+        if (bus != null && TryParseJson(status, out var statusDoc))
+        {
+            using (statusDoc)
+            {
+                if (int.TryParse(GetString(statusDoc.RootElement, "current_sim_slot"), out var slot))
+                    sub = slot;
+            }
+        }
+
+        if (bus != null)
+            return new GlModemEndpoint(bus, sub ?? 1, model, vendor, firmware);
+
+        if (!string.IsNullOrWhiteSpace(configuredBus))
+            return new GlModemEndpoint(configuredBus, null);
+
+        var usbBus = (usb ?? "")
+            .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault(d => Regex.IsMatch(d, @"^\d+-[\d.]+$"));
+
+        return usbBus != null ? new GlModemEndpoint(usbBus, null) : GlModemEndpoint.Unknown;
+    }
+
+    private static GlModemEndpoint FallbackEndpoint(string? configuredBus) =>
+        string.IsNullOrWhiteSpace(configuredBus)
+            ? GlModemEndpoint.Unknown
+            : new GlModemEndpoint(configuredBus, null);
+
+    private static string SectionMarker(int index) => $"===AT{index}===";
+
+    private static Dictionary<string, string> SplitAtSections(string output, IReadOnlyList<string> atCommands)
+    {
+        var markers = atCommands.Select((cmd, i) => (Key: cmd, Marker: SectionMarker(i)));
+        return SplitSections(output, markers);
+    }
+
+    private static Dictionary<string, string> SplitNamedSections(string output, IReadOnlyList<string> keys)
+    {
+        var markers = keys.Select(k => (Key: k, Marker: $"==={k}==="));
+        return SplitSections(output, markers);
+    }
+
+    private static Dictionary<string, string> SplitSections(
+        string output, IEnumerable<(string Key, string Marker)> markers)
+    {
+        var markerList = markers.ToList();
+        var sections = new Dictionary<string, string>();
+        string? current = null;
+        var buffer = new StringBuilder();
+
+        foreach (var line in output.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            var match = markerList.FirstOrDefault(m => trimmed == m.Marker);
+            if (match.Marker != null)
+            {
+                if (current != null) sections[current] = buffer.ToString();
+                current = match.Key;
+                buffer.Clear();
+                continue;
+            }
+            buffer.AppendLine(line);
+        }
+
+        if (current != null) sections[current] = buffer.ToString();
+        return sections;
+    }
+
+    private static bool TryParseJson(string? text, out JsonDocument document)
+    {
+        document = null!;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        try
+        {
+            document = JsonDocument.Parse(text);
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static string? GetString(JsonElement element, string property) =>
+        element.ValueKind == JsonValueKind.Object &&
+        element.TryGetProperty(property, out var value) &&
+        value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+}
+
+/// <summary>Outcome of a batch of AT commands run through <see cref="GlModemTransport"/>.</summary>
+public sealed record GlModemAtResult
+{
+    public bool Success { get; init; }
+
+    /// <summary>gl_modem answered with its usage text, so no AT command reached the modem.</summary>
+    public bool RejectedCommandLine { get; init; }
+
+    public string? Error { get; init; }
+
+    /// <summary>Output of each AT command, keyed by the command itself.</summary>
+    public Dictionary<string, string> Sections { get; init; } = new();
+
+    public GlModemEndpoint Endpoint { get; init; } = GlModemEndpoint.Unknown;
+
+    public string For(string atCommand) => Sections.TryGetValue(atCommand, out var s) ? s : "";
+}

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -20,7 +20,8 @@ public sealed record GlModemEndpoint(
     int? Sub,
     string? Model = null,
     string? Vendor = null,
-    string? Firmware = null)
+    string? SoftwareVersion = null,
+    string? HostVersion = null)
 {
     /// <summary>Endpoint used when discovery finds nothing: let gl_modem pick the modem itself.</summary>
     public static readonly GlModemEndpoint Unknown = new(null, null);
@@ -175,7 +176,9 @@ public sealed class GlModemTransport
         const string command =
             "echo '===INFO==='; ubus call cellular.modem info '{\"bus\":\"cpu\"}' 2>/dev/null; " +
             "echo '===STATUS==='; ubus call cellular.modem status '{\"bus\":\"cpu\"}' 2>/dev/null; " +
-            "echo '===USB==='; ls /sys/bus/usb/devices 2>/dev/null";
+            "echo '===USB==='; ls /sys/bus/usb/devices 2>/dev/null; " +
+            "echo '===GLVER==='; cat /etc/glversion 2>/dev/null; " +
+            "echo '===BOARD==='; ubus call system board 2>/dev/null";
 
         try
         {
@@ -186,9 +189,10 @@ public sealed class GlModemTransport
             {
                 var endpoint = ParseDiscovery(result.Output ?? "", context.TransportPath);
                 _logger.LogInformation(
-                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model}, firmware {Firmware})",
+                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model} {Software}, host {Host})",
                     context.Name, endpoint.Bus ?? "auto", endpoint.Sub?.ToString() ?? "none",
-                    endpoint.Description ?? "unidentified", endpoint.Firmware ?? "unknown");
+                    endpoint.Description ?? "unidentified", endpoint.SoftwareVersion ?? "unknown",
+                    endpoint.HostVersion ?? "unknown");
                 return endpoint;
             }
 
@@ -205,13 +209,15 @@ public sealed class GlModemTransport
     /// <summary>Parse the discovery script's sections. Internal for tests.</summary>
     internal static GlModemEndpoint ParseDiscovery(string output, string? configuredBus)
     {
-        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "USB" });
+        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "USB", "GLVER", "BOARD" });
 
         sections.TryGetValue("INFO", out var info);
         sections.TryGetValue("STATUS", out var status);
         sections.TryGetValue("USB", out var usb);
 
-        string? bus = null, model = null, vendor = null, firmware = null;
+        var hostVersion = ParseHostVersion(sections);
+
+        string? bus = null, model = null, vendor = null, software = null;
         int? sub = null;
 
         if (TryParseJson(info, out var infoDoc))
@@ -222,7 +228,7 @@ public sealed class GlModemTransport
                 bus = GetString(root, "bus");
                 model = GetString(root, "name");
                 vendor = GetString(root, "vendor");
-                firmware = GetString(root, "version");
+                software = GetString(root, "version");
             }
         }
 
@@ -237,16 +243,46 @@ public sealed class GlModemTransport
         }
 
         if (bus != null)
-            return new GlModemEndpoint(bus, sub ?? 1, model, vendor, firmware);
+            return new GlModemEndpoint(bus, sub ?? 1, model, vendor, software, hostVersion);
 
         if (!string.IsNullOrWhiteSpace(configuredBus))
-            return new GlModemEndpoint(configuredBus, null);
+            return new GlModemEndpoint(configuredBus, null, HostVersion: hostVersion);
 
         var usbBus = (usb ?? "")
             .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
             .FirstOrDefault(d => Regex.IsMatch(d, @"^\d+-[\d.]+$"));
 
-        return usbBus != null ? new GlModemEndpoint(usbBus, null) : GlModemEndpoint.Unknown;
+        return usbBus != null
+            ? new GlModemEndpoint(usbBus, null, HostVersion: hostVersion)
+            : GlModemEndpoint.Unknown with { HostVersion = hostVersion };
+    }
+
+    /// <summary>
+    /// The router's own build. GL stamps their firmware version in /etc/glversion - the number
+    /// their UI shows and the one an owner quotes - so it wins over the OpenWrt base underneath.
+    /// </summary>
+    private static string? ParseHostVersion(Dictionary<string, string> sections)
+    {
+        if (sections.TryGetValue("GLVER", out var glVersion))
+        {
+            var trimmed = glVersion.Trim();
+            if (trimmed.Length > 0)
+                return trimmed;
+        }
+
+        if (sections.TryGetValue("BOARD", out var board) && TryParseJson(board, out var boardDoc))
+        {
+            using (boardDoc)
+            {
+                if (boardDoc.RootElement.ValueKind == JsonValueKind.Object &&
+                    boardDoc.RootElement.TryGetProperty("release", out var release))
+                {
+                    return GetString(release, "description") ?? GetString(release, "version");
+                }
+            }
+        }
+
+        return null;
     }
 
     private static GlModemEndpoint FallbackEndpoint(string? configuredBus) =>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -127,7 +127,10 @@ public sealed class GlModemTransport
             };
         }
 
-        if (!result.Success)
+        // A chain's exit status is only the last command's, so it cannot speak for the rest:
+        // judging the batch by it would let a failed enrichment command discard signal data
+        // already in hand. Transport failures still surface, having produced no stdout at all.
+        if (!result.Success && string.IsNullOrWhiteSpace(result.Output))
             return new GlModemAtResult { Success = false, Error = SshFailureSummary.Describe(combined, connection.Host) };
 
         return new GlModemAtResult
@@ -183,9 +186,9 @@ public sealed class GlModemTransport
             {
                 var endpoint = ParseDiscovery(result.Output ?? "", context.TransportPath);
                 _logger.LogInformation(
-                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model})",
+                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model}, firmware {Firmware})",
                     context.Name, endpoint.Bus ?? "auto", endpoint.Sub?.ToString() ?? "none",
-                    endpoint.Description ?? "unidentified");
+                    endpoint.Description ?? "unidentified", endpoint.Firmware ?? "unknown");
                 return endpoint;
             }
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -61,6 +61,13 @@ public sealed class GlModemTransport
     }
 
     /// <summary>
+    /// Drop what we know about this modem, so the next poll rediscovers it. Called whenever a
+    /// poll fails: a firmware upgrade or rollback reboots the router, and the cached endpoint
+    /// carries its versions, which must not outlive the firmware they name.
+    /// </summary>
+    public void Forget(string cacheKey) => _endpoints.TryRemove(cacheKey, out _);
+
+    /// <summary>
     /// Run one or more AT commands in a single SSH session. Results come back keyed by
     /// the command that produced them.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -31,10 +31,7 @@ public sealed record GlModemEndpoint(
     public string? Description =>
         string.IsNullOrWhiteSpace(Model) ? null
         : string.IsNullOrWhiteSpace(Vendor) ? Model
-        : $"{Capitalize(Vendor!)} {Model}";
-
-    private static string Capitalize(string s) =>
-        s.Length > 0 && char.IsLower(s[0]) ? char.ToUpperInvariant(s[0]) + s[1..] : s;
+        : $"{Vendor} {Model}";
 }
 
 /// <summary>
@@ -51,7 +48,9 @@ public sealed class GlModemTransport
 {
     private readonly ILogger<GlModemTransport> _logger;
     private readonly SshClientService _sshClient;
-    private readonly ConcurrentDictionary<string, GlModemEndpoint> _endpoints = new();
+    // Keyed on CacheKey, holding the configured bus the entry was resolved under so editing
+    // Modem Bus in Settings takes effect on the next poll instead of waiting for a restart.
+    private readonly ConcurrentDictionary<string, (GlModemEndpoint Endpoint, string ConfiguredBus)> _endpoints = new();
 
     private const string UsageMarker = "Usage: gl_modem";
 
@@ -77,9 +76,10 @@ public sealed class GlModemTransport
                 throw new ArgumentException($"Unsupported characters in AT command: {at}");
         }
 
-        var wasCached = _endpoints.TryGetValue(context.CacheKey, out var cached);
+        var wasCached = _endpoints.TryGetValue(context.CacheKey, out var cached)
+                        && cached.ConfiguredBus == context.TransportPath;
         var endpoint = wasCached
-            ? cached!
+            ? cached.Endpoint
             : await DiscoverAsync(context, connection, cancellationToken);
 
         var result = await ExecuteAsync(endpoint, connection, atCommands, cancellationToken);
@@ -95,8 +95,13 @@ public sealed class GlModemTransport
             result = await ExecuteAsync(endpoint, connection, atCommands, cancellationToken);
         }
 
-        if (result.Success)
-            _endpoints[context.CacheKey] = endpoint;
+        // Cache only what the modem actually answered on. The section markers echo whether or
+        // not gl_modem produced anything, so Success alone would pin a wrong bus in place and
+        // every later poll would report no data.
+        if (result.Success && result.Sections.Values.Any(v => !string.IsNullOrWhiteSpace(v)))
+            _endpoints[context.CacheKey] = (endpoint, context.TransportPath);
+        else
+            _endpoints.TryRemove(context.CacheKey, out _);
 
         return result with { Endpoint = endpoint };
     }
@@ -177,7 +182,6 @@ public sealed class GlModemTransport
         const string command =
             "echo '===INFO==='; ubus call cellular.modem info '{\"bus\":\"cpu\"}' 2>/dev/null; " +
             "echo '===STATUS==='; ubus call cellular.modem status '{\"bus\":\"cpu\"}' 2>/dev/null; " +
-            "echo '===USB==='; ls /sys/bus/usb/devices 2>/dev/null; " +
             "echo '===GLVER==='; cat /etc/glversion 2>/dev/null; " +
             "echo '===BOARD==='; ubus call system board 2>/dev/null";
 
@@ -213,11 +217,10 @@ public sealed class GlModemTransport
     /// <summary>Parse the discovery script's sections. Internal for tests.</summary>
     internal static GlModemEndpoint ParseDiscovery(string output, string? configuredBus)
     {
-        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "USB", "GLVER", "BOARD" });
+        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "GLVER", "BOARD" });
 
         sections.TryGetValue("INFO", out var info);
         sections.TryGetValue("STATUS", out var status);
-        sections.TryGetValue("USB", out var usb);
 
         var hostVersion = ParseHostVersion(sections);
         var product = ParseProduct(sections);
@@ -232,7 +235,7 @@ public sealed class GlModemTransport
                 var root = infoDoc.RootElement;
                 bus = GetString(root, "bus");
                 model = GetString(root, "name");
-                vendor = GetString(root, "vendor");
+                vendor = Capitalize(GetString(root, "vendor"));
                 software = GetString(root, "version");
             }
         }
@@ -242,8 +245,7 @@ public sealed class GlModemTransport
         {
             using (statusDoc)
             {
-                if (int.TryParse(GetString(statusDoc.RootElement, "current_sim_slot"), out var slot))
-                    sub = slot;
+                sub = GetIntFlexible(statusDoc.RootElement, "current_sim_slot");
             }
         }
 
@@ -253,13 +255,10 @@ public sealed class GlModemTransport
         if (!string.IsNullOrWhiteSpace(configuredBus))
             return new GlModemEndpoint(configuredBus, null, HostVersion: hostVersion, Product: product);
 
-        var usbBus = (usb ?? "")
-            .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-            .FirstOrDefault(d => Regex.IsMatch(d, @"^\d+-[\d.]+$"));
-
-        return usbBus != null
-            ? new GlModemEndpoint(usbBus, null, HostVersion: hostVersion, Product: product)
-            : GlModemEndpoint.Unknown with { HostVersion = hostVersion, Product = product };
+        // No bus rather than a guess from USB enumeration: `ls` sorts lexically, so a modem
+        // behind a hub loses to the hub, and gl_modem auto-detects the plug-in modules this
+        // would have been guessing for. Never re-add it: forcing -B is worse than omitting it.
+        return GlModemEndpoint.Unknown with { HostVersion = hostVersion, Product = product };
     }
 
     /// <summary>
@@ -374,6 +373,23 @@ public sealed class GlModemTransport
             return false;
         }
     }
+
+    /// <summary>Reads a property that firmware may encode as either a JSON string or a number.</summary>
+    private static int? GetIntFlexible(JsonElement element, string property)
+    {
+        if (element.ValueKind != JsonValueKind.Object || !element.TryGetProperty(property, out var value))
+            return null;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.Number when value.TryGetInt32(out var n) => n,
+            JsonValueKind.String when int.TryParse(value.GetString(), out var s) => s,
+            _ => null,
+        };
+    }
+
+    private static string? Capitalize(string? s) =>
+        string.IsNullOrEmpty(s) || !char.IsLower(s[0]) ? s : char.ToUpperInvariant(s[0]) + s[1..];
 
     private static string? GetString(JsonElement element, string property) =>
         element.ValueKind == JsonValueKind.Object &&

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -21,7 +21,8 @@ public sealed record GlModemEndpoint(
     string? Model = null,
     string? Vendor = null,
     string? SoftwareVersion = null,
-    string? HostVersion = null)
+    string? HostVersion = null,
+    string? Product = null)
 {
     /// <summary>Endpoint used when discovery finds nothing: let gl_modem pick the modem itself.</summary>
     public static readonly GlModemEndpoint Unknown = new(null, null);
@@ -216,6 +217,7 @@ public sealed class GlModemTransport
         sections.TryGetValue("USB", out var usb);
 
         var hostVersion = ParseHostVersion(sections);
+        var product = ParseProduct(sections);
 
         string? bus = null, model = null, vendor = null, software = null;
         int? sub = null;
@@ -243,18 +245,43 @@ public sealed class GlModemTransport
         }
 
         if (bus != null)
-            return new GlModemEndpoint(bus, sub ?? 1, model, vendor, software, hostVersion);
+            return new GlModemEndpoint(bus, sub ?? 1, model, vendor, software, hostVersion, product);
 
         if (!string.IsNullOrWhiteSpace(configuredBus))
-            return new GlModemEndpoint(configuredBus, null, HostVersion: hostVersion);
+            return new GlModemEndpoint(configuredBus, null, HostVersion: hostVersion, Product: product);
 
         var usbBus = (usb ?? "")
             .Split('\n', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
             .FirstOrDefault(d => Regex.IsMatch(d, @"^\d+-[\d.]+$"));
 
         return usbBus != null
-            ? new GlModemEndpoint(usbBus, null, HostVersion: hostVersion)
-            : GlModemEndpoint.Unknown with { HostVersion = hostVersion };
+            ? new GlModemEndpoint(usbBus, null, HostVersion: hostVersion, Product: product)
+            : GlModemEndpoint.Unknown with { HostVersion = hostVersion, Product = product };
+    }
+
+    /// <summary>
+    /// The router model the owner bought, from the board's model string
+    /// ("GL.iNet E5800, Qualcomm Technologies, Inc. SDXPINN IDP MBB" gives "E5800").
+    /// The brand is implied by the provider, so it is stripped rather than stored twice.
+    /// </summary>
+    private static string? ParseProduct(Dictionary<string, string> sections)
+    {
+        if (!sections.TryGetValue("BOARD", out var board) || !TryParseJson(board, out var doc))
+            return null;
+
+        using (doc)
+        {
+            var model = GetString(doc.RootElement, "model");
+            if (string.IsNullOrWhiteSpace(model))
+                return null;
+
+            var comma = model.IndexOf(',');
+            if (comma > 0)
+                model = model[..comma];
+
+            model = Regex.Replace(model.Trim(), @"^GL[.-]?iNet\s+", "", RegexOptions.IgnoreCase).Trim();
+            return model.Length > 0 ? model : null;
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -186,7 +186,10 @@ public sealed class GlModemTransport
             var result = await _sshClient.ExecuteCommandAsync(
                 connection, command, cancellationToken: cancellationToken);
 
-            if (result.Success)
+            // Judged on output, not exit status: the chain ends with the board query, so a
+            // device that answers about its modem but not its board would otherwise have
+            // perfectly good discovery thrown away.
+            if (!string.IsNullOrWhiteSpace(result.Output))
             {
                 var endpoint = ParseDiscovery(result.Output ?? "", context.TransportPath);
                 _logger.LogInformation(
@@ -197,7 +200,7 @@ public sealed class GlModemTransport
                 return endpoint;
             }
 
-            _logger.LogDebug("Modem discovery command failed on {Name}", context.Name);
+            _logger.LogDebug("Modem discovery returned nothing on {Name}", context.Name);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using NetworkOptimizer.Monitoring;
 using NetworkOptimizer.Monitoring.Models;
 using NetworkOptimizer.Monitoring.Providers;
@@ -23,13 +24,13 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     private readonly UniFiSshService _sshService;
 
     /// <summary>
-    /// Which module is fitted. Read once per modem: an EM9291 does not become something else,
-    /// so asking every poll buys nothing. Its FIRMWARE is deliberately not cached - see
-    /// <see cref="ModuleCommands"/>.
+    /// Which module is fitted. Read once per modem: an EM9291 does not become something else.
+    /// Its FIRMWARE is deliberately not cached - see <see cref="ModuleCommands"/>.
     /// </summary>
-    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ModuleIdentity> _modules = new();
+    private readonly ConcurrentDictionary<string, ModuleIdentity> _modules = new();
 
-    private sealed record ModuleIdentity(string? Vendor, string? Model);
+    /// <summary>Also holds where it was read, so repointing a config at another device re-reads it.</summary>
+    private sealed record ModuleIdentity(string? Vendor, string? Model, string Host, string TransportPath);
 
     // Created per site by ModemMonitorRegistry with that site's device SSH
     // service, so qmicli commands reach the site's modem host (tunnel-routed
@@ -55,9 +56,8 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             ? PollResult<CellularModemStats>.Ok(stats)
             : await PollViaQmicliAsync(context);
 
-        // A firmware upgrade or rollback reboots the modem, so it reaches us as a failed poll.
-        // Forgetting the module on any failure is what keeps a cached version from outliving
-        // the firmware it names - the cache survives only an unbroken run of healthy polls.
+        // Covers a module swapped behind the same configuration. The firmware version is not
+        // cached at all, so it needs no eviction.
         if (!result.Success)
             _modules.TryRemove(context.CacheKey, out _);
 
@@ -213,7 +213,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     {
         var commands = $"; echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
 
-        if (!_modules.ContainsKey(context.CacheKey))
+        if (KnownModule(context) == null)
         {
             commands += $"; echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true" +
                         $"; echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
@@ -221,6 +221,14 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
 
         return commands;
     }
+
+    /// <summary>The cached module for this config, or null when it was read from a different device.</summary>
+    private ModuleIdentity? KnownModule(ModemPollContext context) =>
+        _modules.TryGetValue(context.CacheKey, out var identity)
+        && identity.Host == context.Host
+        && identity.TransportPath == context.TransportPath
+            ? identity
+            : null;
 
     /// <summary>
     /// Stamp the module and its firmware on this poll. The firmware is whatever this poll read;
@@ -232,25 +240,25 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
         if (sections.TryGetValue("REVISION", out var revision))
             stats.SoftwareVersion = QmicliParser.ParseRevision(revision);
 
-        if (!_modules.TryGetValue(context.CacheKey, out var identity))
+        var identity = KnownModule(context);
+        if (identity == null)
         {
             sections.TryGetValue("MODULE", out var model);
             sections.TryGetValue("MAKER", out var maker);
 
-            identity = new ModuleIdentity(
-                QmicliParser.ParseVendor(maker),
-                QmicliParser.ParseQuotedValue(model));
+            var vendor = QmicliParser.ParseVendor(maker);
+            var name = QmicliParser.ParseQuotedValue(model);
 
-            if (identity.Vendor == null && identity.Model == null)
+            // Both or neither: a half answer stays uncached so the missing side is asked again.
+            if (vendor == null || name == null)
             {
                 _logger.LogDebug("Modem {Name} did not say which module is fitted", context.Name);
                 return;
             }
 
+            identity = new ModuleIdentity(vendor, name, context.Host, context.TransportPath);
             _modules[context.CacheKey] = identity;
-            _logger.LogInformation(
-                "Modem {Name} module: {Vendor} {Model}",
-                context.Name, identity.Vendor ?? "unknown", identity.Model ?? "unknown");
+            _logger.LogInformation("Modem {Name} module: {Vendor} {Model}", context.Name, vendor, name);
         }
 
         stats.ModuleVendor = identity.Vendor;
@@ -281,10 +289,8 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 $"echo '===SERVING===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-serving-system; " +
                 $"echo '===CELL===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-cell-location-info; " +
                 $"echo '===BAND===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-rf-band-info; " +
-                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
-                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true; " +
-                $"echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true; " +
-                $"echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
+                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info" +
+                ModuleCommands(qmiDevice, context);
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -142,7 +142,16 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             }
 
             if (sections.TryGetValue("REVISION", out var revisionOutput))
+            {
                 stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
+                _logger.LogDebug(
+                    "Modem {Name} module firmware: {Software} (from {Bytes} bytes of revision output)",
+                    context.Name, stats.SoftwareVersion ?? "unreadable", revisionOutput.Length);
+            }
+            else
+            {
+                _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
+            }
         }
         catch (Exception ex)
         {
@@ -227,7 +236,16 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO", "REVISION");
 
             if (sections.TryGetValue("REVISION", out var revisionOutput))
+            {
                 stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
+                _logger.LogDebug(
+                    "Modem {Name} module firmware: {Software} (from {Bytes} bytes of revision output)",
+                    context.Name, stats.SoftwareVersion ?? "unreadable", revisionOutput.Length);
+            }
+            else
+            {
+                _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
+            }
 
             if (sections.TryGetValue("SIGNAL", out var signalOutput))
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -23,13 +23,13 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     private readonly UniFiSshService _sshService;
 
     /// <summary>
-    /// What the module says about itself. Read once per modem, not per poll: it changes only
-    /// when the hardware is replaced or its firmware is upgraded, and keeping the DMS queries
-    /// out of the routine chain keeps them from ever delaying a signal read.
+    /// Which module is fitted. Read once per modem: an EM9291 does not become something else,
+    /// so asking every poll buys nothing. Its FIRMWARE is deliberately not cached - see
+    /// <see cref="ModuleCommands"/>.
     /// </summary>
     private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ModuleIdentity> _modules = new();
 
-    private sealed record ModuleIdentity(string? Vendor, string? Model, string? SoftwareVersion);
+    private sealed record ModuleIdentity(string? Vendor, string? Model);
 
     // Created per site by ModemMonitorRegistry with that site's device SSH
     // service, so qmicli commands reach the site's modem host (tunnel-routed
@@ -51,11 +51,17 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
 
         // Try uiwwand first - available on all modern UniFi cellular modems
         var stats = await TryPollViaUiwwandAsync(context);
-        if (stats != null)
-            return PollResult<CellularModemStats>.Ok(stats);
+        var result = stats != null
+            ? PollResult<CellularModemStats>.Ok(stats)
+            : await PollViaQmicliAsync(context);
 
-        // Fall back to raw qmicli commands
-        return await PollViaQmicliAsync(context);
+        // A firmware upgrade or rollback reboots the modem, so it reaches us as a failed poll.
+        // Forgetting the module on any failure is what keeps a cached version from outliving
+        // the firmware it names - the cache survives only an unbroken run of healthy polls.
+        if (!result.Success)
+            _modules.TryRemove(context.CacheKey, out _);
+
+        return result;
     }
 
     /// <summary>
@@ -195,54 +201,60 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     }
 
     /// <summary>
-    /// The DMS queries, or nothing once the module has already identified itself. Each is
-    /// guarded: a chain reports only its last command's exit status, so an unsupported query
-    /// here must not speak for the signal commands ahead of it.
+    /// The DMS queries for this poll. The revision runs every time: firmware is the one field
+    /// whose job is to change, and Firmware Rollout changes it from inside this app - an upgrade
+    /// that completes between two polls would otherwise leave a cached version standing forever.
+    /// Which module is fitted is asked only until it answers.
+    ///
+    /// Each is guarded: a chain reports only its last command's exit status, so an unsupported
+    /// query here must not speak for the signal commands ahead of it.
     /// </summary>
     private string ModuleCommands(string qmiDevice, ModemPollContext context)
     {
-        if (_modules.ContainsKey(context.CacheKey))
-            return "";
+        var commands = $"; echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
 
-        return $"; echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true" +
-               $"; echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true" +
-               $"; echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
+        if (!_modules.ContainsKey(context.CacheKey))
+        {
+            commands += $"; echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true" +
+                        $"; echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
+        }
+
+        return commands;
     }
 
     /// <summary>
-    /// Remember what the module reported, and stamp it on this poll's stats. Cached only when
-    /// something came back, so a modem that answers nothing is asked again next time.
+    /// Stamp the module and its firmware on this poll. The firmware is whatever this poll read;
+    /// which module is fitted is remembered once it answers, so later polls stop asking.
     /// </summary>
     private void ApplyModuleIdentity(
         ModemPollContext context, Dictionary<string, string> sections, CellularModemStats stats)
     {
+        if (sections.TryGetValue("REVISION", out var revision))
+            stats.SoftwareVersion = QmicliParser.ParseRevision(revision);
+
         if (!_modules.TryGetValue(context.CacheKey, out var identity))
         {
-            sections.TryGetValue("REVISION", out var revision);
             sections.TryGetValue("MODULE", out var model);
             sections.TryGetValue("MAKER", out var maker);
 
             identity = new ModuleIdentity(
                 QmicliParser.ParseVendor(maker),
-                QmicliParser.ParseQuotedValue(model),
-                QmicliParser.ParseRevision(revision));
+                QmicliParser.ParseQuotedValue(model));
 
-            if (identity.Vendor == null && identity.Model == null && identity.SoftwareVersion == null)
+            if (identity.Vendor == null && identity.Model == null)
             {
-                _logger.LogDebug("Modem {Name} reported no module identity", context.Name);
+                _logger.LogDebug("Modem {Name} did not say which module is fitted", context.Name);
                 return;
             }
 
             _modules[context.CacheKey] = identity;
             _logger.LogInformation(
-                "Modem {Name} module: {Vendor} {Model} on {Software}",
-                context.Name, identity.Vendor ?? "unknown", identity.Model ?? "unknown",
-                identity.SoftwareVersion ?? "unknown");
+                "Modem {Name} module: {Vendor} {Model}",
+                context.Name, identity.Vendor ?? "unknown", identity.Model ?? "unknown");
         }
 
         stats.ModuleVendor = identity.Vendor;
         stats.ModuleModel = identity.Model;
-        stats.SoftwareVersion = identity.SoftwareVersion;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -22,6 +22,15 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     private readonly ILogger<QmicliModemProvider> _logger;
     private readonly UniFiSshService _sshService;
 
+    /// <summary>
+    /// What the module says about itself. Read once per modem, not per poll: it changes only
+    /// when the hardware is replaced or its firmware is upgraded, and keeping the DMS queries
+    /// out of the routine chain keeps them from ever delaying a signal read.
+    /// </summary>
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, ModuleIdentity> _modules = new();
+
+    private sealed record ModuleIdentity(string? Vendor, string? Model, string? SoftwareVersion);
+
     // Created per site by ModemMonitorRegistry with that site's device SSH
     // service, so qmicli commands reach the site's modem host (tunnel-routed
     // when the site's devices are reached via agent).
@@ -117,12 +126,8 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
         {
             var combinedCommand =
                 "echo '===TOWER===' && ubus call uiwwand call '{\"method\":\"get-cell-tower-info\",\"params\":{}}'; " +
-                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
-                // Enrichment, and last in the chain, so its exit status would become the batch's:
-                // a modem without DMS revision support must not fail a poll that has signal data.
-                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true; " +
-                $"echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true; " +
-                $"echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
+                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info" +
+                ModuleCommands(qmiDevice, context);
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
             if (!success || string.IsNullOrWhiteSpace(output))
@@ -143,23 +148,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 stats.IsDcnrRestricted = dcnrRestricted;
             }
 
-            if (sections.TryGetValue("REVISION", out var revisionOutput))
-            {
-                stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
-                _logger.LogDebug(
-                    "Modem {Name} module firmware: {Software} (from {Bytes} bytes of revision output)",
-                    context.Name, stats.SoftwareVersion ?? "unreadable", revisionOutput.Length);
-            }
-            else
-            {
-                _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
-            }
-
-            if (sections.TryGetValue("MODULE", out var moduleOutput))
-                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput);
-
-            if (sections.TryGetValue("MAKER", out var makerOutput))
-                stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);
+            ApplyModuleIdentity(context, sections, stats);
         }
         catch (Exception ex)
         {
@@ -206,6 +195,57 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
     }
 
     /// <summary>
+    /// The DMS queries, or nothing once the module has already identified itself. Each is
+    /// guarded: a chain reports only its last command's exit status, so an unsupported query
+    /// here must not speak for the signal commands ahead of it.
+    /// </summary>
+    private string ModuleCommands(string qmiDevice, ModemPollContext context)
+    {
+        if (_modules.ContainsKey(context.CacheKey))
+            return "";
+
+        return $"; echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true" +
+               $"; echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true" +
+               $"; echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
+    }
+
+    /// <summary>
+    /// Remember what the module reported, and stamp it on this poll's stats. Cached only when
+    /// something came back, so a modem that answers nothing is asked again next time.
+    /// </summary>
+    private void ApplyModuleIdentity(
+        ModemPollContext context, Dictionary<string, string> sections, CellularModemStats stats)
+    {
+        if (!_modules.TryGetValue(context.CacheKey, out var identity))
+        {
+            sections.TryGetValue("REVISION", out var revision);
+            sections.TryGetValue("MODULE", out var model);
+            sections.TryGetValue("MAKER", out var maker);
+
+            identity = new ModuleIdentity(
+                QmicliParser.ParseVendor(maker),
+                QmicliParser.ParseQuotedValue(model),
+                QmicliParser.ParseRevision(revision));
+
+            if (identity.Vendor == null && identity.Model == null && identity.SoftwareVersion == null)
+            {
+                _logger.LogDebug("Modem {Name} reported no module identity", context.Name);
+                return;
+            }
+
+            _modules[context.CacheKey] = identity;
+            _logger.LogInformation(
+                "Modem {Name} module: {Vendor} {Model} on {Software}",
+                context.Name, identity.Vendor ?? "unknown", identity.Model ?? "unknown",
+                identity.SoftwareVersion ?? "unknown");
+        }
+
+        stats.ModuleVendor = identity.Vendor;
+        stats.ModuleModel = identity.Model;
+        stats.SoftwareVersion = identity.SoftwareVersion;
+    }
+
+    /// <summary>
     /// Poll via raw qmicli commands. Fallback path when uiwwand is unavailable.
     /// </summary>
     private async Task<PollResult<CellularModemStats>> PollViaQmicliAsync(ModemPollContext context)
@@ -245,23 +285,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
 
             var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO", "REVISION", "MODULE", "MAKER");
 
-            if (sections.TryGetValue("REVISION", out var revisionOutput))
-            {
-                stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
-                _logger.LogDebug(
-                    "Modem {Name} module firmware: {Software} (from {Bytes} bytes of revision output)",
-                    context.Name, stats.SoftwareVersion ?? "unreadable", revisionOutput.Length);
-            }
-            else
-            {
-                _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
-            }
-
-            if (sections.TryGetValue("MODULE", out var moduleOutput))
-                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput);
-
-            if (sections.TryGetValue("MAKER", out var makerOutput))
-                stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);
+            ApplyModuleIdentity(context, sections, stats);
 
             if (sections.TryGetValue("SIGNAL", out var signalOutput))
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -156,7 +156,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             }
 
             if (sections.TryGetValue("MODULE", out var moduleOutput))
-                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput, "Device model");
+                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput);
 
             if (sections.TryGetValue("MAKER", out var makerOutput))
                 stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);
@@ -258,7 +258,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             }
 
             if (sections.TryGetValue("MODULE", out var moduleOutput))
-                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput, "Device model");
+                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput);
 
             if (sections.TryGetValue("MAKER", out var makerOutput))
                 stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -117,7 +117,10 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
         {
             var combinedCommand =
                 "echo '===TOWER===' && ubus call uiwwand call '{\"method\":\"get-cell-tower-info\",\"params\":{}}'; " +
-                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info";
+                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
+                // Enrichment, and last in the chain, so its exit status would become the batch's:
+                // a modem without DMS revision support must not fail a poll that has signal data.
+                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
             if (!success || string.IsNullOrWhiteSpace(output))
@@ -126,7 +129,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 return;
             }
 
-            var sections = ParseCombinedOutput(output, "TOWER", "SYSINFO");
+            var sections = ParseCombinedOutput(output, "TOWER", "SYSINFO", "REVISION");
 
             if (sections.TryGetValue("TOWER", out var towerOutput) && towerOutput.Contains("\"result\""))
                 UiwwandParser.ParseCellTowerInfo(towerOutput, stats);
@@ -137,6 +140,9 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 stats.Is5gNsaAvailable = nsaAvailable;
                 stats.IsDcnrRestricted = dcnrRestricted;
             }
+
+            if (sections.TryGetValue("REVISION", out var revisionOutput))
+                stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
         }
         catch (Exception ex)
         {
@@ -206,7 +212,8 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 $"echo '===SERVING===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-serving-system; " +
                 $"echo '===CELL===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-cell-location-info; " +
                 $"echo '===BAND===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-rf-band-info; " +
-                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info";
+                $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
+                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
 
@@ -217,7 +224,10 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                     SshFailureSummary.Describe(output, context.ConfiguredHost ?? context.Host));
             }
 
-            var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO");
+            var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO", "REVISION");
+
+            if (sections.TryGetValue("REVISION", out var revisionOutput))
+                stats.SoftwareVersion = QmicliParser.ParseRevision(revisionOutput);
 
             if (sections.TryGetValue("SIGNAL", out var signalOutput))
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -299,6 +299,20 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 stats.IsDcnrRestricted = dcnrRestricted;
             }
 
+            // The section markers are echoed whether or not their command produced anything, and
+            // the chain's exit status belongs to the last command, so neither proves the modem
+            // answered. Empty radio sections mean it did not - which is not the same as a modem
+            // that answered and has no coverage, and must not read as a good poll.
+            var answered = new[] { "SIGNAL", "SERVING", "CELL", "BAND" }
+                .Any(key => sections.TryGetValue(key, out var body) && !string.IsNullOrWhiteSpace(body));
+
+            if (!answered)
+            {
+                _logger.LogWarning("Modem {Name} returned no qmicli output", context.Name);
+                return PollResult<CellularModemStats>.Failed(
+                    $"{context.ConfiguredHost ?? context.Host} answered over SSH but the modem returned no data.");
+            }
+
             _logger.LogDebug(
                 "Successfully polled modem {Name} via qmicli: {Carrier}, Signal Quality: {Quality}%",
                 context.Name, stats.Carrier, stats.SignalQuality);

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QmicliModemProvider.cs
@@ -120,7 +120,9 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
                 // Enrichment, and last in the chain, so its exit status would become the batch's:
                 // a modem without DMS revision support must not fail a poll that has signal data.
-                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
+                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true; " +
+                $"echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true; " +
+                $"echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
             if (!success || string.IsNullOrWhiteSpace(output))
@@ -129,7 +131,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 return;
             }
 
-            var sections = ParseCombinedOutput(output, "TOWER", "SYSINFO", "REVISION");
+            var sections = ParseCombinedOutput(output, "TOWER", "SYSINFO", "REVISION", "MODULE", "MAKER");
 
             if (sections.TryGetValue("TOWER", out var towerOutput) && towerOutput.Contains("\"result\""))
                 UiwwandParser.ParseCellTowerInfo(towerOutput, stats);
@@ -152,6 +154,12 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             {
                 _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
             }
+
+            if (sections.TryGetValue("MODULE", out var moduleOutput))
+                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput, "Device model");
+
+            if (sections.TryGetValue("MAKER", out var makerOutput))
+                stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);
         }
         catch (Exception ex)
         {
@@ -222,7 +230,9 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                 $"echo '===CELL===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-cell-location-info; " +
                 $"echo '===BAND===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-rf-band-info; " +
                 $"echo '===SYSINFO===' && qmicli -d {qmiDevice} --device-open-proxy --nas-get-system-info; " +
-                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true";
+                $"echo '===REVISION===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-revision || true; " +
+                $"echo '===MODULE===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-model || true; " +
+                $"echo '===MAKER===' && qmicli -d {qmiDevice} --device-open-proxy --dms-get-manufacturer || true";
 
             var (success, output) = await _sshService.RunCommandAsync(context.Host, combinedCommand);
 
@@ -233,7 +243,7 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
                     SshFailureSummary.Describe(output, context.ConfiguredHost ?? context.Host));
             }
 
-            var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO", "REVISION");
+            var sections = ParseCombinedOutput(output, "SIGNAL", "SERVING", "CELL", "BAND", "SYSINFO", "REVISION", "MODULE", "MAKER");
 
             if (sections.TryGetValue("REVISION", out var revisionOutput))
             {
@@ -246,6 +256,12 @@ public sealed class QmicliModemProvider : ICellularModemProvider, ISupportsRadio
             {
                 _logger.LogDebug("Modem {Name} returned no revision section", context.Name);
             }
+
+            if (sections.TryGetValue("MODULE", out var moduleOutput))
+                stats.ModuleModel = QmicliParser.ParseQuotedValue(moduleOutput, "Device model");
+
+            if (sections.TryGetValue("MAKER", out var makerOutput))
+                stats.ModuleVendor = QmicliParser.ParseVendor(makerOutput);
 
             if (sections.TryGetValue("SIGNAL", out var signalOutput))
             {

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -64,7 +64,10 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
 
             // The model is the router the owner bought, not the module inside it - the module
             // is reported separately below.
-            var product = string.IsNullOrWhiteSpace(result.Endpoint.Product) ? context.ModemType : result.Endpoint.Product!;
+            // "GL-iNet" is the placeholder the Settings form writes, not a model. Leaving it
+            // empty shows the brand alone rather than "GL.iNet GL-iNet".
+            var product = result.Endpoint.Product
+                ?? (context.ModemType == "GL-iNet" ? "" : context.ModemType);
             var stats = QuectelAtParser.Parse(result.For(ServingCellCommand), host, context.Name, product);
 
             if (stats == null)

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -7,12 +7,12 @@ namespace NetworkOptimizer.Web.Services.CellularModemProviders;
 
 /// <summary>
 /// Cellular modem provider for GL-iNet routers and other devices with Quectel modems.
-/// Uses per-modem SSH credentials (not the shared UniFi SSH service) to connect
-/// and run <c>gl_modem AT AT+QENG="servingcell"</c>, then parses the response
-/// with <see cref="QuectelAtParser"/>.
+/// Uses per-modem SSH credentials (not the shared UniFi SSH service) to run
+/// <c>gl_modem ... AT AT+QENG="servingcell"</c> and parse the response with
+/// <see cref="QuectelAtParser"/>.
 ///
-/// The TransportPath field stores the USB bus path (e.g. "1-1.2") used by
-/// gl_modem's <c>-B</c> flag. If empty, gl_modem auto-detects the first modem.
+/// <see cref="GlModemTransport"/> owns how gl_modem is addressed; the TransportPath
+/// field is only a user-supplied hint for hardware discovery cannot identify.
 /// </summary>
 public sealed class QuectelAtModemProvider : ICellularModemProvider
 {
@@ -22,15 +22,18 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     /// <inheritdoc/>
     public string DisplayName => "GL-iNet / Quectel modem (SSH)";
 
+    private const string ServingCellCommand = "AT+QENG=\"servingcell\"";
+    private const string OperatorCommand = "AT+COPS?";
+
     private readonly ILogger<QuectelAtModemProvider> _logger;
-    private readonly SshClientService _sshClient;
+    private readonly GlModemTransport _transport;
 
     public QuectelAtModemProvider(
         ILogger<QuectelAtModemProvider> logger,
-        SshClientService sshClient)
+        GlModemTransport transport)
     {
         _logger = logger;
-        _sshClient = sshClient;
+        _transport = transport;
     }
 
     /// <inheritdoc/>
@@ -50,19 +53,23 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
 
         try
         {
-            var command = BuildAtCommand(context.TransportPath);
-            var result = await _sshClient.ExecuteCommandAsync(connection, command, cancellationToken: cancellationToken);
+            var result = await _transport.RunAtAsync(
+                context, connection, new[] { ServingCellCommand, OperatorCommand }, cancellationToken);
 
             if (!result.Success)
             {
                 _logger.LogWarning("AT command failed on {Name}: {Error}", context.Name, result.Error);
-                return PollResult<CellularModemStats>.Failed(SshFailureSummary.Describe(result.CombinedOutput, host));
+                return PollResult<CellularModemStats>.Failed(result.Error ?? $"{host} did not answer the AT command.");
             }
 
-            var stats = QuectelAtParser.Parse(result.Output, host, context.Name, context.ModemType);
+            var model = string.IsNullOrWhiteSpace(result.Endpoint.Model) ? context.ModemType : result.Endpoint.Model!;
+            var stats = QuectelAtParser.Parse(result.For(ServingCellCommand), host, context.Name, model);
 
             if (stats == null)
                 return PollResult<CellularModemStats>.Failed($"{host} answered over SSH but the modem returned no signal data.");
+
+            // AT+QENG reports only MCC/MNC, so the operator name comes from AT+COPS?.
+            stats.Carrier = QuectelAtParser.ParseOperator(result.For(OperatorCommand)) ?? stats.Carrier;
 
             _logger.LogInformation(
                 "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",
@@ -88,41 +95,32 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
 
         try
         {
-            var command = BuildAtCommand(context.TransportPath);
-            var result = await _sshClient.ExecuteCommandAsync(connection, command, cancellationToken: cancellationToken);
+            var result = await _transport.RunAtAsync(
+                context, connection, new[] { ServingCellCommand }, cancellationToken);
 
-            if (result.Success && !string.IsNullOrWhiteSpace(result.Output) && result.Output.Contains("+QENG"))
+            var identity = result.Endpoint.Description;
+            var found = identity != null ? $"Found {identity}. " : "";
+
+            if (result.Success && result.For(ServingCellCommand).Contains("+QENG"))
+                return (true, $"{found}Connected and the modem responded to the AT command.");
+
+            if (result.RejectedCommandLine)
             {
-                return (true, "Connected and modem responded to AT command");
+                return (false, identity != null
+                    ? $"{found}Its gl_modem did not accept the command line, so no AT command reached the modem."
+                    : "The router's gl_modem did not accept the command line, and the modem could not be identified. " +
+                      "Check the Modem Bus field.");
             }
 
             if (result.Success)
-            {
-                return (false, $"SSH connected but modem did not respond. Output: {Truncate(result.Output, 200)}");
-            }
+                return (false, $"{found}SSH connected but the modem did not respond to AT+QENG.");
 
-            return (false, SshFailureSummary.Describe(result.CombinedOutput, context.ConfiguredHost ?? context.Host));
+            return (false, result.Error ?? "The AT command failed.");
         }
         catch (Exception ex)
         {
             return (false, $"Connection failed: {ex.Message}");
         }
-    }
-
-    /// <summary>
-    /// Build the AT command string. Uses gl_modem with optional bus path.
-    /// Validates the bus path to prevent shell injection.
-    /// </summary>
-    private static string BuildAtCommand(string? transportPath)
-    {
-        if (!string.IsNullOrWhiteSpace(transportPath))
-        {
-            if (!System.Text.RegularExpressions.Regex.IsMatch(transportPath, @"^[0-9A-Za-z._:-]+$"))
-                throw new ArgumentException($"Invalid USB bus path: {transportPath}");
-            return $"gl_modem -B {transportPath} AT AT+QENG=\\\"servingcell\\\"";
-        }
-
-        return "gl_modem AT AT+QENG=\\\"servingcell\\\"";
     }
 
     /// <summary>
@@ -136,10 +134,4 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         Password = context.Password,
         PrivateKeyPath = context.PrivateKeyPath,
     };
-
-    private static string Truncate(string? s, int maxLength)
-    {
-        if (string.IsNullOrEmpty(s)) return "";
-        return s.Length <= maxLength ? s : s[..maxLength] + "...";
-    }
 }

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -25,6 +25,13 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     private const string ServingCellCommand = "AT+QENG=\"servingcell\"";
     private const string OperatorCommand = "AT+COPS?";
 
+    /// <summary>
+    /// The module's own firmware, asked on every poll rather than taken from the cached
+    /// discovery: firmware is the one field whose job is to change, and an upgrade that
+    /// completes between two polls would leave a cached version standing forever.
+    /// </summary>
+    private const string RevisionCommand = "AT+CGMR";
+
     private readonly ILogger<QuectelAtModemProvider> _logger;
     private readonly GlModemTransport _transport;
 
@@ -54,11 +61,12 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         try
         {
             var result = await _transport.RunAtAsync(
-                context, connection, new[] { ServingCellCommand, OperatorCommand }, cancellationToken);
+                context, connection, new[] { ServingCellCommand, OperatorCommand, RevisionCommand }, cancellationToken);
 
             if (!result.Success)
             {
                 _logger.LogWarning("AT command failed on {Name}: {Error}", context.Name, result.Error);
+                _transport.Forget(context.CacheKey);
                 return PollResult<CellularModemStats>.Failed(result.Error ?? $"{host} did not answer the AT command.");
             }
 
@@ -71,11 +79,15 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
             var stats = QuectelAtParser.Parse(result.For(ServingCellCommand), host, context.Name, product);
 
             if (stats == null)
+            {
+                _transport.Forget(context.CacheKey);
                 return PollResult<CellularModemStats>.Failed($"{host} answered over SSH but the modem returned no signal data.");
+            }
 
             // AT+QENG reports only MCC/MNC, so the operator name comes from AT+COPS?.
             stats.Carrier = QuectelAtParser.ParseOperator(result.For(OperatorCommand)) ?? stats.Carrier;
-            stats.SoftwareVersion = result.Endpoint.SoftwareVersion;
+            stats.SoftwareVersion = QuectelAtParser.ParseRevisionResponse(result.For(RevisionCommand))
+                ?? result.Endpoint.SoftwareVersion;
             stats.HostVersion = result.Endpoint.HostVersion;
             stats.ModuleVendor = result.Endpoint.Vendor;
             stats.ModuleModel = result.Endpoint.Model;
@@ -89,6 +101,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error polling GL-iNet modem {Name}", context.Name);
+            _transport.Forget(context.CacheKey);
             return PollResult<CellularModemStats>.Failed(SshFailureSummary.Describe(ex.Message, host));
         }
     }

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -43,6 +43,13 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     {
         _logger.LogInformation("Polling GL-iNet modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
 
+        // TEMPORARY REVIEW HARNESS - REMOVE BEFORE MERGING THIS BRANCH.
+        // A modem named "Test" renders GL.iNet sample data so the card can be reviewed
+        // without the hardware, which no test site has. Runs the real parser, so what it
+        // shows is what a real E5800 would produce.
+        if (context.Name == "Test")
+            return PollResult<CellularModemStats>.Ok(BuildSampleStats(context));
+
         var host = context.ConfiguredHost ?? context.Host;
         var connection = ToConnectionInfo(context);
         if (!connection.HasCredentials)
@@ -62,8 +69,10 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
                 return PollResult<CellularModemStats>.Failed(result.Error ?? $"{host} did not answer the AT command.");
             }
 
-            var model = string.IsNullOrWhiteSpace(result.Endpoint.Model) ? context.ModemType : result.Endpoint.Model!;
-            var stats = QuectelAtParser.Parse(result.For(ServingCellCommand), host, context.Name, model);
+            // The model is the router the owner bought, not the module inside it - the module
+            // is reported separately below.
+            var product = string.IsNullOrWhiteSpace(result.Endpoint.Product) ? context.ModemType : result.Endpoint.Product!;
+            var stats = QuectelAtParser.Parse(result.For(ServingCellCommand), host, context.Name, product);
 
             if (stats == null)
                 return PollResult<CellularModemStats>.Failed($"{host} answered over SSH but the modem returned no signal data.");
@@ -72,6 +81,8 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
             stats.Carrier = QuectelAtParser.ParseOperator(result.For(OperatorCommand)) ?? stats.Carrier;
             stats.SoftwareVersion = result.Endpoint.SoftwareVersion;
             stats.HostVersion = result.Endpoint.HostVersion;
+            stats.ModuleVendor = result.Endpoint.Vendor;
+            stats.ModuleModel = result.Endpoint.Model;
 
             _logger.LogInformation(
                 "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",
@@ -123,6 +134,26 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         {
             return (false, $"Connection failed: {ex.Message}");
         }
+    }
+
+    // TEMPORARY REVIEW HARNESS - REMOVE BEFORE MERGING THIS BRANCH.
+    private static CellularModemStats BuildSampleStats(ModemPollContext context)
+    {
+        const string servingCell = """
++QENG: "servingcell","NOCONN"
++QENG: "LTE","FDD",310,260,"0A1B2C3",438,975,2,4,4,"1234",-95,-7,-68,20,15,150,-
++QENG: "NR5G-NSA",310,260,46,-81,34,-10,502110,41,11,1
+
+OK
+""";
+
+        var stats = QuectelAtParser.Parse(servingCell, context.Host, context.Name, "E5800")!;
+        stats.Carrier = QuectelAtParser.ParseOperator("+COPS: 0,0,\"T-Mobile\",13") ?? "";
+        stats.SoftwareVersion = "QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005";
+        stats.HostVersion = "4.8.5";
+        stats.ModuleVendor = "Quectel";
+        stats.ModuleModel = "RG650V-NA";
+        return stats;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -25,11 +25,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     private const string ServingCellCommand = "AT+QENG=\"servingcell\"";
     private const string OperatorCommand = "AT+COPS?";
 
-    /// <summary>
-    /// The module's own firmware, asked on every poll rather than taken from the cached
-    /// discovery: firmware is the one field whose job is to change, and an upgrade that
-    /// completes between two polls would leave a cached version standing forever.
-    /// </summary>
+    /// <summary>The module's own firmware, asked every poll rather than taken from cached discovery.</summary>
     private const string RevisionCommand = "AT+CGMR";
 
     private readonly ILogger<QuectelAtModemProvider> _logger;

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -70,7 +70,8 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
 
             // AT+QENG reports only MCC/MNC, so the operator name comes from AT+COPS?.
             stats.Carrier = QuectelAtParser.ParseOperator(result.For(OperatorCommand)) ?? stats.Carrier;
-            stats.SoftwareVersion = result.Endpoint.Firmware;
+            stats.SoftwareVersion = result.Endpoint.SoftwareVersion;
+            stats.HostVersion = result.Endpoint.HostVersion;
 
             _logger.LogInformation(
                 "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -43,13 +43,6 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
     {
         _logger.LogInformation("Polling GL-iNet modem {Name} at {Host}", context.Name, context.ConfiguredHost ?? context.Host);
 
-        // TEMPORARY REVIEW HARNESS - REMOVE BEFORE MERGING THIS BRANCH.
-        // A modem named "Test" renders GL.iNet sample data so the card can be reviewed
-        // without the hardware, which no test site has. Runs the real parser, so what it
-        // shows is what a real E5800 would produce.
-        if (context.Name == "Test")
-            return PollResult<CellularModemStats>.Ok(BuildSampleStats(context));
-
         var host = context.ConfiguredHost ?? context.Host;
         var connection = ToConnectionInfo(context);
         if (!connection.HasCredentials)
@@ -134,26 +127,6 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
         {
             return (false, $"Connection failed: {ex.Message}");
         }
-    }
-
-    // TEMPORARY REVIEW HARNESS - REMOVE BEFORE MERGING THIS BRANCH.
-    private static CellularModemStats BuildSampleStats(ModemPollContext context)
-    {
-        const string servingCell = """
-+QENG: "servingcell","NOCONN"
-+QENG: "LTE","FDD",310,260,"0A1B2C3",438,975,2,4,4,"1234",-95,-7,-68,20,15,150,-
-+QENG: "NR5G-NSA",310,260,46,-81,34,-10,502110,41,11,1
-
-OK
-""";
-
-        var stats = QuectelAtParser.Parse(servingCell, context.Host, context.Name, "E5800")!;
-        stats.Carrier = QuectelAtParser.ParseOperator("+COPS: 0,0,\"T-Mobile\",13") ?? "";
-        stats.SoftwareVersion = "QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005";
-        stats.HostVersion = "4.8.5";
-        stats.ModuleVendor = "Quectel";
-        stats.ModuleModel = "RG650V-NA";
-        return stats;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/QuectelAtModemProvider.cs
@@ -70,6 +70,7 @@ public sealed class QuectelAtModemProvider : ICellularModemProvider
 
             // AT+QENG reports only MCC/MNC, so the operator name comes from AT+COPS?.
             stats.Carrier = QuectelAtParser.ParseOperator(result.For(OperatorCommand)) ?? stats.Carrier;
+            stats.SoftwareVersion = result.Endpoint.Firmware;
 
             _logger.LogInformation(
                 "Successfully polled GL-iNet modem {Name}: Signal Quality: {Quality}%",

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -290,6 +290,9 @@ public class CellularModemService : ICellularModemService
 
             if (stats != null)
             {
+                if (string.IsNullOrWhiteSpace(stats.HostVersion))
+                    await TryFillHostVersionFromConsoleAsync(modem, stats);
+
                 if (await UpdateModemConfigAsync(modem.Id, null, success: true, detectedModel: stats.ModemModel))
                 {
                     lock (_lock)
@@ -440,6 +443,29 @@ public class CellularModemService : ICellularModemService
         }
     }
 
+    /// <summary>
+    /// A UniFi modem's own firmware, which the console knows and the modem does not report over
+    /// SSH, matched on the configured host address. Best effort: a miss leaves it unset. Skipped
+    /// for providers that already read the host build off the device itself.
+    /// </summary>
+    private async Task TryFillHostVersionFromConsoleAsync(ModemConfiguration modem, CellularModemStats stats)
+    {
+        try
+        {
+            var devices = await _connectionService.GetDiscoveredDevicesAsync();
+            var device = devices.FirstOrDefault(d =>
+                string.Equals(d.IpAddress, modem.Host, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(d.LanIpAddress, modem.Host, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(device?.Firmware))
+                stats.HostVersion = device.Firmware;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read the console firmware for modem {Name}", modem.Name);
+        }
+    }
+
     private async Task<bool> UpdateModemConfigAsync(int modemId, string? error, bool success, string? detectedModel = null)
     {
         try
@@ -495,7 +521,9 @@ public class CellularModemService : ICellularModemService
                 isRoaming: stats.IsRoaming,
                 timestamp: stats.Timestamp,
                 softwareVersion: stats.SoftwareVersion,
-                hostVersion: stats.HostVersion);
+                hostVersion: stats.HostVersion,
+                moduleVendor: stats.ModuleVendor,
+                moduleModel: stats.ModuleModel);
         }
 
         // Write LTE signal (always present in LTE-only and NSA modes)
@@ -532,7 +560,9 @@ public class CellularModemService : ICellularModemService
                 neighborCount: hasTowerInfo ? stats.NeighborCells.Count : null,
                 nsaAvailable: stats.Is5gNsaAvailable,
                 softwareVersion: stats.SoftwareVersion,
-                hostVersion: stats.HostVersion);
+                hostVersion: stats.HostVersion,
+                moduleVendor: stats.ModuleVendor,
+                moduleModel: stats.ModuleModel);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -290,7 +290,7 @@ public class CellularModemService : ICellularModemService
 
             if (stats != null)
             {
-                if (await UpdateModemConfigAsync(modem.Id, null, success: true))
+                if (await UpdateModemConfigAsync(modem.Id, null, success: true, detectedModel: stats.ModemModel))
                 {
                     lock (_lock)
                     {
@@ -440,14 +440,14 @@ public class CellularModemService : ICellularModemService
         }
     }
 
-    private async Task<bool> UpdateModemConfigAsync(int modemId, string? error, bool success)
+    private async Task<bool> UpdateModemConfigAsync(int modemId, string? error, bool success, string? detectedModel = null)
     {
         try
         {
             using var scope = CreateSiteScope();
             var repository = scope.ServiceProvider.GetRequiredService<IModemRepository>();
             return await repository.UpdateModemPollResultAsync(
-                modemId, success ? DateTime.UtcNow : (DateTime?)null, error);
+                modemId, success ? DateTime.UtcNow : (DateTime?)null, error, detectedModel);
         }
         catch (Exception ex)
         {

--- a/src/NetworkOptimizer.Web/Services/CellularModemService.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemService.cs
@@ -493,7 +493,9 @@ public class CellularModemService : ICellularModemService
                 signalQuality: stats.SignalQuality,
                 signalBars: stats.Nr5g.Bars,
                 isRoaming: stats.IsRoaming,
-                timestamp: stats.Timestamp);
+                timestamp: stats.Timestamp,
+                softwareVersion: stats.SoftwareVersion,
+                hostVersion: stats.HostVersion);
         }
 
         // Write LTE signal (always present in LTE-only and NSA modes)
@@ -528,7 +530,9 @@ public class CellularModemService : ICellularModemService
                 cellId: ParseCellNumber(cell?.GlobalCellId),
                 tac: ParseCellNumber(cell?.Tac),
                 neighborCount: hasTowerInfo ? stats.NeighborCells.Count : null,
-                nsaAvailable: stats.Is5gNsaAvailable);
+                nsaAvailable: stats.Is5gNsaAvailable,
+                softwareVersion: stats.SoftwareVersion,
+                hostVersion: stats.HostVersion);
         }
     }
 

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2253,6 +2253,13 @@ a.stat-card-link:active {
     margin-bottom: 0.25rem;
 }
 
+/* The first column of each metric group. Same highlight the nav jump tints a row with, held on
+   and far weaker: this one is read against, not glanced at. */
+.data-table th.stats-lead,
+.data-table td.stats-lead {
+    background-color: color-mix(in srgb, var(--highlight-color) 10%, transparent);
+}
+
 .data-table {
     width: 100%;
     border-collapse: collapse;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -2247,6 +2247,10 @@ a.stat-card-link:active {
     -webkit-overflow-scrolling: touch;
 }
 
+.detail-table {
+    margin-bottom: 0.25rem;
+}
+
 .data-table {
     width: 100%;
     border-collapse: collapse;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1941,7 +1941,9 @@ a.stat-card-link:active {
     margin-left: 0.6rem;
 }
 
-.signal-gauge {
+/* The CM and ONT level bar. Scoped: Client Performance had .signal-gauge first, for its
+   dBm readout, and an unscoped rule here sizes that box to 14px and clips the value. */
+.signal-with-model .signal-gauge {
     width: 14px;
     height: 52px;
     border-radius: 7px;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1941,8 +1941,8 @@ a.stat-card-link:active {
     margin-left: 0.6rem;
 }
 
-/* The CM and ONT level bar. Scoped: Client Performance had .signal-gauge first, for its
-   dBm readout, and an unscoped rule here sizes that box to 14px and clips the value. */
+/* Scoped: Client Performance declares its own .signal-gauge for a dBm readout, and this
+   rule must never size that box. */
 .signal-with-model .signal-gauge {
     width: 14px;
     height: 52px;

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as sfp-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
@@ -244,17 +244,19 @@ function renderStatsTable(container, showAll) {
         const meta = modemMeta.find(mm => mm.id === m.id);
         return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
             visible: meta && visibility[meta.id] !== false,
-            values: [rsrp?.mean, rsrp?.min, rsrp?.max, rsrq?.mean, rsrq?.min, rsrq?.max,
-                snr?.mean, snr?.min, snr?.max, quality?.mean, quality?.min, quality?.max] };
+            values: [rsrp?.latest, rsrp?.mean, rsrp?.min, rsrp?.max,
+                rsrq?.latest, rsrq?.mean, rsrq?.min, rsrq?.max,
+                snr?.latest, snr?.mean, snr?.min, snr?.max,
+                quality?.latest, quality?.mean, quality?.min, quality?.max] };
     });
 
     renderTable(el, container, {
         nameHeader: 'Modem', rows, showAllRows: showAll,
         columns: [
-            { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
-            { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
-            { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
-            { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
+            { header: 'RSRP Latest', format: fmtDbm }, { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
+            { header: 'RSRQ Latest', format: fmtDb }, { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
+            { header: 'SNR Latest', format: fmtDb }, { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
+            { header: 'Qual Latest', format: fmtPct }, { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
         ],
         filter: { meta: () => modemMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -253,10 +253,10 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Modem', rows, showAllRows: showAll,
         columns: [
-            { header: 'RSRP Latest', format: fmtDbm }, { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
-            { header: 'RSRQ Latest', format: fmtDb }, { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
-            { header: 'SNR Latest', format: fmtDb }, { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
-            { header: 'Qual Latest', format: fmtPct }, { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
+            { header: 'RSRP Latest', format: fmtDbm , cls: 'stats-lead' }, { header: 'RSRP Mean', format: fmtDbm }, { header: 'RSRP Min', format: fmtDbm }, { header: 'RSRP Max', format: fmtDbm },
+            { header: 'RSRQ Latest', format: fmtDb , cls: 'stats-lead' }, { header: 'RSRQ Mean', format: fmtDb }, { header: 'RSRQ Min', format: fmtDb }, { header: 'RSRQ Max', format: fmtDb },
+            { header: 'SNR Latest', format: fmtDb , cls: 'stats-lead' }, { header: 'SNR Mean', format: fmtDb }, { header: 'SNR Min', format: fmtDb }, { header: 'SNR Max', format: fmtDb },
+            { header: 'Qual Latest', format: fmtPct , cls: 'stats-lead' }, { header: 'Qual Mean', format: fmtPct }, { header: 'Qual Min', format: fmtPct }, { header: 'Qual Max', format: fmtPct },
         ],
         filter: { meta: () => modemMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cellular-charts.js
@@ -9,6 +9,7 @@ import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 import { awaitContainer } from './chart-mount.js?v=1';
 import { loadWindowHours, saveWindowHours, markActiveRange, notifyWindowMoved } from './chart-window.js?v=2';
+import { detailsTableHtml } from './detail-table.js?v=1';
 
 // Storage scope for this tab's remembered time window.
 const WINDOW_TAB = 'cellular';
@@ -184,8 +185,46 @@ async function loadAndUpdate() {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
+        renderDetails(container);
         renderStatsTable(container);
     }
+}
+
+// Current state under the charts. One row per modem in the series, and a column no modem
+// fills is dropped - a single-SIM LTE modem shows far fewer than a 5G one.
+function renderDetails(container) {
+    const el = container.querySelector('.cellular-details');
+    if (!el) return;
+
+    // One row per modem, not per band series: an NSA modem draws an LTE and an NR line off
+    // the same hardware, and the state below is the hardware's.
+    const seen = new Set();
+    const modems = (lastData?.modems || []).filter(m => {
+        if (seen.has(m.modemId)) return false;
+        seen.add(m.modemId);
+        return true;
+    });
+
+    el.innerHTML = detailsTableHtml(modems, [
+        { header: 'Modem', cell: m => escapeHtml(m.label), always: true },
+        { header: 'Carrier', cell: m => m.current?.carrier ? escapeHtml(m.current.carrier) : null },
+        { header: 'Band', cell: m => m.current?.band ? escapeHtml(m.current.band) : null },
+        { header: 'Bandwidth', cell: m => m.current?.bandwidthMhz != null ? `${m.current.bandwidthMhz} MHz` : null },
+        { header: 'Cell ID', cell: m => m.current?.cellId ?? null },
+        { header: 'Roaming', cell: m => m.current?.roaming == null ? null : (m.current.roaming ? 'Yes' : 'No') },
+        {
+            header: 'Module',
+            cell: m => {
+                const v = m.current?.moduleVendor, model = m.current?.moduleModel;
+                if (!v && !model) return null;
+                const text = escapeHtml([v, model].filter(Boolean).join(' '));
+                return m.current?.softwareVersion
+                    ? `<span data-tooltip="Module firmware ${escapeHtml(m.current.softwareVersion)}" data-tooltip-wide>${text}</span>`
+                    : text;
+            },
+        },
+        { header: 'Device Firmware', cell: m => m.current?.hostVersion ? escapeHtml(m.current.hostVersion) : null },
+    ]);
 }
 
 const fmtDbm = v => v != null ? v.toFixed(2) : '-';

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-stats.js
@@ -15,12 +15,18 @@ export function percentile(sorted, p) {
 export function computeStats(values) {
     if (!values || values.length === 0) return null;
     const sorted = [...values].sort((a, b) => a - b);
+    const total = values.reduce((s, v) => s + v, 0);
     return {
-        mean: values.reduce((s, v) => s + v, 0) / values.length,
+        mean: total / values.length,
         min: sorted[0],
         max: sorted[sorted.length - 1],
         p95: percentile(sorted, 95),
         p99: percentile(sorted, 99),
+        // Callers pass values in series order with the gaps filtered out, so the last one is
+        // the newest reading - not the same as max, and the only "right now" figure on the tab.
+        latest: values[values.length - 1],
+        // Only meaningful where the series is a per-interval delta: a window's error count.
+        total,
     };
 }
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
@@ -235,18 +235,20 @@ function renderStatsTable(container, showAll) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
             visible: meta && visibility[meta.id] !== false,
-            values: [dsPower?.mean, dsPower?.min, dsPower?.max, dsSnr?.mean, dsSnr?.min, dsSnr?.max,
-                usPower?.mean, usPower?.min, usPower?.max, uncorr?.mean, uncorr?.max, corr?.mean, corr?.max] };
+            values: [dsPower?.latest, dsPower?.mean, dsPower?.min, dsPower?.max,
+                dsSnr?.latest, dsSnr?.mean, dsSnr?.min, dsSnr?.max,
+                usPower?.latest, usPower?.mean, usPower?.min, usPower?.max,
+                uncorr?.total, uncorr?.mean, uncorr?.max, corr?.total, corr?.mean, corr?.max] };
     });
 
     renderTable(el, container, {
         nameHeader: 'Device', rows, showAllRows: showAll,
         columns: [
-            { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
-            { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
-            { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
-            { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
-            { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
+            { header: 'DS Pwr Latest', format: fmtDbmv }, { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
+            { header: 'DS SNR Latest', format: fmtDb }, { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
+            { header: 'US Pwr Latest', format: fmtDbmv }, { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
+            { header: 'Uncorr Total', format: fmtInt }, { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
+            { header: 'Corr Total', format: fmtInt }, { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -244,11 +244,11 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Device', rows, showAllRows: showAll,
         columns: [
-            { header: 'DS Pwr Latest', format: fmtDbmv }, { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
-            { header: 'DS SNR Latest', format: fmtDb }, { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
-            { header: 'US Pwr Latest', format: fmtDbmv }, { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
-            { header: 'Uncorr Total', format: fmtInt }, { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
-            { header: 'Corr Total', format: fmtInt }, { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
+            { header: 'DS Pwr Latest', format: fmtDbmv , cls: 'stats-lead' }, { header: 'DS Pwr Mean', format: fmtDbmv }, { header: 'DS Pwr Min', format: fmtDbmv }, { header: 'DS Pwr Max', format: fmtDbmv },
+            { header: 'DS SNR Latest', format: fmtDb , cls: 'stats-lead' }, { header: 'DS SNR Mean', format: fmtDb }, { header: 'DS SNR Min', format: fmtDb }, { header: 'DS SNR Max', format: fmtDb },
+            { header: 'US Pwr Latest', format: fmtDbmv , cls: 'stats-lead' }, { header: 'US Pwr Mean', format: fmtDbmv }, { header: 'US Pwr Min', format: fmtDbmv }, { header: 'US Pwr Max', format: fmtDbmv },
+            { header: 'Uncorr Total', format: fmtInt , cls: 'stats-lead' }, { header: 'Uncorr Mean', format: fmtInt }, { header: 'Uncorr Max', format: fmtInt },
+            { header: 'Corr Total', format: fmtInt , cls: 'stats-lead' }, { header: 'Corr Mean', format: fmtInt }, { header: 'Corr Max', format: fmtInt },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/cm-charts.js
@@ -9,6 +9,7 @@ import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 import { awaitContainer } from './chart-mount.js?v=1';
 import { loadWindowHours, saveWindowHours, markActiveRange, notifyWindowMoved } from './chart-window.js?v=2';
+import { detailsTableHtml } from './detail-table.js?v=1';
 
 // Storage scope for this tab's remembered time window.
 const WINDOW_TAB = 'cm';
@@ -211,6 +212,7 @@ async function loadAndUpdate() {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
+        renderDetails(container);
         renderStatsTable(container);
     }
 }
@@ -567,4 +569,21 @@ export function unmount() {
     customTo = null;
     isInViewport = true;
     axisDate.reset();
+}
+
+// Current state under the charts. A column no modem fills is dropped.
+function renderDetails(container) {
+    const el = container.querySelector('.cm-details');
+    if (!el) return;
+
+    el.innerHTML = detailsTableHtml(lastData?.devices || [], [
+        { header: 'Modem', cell: d => escapeHtml(d.label), always: true },
+        {
+            header: 'Locked Channels DS / US',
+            cell: d => {
+                const ds = d.current?.lockedDsChannels, us = d.current?.lockedUsChannels;
+                return ds == null && us == null ? null : `${ds ?? '-'} / ${us ?? '-'}`;
+            },
+        },
+    ]);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/detail-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/detail-table.js
@@ -1,0 +1,42 @@
+// The current-state table drawn under a tab's time-series charts, shared by every device type.
+//
+// One renderer, a column list per device: a column no device in the series fills is dropped
+// rather than printed as a row of dashes, so the same tab shows seven columns for hardware
+// that reports everything and three for hardware that reports little.
+
+const _esc = document.createElement('span');
+export function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+
+/// Format seconds as the uptime string these tables use.
+export function fmtUptime(s) {
+    if (s == null) return null;
+    return `${Math.floor(s / 86400)}d ${Math.floor(s % 86400 / 3600)}h ${Math.floor(s % 3600 / 60)}m`;
+}
+
+/// The last point in a series that filled `key`, for a table showing current state rather
+/// than history. Devices stop reporting individual fields while still reporting others.
+export function lastValue(points, key) {
+    if (!points?.length) return null;
+    for (let i = points.length - 1; i >= 0; i--) {
+        if (points[i]?.[key] != null) return points[i][key];
+    }
+    return null;
+}
+
+/// Render the table. Each column is `{ header, cell(item), always }`; `always` pins a column
+/// that must show even when empty, which is how the name column survives.
+export function detailsTableHtml(items, columns) {
+    if (!items?.length) return '';
+
+    const values = items.map(item => columns.map(c => c.cell(item)));
+    const shown = columns.filter((c, i) => c.always || values.some(row => row[i] != null));
+    if (!shown.length) return '';
+
+    const head = shown.map(c => `<th>${c.header}</th>`).join('');
+    const rows = values.map(row =>
+        `<tr>${shown.map(c => `<td>${row[columns.indexOf(c)] ?? '-'}</td>`).join('')}</tr>`).join('');
+
+    return `<div class="table-responsive detail-table"><table class="data-table">
+        <thead><tr>${head}</tr></thead>
+        <tbody>${rows}</tbody></table></div>`;
+}

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -331,6 +331,7 @@ function renderStatsTable(container, showAll) {
     const customCols = [];
     for (const def of customFieldDefs) {
         customCols.push(
+            { header: `${def.description} Latest`, format: fmtCustom, cls: 'stats-lead' },
             { header: `${def.description} Mean`, format: fmtCustom },
             { header: `${def.description} Min`, format: fmtCustom },
             { header: `${def.description} Max`, format: fmtCustom },
@@ -339,6 +340,7 @@ function renderStatsTable(container, showAll) {
 
     const hasFanData = lastData.devices.some(d => (d.data || []).some(p => p.fan != null));
     const fanCols = hasFanData ? [
+        { header: 'Fan Latest', format: fmtRpm, cls: 'stats-lead' },
         { header: 'Fan Mean', format: fmtRpm }, { header: 'Fan Min', format: fmtRpm }, { header: 'Fan Max', format: fmtRpm },
     ] : [];
 
@@ -347,17 +349,19 @@ function renderStatsTable(container, showAll) {
         const temp = computeStats(pts.map(p => p.temp).filter(v => v != null));
         const cpu = computeStats(pts.map(p => p.cpu).filter(v => v != null));
         const mem = computeStats(pts.map(p => p.mem).filter(v => v != null));
-        const baseValues = [temp?.mean, temp?.min, temp?.max, cpu?.mean, cpu?.min, cpu?.max, mem?.mean, mem?.min, mem?.max];
+        const baseValues = [temp?.latest, temp?.mean, temp?.min, temp?.max,
+            cpu?.latest, cpu?.mean, cpu?.min, cpu?.max,
+            mem?.latest, mem?.mean, mem?.min, mem?.max];
 
         if (hasFanData) {
             const fan = computeStats(pts.map(p => p.fan).filter(v => v != null));
-            baseValues.push(fan?.mean, fan?.min, fan?.max);
+            baseValues.push(fan?.latest, fan?.mean, fan?.min, fan?.max);
         }
 
         for (const def of customFieldDefs) {
             const vals = (d.custom?.[def.fieldName] || []).map(p => p.value).filter(v => v != null);
             const stats = computeStats(vals);
-            baseValues.push(stats?.mean, stats?.min, stats?.max);
+            baseValues.push(stats?.latest, stats?.mean, stats?.min, stats?.max);
         }
 
         return { id: d.mac, label: d.name, color: hashColor(d.name),
@@ -368,9 +372,9 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Device', rows, showAllRows: showAll,
         columns: [
-            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
-            { header: 'CPU Mean', format: fmtPct }, { header: 'CPU Min', format: fmtPct }, { header: 'CPU Max', format: fmtPct },
-            { header: 'Mem Mean', format: fmtPct }, { header: 'Mem Min', format: fmtPct }, { header: 'Mem Max', format: fmtPct },
+            { header: 'Temp Latest', format: fmtTemp, cls: 'stats-lead' }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'CPU Latest', format: fmtPct, cls: 'stats-lead' }, { header: 'CPU Mean', format: fmtPct }, { header: 'CPU Min', format: fmtPct }, { header: 'CPU Max', format: fmtPct },
+            { header: 'Mem Latest', format: fmtPct, cls: 'stats-lead' }, { header: 'Mem Mean', format: fmtPct }, { header: 'Mem Min', format: fmtPct }, { header: 'Mem Max', format: fmtPct },
             ...fanCols,
             ...customCols,
         ],

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -2,7 +2,7 @@
 // filter badges, poll interval scaling) into a shared module so latency-charts,
 // device-health-charts, and future chart sets share one implementation.
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=4';

--- a/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/latency-charts.js
@@ -5,7 +5,7 @@
 // device-health-charts, and future chart sets share one implementation.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld } from './chart-tooltip.js?v=15';
 import { renderFilterReset, renderInactiveToggle, isFiltered } from './chart-filter.js?v=6';
 import { downloadColor, uploadColor } from './chart-colors.js?v=2';

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -7,7 +7,7 @@ import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=4';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
-import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=2';
+import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 import { awaitContainer } from './chart-mount.js?v=1';
 import { loadWindowHours, saveWindowHours, markActiveRange, notifyWindowMoved } from './chart-window.js?v=2';

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -342,9 +342,9 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Device', rows, showAllRows: showAll,
         columns: [
-            { header: 'RX Latest', format: fmtDbm }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
-            { header: 'TX Latest', format: fmtDbm }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
-            { header: 'Temp Latest', format: fmtTemp }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'RX Latest', format: fmtDbm , cls: 'stats-lead' }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Latest', format: fmtDbm , cls: 'stats-lead' }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Latest', format: fmtTemp , cls: 'stats-lead' }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as cellular-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=4';
@@ -335,15 +335,16 @@ function renderStatsTable(container, showAll) {
         const meta = deviceMeta.find(dm => dm.id === d.id);
         return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
             visible: meta && visibility[meta.id] !== false,
-            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
+            values: [rx?.latest, rx?.mean, rx?.min, rx?.max, tx?.latest, tx?.mean, tx?.min, tx?.max,
+                     temp?.latest, temp?.mean, temp?.min, temp?.max] };
     });
 
     renderTable(el, container, {
         nameHeader: 'Device', rows, showAllRows: showAll,
         columns: [
-            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
-            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
-            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'RX Latest', format: fmtDbm }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Latest', format: fmtDbm }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Latest', format: fmtTemp }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/pon-section.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/pon-section.js
@@ -5,9 +5,7 @@
 // groups and event marks stay with each tab, which owns its own layout.
 
 import { alignedPoints } from './chart-tooltip.js?v=15';
-
-const _esc = document.createElement('span');
-function escapeHtml(s) { _esc.textContent = s; return _esc.innerHTML; }
+import { detailsTableHtml, escapeHtml, fmtUptime } from './detail-table.js?v=1';
 
 // Same encoding PonLinkStateExtensions.ToInfluxValue uses for pon_link_status.
 export const PLOAM_LABELS = {
@@ -92,11 +90,9 @@ export function updatePonCard(container, cardSelector, chart, series, prepare = 
 /// The details table. `labelHeader` names the first column, `extras` appends tab-specific ones.
 /// A column no ONT fills is dropped rather than printed as a row of dashes.
 export function ponDetailsHtml(items, labelHeader, extras = []) {
-    const fmtUp = s => s == null ? null
-        : `${Math.floor(s / 86400)}d ${Math.floor(s % 86400 / 3600)}h ${Math.floor(s % 3600 / 60)}m`;
     const lastOf = item => [...item.pon].reverse().find(p => p.state != null) || item.pon[item.pon.length - 1];
 
-    const columns = [
+    return detailsTableHtml(items, [
         { header: escapeHtml(labelHeader), cell: item => escapeHtml(item.label), always: true },
         { header: 'PLOAM State', cell: item => { const l = lastOf(item); return l.state == null ? null : escapeHtml(PLOAM_LABELS[l.state] || l.state); } },
         { header: 'ONU ID', cell: item => lastOf(item).onuId },
@@ -111,16 +107,7 @@ export function ponDetailsHtml(items, labelHeader, extras = []) {
         },
         // Module uptime where the ONT reports it, link uptime where it reports that instead.
         // No provider serves both, so the column never has to choose between them.
-        { header: 'ONT Uptime', cell: item => fmtUp(lastOf(item).uptime ?? item.linkUptime) },
+        { header: 'ONT Uptime', cell: item => fmtUptime(lastOf(item).uptime ?? item.linkUptime) },
         ...extras,
-    ];
-
-    const values = items.map(item => columns.map(c => c.cell(item)));
-    const shown = columns.filter((c, i) => c.always || values.some(row => row[i] != null));
-    const head = shown.map(c => `<th>${c.header}</th>`).join('');
-    const rows = values.map(row =>
-        `<tr>${shown.map(c => `<td>${row[columns.indexOf(c)] ?? '-'}</td>`).join('')}</tr>`).join('');
-    return `<div class="table-responsive"><table class="data-table">
-        <thead><tr>${head}</tr></thead>
-        <tbody>${rows}</tbody></table></div>`;
+    ]);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/port-stats-table.js
@@ -2,7 +2,7 @@
 // at the current map scrubber position (or live), renders them via the shared
 // renderStatsTable(), and exposes selectDevice() so a map double-click can
 // isolate a single switch/gateway.
-import { renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { renderFilterReset } from './chart-filter.js?v=6';
 
 const _esc = document.createElement('span');

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -8,7 +8,7 @@ import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=4';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';
-import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=2';
+import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=3';
 import { awaitContainer } from './chart-mount.js?v=1';
 import { loadWindowHours, saveWindowHours, markActiveRange, notifyWindowMoved } from './chart-window.js?v=2';
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -2,7 +2,7 @@
 // Same control pattern as latency-charts.js and device-health-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createMarkLayer } from './chart-event-marks.js?v=4';
@@ -384,15 +384,16 @@ function renderStatsTable(container, showAll) {
         const meta = moduleMeta.find(mm => mm.id === m.id);
         return { id: m.id, label: m.label, color: meta?.color || '#9ca3af',
             visible: meta && visibility[meta.id] !== false,
-            values: [rx?.mean, rx?.min, rx?.max, tx?.mean, tx?.min, tx?.max, temp?.mean, temp?.min, temp?.max] };
+            values: [rx?.latest, rx?.mean, rx?.min, rx?.max, tx?.latest, tx?.mean, tx?.min, tx?.max,
+                     temp?.latest, temp?.mean, temp?.min, temp?.max] };
     });
 
     renderTable(el, container, {
         nameHeader: 'Module', rows, showAllRows: showAll,
         columns: [
-            { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
-            { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
-            { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'RX Latest', format: fmtDbm }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Latest', format: fmtDbm }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Latest', format: fmtTemp }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
         ],
         filter: { meta: () => moduleMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -391,9 +391,9 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Module', rows, showAllRows: showAll,
         columns: [
-            { header: 'RX Latest', format: fmtDbm }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
-            { header: 'TX Latest', format: fmtDbm }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
-            { header: 'Temp Latest', format: fmtTemp }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
+            { header: 'RX Latest', format: fmtDbm , cls: 'stats-lead' }, { header: 'RX Mean', format: fmtDbm }, { header: 'RX Min', format: fmtDbm }, { header: 'RX Max', format: fmtDbm },
+            { header: 'TX Latest', format: fmtDbm , cls: 'stats-lead' }, { header: 'TX Mean', format: fmtDbm }, { header: 'TX Min', format: fmtDbm }, { header: 'TX Max', format: fmtDbm },
+            { header: 'Temp Latest', format: fmtTemp , cls: 'stats-lead' }, { header: 'Temp Mean', format: fmtTemp }, { header: 'Temp Min', format: fmtTemp }, { header: 'Temp Max', format: fmtTemp },
         ],
         filter: { meta: () => moduleMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -10,6 +10,7 @@ import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';
 import { awaitContainer } from './chart-mount.js?v=1';
 import { loadWindowHours, saveWindowHours, markActiveRange, notifyWindowMoved } from './chart-window.js?v=2';
+import { detailsTableHtml, fmtUptime } from './detail-table.js?v=1';
 
 // Storage scope for this tab's remembered time window.
 const WINDOW_TAB = 'starlink';
@@ -217,6 +218,7 @@ async function loadAndUpdate() {
     const container = document.getElementById(containerId);
     if (container) {
         renderBadges(container);
+        renderDetails(container);
         renderStatsTable(container);
     }
 }
@@ -592,4 +594,19 @@ export function unmount() {
     customTo = null;
     isInViewport = true;
     axisDate.reset();
+}
+
+// Current state under the charts. A column no dish fills is dropped.
+function renderDetails(container) {
+    const el = container.querySelector('.starlink-details');
+    if (!el) return;
+
+    el.innerHTML = detailsTableHtml(lastData?.devices || [], [
+        { header: 'Dish', cell: d => escapeHtml(d.label), always: true },
+        { header: 'Uptime', cell: d => fmtUptime(d.current?.uptimeSeconds) },
+        { header: 'Ethernet', cell: d => d.current?.ethSpeedMbps != null ? `${d.current.ethSpeedMbps} Mbps` : null },
+        { header: 'GPS Satellites', cell: d => d.current?.gpsSats ?? null },
+        { header: 'Obstruction', cell: d => d.current?.obstructed != null ? `${(d.current.obstructed * 100).toFixed(2)}%` : null },
+        { header: 'Active Alerts', cell: d => d.current?.alertCount ?? null },
+    ]);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -602,7 +602,7 @@ function renderDetails(container) {
     if (!el) return;
 
     el.innerHTML = detailsTableHtml(lastData?.devices || [], [
-        { header: 'Dish', cell: d => escapeHtml(d.label), always: true },
+        { header: 'Terminal', cell: d => escapeHtml(d.label), always: true },
         { header: 'Uptime', cell: d => fmtUptime(d.current?.uptimeSeconds) },
         { header: 'Ethernet', cell: d => d.current?.ethSpeedMbps != null ? `${d.current.ethSpeedMbps} Mbps` : null },
         { header: 'GPS Satellites', cell: d => d.current?.gpsSats ?? null },

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -3,7 +3,7 @@
 // Same control pattern as cellular-charts.js and cm-charts.js.
 
 import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
-import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=7';
+import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
@@ -246,19 +246,21 @@ function renderStatsTable(container, showAll) {
         const meta = deviceMeta.find(mm => mm.id === d.id);
         return { id: d.id, label: d.label, color: meta?.color || '#9ca3af',
             visible: meta && visibility[meta.id] !== false,
-            values: [power?.mean, powerMax?.max, drop?.mean, dropMax?.max,
-                obstr?.mean, obstr?.max, outageSum, gps?.mean, align?.mean, align?.max] };
+            values: [power?.latest, power?.mean, powerMax?.max,
+                drop?.latest, drop?.mean, dropMax?.max,
+                obstr?.latest, obstr?.mean, obstr?.max, outageSum,
+                gps?.latest, gps?.mean, align?.latest, align?.mean, align?.max] };
     });
 
     renderTable(el, container, {
         nameHeader: 'Terminal', rows, showAllRows: showAll,
         columns: [
-            { header: 'Power Mean', format: fmtW }, { header: 'Power Max', format: fmtW },
-            { header: 'Drop Mean', format: fmtPct }, { header: 'Drop Max', format: fmtPct },
-            { header: 'Obstr Mean', format: fmtPct }, { header: 'Obstr Max', format: fmtPct },
+            { header: 'Power Latest', format: fmtW }, { header: 'Power Mean', format: fmtW }, { header: 'Power Max', format: fmtW },
+            { header: 'Drop Latest', format: fmtPct }, { header: 'Drop Mean', format: fmtPct }, { header: 'Drop Max', format: fmtPct },
+            { header: 'Obstr Latest', format: fmtPct }, { header: 'Obstr Mean', format: fmtPct }, { header: 'Obstr Max', format: fmtPct },
             { header: 'Outage Total', format: fmtSec },
-            { header: 'GPS Mean', format: fmtSats },
-            { header: 'Align Mean', format: fmtDeg }, { header: 'Align Max', format: fmtDeg },
+            { header: 'GPS Latest', format: fmtSats }, { header: 'GPS Mean', format: fmtSats },
+            { header: 'Align Latest', format: fmtDeg }, { header: 'Align Mean', format: fmtDeg }, { header: 'Align Max', format: fmtDeg },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/starlink-charts.js
@@ -255,12 +255,12 @@ function renderStatsTable(container, showAll) {
     renderTable(el, container, {
         nameHeader: 'Terminal', rows, showAllRows: showAll,
         columns: [
-            { header: 'Power Latest', format: fmtW }, { header: 'Power Mean', format: fmtW }, { header: 'Power Max', format: fmtW },
-            { header: 'Drop Latest', format: fmtPct }, { header: 'Drop Mean', format: fmtPct }, { header: 'Drop Max', format: fmtPct },
-            { header: 'Obstr Latest', format: fmtPct }, { header: 'Obstr Mean', format: fmtPct }, { header: 'Obstr Max', format: fmtPct },
-            { header: 'Outage Total', format: fmtSec },
-            { header: 'GPS Latest', format: fmtSats }, { header: 'GPS Mean', format: fmtSats },
-            { header: 'Align Latest', format: fmtDeg }, { header: 'Align Mean', format: fmtDeg }, { header: 'Align Max', format: fmtDeg },
+            { header: 'Power Latest', format: fmtW , cls: 'stats-lead' }, { header: 'Power Mean', format: fmtW }, { header: 'Power Max', format: fmtW },
+            { header: 'Drop Latest', format: fmtPct , cls: 'stats-lead' }, { header: 'Drop Mean', format: fmtPct }, { header: 'Drop Max', format: fmtPct },
+            { header: 'Obstr Latest', format: fmtPct , cls: 'stats-lead' }, { header: 'Obstr Mean', format: fmtPct }, { header: 'Obstr Max', format: fmtPct },
+            { header: 'Outage Total', format: fmtSec , cls: 'stats-lead' },
+            { header: 'GPS Latest', format: fmtSats , cls: 'stats-lead' }, { header: 'GPS Mean', format: fmtSats },
+            { header: 'Align Latest', format: fmtDeg , cls: 'stats-lead' }, { header: 'Align Mean', format: fmtDeg }, { header: 'Align Max', format: fmtDeg },
         ],
         filter: { meta: () => deviceMeta, key: 'id', visibility: () => visibility,
             resetVisibility: () => { visibility = {}; },

--- a/tests/NetworkOptimizer.Monitoring.Tests/QmicliParserTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/QmicliParserTests.cs
@@ -485,4 +485,34 @@ LTE:
     }
 
     #endregion
+
+    #region Module firmware revision
+
+    [Fact]
+    public void ParseRevision_KeepsTheVersionAndDropsBuildMetadata()
+    {
+        var output = @"[/dev/wwan0qmi0] Device revision retrieved:
+        Revision: 'SWIX65C_03.04.10.01 00b8ca jenkins 2025/06/18 05:56:16'";
+
+        QmicliParser.ParseRevision(output).Should().Be("SWIX65C_03.04.10.01");
+    }
+
+    [Fact]
+    public void ParseRevision_BareVersion_ReturnsItWhole()
+    {
+        var output = "        Revision: 'EM9291_01.02.03'";
+
+        QmicliParser.ParseRevision(output).Should().Be("EM9291_01.02.03");
+    }
+
+    [Fact]
+    public void ParseRevision_UnsupportedOrEmpty_ReturnsNull()
+    {
+        QmicliParser.ParseRevision(null).Should().BeNull();
+        QmicliParser.ParseRevision("").Should().BeNull();
+        QmicliParser.ParseRevision("error: couldn't get revision: QMI protocol error").Should().BeNull();
+        QmicliParser.ParseRevision("qmicli: unrecognized option '--dms-get-revision'").Should().BeNull();
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
@@ -340,6 +340,22 @@ OK
     }
 
     [Fact]
+    public void ParseRevisionResponse_IgnoresBootNoticesFromAJustRebootedModem()
+    {
+        var output = @"
+RDY
++CPIN: READY
++QUSIM: 1
+QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005
+
+OK
+";
+
+        QuectelAtParser.ParseRevisionResponse(output)
+            .Should().Be("QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005");
+    }
+
+    [Fact]
     public void ParseRevisionResponse_UnsupportedOrEmpty_ReturnsNull()
     {
         QuectelAtParser.ParseRevisionResponse(null).Should().BeNull();

--- a/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
@@ -211,4 +211,103 @@ OK
     }
 
     #endregion
+
+    #region Bandwidth enum (real device)
+
+    // Sample from a GL-E5800 with an SoC-integrated RG650V-NA. Cell identity is replaced
+    // with test values; signal and bandwidth fields are as reported. The router's own
+    // cellular ubus service called the NR leg 90 MHz, and AT+QCAINFO put the LTE anchor
+    // at 75 resource blocks, which is 15 MHz.
+    private const string Rg650vNsaOutput = @"
++QENG: ""servingcell"",""NOCONN""
++QENG: ""LTE"",""FDD"",310,260,""0A1B2C3"",438,975,2,4,4,""1234"",-95,-7,-68,20,15,150,-
++QENG: ""NR5G-NSA"",310,260,46,-81,34,-10,502110,41,11,1
+
+OK
+";
+
+    [Fact]
+    public void Parse_Nr5gNsa_MapsBandwidthIndexToMhz()
+    {
+        var stats = QuectelAtParser.Parse(Rg650vNsaOutput, TestHost, TestName, TestModel);
+
+        stats.Should().NotBeNull();
+        stats!.ActiveBand.Should().NotBeNull();
+        stats.ActiveBand!.BandClass.Should().Be("n41");
+        stats.ActiveBand.BandwidthMhz.Should().Be(90);
+    }
+
+    [Fact]
+    public void Parse_Lte_MapsBandwidthIndexToMhz()
+    {
+        // The NSA line overrides ActiveBand with the NR leg, so read the LTE anchor
+        // on its own to reach the LTE bandwidth field.
+        var lteOnly = @"
++QENG: ""servingcell"",""NOCONN""
++QENG: ""LTE"",""FDD"",310,260,""0A1B2C3"",438,975,2,4,4,""1234"",-95,-7,-68,20,15,150,-
+
+OK
+";
+
+        var stats = QuectelAtParser.Parse(lteOnly, TestHost, TestName, TestModel);
+
+        stats.Should().NotBeNull();
+        stats!.ActiveBand.Should().NotBeNull();
+        stats.ActiveBand!.BandClass.Should().Be("eutran-2");
+        stats.ActiveBand.BandwidthMhz.Should().Be(15);
+    }
+
+    [Fact]
+    public void Parse_Nr5gNsa_ReadsSignalFromBothLegs()
+    {
+        var stats = QuectelAtParser.Parse(Rg650vNsaOutput, TestHost, TestName, TestModel);
+
+        stats.Should().NotBeNull();
+        stats!.NetworkMode.Should().Be(CellularNetworkMode.Nr5gNsa);
+        stats.Lte!.Rsrp.Should().Be(-95);
+        stats.Lte.Rsrq.Should().Be(-7);
+        stats.Lte.Snr.Should().Be(20);
+        stats.Nr5g!.Rsrp.Should().Be(-81);
+        stats.Nr5g.Rsrq.Should().Be(-10);
+        stats.Nr5g.Snr.Should().Be(34);
+        stats.ServingCell!.PhysicalCellId.Should().Be(438);
+        stats.ServingCell.Earfcn.Should().Be(975);
+    }
+
+    #endregion
+
+    #region Operator name
+
+    [Fact]
+    public void ParseOperator_ReturnsCarrierName()
+    {
+        var output = @"
++COPS: 0,0,""T-Mobile"",13
+
+OK
+";
+
+        QuectelAtParser.ParseOperator(output).Should().Be("T-Mobile");
+    }
+
+    [Fact]
+    public void ParseOperator_NotRegistered_ReturnsNull()
+    {
+        var output = @"
++COPS: 0
+
+OK
+";
+
+        QuectelAtParser.ParseOperator(output).Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseOperator_NoResponse_ReturnsNull()
+    {
+        QuectelAtParser.ParseOperator("").Should().BeNull();
+        QuectelAtParser.ParseOperator("ERROR").Should().BeNull();
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
+++ b/tests/NetworkOptimizer.Monitoring.Tests/QuectelAtParserTests.cs
@@ -310,4 +310,45 @@ OK
     }
 
     #endregion
+
+    #region Module firmware (AT+CGMR)
+
+    [Fact]
+    public void ParseRevisionResponse_ReturnsTheBareVersion()
+    {
+        var output = @"
+AT+CGMR
+
+QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005
+
+OK
+";
+
+        QuectelAtParser.ParseRevisionResponse(output)
+            .Should().Be("QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005");
+    }
+
+    [Fact]
+    public void ParseRevisionResponse_StripsThePrefixWhenFirmwareUsesOne()
+    {
+        var output = @"+CGMR: EG25GGBR07A08M2G
+
+OK
+";
+
+        QuectelAtParser.ParseRevisionResponse(output).Should().Be("EG25GGBR07A08M2G");
+    }
+
+    [Fact]
+    public void ParseRevisionResponse_UnsupportedOrEmpty_ReturnsNull()
+    {
+        QuectelAtParser.ParseRevisionResponse(null).Should().BeNull();
+        QuectelAtParser.ParseRevisionResponse("").Should().BeNull();
+        QuectelAtParser.ParseRevisionResponse(@"
+ERROR
+").Should().BeNull();
+        QuectelAtParser.ParseRevisionResponse("+CME ERROR: 4").Should().BeNull();
+    }
+
+    #endregion
 }

--- a/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/ModemRepositoryTests.cs
@@ -220,4 +220,52 @@ public class ModemRepositoryTests : IDisposable
     {
         (await _repository.UpdateModemPollResultAsync(9999, DateTime.UtcNow, null)).Should().BeFalse();
     }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_DetectedModel_ReplacesTheProviderPlaceholder()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "Cellular Backup", Host = "192.0.2.20", Enabled = true, ModemType = "GL-iNet",
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.UpdateModemPollResultAsync(modem.Id, DateTime.UtcNow, null, "RG650V-NA");
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.ModemType.Should().Be("RG650V-NA");
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_DetectedModel_LeavesAModelTheUserChose()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "Cellular Backup", Host = "192.0.2.20", Enabled = true, ModemType = "Spare unit in the garage",
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.UpdateModemPollResultAsync(modem.Id, DateTime.UtcNow, null, "RG650V-NA");
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.ModemType.Should().Be("Spare unit in the garage");
+    }
+
+    [Fact]
+    public async Task UpdateModemPollResultAsync_NoDetectedModel_LeavesModemTypeAlone()
+    {
+        var modem = new ModemConfiguration
+        {
+            Name = "Cellular Backup", Host = "192.0.2.20", Enabled = true, ModemType = "GL-iNet",
+        };
+        _context.ModemConfigurations.Add(modem);
+        await _context.SaveChangesAsync();
+
+        await _repository.UpdateModemPollResultAsync(modem.Id, DateTime.UtcNow, null);
+
+        var reloaded = await _repository.GetModemConfigurationAsync(modem.Id);
+        reloaded!.ModemType.Should().Be("GL-iNet");
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
@@ -162,4 +162,21 @@ usb1
 
         act.Should().Throw<ArgumentException>();
     }
+
+    [Fact]
+    public void ParseDiscovery_BoardQueryUnsupported_StillResolvesTheModem()
+    {
+        // A GL device that answers about its modem but not its board: the sections that did
+        // come back must still be used.
+        var output = IntegratedModemDiscovery[..IntegratedModemDiscovery.IndexOf("===GLVER===")]
+                     + "===GLVER===\n===BOARD===\n";
+
+        var endpoint = GlModemTransport.ParseDiscovery(output, configuredBus: "");
+
+        endpoint.Bus.Should().Be("cpu");
+        endpoint.Sub.Should().Be(1);
+        endpoint.Model.Should().Be("RG650V-NA");
+        endpoint.HostVersion.Should().BeNull();
+        endpoint.Product.Should().BeNull();
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
@@ -28,6 +28,20 @@ public class GlModemTransportTests
         "slot_switch_count": 0
 }
 ===USB===
+===GLVER===
+4.8.5
+===BOARD===
+{
+        "kernel": "5.15.170-perf",
+        "hostname": "GL-E5800",
+        "board_name": "qcom,sdxpinn-idp",
+        "release": {
+                "distribution": "OpenWrt",
+                "version": "23.05.4",
+                "target": "sdx75/generic",
+                "description": "OpenWrt 23.05.4 r24012-d8dd03c46f"
+        }
+}
 """;
 
     private const string UsbOnlyDiscovery = """
@@ -37,6 +51,15 @@ public class GlModemTransportTests
 1-1
 1-1.2
 usb1
+===GLVER===
+===BOARD===
+{
+        "release": {
+                "distribution": "OpenWrt",
+                "version": "23.05.4",
+                "description": "OpenWrt 23.05.4 r24012-d8dd03c46f"
+        }
+}
 """;
 
     [Fact]
@@ -49,6 +72,24 @@ usb1
         endpoint.Model.Should().Be("RG650V-NA");
         endpoint.Vendor.Should().Be("quectel");
         endpoint.Description.Should().Be("Quectel RG650V-NA");
+        endpoint.SoftwareVersion.Should().Be("QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005");
+        endpoint.HostVersion.Should().Be("4.8.5", "GL stamps their own firmware version, which is what the owner sees");
+    }
+
+    [Fact]
+    public void ParseDiscovery_NoGlVersionFile_FallsBackToTheOpenWrtBase()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(UsbOnlyDiscovery, configuredBus: "");
+
+        endpoint.HostVersion.Should().Be("OpenWrt 23.05.4 r24012-d8dd03c46f");
+    }
+
+    [Fact]
+    public void ParseDiscovery_NeitherSource_LeavesHostVersionUnset()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery("===INFO===\n===STATUS===\n===USB===\n", configuredBus: "");
+
+        endpoint.HostVersion.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
@@ -27,7 +27,6 @@ public class GlModemTransportTests
         "current_sim_slot": "1",
         "slot_switch_count": 0
 }
-===USB===
 ===GLVER===
 4.8.5
 ===BOARD===
@@ -47,10 +46,6 @@ public class GlModemTransportTests
     private const string UsbOnlyDiscovery = """
 ===INFO===
 ===STATUS===
-===USB===
-1-1
-1-1.2
-usb1
 ===GLVER===
 ===BOARD===
 {
@@ -70,7 +65,7 @@ usb1
         endpoint.Bus.Should().Be("cpu");
         endpoint.Sub.Should().Be(1);
         endpoint.Model.Should().Be("RG650V-NA");
-        endpoint.Vendor.Should().Be("quectel");
+        endpoint.Vendor.Should().Be("Quectel", "GL reports it lowercase; the stats and Test Connection must agree");
         endpoint.Description.Should().Be("Quectel RG650V-NA");
         endpoint.SoftwareVersion.Should().Be("QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005");
         endpoint.HostVersion.Should().Be("4.8.5", "GL stamps their own firmware version, which is what the owner sees");
@@ -110,11 +105,11 @@ usb1
     }
 
     [Fact]
-    public void ParseDiscovery_NoUbusNoConfiguredBus_TakesFirstUsbPath()
+    public void ParseDiscovery_NoUbusNoConfiguredBus_LeavesTheBusToGlModem()
     {
         var endpoint = GlModemTransport.ParseDiscovery(UsbOnlyDiscovery, configuredBus: "");
 
-        endpoint.Bus.Should().Be("1-1");
+        endpoint.Bus.Should().BeNull("forcing -B at a guessed USB path addresses the hub a modem sits behind");
         endpoint.Sub.Should().BeNull();
     }
 

--- a/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Services.CellularModemProviders;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// Tests for gl_modem addressing discovery. Fixtures are trimmed from a GL-E5800
+/// running an SoC-integrated Quectel RG650V-NA.
+/// </summary>
+public class GlModemTransportTests
+{
+    private const string IntegratedModemDiscovery = """
+===INFO===
+{
+        "bus": "cpu",
+        "name": "RG650V-NA",
+        "version": "QRM650VNA01ACR02A04G8G_OCPU_RGH_01.005.01.005",
+        "vendor": "quectel",
+        "sim_slot_num": 2,
+        "at_port": "/dev/smd9"
+}
+===STATUS===
+{
+        "bus": "cpu",
+        "status": 0,
+        "current_sim_slot": "1",
+        "slot_switch_count": 0
+}
+===USB===
+""";
+
+    private const string UsbOnlyDiscovery = """
+===INFO===
+===STATUS===
+===USB===
+1-1
+1-1.2
+usb1
+""";
+
+    [Fact]
+    public void ParseDiscovery_IntegratedModem_UsesCpuBusAndCurrentSimSlot()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(IntegratedModemDiscovery, configuredBus: "");
+
+        endpoint.Bus.Should().Be("cpu");
+        endpoint.Sub.Should().Be(1);
+        endpoint.Model.Should().Be("RG650V-NA");
+        endpoint.Vendor.Should().Be("quectel");
+        endpoint.Description.Should().Be("Quectel RG650V-NA");
+    }
+
+    [Fact]
+    public void ParseDiscovery_IntegratedModem_WinsOverConfiguredBus()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(IntegratedModemDiscovery, configuredBus: "1-1.2");
+
+        endpoint.Bus.Should().Be("cpu");
+    }
+
+    [Fact]
+    public void ParseDiscovery_NoUbus_PrefersConfiguredBusAndOmitsSub()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(UsbOnlyDiscovery, configuredBus: "1-1.4");
+
+        endpoint.Bus.Should().Be("1-1.4");
+        endpoint.Sub.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDiscovery_NoUbusNoConfiguredBus_TakesFirstUsbPath()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(UsbOnlyDiscovery, configuredBus: "");
+
+        endpoint.Bus.Should().Be("1-1");
+        endpoint.Sub.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParseDiscovery_NothingFound_LeavesGlModemToChoose()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery("===INFO===\n===STATUS===\n===USB===\n", configuredBus: "");
+
+        endpoint.Bus.Should().BeNull();
+        endpoint.Sub.Should().BeNull();
+        endpoint.Description.Should().BeNull();
+    }
+
+    [Fact]
+    public void BuildAtCommand_IntegratedModem_PassesBothFlags()
+    {
+        var command = GlModemTransport.BuildAtCommand(new GlModemEndpoint("cpu", 1), "AT+QENG=\"servingcell\"");
+
+        command.Should().Be("gl_modem -B cpu -U 1 AT 'AT+QENG=\"servingcell\"'");
+    }
+
+    [Fact]
+    public void BuildAtCommand_UsbModem_OmitsSubFlag()
+    {
+        var command = GlModemTransport.BuildAtCommand(new GlModemEndpoint("1-1.2", null), "AT+COPS?");
+
+        command.Should().Be("gl_modem -B 1-1.2 AT 'AT+COPS?'");
+    }
+
+    [Fact]
+    public void BuildAtCommand_UnknownEndpoint_MatchesLegacyForm()
+    {
+        var command = GlModemTransport.BuildAtCommand(GlModemEndpoint.Unknown, "AT+COPS?");
+
+        command.Should().Be("gl_modem AT 'AT+COPS?'");
+    }
+
+    [Theory]
+    [InlineData("cpu; reboot")]
+    [InlineData("$(id)")]
+    [InlineData("../../etc")]
+    public void BuildAtCommand_RejectsBusThatIsNotAPath(string bus)
+    {
+        var act = () => GlModemTransport.BuildAtCommand(new GlModemEndpoint(bus, null), "AT");
+
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
A GL.iNet 5G router could not be monitored at all: those units carry the modem on the SoC rather than on USB, where `gl_modem` needs a different command line, so every poll came back as its usage text and surfaced as "the modem did not respond" - pointing at the modem instead of at us.

Fixing that turned into a pass over what we record about a monitored device, and what every Monitoring tab shows underneath its charts.

## Monitoring

### Cellular Stats

- **GL.iNet routers with an integrated modem now work** - The gl_modem addressing is resolved per modem from GL's own cellular service, and re-resolved if a cached command line stops being accepted. Leave **Modem Bus** empty and detection handles it; a plug-in USB modem gets the same command line it got before.

- **Reported channel bandwidth was wrong** - The bandwidth field in the modem's response is an index into a table, not a figure in MHz. A modem on band n41 at 90 MHz reported `11`, recorded as 11 MHz; an LTE anchor at 15 MHz reported `4`, recorded as 4 MHz. Both now map through the correct table, verified against two independent sources on the same device. Firmware that does report MHz directly is unaffected.

- **Carrier name is filled in** - It was blank on every GL.iNet modem, because the serving-cell response carries only the numeric network codes.

- **The device and the module are both recorded** - `SoftwareVersion` and `HostVersion` hold the build of the thing being monitored and of the device containing it, split by layer rather than by vendor wording. `ModuleVendor` and `ModuleModel` record the radio module itself: a Quectel RG650V-NA inside a GL.iNet router, a Sierra Wireless EM9291 inside a UniFi modem. All four reach InfluxDB as fields.

- **Firmware is read on every poll, never cached** - Firmware Rollout upgrades and rolls back these devices from inside this app, so a remembered version would be wrong exactly when it matters. Which module is fitted is remembered once, since that does not change.

- **The card shows the device you bought** - The badge names the brand and product, with the module on its own row and firmware on hover. The device icon is drawn only for UniFi modems: previously any unrecognized model fell back to a U5G-Max picture, so a GL.iNet router displayed UniFi hardware.

- **Modem Bus** - The Settings field was labelled `USB Bus Path` and pointed at a `gl_modem` flag that does not exist on current firmware.

### Status tables under the charts

- **Cable Modem Stats, Cellular Stats and Starlink Stats gain the status table** SFP Stats and ONT Stats already had. It is one shared renderer now, with a column list per device type, and a column no device in the series fills is still dropped - which is why the same table shows seven columns for an SFP module and three for an ONT. Cable Modem starts thin: only its counters reach InfluxDB today.

### Statistics tables

- **The current reading** - Every level metric gains a **Latest** column across all six tabs, including Device Stats. Mean, min and max without "now" was an incomplete set, and the current value was not written anywhere on these tabs - only drawn on the chart.

- **A window total for error counters** - Uncorrectables and correctables are per-interval deltas, so mean and max never answered how many errors fell in the window.

- **The column opening each metric group is tinted**, so the three that follow read as that value's range rather than as one undifferentiated wall.

### Starlink Stats

- **Terminal, not Dish** - Settings and the history card said Terminal, while a chart title, a metric label and three alert descriptions said Dish. The `starlink.dish_alert` event type keeps its name; it is an identifier, not copy.

## Fixes

- **Client Performance signal readout** - `.signal-gauge` belonged to Client Performance's dBm value, declared in its own style block. The CM and ONT level bar took the same name globally, and the width, height, flex and overflow it adds - none of which Client Performance overrode - sized the "-75 dBm" box to 14px and clipped the value.

- **A poll is judged by what the modem answered** - Four places decided success from a shell chain's exit status, which belongs to the last command only and so spoke for none of the others. A failed optional query could discard signal data already collected, and a failed board query could discard a modem that had already been identified.

## Notes for review

- 31 new tests: serving-cell and bandwidth parsing against real device output, operator and firmware parsing, addressing discovery, command building, and the placeholder-model rules.
- Verified on live hardware: the UniFi module identity and firmware end to end into InfluxDB, the console-sourced host version, and the CSS fix by rendering against app.css.
- **Not verified on hardware:** the GL.iNet paths. Every input they depend on was captured from a real GL-E5800 and is pinned in the fixtures, but no test site has one, so the composed command chain has not run against a real router. Those users cannot poll that hardware at all today, so the downside is unchanged for them.
