### PR TITLE
Bind the agent tunnel at startup instead of gating it on multi-site

### DIFF
--- a/docker/DEPLOYMENT.md
+++ b/docker/DEPLOYMENT.md
@@ -420,6 +420,8 @@ See [NetworkOptimizer-Proxy](https://github.com/Ozark-Connect/NetworkOptimizer-P
 curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer-Proxy/main/add-agent-tunnel.sh | bash
 ```
 
+The server binds the tunnel on port 8043 at startup whether or not you run agents, so enabling multi-site never needs a restart. Reach it through the proxy route above rather than exposing 8043 itself; only an enrolled agent's key opens a tunnel, but the port has no other reason to be public.
+
 **Proxmox users:** The [Proxmox LXC installer](../scripts/proxmox/README.md) can set up Traefik automatically during installation.
 
 **Windows users:** Traefik is available as an optional feature in the MSI installer.

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -672,34 +672,24 @@ host networking that is correct; if the agent can't see the real LAN address
 
 Probes leave by the default WAN unless something sends them elsewhere, so a
 second or third WAN goes unmeasured until you give it a Vantage. Vantages live on
-Monitoring - Network Performance, in the Multi-WAN Monitoring - Vantages card
-(hidden on single-WAN sites). A Vantage
-pairs a WAN with the box that probes it, and the targets you assign to it are
-then measured over that WAN rather than whichever one the routing table
-preferred. None of this is multi-site only: the default site takes Vantages the
-same way, and you enroll the extra Agent against it.
+Monitoring - Network Performance, in the Multi-WAN Monitoring - Vantages card. A
+Vantage pairs a WAN with the box that probes it, and the targets you assign to it
+are measured over that WAN.
 
-The easiest box to pair is an Agent running on the UniFi Gateway itself. It
-reaches each WAN by that WAN's own interface, so one Agent covers all of them,
-there is no routing policy to build, and the Vantage's Interface fills in from
-the WAN you select. Set one up in Settings - Multi-Site.
+The easiest box to pair is an Agent on the UniFi Gateway itself. It reaches each
+WAN by that WAN's own interface, so one Agent covers all of them with no routing
+to build. Set one up in Settings - Multi-Site.
 
-Any other Agent has to be forced out the WAN you are measuring. Give the Vantage
-a Probe source IP, then add a Policy-Based Route in UniFi Network that sends that
-address out that WAN. The server pushes the Vantage's source down with every
-target it assigns, and the Agent binds it per probe (`ping -I` on Linux, `-S` or
-`-b` on BSD), so the latency and loss coming back describe that WAN.
+Any other Agent has to be forced out the WAN you are measuring. Give the Vantage a
+Probe source IP, then add a Policy-Based Route in UniFi Network sending that
+address out that WAN. UniFi matches a route's source by Client Device, which is a
+MAC, so the address needs an interface of its own (an LXC, a VM, or a Docker
+container on macvlan). WAN Steering matches on IP instead, so steering the Agent
+there sidesteps that entirely.
 
-UniFi matches a route's source by Client Device, which is a MAC, so the address
-needs an interface of its own. An LXC or VM has one, a Docker container can be
-given one with macvlan, and a plain second address on a host already on the
-network will not route differently. WAN Steering matches on IP instead, so
-steering the Agent there sidesteps the interface requirement entirely.
-
-Source binding rides the native ping binary, so an Agent probing a WAN this way
-belongs on Linux or macOS. On Windows the managed path fails loudly rather than
-quietly measuring the wrong WAN. An Agent can also carry a source address of its
-own, used only for a target that arrives without one from its Vantage:
+Source binding rides the native ping binary (`ping -I` on Linux), so an Agent
+probing a WAN this way belongs on Linux or macOS. It can also carry a source of
+its own, used for any target that arrives without one:
 
 ```json
 {

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -668,10 +668,25 @@ host networking that is correct; if the agent can't see the real LAN address
 (Docker bridge mode, or a multi-NIC host picks the wrong interface), set
 `NO_AGENT_LAN_IP=<ip>` in its environment to override it.
 
-## Probe-only mode for multi-WAN monitoring
+## Monitoring additional WANs
 
-To monitor a secondary WAN, run an additional agent instance with its own IP
-(LXC, Docker macvlan, or a small VM) and bind its probes to that IP:
+Every WAN you want measured gets a Vantage, set up on Monitoring - Network
+Performance under Multi-WAN Monitoring - Vantages. A Vantage pairs the WAN with
+the Agent that probes it.
+
+The easiest Agent to pair is one running on the UniFi Gateway itself. It reaches
+every WAN by that WAN's own interface, so a single Agent covers all of them and
+there is no routing to build. Set one up in Settings - Multi-Site.
+
+Any other Agent needs its probes forced out the WAN you are measuring. Give the
+Vantage a source IP, then policy-route that address out that WAN in UniFi Network.
+Probes for that Vantage bind to the source (`ping -I` on Linux), so the latency
+and loss you get back describe that WAN rather than whichever one the routing
+table preferred. None of this is multi-site only: the default site takes Vantages
+the same way, and you enroll the extra Agent against it.
+
+An Agent can also carry a source IP of its own, used for any target that does not
+bring one from its Vantage:
 
 ```json
 {
@@ -682,11 +697,8 @@ To monitor a secondary WAN, run an additional agent instance with its own IP
 }
 ```
 
-Then policy-route `192.0.2.50` out the WAN you want measured on the gateway.
-Every probe binds to that source (`ping -I` on Linux), so its latency and loss
-reflect that WAN specifically. This works on the main site too - enroll the
-extra agent against the default site. Source binding needs the native ping
-binary, so probe-only agents should run on Linux or macOS.
+Source binding rides the native ping binary, so an Agent probing a WAN this way
+should run on Linux or macOS.
 
 Secrets at rest: the server stores only SHA-256 hashes of tokens and keys. If
 `agent.json` is lost, remove the old agent in the UI and enroll a new one.

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -673,7 +673,7 @@ host networking that is correct; if the agent can't see the real LAN address
 Probes leave by the default WAN unless something sends them elsewhere, so a
 second or third WAN goes unmeasured until you give it a Vantage. Vantages live on
 Monitoring - Network Performance, in the Multi-WAN Monitoring - Vantages card
-(hidden on single-WAN sites, where there is nothing to disambiguate). A Vantage
+(hidden on single-WAN sites). A Vantage
 pairs a WAN with the box that probes it, and the targets you assign to it are
 then measured over that WAN rather than whichever one the routing table
 preferred. None of this is multi-site only: the default site takes Vantages the
@@ -688,11 +688,13 @@ Any other Agent has to be forced out the WAN you are measuring. Give the Vantage
 a Probe source IP, then add a Policy-Based Route in UniFi Network that sends that
 address out that WAN. The server pushes the Vantage's source down with every
 target it assigns, and the Agent binds it per probe (`ping -I` on Linux, `-S` or
-`-b` on BSD), so the latency and loss coming back describe that WAN. One thing to
-settle before you build the route: UniFi matches the source by Client Device,
-which is a MAC, so the address needs an interface of its own. An LXC or VM has
-one, a Docker container can be given one with macvlan, and a plain second address
-on a host already on the network will not route differently.
+`-b` on BSD), so the latency and loss coming back describe that WAN.
+
+UniFi matches a route's source by Client Device, which is a MAC, so the address
+needs an interface of its own. An LXC or VM has one, a Docker container can be
+given one with macvlan, and a plain second address on a host already on the
+network will not route differently. WAN Steering matches on IP instead, so
+steering the Agent there sidesteps the interface requirement entirely.
 
 Source binding rides the native ping binary, so an Agent probing a WAN this way
 belongs on Linux or macOS. On Windows the managed path fails loudly rather than

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -670,23 +670,34 @@ host networking that is correct; if the agent can't see the real LAN address
 
 ## Monitoring additional WANs
 
-Every WAN you want measured gets a Vantage, set up on Monitoring - Network
-Performance under Multi-WAN Monitoring - Vantages. A Vantage pairs the WAN with
-the Agent that probes it.
+Probes leave by the default WAN unless something sends them elsewhere, so a
+second or third WAN goes unmeasured until you give it a Vantage. Vantages live on
+Monitoring - Network Performance, in the Multi-WAN Monitoring - Vantages card
+(hidden on single-WAN sites, where there is nothing to disambiguate). A Vantage
+pairs a WAN with the box that probes it, and the targets you assign to it are
+then measured over that WAN rather than whichever one the routing table
+preferred. None of this is multi-site only: the default site takes Vantages the
+same way, and you enroll the extra Agent against it.
 
-The easiest Agent to pair is one running on the UniFi Gateway itself. It reaches
-every WAN by that WAN's own interface, so a single Agent covers all of them and
-there is no routing to build. Set one up in Settings - Multi-Site.
+The easiest box to pair is an Agent running on the UniFi Gateway itself. It
+reaches each WAN by that WAN's own interface, so one Agent covers all of them,
+there is no routing policy to build, and the Vantage's Interface fills in from
+the WAN you select. Set one up in Settings - Multi-Site.
 
-Any other Agent needs its probes forced out the WAN you are measuring. Give the
-Vantage a source IP, then policy-route that address out that WAN in UniFi Network.
-Probes for that Vantage bind to the source (`ping -I` on Linux), so the latency
-and loss you get back describe that WAN rather than whichever one the routing
-table preferred. None of this is multi-site only: the default site takes Vantages
-the same way, and you enroll the extra Agent against it.
+Any other Agent has to be forced out the WAN you are measuring. Give the Vantage
+a Probe source IP, then add a Policy-Based Route in UniFi Network that sends that
+address out that WAN. The server pushes the Vantage's source down with every
+target it assigns, and the Agent binds it per probe (`ping -I` on Linux, `-S` or
+`-b` on BSD), so the latency and loss coming back describe that WAN. One thing to
+settle before you build the route: UniFi matches the source by Client Device,
+which is a MAC, so the address needs an interface of its own. An LXC or VM has
+one, a Docker container can be given one with macvlan, and a plain second address
+on a host already on the network will not route differently.
 
-An Agent can also carry a source IP of its own, used for any target that does not
-bring one from its Vantage:
+Source binding rides the native ping binary, so an Agent probing a WAN this way
+belongs on Linux or macOS. On Windows the managed path fails loudly rather than
+quietly measuring the wrong WAN. An Agent can also carry a source address of its
+own, used only for a target that arrives without one from its Vantage:
 
 ```json
 {
@@ -696,9 +707,6 @@ bring one from its Vantage:
   "probeSourceIp": "192.0.2.50"
 }
 ```
-
-Source binding rides the native ping binary, so an Agent probing a WAN this way
-should run on Linux or macOS.
 
 Secrets at rest: the server stores only SHA-256 hashes of tokens and keys. If
 `agent.json` is lost, remove the old agent in the UI and enroll a new one.

--- a/src/NetworkOptimizer.Agent/README.md
+++ b/src/NetworkOptimizer.Agent/README.md
@@ -319,13 +319,15 @@ On first run it exchanges the one-time token for an agent key via
 `POST /api/public/agents/enrollments`, writes the key and site slug back into
 `agent.json`, and discards the token. It then holds a persistent gRPC tunnel to
 the server, heartbeating every 30 seconds; the Multi-Site tab and Sites page
-show it as Online. If the tunnel is unreachable (server-side tunnel not enabled,
-or the reverse-proxy gRPC route is missing), it falls back to
+show it as Online. If the tunnel is unreachable (the reverse-proxy gRPC route is
+missing, or the server could not bind its listener), it falls back to
 `POST /api/public/agents/heartbeats` and keeps retrying the tunnel.
 
-The tunnel listener (default port 8043, `AgentTunnel__Port` on the server) only
-starts when multi-site is enabled at server startup - enable multi-site, then
-restart the server once.
+The tunnel listener (default port 8043, `AgentTunnel__Port` on the server) binds
+at startup on every install, so enabling multi-site needs no restart. The one
+case it does not bind is a server serving its own HTTPS, where its ports cannot
+be re-bound alongside the tunnel; it says so at startup, and those installs stay
+on REST heartbeats. Put the server behind the reverse proxy instead.
 
 ### Run as a service (systemd)
 

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1302,7 +1302,7 @@ if (!agentTunnelBound)
     var multiSiteSetting = await tunnelBindDb.SystemSettings
         .FirstOrDefaultAsync(setting => setting.Key == SystemSettingKeys.MultiSiteEnabled);
     if (bool.TryParse(multiSiteSetting?.Value, out var multiSiteOn) && multiSiteOn)
-        Console.WriteLine(
+        app.Logger.LogWarning(
             "Agent tunnel not bound: ASPNETCORE_URLS contains bindings the tunnel listener cannot " +
             "co-exist with (HTTPS or non-port URLs). Agents stay on REST heartbeats.");
 }

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -178,71 +178,48 @@ builder.Services.AddSingleton<IDbContextFactory<NetworkOptimizerDbContext>>(
 builder.Services.AddSingleton(new NetworkOptimizer.Storage.Services.SiteDatabasePaths(dbPath));
 builder.Services.AddSingleton<NetworkOptimizer.Storage.Services.SiteDbContextFactory>();
 
-// ---- Multi-site agent tunnel listener ----
+// ---- Agent tunnel listener ----
 // The agent tunnel is gRPC, which needs HTTP/2. The main port stays HTTP/1.1
 // (reverse proxies, browsers), so the tunnel gets its own HTTP/2 listener,
 // served over TLS with an ephemeral self-signed cert (see
 // CreateSelfSignedTunnelCert) so the reverse-proxy-to-app hop is encrypted even
 // across a box boundary. Explicit Kestrel Listen calls override URL-based configuration,
-// so when the tunnel is active the main HTTP port(s) are re-bound explicitly
-// alongside it. Single-site installs never take this branch: no new port, no
-// binding changes. The flag is read with raw SQLite because Kestrel must be
-// configured before the service provider (and EF) exist.
+// so the main HTTP port(s) are re-bound explicitly alongside it.
+// Bound whenever it can be, never gated on multi-site: that flag lives in the database,
+// so gating on it deferred the bind to the next restart and left enabled installs with
+// agents dialing a dead port. An idle listener holds no valid agent keys.
 var agentTunnelPort = builder.Configuration.GetValue("AgentTunnel:Port", 8043);
-var agentTunnelEnabled = false;
-try
+// Null means a custom HTTPS or non-port URL configuration we cannot faithfully re-bind.
+// Reported once the app is built, where multi-site is readable and the warning can be
+// aimed at the installs that actually have agents.
+var mainBindings = StartupHelpers.ResolveHttpBindings();
+var agentTunnelBound = mainBindings != null;
+if (agentTunnelBound)
 {
-    if (File.Exists(dbPath))
+    builder.WebHost.ConfigureKestrel(options =>
     {
-        using var flagConnection = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
-        flagConnection.Open();
-        using var flagCommand = flagConnection.CreateCommand();
-        flagCommand.CommandText = "SELECT Value FROM SystemSettings WHERE Key = @key";
-        flagCommand.Parameters.AddWithValue("@key", NetworkOptimizer.Storage.Models.SystemSettingKeys.MultiSiteEnabled);
-        agentTunnelEnabled = bool.TryParse(flagCommand.ExecuteScalar() as string, out var multiSiteFlag) && multiSiteFlag;
-    }
-}
-catch
-{
-    // Fresh install or pre-multi-site schema: tunnel stays off until enabled + restart.
-}
-
-if (agentTunnelEnabled)
-{
-    var mainBindings = StartupHelpers.ResolveHttpBindings();
-    if (mainBindings == null)
-    {
-        // Custom HTTPS or non-port URL configuration we can't safely re-bind.
-        Console.WriteLine("Agent tunnel disabled: ASPNETCORE_URLS contains bindings the tunnel listener cannot co-exist with (HTTPS or non-port URLs)");
-        agentTunnelEnabled = false;
-    }
-    else
-    {
-        builder.WebHost.ConfigureKestrel(options =>
+        foreach (var (host, port) in mainBindings!)
         {
-            foreach (var (host, port) in mainBindings)
-            {
-                if (host == "localhost")
-                    options.ListenLocalhost(port);
-                else if (System.Net.IPAddress.TryParse(host, out var ip))
-                    options.Listen(ip, port);
-                else
-                    options.ListenAnyIP(port);
-            }
-            options.ListenAnyIP(agentTunnelPort, listen =>
-            {
-                listen.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2;
-                // TLS on the tunnel port so the reverse-proxy-to-app hop is
-                // encrypted even when the proxy runs on a separate box (the
-                // agent key and pushed SNMP credentials would otherwise cross
-                // that LAN segment in cleartext h2c). The proxy is configured to
-                // skip verification, so an ephemeral self-signed cert suffices.
-                listen.UseHttps(StartupHelpers.CreateSelfSignedTunnelCert());
-            });
+            if (host == "localhost")
+                options.ListenLocalhost(port);
+            else if (System.Net.IPAddress.TryParse(host, out var ip))
+                options.Listen(ip, port);
+            else
+                options.ListenAnyIP(port);
+        }
+        options.ListenAnyIP(agentTunnelPort, listen =>
+        {
+            listen.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http2;
+            // TLS on the tunnel port so the reverse-proxy-to-app hop is
+            // encrypted even when the proxy runs on a separate box (the
+            // agent key and pushed SNMP credentials would otherwise cross
+            // that LAN segment in cleartext h2c). The proxy is configured to
+            // skip verification, so an ephemeral self-signed cert suffices.
+            listen.UseHttps(StartupHelpers.CreateSelfSignedTunnelCert());
         });
-    }
+    });
 }
-builder.Services.AddSingleton(new AgentTunnelOptions(agentTunnelEnabled, agentTunnelPort));
+builder.Services.AddSingleton(new AgentTunnelOptions(agentTunnelBound, agentTunnelPort));
 builder.Services.AddGrpc();
 builder.Services.AddSingleton<AgentTunnelRegistry>();
 builder.Services.AddSingleton<AgentProbeResultSink>();
@@ -1300,7 +1277,7 @@ if (!string.Equals(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAIN
     // so the redirect middleware adopts that port and sends every request to an HTTP/2-only gRPC
     // listener holding a self-signed cert. The tunnel binds only when the app itself is HTTP-only
     // (ResolveHttpBindings rejects an https URL), so there is never a correct port to redirect to.
-    if (!agentTunnelEnabled)
+    if (!agentTunnelBound)
         app.UseHttpsRedirection();
 
     app.UseHsts();
@@ -1313,6 +1290,22 @@ await ieeeOuiDb.InitializeAsync();
 // Warm the agent-coverage flags before collection starts, so no synchronous gate answers
 // "not covered" for a site that is while the cache fills.
 await app.Services.GetRequiredService<SiteAgentCoverage>().WarmAsync();
+
+// An install whose bindings could not be re-bound has no tunnel listener, so its agents
+// dial a port nothing serves and fall back to REST heartbeats. Warned here rather than at
+// bind time: the multi-site flag is only readable once the app is built, and without it
+// every single-site install on an HTTPS binding would see this too.
+if (!agentTunnelBound)
+{
+    await using var tunnelBindDb = await app.Services
+        .GetRequiredService<IDbContextFactory<NetworkOptimizerDbContext>>().CreateDbContextAsync();
+    var multiSiteSetting = await tunnelBindDb.SystemSettings
+        .FirstOrDefaultAsync(setting => setting.Key == SystemSettingKeys.MultiSiteEnabled);
+    if (bool.TryParse(multiSiteSetting?.Value, out var multiSiteOn) && multiSiteOn)
+        Console.WriteLine(
+            "Agent tunnel not bound: ASPNETCORE_URLS contains bindings the tunnel listener cannot " +
+            "co-exist with (HTTPS or non-port URLs). Agents stay on REST heartbeats.");
+}
 
 // Log admin auth startup configuration
 using (var startupScope = app.Services.CreateScope())

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -1621,7 +1621,10 @@ static partial class StartupHelpers
                 if (colon < 0 || !int.TryParse(hostPort[(colon + 1)..], out var port))
                     return null;
                 var host = hostPort[..colon];
-                bindings.Add((host is "*" or "+" or "0.0.0.0" ? "*" : host, port));
+                if (host.Length == 0)
+                    return null;
+                // "0.0.0.0" stays literal: Kestrel binds it IPv4-only, unlike * / + (dual-stack).
+                bindings.Add((host is "*" or "+" ? "*" : host, port));
             }
         }
         else if (!string.IsNullOrWhiteSpace(httpPorts))


### PR DESCRIPTION
Enabling multi-site wrote a flag that nothing read again until the next restart, so the agent tunnel's listener never came up and enrolled agents dialed a dead port. Nothing in Settings said a restart was needed. What the user sees is a 502 from their reverse proxy, which reads as a broken proxy route rather than a server that has not bound the port yet.

## Agent tunnel

- **The listener binds at startup on every install** - The gate was `multisite.enabled`, read with raw ADO because Kestrel has to be configured before EF exists. It is now `ResolveHttpBindings() != null`, so enabling multi-site is a pure data change with nothing left to re-bind. The installs that no longer get a tunnel are the ones that never got one: a server serving its own HTTPS, whose ports cannot be reproduced alongside the listener.
- **8043 is now open on every install** - It has to stay `ListenAnyIP`, since the proxy may be on another box, which is why that hop has TLS in the first place. With nothing enrolled, every connection fails agent-key auth. Documented in `docker/DEPLOYMENT.md` as belonging behind the proxy route.
- **The bind warning moved after `Build()`** - It is gated on multi-site actually being on, so it reaches installs that have agents instead of every single-site install on an HTTPS binding, and it goes through Serilog rather than stdout. A Windows service install discards stdout, so the warning could not reach a large share of the installs it is aimed at.
- `AgentTunnelOptions.Enabled` keeps its name and now means "bound". That matches what `AgentTunnelRegistry` already documented it as, and it is correct for the `tunnelPort` handed back at enrollment too: an agent should only be told about a port that is actually listening. The state that disappears is a multi-site install before its restart, where a permanently tunnel-less agent showed Online off REST heartbeats.

## ResolveHttpBindings

This helper and the explicit Kestrel `Listen` calls used to run only on multi-site installs. They now run everywhere, so two latent divergences from URL-based configuration became worth fixing:

- **`0.0.0.0` no longer folds into `*`** - Kestrel binds that host IPv4-only while `*` and `+` are dual-stack, so the old normalization added an IPv6 listener nobody configured. It is a real configured value on the Mac test site.
- **An empty host is rejected** - `http://:8042` fell through to `ListenAnyIP`, where URL-based configuration fails loudly instead. The contract is malformed input returns null, and Kestrel now surfaces its own error.

Every other shape our installers, compose files, entrypoint, and MSI actually produce was checked against what URL-based Kestrel would bind, and matches.

## Not changing

`app.UseHttpsRedirection()` stays as it is. The gate now leaves it active only on a non-container install serving its own HTTPS, which is the one case where it has a real port to redirect to. That is effectively local dev via `launchSettings.json`; we do not suggest native TLS in production because the speed test needs its own certificate on a different host, with no ACME for either.

## Note for the dev to main merge

The Agent README's multi-WAN section rewrite is already on `main` as 5e11e903. The same change is in this branch, so expect it to replay as a no-op or want a conflict resolution at merge time.
