### PR TITLE
Warn when a non-primary WAN vantage has no probe binding

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -634,7 +634,7 @@
                         <div class="banner-content">
                             <span class="banner-icon banner-icon-warning">!</span>
                             <div class="banner-text" style="flex: 1;">
-                                @focusedLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these charts reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
+                                @focusedLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
                             </div>
                             <div class="banner-actions">
                                 <button class="btn btn-sm btn-primary" @onclick="@(() => { _forceExpandWanContexts = true; _scrollToWanContextsPending = true; StateHasChanged(); })">Configure Vantage</button>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -624,6 +624,24 @@
                                       OnClick="JumpToLiveAsync" />
             </div>
             <div class="card-body">
+                @if (FocusedWanProbesViaDefaultRoute)
+                {
+                    var focusedWan = _wanOptions.FirstOrDefault(w => string.Equals(w.Key, FocusedWanKey, StringComparison.OrdinalIgnoreCase));
+                    var focusedLabel = focusedWan != null
+                        ? NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabelInProse(focusedWan.Label, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(focusedWan.Key))
+                        : "This WAN";
+                    <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+                        <div class="banner-content">
+                            <span class="banner-icon banner-icon-warning">!</span>
+                            <div class="banner-text" style="flex: 1;">
+                                @focusedLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these charts reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                            </div>
+                            <div class="banner-actions">
+                                <button class="btn btn-sm btn-primary" @onclick="@(() => { _forceExpandWanContexts = true; _scrollToWanContextsPending = true; StateHasChanged(); })">Configure vantage</button>
+                            </div>
+                        </div>
+                    </div>
+                }
                 <div class="latency-filter-badges wan-filter-badges"></div>
                 @* Anchored on the chart rather than the card: the sync is something the plot does
                    under the pointer, and it only reads as that with a line to hover. *@
@@ -2196,6 +2214,27 @@
     /// and offering to clear it would read as offering to undo their choice of WAN.
     /// </summary>
     private bool WanFilterIsNarrowed => _multiWanUiVisible && _selectedWanKeys.Count > 1;
+
+    /// <summary>
+    /// The focused WAN's vantage has no probe binding (no agent, no source IP), so the server
+    /// probes its targets via the default route. Only fires for non-primary, single-WAN
+    /// selection, with a context that exists but binds nothing.
+    /// </summary>
+    private bool FocusedWanProbesViaDefaultRoute
+    {
+        get
+        {
+            if (!_multiWanUiVisible || _lanScope || _allScope || _selectedWanKeys.Count != 1) return false;
+            var key = FocusedWanKey;
+            var wan = _wanOptions.FirstOrDefault(w => string.Equals(w.Key, key, StringComparison.OrdinalIgnoreCase));
+            if (wan is not { IsPrimary: false }) return false;
+            var matching = _wanContexts.Where(c => !string.IsNullOrEmpty(c.WanInterface)
+                && string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!),
+                    key, StringComparison.OrdinalIgnoreCase)).ToList();
+            return matching.Count > 0
+                && matching.All(c => c.AgentId == null && string.IsNullOrEmpty(c.ProbeSourceIp));
+        }
+    }
 
     /// <summary>Whether every WAN is on screen, which is what the All pill means.</summary>
     private bool AllWansSelected =>

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -634,10 +634,10 @@
                         <div class="banner-content">
                             <span class="banner-icon banner-icon-warning">!</span>
                             <div class="banner-text" style="flex: 1;">
-                                @focusedLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these charts reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                                @focusedLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these charts reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
                             </div>
                             <div class="banner-actions">
-                                <button class="btn btn-sm btn-primary" @onclick="@(() => { _forceExpandWanContexts = true; _scrollToWanContextsPending = true; StateHasChanged(); })">Configure vantage</button>
+                                <button class="btn btn-sm btn-primary" @onclick="@(() => { _forceExpandWanContexts = true; _scrollToWanContextsPending = true; StateHasChanged(); })">Configure Vantage</button>
                             </div>
                         </div>
                     </div>
@@ -2216,7 +2216,7 @@
     private bool WanFilterIsNarrowed => _multiWanUiVisible && _selectedWanKeys.Count > 1;
 
     /// <summary>
-    /// The focused WAN's vantage has no probe binding (no agent, no source IP), so the server
+    /// The focused WAN's Vantage has no probe binding (no agent, no source IP), so the server
     /// probes its targets via the default route. Only fires for non-primary, single-WAN
     /// selection, with a context that exists but binds nothing.
     /// </summary>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -126,6 +126,20 @@
 }
 else if (_report == null)
 {
+    @if (ProbesViaDefaultRoute && Svc.Status != IspHealthStatus.NeedsDiscovery)
+    {
+        <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-warning">!</span>
+                <div class="banner-text" style="flex: 1;">
+                    @SelectedWanLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these readings reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure vantage</button>
+                </div>
+            </div>
+        </div>
+    }
     @if (Svc.Status == IspHealthStatus.Computing)
     {
         <div class="isp-health-loading card">
@@ -246,6 +260,20 @@ else if (_report == null)
 else
 {
     var r = _report;
+    @if (ProbesViaDefaultRoute)
+    {
+        <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-warning">!</span>
+                <div class="banner-text" style="flex: 1;">
+                    @SelectedWanLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these scores reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure vantage</button>
+                </div>
+            </div>
+        </div>
+    }
     @if (!r.HasUpstreamTraceMap)
     {
         <div class="alert alert-info" style="margin-bottom: 0.75rem;">
@@ -1106,6 +1134,7 @@ else
     // Which WANs a context names. A secondary WAN without one is not "not discovered yet" - it is
     // not probed at all, and discovery cannot change that.
     private HashSet<string> _wansWithContext = new(StringComparer.OrdinalIgnoreCase);
+    private HashSet<string> _wansWithProbeBinding = new(StringComparer.OrdinalIgnoreCase);
     private string _selectedWanKey = "";
 
     /// <summary>
@@ -1151,6 +1180,11 @@ else
             _wansWithContext = contexts
                 .Where(c => !string.IsNullOrEmpty(c.WanInterface))
                 .Select(c => c.WanInterface!.ToLowerInvariant())
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _wansWithProbeBinding = contexts
+                .Where(c => !string.IsNullOrEmpty(c.WanInterface)
+                    && (c.AgentId != null || !string.IsNullOrEmpty(c.ProbeSourceIp)))
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var ctx in contexts)
             {
@@ -1373,6 +1407,23 @@ else
             var wan = _wanOptions.FirstOrDefault(
                 w => string.Equals(w.Key, _selectedWanKey, StringComparison.OrdinalIgnoreCase));
             return wan is { IsPrimary: false } && !_wansWithContext.Contains(wan.Key);
+        }
+    }
+
+    /// <summary>
+    /// The selected WAN has a vantage but no probe binding (no agent, no source IP), so the
+    /// server probes its targets via the default route - which is the primary WAN's path. The
+    /// readings and scores reflect the primary connection, not this one.
+    /// </summary>
+    private bool ProbesViaDefaultRoute
+    {
+        get
+        {
+            var wan = _wanOptions.FirstOrDefault(
+                w => string.Equals(w.Key, _selectedWanKey, StringComparison.OrdinalIgnoreCase));
+            return wan is { IsPrimary: false }
+                && _wansWithContext.Contains(wan.Key)
+                && !_wansWithProbeBinding.Contains(wan.Key);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -132,7 +132,7 @@ else if (_report == null)
             <div class="banner-content">
                 <span class="banner-icon banner-icon-warning">!</span>
                 <div class="banner-text" style="flex: 1;">
-                    @SelectedWanLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these readings reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
+                    @SelectedWanLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
                 </div>
                 <div class="banner-actions">
                     <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>
@@ -266,7 +266,7 @@ else
             <div class="banner-content">
                 <span class="banner-icon banner-icon-warning">!</span>
                 <div class="banner-text" style="flex: 1;">
-                    @SelectedWanLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these scores reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
+                    @SelectedWanLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
                 </div>
                 <div class="banner-actions">
                     <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -132,10 +132,10 @@ else if (_report == null)
             <div class="banner-content">
                 <span class="banner-icon banner-icon-warning">!</span>
                 <div class="banner-text" style="flex: 1;">
-                    @SelectedWanLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these readings reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                    @SelectedWanLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these readings reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
                 </div>
                 <div class="banner-actions">
-                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure vantage</button>
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>
                 </div>
             </div>
         </div>
@@ -155,7 +155,7 @@ else if (_report == null)
                 <div class="banner-text" style="flex: 1;">
                     @if (NeedsContextFirst)
                     {
-                        <text>@SelectedWanLabel has no vantage yet, so nothing probes it. Give it one, then discovery can trace its path.</text>
+                        <text>@SelectedWanLabel has no Vantage yet, so nothing probes it. Give it one, then discovery can trace its path.</text>
                     }
                     else
                     {
@@ -165,7 +165,7 @@ else if (_report == null)
                 <div class="banner-actions">
                     @if (NeedsContextFirst)
                     {
-                        <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Add a WAN vantage</button>
+                        <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Add a WAN Vantage</button>
                     }
                     else
                     {
@@ -266,10 +266,10 @@ else
             <div class="banner-content">
                 <span class="banner-icon banner-icon-warning">!</span>
                 <div class="banner-text" style="flex: 1;">
-                    @SelectedWanLabel's vantage has no probe binding, so probes leave by the default route (your primary connection) and these scores reflect the primary path. Assign a gateway agent or bind a source address to measure this connection directly.
+                    @SelectedWanLabel's Vantage has no probe binding, so probes leave by the default route (your primary connection) and these scores reflect the primary path. Assign a Gateway Agent or bind a source address to measure this connection directly.
                 </div>
                 <div class="banner-actions">
-                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure vantage</button>
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>
                 </div>
             </div>
         </div>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -1166,7 +1166,7 @@ else
         try
         {
             foreach (var wan in await PathView.GetWansAsync())
-                options.Add(new WanChoice(wan.WanInterface.ToLowerInvariant(),
+                options.Add(new WanChoice(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wan.WanInterface),
                     NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabel(
                         wan.FriendlyName, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(wan.WanInterface), null, null),
                     wan.IsPrimary));
@@ -1179,7 +1179,7 @@ else
                 Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AsNoTracking(db.WanContexts));
             _wansWithContext = contexts
                 .Where(c => !string.IsNullOrEmpty(c.WanInterface))
-                .Select(c => c.WanInterface!.ToLowerInvariant())
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             _wansWithProbeBinding = contexts
                 .Where(c => !string.IsNullOrEmpty(c.WanInterface)
@@ -1189,7 +1189,7 @@ else
             foreach (var ctx in contexts)
             {
                 if (string.IsNullOrEmpty(ctx.WanInterface)) continue;
-                var key = ctx.WanInterface!.ToLowerInvariant();
+                var key = NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(ctx.WanInterface!);
                 if (!options.Any(o => o.Key == key))
                     options.Add(new WanChoice(key,
                         NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabel(


### PR DESCRIPTION
## Summary

- Adds a warning banner when a non-primary WAN's vantage has no probe binding (no gateway agent, no source IP), so the user knows their latency readings and ISP Health scores reflect the primary WAN's path, not the secondary's
- Banner appears on ISP Health (above scores and above status banners) and on Network Performance (above the latency charts)
- The advisory only fires when a single non-primary WAN is selected and every WanContext for that WAN has both AgentId and ProbeSourceIp null; it does not fire for the primary WAN, agent-bound vantages, source-IP vantages, the no-vantage case (handled by NeedsContextFirst), single-WAN sites, or LAN/All/comparison scope
- Button navigates to the WAN Vantages card for configuration

Refs #936