### PR TITLE
v2.7.3 Release Changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-            type=raw,value=preview,enable=${{ contains(github.ref_name, '-') }}
+            type=raw,value=preview
 
       - name: Create manifest list and push
         working-directory: /tmp/digests
@@ -187,7 +187,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-            type=raw,value=preview,enable=${{ contains(github.ref_name, '-') }}
+            type=raw,value=preview
 
       - name: Create agent manifest list and push
         working-directory: /tmp/agent-digests
@@ -210,7 +210,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-            type=raw,value=preview,enable=${{ contains(github.ref_name, '-') }}
+            type=raw,value=preview
 
       - name: Build and push speedtest image
         uses: docker/build-push-action@v5

--- a/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiProductDatabase.cs
@@ -805,6 +805,35 @@ public static class UniFiProductDatabase
     }
 
     /// <summary>
+    /// Switches that have no SSH daemon. These are managed exclusively through the
+    /// UniFi Network Application and will reject SSH connections at the transport layer.
+    /// </summary>
+    private static readonly HashSet<string> DevicesWithoutSsh = new(StringComparer.OrdinalIgnoreCase)
+    {
+        // Flex Series (excluding Flex XG, which does have SSH)
+        "USW-Flex",
+        "USW-Flex-Mini",
+        "USW-Flex-2.5G-5",
+        "USW-Flex-2.5G-8",
+        "USW-Flex-2.5G-8-PoE",
+
+        // Ultra Series
+        "USW-Ultra",
+        "USW-Ultra-60W",
+        "USW-Ultra-210W",
+    };
+
+    /// <summary>
+    /// Whether a device accepts SSH connections. Returns false for switch models known
+    /// to have no SSH daemon (Flex and Ultra families).
+    /// </summary>
+    public static bool HasSsh(string? model, string? shortname)
+    {
+        var productName = GetBestProductName(model, shortname);
+        return string.IsNullOrEmpty(productName) || !DevicesWithoutSsh.Contains(productName);
+    }
+
+    /// <summary>
     /// UniFi power devices (UPS, PDU, redundant power supplies, smart plugs/strips).
     /// Ubiquiti reports these with power-device capabilities and exposes a single
     /// internal/management port_table row. That port is not a controllable

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -698,6 +698,17 @@
                     m.classList.contains('components-reconnect-rejected'));
             }
 
+            async function serverIsUp() {
+                const ctrl = new AbortController();
+                const t = setTimeout(() => ctrl.abort(), 2000);
+                try {
+                    const resp = await fetch('/api/health?probe=resume',
+                        { signal: ctrl.signal, cache: 'no-store' });
+                    return resp.ok;
+                } catch { return false; }
+                finally { clearTimeout(t); }
+            }
+
             async function circuitAlive() {
                 if (!window.DotNet) return false;
                 try {
@@ -720,25 +731,32 @@
                 if (hiddenAt === null) return;
                 const hiddenMs = Date.now() - hiddenAt;
                 hiddenAt = null;
-                if (hiddenMs < STALE_HIDDEN_MS || blazorHandlingDrop()) return;
+                if (hiddenMs < STALE_HIDDEN_MS) return;
 
-                // Only reload when the circuit is genuinely dead; otherwise pick up exactly where
-                // we left off. One probe is not enough to decide that: coming back from the
-                // background, Blazor is often mid-reconnect and the first ping times out on a
-                // circuit that is about to work. Keep asking for a few seconds and stand the
-                // reload down the moment it answers - a refresh that throws away the user's place
-                // costs more than waiting does. Re-check the modal each time too, in case Blazor
-                // surfaced its own reconnect UI meanwhile, since that path owns the reload.
+                // iOS/Android suspend setInterval while backgrounded, so the
+                // stuck-spinner timer may be dead. If the modal is already up
+                // and the server answers, the circuit is wedged - reload now.
+                if (blazorHandlingDrop()) {
+                    if (await serverIsUp()) location.reload();
+                    return;
+                }
+
+                // No modal - probe the circuit. One probe isn't enough: Blazor
+                // is often mid-reconnect on resume and the first ping times out
+                // on a circuit that's about to work.
                 const GIVE_UP_AFTER_MS = 12000;
                 const deadline = Date.now() + GIVE_UP_AFTER_MS;
                 while (Date.now() < deadline) {
-                    if (blazorHandlingDrop()) return;
+                    if (blazorHandlingDrop()) {
+                        if (await serverIsUp()) location.reload();
+                        return;
+                    }
                     if (await circuitAlive()) return;
                     await new Promise(r => setTimeout(r, 1000));
                 }
-                if (!blazorHandlingDrop()) {
-                    location.reload();
-                }
+                // Still no circuit and no modal - server may be down. Reload
+                // only if it answers; otherwise we'd strand on a blank page.
+                if (await serverIsUp()) location.reload();
             });
         })();
     </script>

--- a/src/NetworkOptimizer.Web/App.razor
+++ b/src/NetworkOptimizer.Web/App.razor
@@ -734,18 +734,24 @@
                 if (hiddenMs < STALE_HIDDEN_MS) return;
 
                 // iOS/Android suspend setInterval while backgrounded, so the
-                // stuck-spinner timer may be dead. If the modal is already up
-                // and the server answers, the circuit is wedged - reload now.
+                // stuck-spinner timer may be dead. Probe the server ourselves.
+                // Retry: mobile network stacks take a few seconds to re-attach
+                // after resume (Wi-Fi rejoin, cellular radio wake).
+                const GIVE_UP_AFTER_MS = 12000;
+                const deadline = Date.now() + GIVE_UP_AFTER_MS;
+
                 if (blazorHandlingDrop()) {
-                    if (await serverIsUp()) location.reload();
+                    while (Date.now() < deadline) {
+                        if (!blazorHandlingDrop()) break;
+                        if (await serverIsUp()) { location.reload(); return; }
+                        await new Promise(r => setTimeout(r, 1000));
+                    }
                     return;
                 }
 
                 // No modal - probe the circuit. One probe isn't enough: Blazor
                 // is often mid-reconnect on resume and the first ping times out
                 // on a circuit that's about to work.
-                const GIVE_UP_AFTER_MS = 12000;
-                const deadline = Date.now() + GIVE_UP_AFTER_MS;
                 while (Date.now() < deadline) {
                     if (blazorHandlingDrop()) {
                         if (await serverIsUp()) location.reload();

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -226,7 +226,7 @@
         {
             <SiteAdminOnly>
                 <div class="dashboard-card-wrapper">
-                    <div class="card add-card-placeholder" @onclick="EnterEditMode" data-tooltip="Add widgets or edit layout">
+                    <div class="card add-card-placeholder" @onclick="EnterEditModeFromPlaceholder" data-tooltip="Add widgets or edit layout">
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
                     </div>
                 </div>
@@ -268,6 +268,11 @@
                     @RenderCard(stacked.ChildId)
                 </div>
             }
+
+            <div class="edit-bottom-actions card-span-2" id="edit-bottom">
+                <button class="btn btn-sm btn-primary" @onclick="ExitEditMode">Done</button>
+                <button class="btn btn-sm btn-secondary" @onclick="CancelEditMode">Cancel</button>
+            </div>
         }
     }
 </div>
@@ -933,6 +938,15 @@
     {
         _layoutSnapshot = System.Text.Json.JsonSerializer.Serialize(_layout);
         _editMode = true;
+    }
+
+    private async Task EnterEditModeFromPlaceholder()
+    {
+        EnterEditMode();
+        StateHasChanged();
+        await Task.Yield();
+        await JS.InvokeVoidAsync("eval",
+            "document.getElementById('edit-bottom')?.scrollIntoView({ behavior: 'smooth', block: 'end' })");
     }
 
     private async Task ExitEditMode()

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -222,6 +222,17 @@
             </div>
         }
 
+        @if (!_editMode)
+        {
+            <SiteAdminOnly>
+                <div class="dashboard-card-wrapper">
+                    <div class="card add-card-placeholder" @onclick="EnterEditMode" data-tooltip="Add widgets or edit layout">
+                        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
+                    </div>
+                </div>
+            </SiteAdminOnly>
+        }
+
         @* Hidden + stacked cards at the bottom in edit mode *@
         @if (_editMode)
         {

--- a/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Dashboard.razor
@@ -226,7 +226,7 @@
         {
             <SiteAdminOnly>
                 <div class="dashboard-card-wrapper">
-                    <div class="card add-card-placeholder" @onclick="EnterEditModeFromPlaceholder" data-tooltip="Add widgets or edit layout">
+                    <div class="card add-card-placeholder" @onclick="EnterEditModeFromPlaceholder" data-tooltip="Add widgets or edit layout" data-tooltip-hover-only>
                         <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>
                     </div>
                 </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/FirmwareRollout.razor
@@ -651,7 +651,7 @@ else
                 }
                 <div class="table-responsive">
                     <table class="data-table">
-                        <thead><tr><th>Device</th><th>Model</th><th class="hide-mobile">From</th><th>To</th><th>Downtime</th><th class="hide-mobile">CPU</th><th>Outcome</th></tr></thead>
+                        <thead><tr><th>Device</th><th>Model</th><th class="hide-mobile">From</th><th>To</th><th>Downtime</th><th class="hide-mobile">CPU</th><th class="hide-mobile">Mem</th><th>Outcome</th></tr></thead>
                         <tbody>
                             @foreach (var row in rep.Rows)
                             {
@@ -662,6 +662,7 @@ else
                                     <td>@(FirmwareVersionFormat.ShortOrNull(row.ToVersion) ?? "-")</td>
                                     <td>@(row.DowntimeSeconds is int d ? Duration(d) : "-")</td>
                                     <td class="hide-mobile">@(row.CpuBeforeMean is { } rcb && row.CpuAfterMean is { } rca ? $"{rcb:0}% → {rca:0}%" : "-")</td>
+                                    <td class="hide-mobile">@(row.MemBeforeMean is { } rmb && row.MemAfterMean is { } rma ? $"{rmb:0}% → {rma:0}%" : "-")</td>
                                     <td>
                                         <span class="firmware-rollout-chip @OutcomeChipClass(row.Outcome)">@row.Outcome</span>
                                         @if (row.Issue != null)

--- a/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Monitoring.razor
@@ -624,6 +624,24 @@
                                       OnClick="JumpToLiveAsync" />
             </div>
             <div class="card-body">
+                @if (FocusedWanProbesViaDefaultRoute)
+                {
+                    var focusedWan = _wanOptions.FirstOrDefault(w => string.Equals(w.Key, FocusedWanKey, StringComparison.OrdinalIgnoreCase));
+                    var focusedLabel = focusedWan != null
+                        ? NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabelInProse(focusedWan.Label, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(focusedWan.Key))
+                        : "This WAN";
+                    <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+                        <div class="banner-content">
+                            <span class="banner-icon banner-icon-warning">!</span>
+                            <div class="banner-text" style="flex: 1;">
+                                @focusedLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
+                            </div>
+                            <div class="banner-actions">
+                                <button class="btn btn-sm btn-primary" @onclick="@(() => { _forceExpandWanContexts = true; _scrollToWanContextsPending = true; StateHasChanged(); })">Configure Vantage</button>
+                            </div>
+                        </div>
+                    </div>
+                }
                 <div class="latency-filter-badges wan-filter-badges"></div>
                 @* Anchored on the chart rather than the card: the sync is something the plot does
                    under the pointer, and it only reads as that with a line to hover. *@
@@ -2196,6 +2214,27 @@
     /// and offering to clear it would read as offering to undo their choice of WAN.
     /// </summary>
     private bool WanFilterIsNarrowed => _multiWanUiVisible && _selectedWanKeys.Count > 1;
+
+    /// <summary>
+    /// The focused WAN's Vantage has no probe binding (no agent, no source IP), so the server
+    /// probes its targets via the default route. Only fires for non-primary, single-WAN
+    /// selection, with a context that exists but binds nothing.
+    /// </summary>
+    private bool FocusedWanProbesViaDefaultRoute
+    {
+        get
+        {
+            if (!_multiWanUiVisible || _lanScope || _allScope || _selectedWanKeys.Count != 1) return false;
+            var key = FocusedWanKey;
+            var wan = _wanOptions.FirstOrDefault(w => string.Equals(w.Key, key, StringComparison.OrdinalIgnoreCase));
+            if (wan is not { IsPrimary: false }) return false;
+            var matching = _wanContexts.Where(c => !string.IsNullOrEmpty(c.WanInterface)
+                && string.Equals(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!),
+                    key, StringComparison.OrdinalIgnoreCase)).ToList();
+            return matching.Count > 0
+                && matching.All(c => c.AgentId == null && string.IsNullOrEmpty(c.ProbeSourceIp));
+        }
+    }
 
     /// <summary>Whether every WAN is on screen, which is what the All pill means.</summary>
     private bool AllWansSelected =>

--- a/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/Monitoring/IspHealthPanel.razor
@@ -126,6 +126,20 @@
 }
 else if (_report == null)
 {
+    @if (ProbesViaDefaultRoute && Svc.Status != IspHealthStatus.NeedsDiscovery)
+    {
+        <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-warning">!</span>
+                <div class="banner-text" style="flex: 1;">
+                    @SelectedWanLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>
+                </div>
+            </div>
+        </div>
+    }
     @if (Svc.Status == IspHealthStatus.Computing)
     {
         <div class="isp-health-loading card">
@@ -141,7 +155,7 @@ else if (_report == null)
                 <div class="banner-text" style="flex: 1;">
                     @if (NeedsContextFirst)
                     {
-                        <text>@SelectedWanLabel has no vantage yet, so nothing probes it. Give it one, then discovery can trace its path.</text>
+                        <text>@SelectedWanLabel has no Vantage yet, so nothing probes it. Give it one, then discovery can trace its path.</text>
                     }
                     else
                     {
@@ -151,7 +165,7 @@ else if (_report == null)
                 <div class="banner-actions">
                     @if (NeedsContextFirst)
                     {
-                        <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Add a WAN vantage</button>
+                        <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Add a WAN Vantage</button>
                     }
                     else
                     {
@@ -246,6 +260,20 @@ else if (_report == null)
 else
 {
     var r = _report;
+    @if (ProbesViaDefaultRoute)
+    {
+        <div class="alert alert-warning" style="margin-bottom: 0.75rem;">
+            <div class="banner-content">
+                <span class="banner-icon banner-icon-warning">!</span>
+                <div class="banner-text" style="flex: 1;">
+                    @SelectedWanLabel's Vantage has no binding, so its probes follow the default route and reflect its performance. Assign an Agent or bind a Policy-Routed source address to actually measure this connection.
+                </div>
+                <div class="banner-actions">
+                    <button class="btn btn-sm btn-primary" @onclick="@(() => NavigationManager.NavigateTo("/monitoring?tab=performance&contexts=1"))">Configure Vantage</button>
+                </div>
+            </div>
+        </div>
+    }
     @if (!r.HasUpstreamTraceMap)
     {
         <div class="alert alert-info" style="margin-bottom: 0.75rem;">
@@ -1106,6 +1134,7 @@ else
     // Which WANs a context names. A secondary WAN without one is not "not discovered yet" - it is
     // not probed at all, and discovery cannot change that.
     private HashSet<string> _wansWithContext = new(StringComparer.OrdinalIgnoreCase);
+    private HashSet<string> _wansWithProbeBinding = new(StringComparer.OrdinalIgnoreCase);
     private string _selectedWanKey = "";
 
     /// <summary>
@@ -1137,7 +1166,7 @@ else
         try
         {
             foreach (var wan in await PathView.GetWansAsync())
-                options.Add(new WanChoice(wan.WanInterface.ToLowerInvariant(),
+                options.Add(new WanChoice(NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(wan.WanInterface),
                     NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabel(
                         wan.FriendlyName, NetworkOptimizer.UniFi.GatewayWanHelper.WanIndexFromKey(wan.WanInterface), null, null),
                     wan.IsPrimary));
@@ -1150,12 +1179,17 @@ else
                 Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.AsNoTracking(db.WanContexts));
             _wansWithContext = contexts
                 .Where(c => !string.IsNullOrEmpty(c.WanInterface))
-                .Select(c => c.WanInterface!.ToLowerInvariant())
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            _wansWithProbeBinding = contexts
+                .Where(c => !string.IsNullOrEmpty(c.WanInterface)
+                    && (c.AgentId != null || !string.IsNullOrEmpty(c.ProbeSourceIp)))
+                .Select(c => NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(c.WanInterface!))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
             foreach (var ctx in contexts)
             {
                 if (string.IsNullOrEmpty(ctx.WanInterface)) continue;
-                var key = ctx.WanInterface!.ToLowerInvariant();
+                var key = NetworkOptimizer.UniFi.GatewayWanHelper.WanInterfaceKeyFromKey(ctx.WanInterface!);
                 if (!options.Any(o => o.Key == key))
                     options.Add(new WanChoice(key,
                         NetworkOptimizer.UniFi.GatewayWanHelper.FormatWanLabel(
@@ -1373,6 +1407,23 @@ else
             var wan = _wanOptions.FirstOrDefault(
                 w => string.Equals(w.Key, _selectedWanKey, StringComparison.OrdinalIgnoreCase));
             return wan is { IsPrimary: false } && !_wansWithContext.Contains(wan.Key);
+        }
+    }
+
+    /// <summary>
+    /// The selected WAN has a vantage but no probe binding (no agent, no source IP), so the
+    /// server probes its targets via the default route - which is the primary WAN's path. The
+    /// readings and scores reflect the primary connection, not this one.
+    /// </summary>
+    private bool ProbesViaDefaultRoute
+    {
+        get
+        {
+            var wan = _wanOptions.FirstOrDefault(
+                w => string.Equals(w.Key, _selectedWanKey, StringComparison.OrdinalIgnoreCase));
+            return wan is { IsPrimary: false }
+                && _wansWithContext.Contains(wan.Key)
+                && !_wansWithProbeBinding.Contains(wan.Key);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -317,34 +317,34 @@ public static class DeviceHealthChartEndpoints
     /// Short label for an alert mark: the alert's own noun, without the device name the chart
     /// already shows. Falls back to the stored title when the event type is not one we name.
     /// </summary>
-    private static string AlertLabel(string eventType, string title) => eventType switch
+    internal static string AlertLabel(string eventType, string title) => eventType switch
     {
         "device.offline" => "Offline",
         "device.recovered" => "Recovered",
         "monitoring.target_offline" => "Device offline",
         "monitoring.target_recovered" => "Device back online",
-        "device.gateway_high_cpu" => "High CPU",
-        "device.gateway_high_memory" => "High memory",
-        "device.high_temperature" => "High temperature",
+        DeviceHealthAlertEvaluator.HighCpuEventType => "High CPU",
+        DeviceHealthAlertEvaluator.HighMemoryEventType => "High memory",
+        DeviceHealthAlertEvaluator.HighTemperatureEventType => "High temperature",
         _ => title,
     };
 
-    private static readonly Regex ReadingPattern = new(@"(\d+\.?\d*)\s*(%|C)(?!\w)", RegexOptions.Compiled);
+    private static readonly Regex ReadingPattern = new(@"(\d+\.?\d*)\s*(%|°?C)(?!\w)", RegexOptions.Compiled);
 
     /// <summary>
     /// Extracts a short metric reading from the alert message for the collapsed chart tooltip
-    /// subtitle (e.g. "65.3 C", "87 %"). The regex matches the first number+unit in the message,
+    /// subtitle (e.g. "65.3 °C", "87%"). The regex matches the first number+unit in the message,
     /// so every Message format in <see cref="DeviceHealthAlertEvaluator"/> must keep the reading
     /// as the first such token - and new health alert types must be added to the switch below.
     /// </summary>
-    private static string? AlertReading(string eventType, string? message)
+    internal static string? AlertReading(string eventType, string? message)
     {
         if (string.IsNullOrEmpty(message)) return null;
         return eventType switch
         {
-            "device.gateway_high_cpu" or "device.gateway_high_memory" or "device.high_temperature"
+            DeviceHealthAlertEvaluator.HighCpuEventType or DeviceHealthAlertEvaluator.HighMemoryEventType or DeviceHealthAlertEvaluator.HighTemperatureEventType
                 => ReadingPattern.Match(message) is { Success: true } m
-                    ? $"{m.Groups[1].Value}{(m.Groups[2].Value == "%" ? "%" : " C")}" : null,
+                    ? $"{m.Groups[1].Value}{(m.Groups[2].Value == "%" ? "%" : " °C")}" : null,
             _ => null,
         };
     }

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -188,6 +188,7 @@ public static class DeviceHealthChartEndpoints
                     : string.IsNullOrWhiteSpace(reboot.Detail)
                         ? $"Firmware {reboot.FirmwareVersion}"
                         : $"{reboot.Detail}. Firmware {reboot.FirmwareVersion}",
+                firmware = reboot.FirmwareVersion,
             }));
         }
 
@@ -320,6 +321,8 @@ public static class DeviceHealthChartEndpoints
     {
         "device.offline" => "Offline",
         "device.recovered" => "Recovered",
+        "monitoring.target_offline" => "Device offline",
+        "monitoring.target_recovered" => "Device back online",
         "device.gateway_high_cpu" => "High CPU",
         "device.gateway_high_memory" => "High memory",
         "device.high_temperature" => "High temperature",

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -1,5 +1,7 @@
+using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.Web.Services;
@@ -188,7 +190,7 @@ public static class DeviceHealthChartEndpoints
                     : string.IsNullOrWhiteSpace(reboot.Detail)
                         ? $"Firmware {reboot.FirmwareVersion}"
                         : $"{reboot.Detail}. Firmware {reboot.FirmwareVersion}",
-                firmware = reboot.FirmwareVersion,
+                firmware = FirmwareVersionFormat.ShortOrNull(reboot.FirmwareVersion),
             }));
         }
 
@@ -234,11 +236,9 @@ public static class DeviceHealthChartEndpoints
                     AlertSeverity.Warning => "warning",
                     _ => "info",
                 },
-                // Titles carry the device name and a site suffix, which the chart already knows
-                // from the series it sits on; the event type is what distinguishes one mark
-                // from the next.
                 title = AlertLabel(alert.EventType, alert.Title),
                 detail = alert.Message,
+                reading = AlertReading(alert.EventType, alert.Message),
             }));
         }
 
@@ -328,6 +328,25 @@ public static class DeviceHealthChartEndpoints
         "device.high_temperature" => "High temperature",
         _ => title,
     };
+
+    private static readonly Regex ReadingPattern = new(@"(\d+\.?\d*)\s*(%|C)\b", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Extracts a short metric reading from the alert message for the collapsed chart tooltip
+    /// subtitle (e.g. "65.3 C", "87 %"). The regex matches the first number+unit in the message,
+    /// so every Message format in <see cref="DeviceHealthAlertEvaluator"/> must keep the reading
+    /// as the first such token - and new health alert types must be added to the switch below.
+    /// </summary>
+    private static string? AlertReading(string eventType, string? message)
+    {
+        if (string.IsNullOrEmpty(message)) return null;
+        return eventType switch
+        {
+            "device.gateway_high_cpu" or "device.gateway_high_memory" or "device.high_temperature"
+                => ReadingPattern.Match(message) is { Success: true } m ? $"{m.Groups[1].Value} {m.Groups[2].Value}" : null,
+            _ => null,
+        };
+    }
 
     /// <summary>Strips MAC separators and case so spellings from different sources compare equal.</summary>
     private static string NormalizeMac(string mac) =>

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -329,7 +329,7 @@ public static class DeviceHealthChartEndpoints
         _ => title,
     };
 
-    private static readonly Regex ReadingPattern = new(@"(\d+\.?\d*)\s*(%|C)\b", RegexOptions.Compiled);
+    private static readonly Regex ReadingPattern = new(@"(\d+\.?\d*)\s*(%|C)(?!\w)", RegexOptions.Compiled);
 
     /// <summary>
     /// Extracts a short metric reading from the alert message for the collapsed chart tooltip

--- a/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
+++ b/src/NetworkOptimizer.Web/Endpoints/DeviceHealthChartEndpoints.cs
@@ -343,7 +343,8 @@ public static class DeviceHealthChartEndpoints
         return eventType switch
         {
             "device.gateway_high_cpu" or "device.gateway_high_memory" or "device.high_temperature"
-                => ReadingPattern.Match(message) is { Success: true } m ? $"{m.Groups[1].Value} {m.Groups[2].Value}" : null,
+                => ReadingPattern.Match(message) is { Success: true } m
+                    ? $"{m.Groups[1].Value}{(m.Groups[2].Value == "%" ? "%" : " C")}" : null,
             _ => null,
         };
     }

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -1526,7 +1526,8 @@ public class AgentProbeResultSink
                 rebootAddress,
                 uptimeForReboot,
                 rebootFirmware,
-                timestamp);
+                timestamp,
+                model: apiDevice?.Model);
 
             // Threshold evaluation through the site's own evaluator instance, same
             // state machine the local medium tier runs. The name cache captured on

--- a/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
+++ b/src/NetworkOptimizer.Web/Services/CellularModemProviders/GlModemTransport.cs
@@ -8,13 +8,17 @@ using NetworkOptimizer.Web.Services.Ssh;
 namespace NetworkOptimizer.Web.Services.CellularModemProviders;
 
 /// <summary>
-/// Where a GL.iNet router's modem lives and how <c>gl_modem</c> must be addressed to
-/// reach it, plus the identity its firmware reports.
+/// Where a GL.iNet router's modem lives and how to reach it, plus the identity its
+/// firmware reports. Two transports: <c>gl_modem</c> (USB, addressed by <see cref="Bus"/>
+/// and <see cref="Sub"/>) and direct MHI (PCIe, addressed by <see cref="MhiDevice"/>).
 /// </summary>
 /// <param name="Bus">Value for gl_modem's <c>-B</c> flag. "cpu" for a modem integrated
 /// into the SoC, a USB path such as "1-1.2" for a plug-in module.</param>
 /// <param name="Sub">Value for gl_modem's <c>-U</c> flag, or null for firmware whose
 /// gl_modem predates the flag.</param>
+/// <param name="MhiDevice">Device node for a PCIe/MHI modem (e.g. "/dev/mhi_DUN").
+/// When set, AT commands are written directly to this device instead of through
+/// gl_modem. The X3000/XE3000 with an RM520N-GL use this path.</param>
 public sealed record GlModemEndpoint(
     string? Bus,
     int? Sub,
@@ -22,10 +26,14 @@ public sealed record GlModemEndpoint(
     string? Vendor = null,
     string? SoftwareVersion = null,
     string? HostVersion = null,
-    string? Product = null)
+    string? Product = null,
+    string? MhiDevice = null)
 {
     /// <summary>Endpoint used when discovery finds nothing: let gl_modem pick the modem itself.</summary>
     public static readonly GlModemEndpoint Unknown = new(null, null);
+
+    /// <summary>Whether AT commands go through a PCIe/MHI device node rather than gl_modem.</summary>
+    public bool IsMhi => !string.IsNullOrEmpty(MhiDevice);
 
     /// <summary>Human-readable identity for Test Connection, e.g. "Quectel RG650V-NA".</summary>
     public string? Description =>
@@ -113,7 +121,16 @@ public sealed class GlModemTransport
         return result with { Endpoint = endpoint };
     }
 
-    private async Task<GlModemAtResult> ExecuteAsync(
+    private Task<GlModemAtResult> ExecuteAsync(
+        GlModemEndpoint endpoint,
+        SshConnectionInfo connection,
+        IReadOnlyList<string> atCommands,
+        CancellationToken cancellationToken) =>
+        endpoint.IsMhi
+            ? ExecuteMhiAsync(endpoint, connection, atCommands, cancellationToken)
+            : ExecuteGlModemAsync(endpoint, connection, atCommands, cancellationToken);
+
+    private async Task<GlModemAtResult> ExecuteGlModemAsync(
         GlModemEndpoint endpoint,
         SshConnectionInfo connection,
         IReadOnlyList<string> atCommands,
@@ -169,6 +186,40 @@ public sealed class GlModemTransport
     }
 
     /// <summary>
+    /// Execute AT commands by writing directly to a PCIe/MHI device node. Used on
+    /// routers like the X3000/XE3000 whose RM520N-GL sits on PCIe and is unreachable
+    /// by gl_modem.
+    /// </summary>
+    private async Task<GlModemAtResult> ExecuteMhiAsync(
+        GlModemEndpoint endpoint,
+        SshConnectionInfo connection,
+        IReadOnlyList<string> atCommands,
+        CancellationToken cancellationToken)
+    {
+        var device = ValidMhiDevice(endpoint.MhiDevice!);
+        var script = new StringBuilder();
+
+        for (int i = 0; i < atCommands.Count; i++)
+        {
+            if (i > 0) script.Append("; ");
+            script.Append($"echo '{SectionMarker(i)}'; ");
+            script.Append(BuildMhiCommand(device, atCommands[i]));
+        }
+
+        var result = await _sshClient.ExecuteCommandAsync(
+            connection, script.ToString(), cancellationToken: cancellationToken);
+
+        if (!result.Success && string.IsNullOrWhiteSpace(result.Output))
+            return new GlModemAtResult { Success = false, Error = SshFailureSummary.Describe(result.CombinedOutput ?? "", connection.Host) };
+
+        return new GlModemAtResult
+        {
+            Success = true,
+            Sections = SplitAtSections(result.Output ?? "", atCommands),
+        };
+    }
+
+    /// <summary>
     /// Build the gl_modem invocation for one AT command. Both flags are omitted when
     /// unknown, which is the form older firmware accepts.
     /// </summary>
@@ -186,11 +237,28 @@ public sealed class GlModemTransport
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Build a direct AT command to a PCIe/MHI device. Writes the command, then reads
+    /// until the modem answers OK or ERROR (with a timeout fallback).
+    /// </summary>
+    internal static string BuildMhiCommand(string device, string atCommand)
+    {
+        device = ValidMhiDevice(device);
+        return $"echo -ne '{atCommand}\\r' > {device}; " +
+               $"timeout 3 sh -c 'while IFS= read -r l; do echo \"$l\"; " +
+               $"case \"$l\" in OK*|ERROR*|+CME\\ ERROR*|+CMS\\ ERROR*) break;; esac; done < {device}'";
+    }
+
     /// <summary>A bus is interpolated into a shell command, so it may only look like a path.</summary>
     private static string ValidBus(string bus) =>
         Regex.IsMatch(bus, @"^[0-9A-Za-z._:-]+$")
             ? bus
             : throw new ArgumentException($"Invalid modem bus: {bus}");
+
+    private static string ValidMhiDevice(string device) =>
+        Regex.IsMatch(device, @"^/dev/[A-Za-z0-9_]+$")
+            ? device
+            : throw new ArgumentException($"Invalid MHI device: {device}");
 
     /// <summary>
     /// Find the modem's addressing. GL.iNet's own cellular ubus service answers for the
@@ -206,22 +274,23 @@ public sealed class GlModemTransport
             "echo '===INFO==='; ubus call cellular.modem info '{\"bus\":\"cpu\"}' 2>/dev/null; " +
             "echo '===STATUS==='; ubus call cellular.modem status '{\"bus\":\"cpu\"}' 2>/dev/null; " +
             "echo '===GLVER==='; cat /etc/glversion 2>/dev/null; " +
-            "echo '===BOARD==='; ubus call system board 2>/dev/null";
+            "echo '===BOARD==='; ubus call system board 2>/dev/null; " +
+            "echo '===MHI==='; test -c /dev/mhi_DUN && echo yes || echo no";
 
         try
         {
             var result = await _sshClient.ExecuteCommandAsync(
                 connection, command, cancellationToken: cancellationToken);
 
-            // Judged on output, not exit status: the chain ends with the board query, so a
-            // device that answers about its modem but not its board would otherwise have
-            // perfectly good discovery thrown away.
+            // Judged on output, not exit status: any command in the chain can fail without
+            // invalidating what the others returned.
             if (!string.IsNullOrWhiteSpace(result.Output))
             {
                 var endpoint = ParseDiscovery(result.Output ?? "", context.TransportPath);
+                var transport = endpoint.IsMhi ? $"mhi:{endpoint.MhiDevice}" : $"bus:{endpoint.Bus ?? "auto"} sub:{endpoint.Sub?.ToString() ?? "none"}";
                 _logger.LogInformation(
-                    "Resolved GL.iNet modem {Name} to bus {Bus} sub {Sub} ({Model} {Software}, host {Host})",
-                    context.Name, endpoint.Bus ?? "auto", endpoint.Sub?.ToString() ?? "none",
+                    "Resolved GL.iNet modem {Name} via {Transport} ({Model} {Software}, host {Host})",
+                    context.Name, transport,
                     endpoint.Description ?? "unidentified", endpoint.SoftwareVersion ?? "unknown",
                     endpoint.HostVersion ?? "unknown");
                 return endpoint;
@@ -240,13 +309,15 @@ public sealed class GlModemTransport
     /// <summary>Parse the discovery script's sections. Internal for tests.</summary>
     internal static GlModemEndpoint ParseDiscovery(string output, string? configuredBus)
     {
-        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "GLVER", "BOARD" });
+        var sections = SplitNamedSections(output, new[] { "INFO", "STATUS", "GLVER", "BOARD", "MHI" });
 
         sections.TryGetValue("INFO", out var info);
         sections.TryGetValue("STATUS", out var status);
 
         var hostVersion = ParseHostVersion(sections);
         var product = ParseProduct(sections);
+        var hasMhi = sections.TryGetValue("MHI", out var mhi) &&
+                     mhi.Trim().Equals("yes", StringComparison.OrdinalIgnoreCase);
 
         string? bus = null, model = null, vendor = null, software = null;
         int? sub = null;
@@ -263,6 +334,12 @@ public sealed class GlModemTransport
             }
         }
 
+        // Empty strings from ubus mean "I don't know", not "the modem is at bus ''".
+        if (string.IsNullOrWhiteSpace(bus)) bus = null;
+        if (string.IsNullOrWhiteSpace(model)) model = null;
+        if (string.IsNullOrWhiteSpace(vendor)) vendor = null;
+        if (string.IsNullOrWhiteSpace(software)) software = null;
+
         // The AT subscription follows the SIM slot the modem is actually using.
         if (bus != null && TryParseJson(status, out var statusDoc))
         {
@@ -274,6 +351,12 @@ public sealed class GlModemTransport
 
         if (bus != null)
             return new GlModemEndpoint(bus, sub ?? 1, model, vendor, software, hostVersion, product);
+
+        // PCIe/MHI modem (X3000, XE3000 with RM520N-GL): gl_modem can't reach it, but
+        // /dev/mhi_DUN carries AT commands directly.
+        if (hasMhi)
+            return new GlModemEndpoint(null, null, model, vendor, software, hostVersion, product,
+                MhiDevice: "/dev/mhi_DUN");
 
         if (!string.IsNullOrWhiteSpace(configuredBus))
             return new GlModemEndpoint(configuredBus, null, HostVersion: hostVersion, Product: product);

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -840,7 +840,10 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         // is exactly "the gateway step has settled" - and is also the right point on a plan that
         // has no gateway step at all.
         if (document.UniFiOsUpdate is { Triggered: true, Settled: false } && settings.SuppressStandardAlerts)
+        {
             _suppression.RefreshConsoleCycle(_siteSlug, Now);
+            _suppression.RefreshOsCycle(_siteSlug, Now);
+        }
 
         if (!await AdvanceUniFiOsUpdateAsync(plan, document, steps, cancellationToken))
             return;

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutAutopilot.cs
@@ -142,6 +142,7 @@ public class RolloutAutopilot : IRolloutAutopilot
 
         var ripeness = await EvaluateRipenessAsync(inputs.Context.Devices, settings.MinReleaseAgeDays, cancellationToken);
         var result = RolloutPlanComposer.Plan(inputs, settings, ripeness.UnripeMacs);
+        result.Document.TimeZoneId = inputs.Context.TimeZoneId;
         result.Document.Notes.AddRange(ripeness.Notes);
 
         // A console update is reason enough to run. On a Cloud Gateway the console's own UniFi OS

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutSuppressionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutSuppressionRegistry.cs
@@ -27,6 +27,7 @@ public class RolloutSuppressionRegistry
 
     private readonly ConcurrentDictionary<(string Site, string Mac), DateTime> _windowRefreshedAt = new();
     private readonly ConcurrentDictionary<string, DateTime> _consoleCyclingAt = new();
+    private readonly ConcurrentDictionary<string, DateTime> _osCyclingAt = new();
     private readonly ConcurrentDictionary<string, DateTime> _siteActiveAt = new();
 
     /// <summary>
@@ -39,6 +40,21 @@ public class RolloutSuppressionRegistry
     /// <summary>Ends the console-cycle window for a site.</summary>
     public void ClearConsoleCycle(string siteSlug) =>
         _consoleCyclingAt.TryRemove(NormalizeSite(siteSlug), out _);
+
+    /// <summary>
+    /// Marks the site as cycling a UniFi OS update. The gateway reboots during these, taking
+    /// WAN connectivity with it, so WAN outage alerts are suppressed in addition to the
+    /// device/target alerts that <see cref="RefreshConsoleCycle"/> already covers.
+    /// </summary>
+    public void RefreshOsCycle(string siteSlug, DateTime observedAt) =>
+        _osCyclingAt[NormalizeSite(siteSlug)] = observedAt.ToUniversalTime();
+
+    /// <summary>Whether the site's gateway is mid-UniFi OS update (WAN expected to be down).</summary>
+    public bool IsOsCycling(string siteSlug, DateTime now)
+    {
+        var site = NormalizeSite(siteSlug);
+        return _osCyclingAt.TryGetValue(site, out var at) && now.ToUniversalTime() - at <= WindowFreshness;
+    }
 
     /// <summary>
     /// Marks the site as having an active rollout. Any device reboot during a rollout can
@@ -110,6 +126,7 @@ public class RolloutSuppressionRegistry
         var site = NormalizeSite(siteSlug);
         _siteActiveAt.TryRemove(site, out _);
         _consoleCyclingAt.TryRemove(site, out _);
+        _osCyclingAt.TryRemove(site, out _);
         foreach (var key in _windowRefreshedAt.Keys.Where(k => k.Site == site).ToList())
             _windowRefreshedAt.TryRemove(key, out _);
     }

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutSuppressionRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutSuppressionRegistry.cs
@@ -51,7 +51,9 @@ public class RolloutSuppressionRegistry
     public bool IsSiteActiveRollout(string siteSlug, DateTime now)
     {
         var site = NormalizeSite(siteSlug);
-        return _siteActiveAt.TryGetValue(site, out var at) && now.ToUniversalTime() - at <= WindowFreshness;
+        var utcNow = now.ToUniversalTime();
+        return (_siteActiveAt.TryGetValue(site, out var at) && utcNow - at <= WindowFreshness)
+            || (_consoleCyclingAt.TryGetValue(site, out var cycleAt) && utcNow - cycleAt <= WindowFreshness);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -21,6 +21,9 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 /// </summary>
 public class DeviceHealthAlertEvaluator
 {
+    internal const string HighCpuEventType = "device.gateway_high_cpu";
+    internal const string HighMemoryEventType = "device.gateway_high_memory";
+    internal const string HighTemperatureEventType = "device.high_temperature";
 
     private const int CpuWindowSize = 5;
     private const double CpuHighThresholdPercent = 70.0;
@@ -86,7 +89,7 @@ public class DeviceHealthAlertEvaluator
 
                     await _eventBus.PublishAsync(new AlertEvent
                     {
-                        EventType = "device.gateway_high_cpu",
+                        EventType = HighCpuEventType,
                         Source = "device",
                         Severity = AlertSeverity.Warning,
                         Title = $"{label} CPU usage high{_siteSuffix}",
@@ -121,7 +124,7 @@ public class DeviceHealthAlertEvaluator
 
                 await _eventBus.PublishAsync(new AlertEvent
                 {
-                    EventType = "device.gateway_high_memory",
+                    EventType = HighMemoryEventType,
                     Source = "device",
                     Severity = AlertSeverity.Warning,
                     Title = $"{label} memory usage high{_siteSuffix}",
@@ -159,11 +162,11 @@ public class DeviceHealthAlertEvaluator
 
                 await _eventBus.PublishAsync(new AlertEvent
                 {
-                    EventType = "device.high_temperature",
+                    EventType = HighTemperatureEventType,
                     Source = "device",
                     Severity = AlertSeverity.Warning,
                     Title = $"{label} temperature high{_siteSuffix}",
-                    Message = $"{typeLabel} {label} temperature at {temperatureC.Value:0.#} C, exceeding the {threshold:0.#} C threshold.",
+                    Message = $"{typeLabel} {label} temperature at {temperatureC.Value:0.#} °C, exceeding the {threshold:0.#} °C threshold.",
                     DeviceId = deviceMac,
                     DeviceName = deviceName,
                     MetricValue = temperatureC.Value,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceHealthAlertEvaluator.cs
@@ -13,6 +13,11 @@ namespace NetworkOptimizer.Web.Services.Monitoring;
 ///
 /// Temperature is evaluated for gateways and switches against a user-configurable
 /// high threshold (per device type, falling back to <see cref="DefaultDeviceTempHighC"/>).
+///
+/// WARNING: the Message format strings below are parsed by
+/// <c>DeviceHealthChartEndpoints.AlertReading</c> to extract the metric value for the
+/// collapsed chart tooltip. If you change a Message format or add a new health alert type,
+/// update AlertReading to match.
 /// </summary>
 public class DeviceHealthAlertEvaluator
 {

--- a/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/OntAlertEvaluator.cs
@@ -155,7 +155,7 @@ public class OntAlertEvaluator
                 Source = "ont",
                 Severity = AlertSeverity.Warning,
                 Title = $"{ontName} temperature high{_siteSuffix}",
-                Message = $"ONT {ontName} temperature {tempC:0.#} C is above {tempHighC:0} C threshold.",
+                Message = $"ONT {ontName} temperature {tempC:0.#} °C is above {tempHighC:0} °C threshold.",
                 DeviceName = ontName,
                 MetricValue = tempC,
                 ThresholdValue = tempHighC,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootObserver.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootObserver.cs
@@ -162,7 +162,8 @@ public sealed class DeviceRebootObserver : BackgroundService
                 (long)device.Uptime.TotalSeconds,
                 device.Firmware,
                 now,
-                DeviceRebootTracker.UptimeSource.Console);
+                DeviceRebootTracker.UptimeSource.Console,
+                model: device.Model);
         }
 
         // Says the pass happened even when it changes nothing, which is the normal case: without it

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
@@ -166,7 +166,8 @@ public class DeviceRebootTracker
         long? uptimeSeconds,
         string? firmwareVersion,
         DateTime observedAt,
-        UptimeSource source = UptimeSource.Monitoring)
+        UptimeSource source = UptimeSource.Monitoring,
+        string? model = null)
     {
         if (string.IsNullOrWhiteSpace(deviceMac) || uptimeSeconds is null or <= 0)
             return;
@@ -229,7 +230,8 @@ public class DeviceRebootTracker
         }
 
         _ = ResolveInBackgroundAsync(mac, deviceName, deviceType, host, bootedAt, firmwareChanged,
-            previousFirmware: known?.FirmwareVersion, currentFirmware: firmwareVersion);
+            previousFirmware: known?.FirmwareVersion, currentFirmware: firmwareVersion,
+            model: model);
     }
 
     /// <summary>
@@ -311,7 +313,8 @@ public class DeviceRebootTracker
         DateTime bootedAt,
         bool firmwareChanged,
         string? previousFirmware,
-        string? currentFirmware)
+        string? currentFirmware,
+        string? model = null)
     {
         if (string.IsNullOrWhiteSpace(host))
         {
@@ -320,6 +323,9 @@ public class DeviceRebootTracker
                 deviceName ?? "unknown", mac);
             return;
         }
+
+        if (!UniFi.UniFiProductDatabase.HasSsh(model, null))
+            return;
 
         // One probe per device at a time, and a cool-off after a miss. Devices whose SSH is not
         // set up land here on every health sample, so the skip is logged at Debug once per hour

--- a/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/SfpAlertEvaluator.cs
@@ -57,7 +57,7 @@ public class SfpAlertEvaluator
             await CheckHighThreshold(state, "temp", temperatureC.Value, threshold, TempHysteresisC,
                 "monitoring.sfp_temperature",
                 $"SFP temperature on {portLabel}",
-                $"SFP temperature {temperatureC.Value:0.#} C exceeds {threshold} C threshold on {portLabel}",
+                $"SFP temperature {temperatureC.Value:0.#} °C exceeds {threshold} °C threshold on {portLabel}",
                 deviceMac, portName, deviceName, category, ct);
         }
 

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -51,6 +51,7 @@ public class WanOutageEvaluator
     private readonly IAlertEventBus _eventBus;
     private readonly ILogger<WanOutageEvaluator> _logger;
     private readonly WanOutageContextSource _contextSource;
+    private readonly Firmware.RolloutSuppressionRegistry? _rolloutWindows;
     private readonly TimeProvider _time;
     private readonly string _siteSlug;
     private readonly string _siteSuffix;
@@ -71,11 +72,13 @@ public class WanOutageEvaluator
     public WanOutageEvaluator(IAlertEventBus eventBus, ILogger<WanOutageEvaluator> logger,
         WanOutageContextSource contextSource,
         string siteSlug = SiteManagementService.DefaultSiteSlug,
+        Firmware.RolloutSuppressionRegistry? rolloutWindows = null,
         TimeProvider? timeProvider = null)
     {
         _eventBus = eventBus;
         _logger = logger;
         _contextSource = contextSource;
+        _rolloutWindows = rolloutWindows;
         _time = timeProvider ?? TimeProvider.System;
         _siteSlug = string.IsNullOrEmpty(siteSlug) ? SiteManagementService.DefaultSiteSlug : siteSlug;
         _siteSuffix = _siteSlug == SiteManagementService.DefaultSiteSlug ? "" : $" (site {_siteSlug})";
@@ -185,8 +188,15 @@ public class WanOutageEvaluator
         // fire. A WAN that already opened its own alert is folded in - the rollup event resolves
         // the per-WAN alerts it supersedes - so the worst case is one alert then the rollup,
         // rather than one per WAN.
+        // A UniFi OS update reboots the gateway, taking WAN with it. The outage is expected
+        // and the rollout's own alerts cover it, so no WAN alert opens while it is in progress.
+        // Network app updates do NOT suppress: the gateway stays up, so a WAN outage during
+        // one is real. Recovery always flows so a pre-existing alert can close.
+        var osCycling = _rolloutWindows?.IsOsCycling(_siteSlug, now) == true;
+
         var totalEverywhere = byWan.Keys.All(k => GetWanState(k).TotalConfirmedAt != null);
         if (!_rollupOpen
+            && !osCycling
             && byWan.Count >= 2
             && totalEverywhere
             && now - byWan.Keys.Min(k => GetWanState(k).TotalConfirmedAt!.Value)
@@ -210,17 +220,12 @@ public class WanOutageEvaluator
             var info = WanInfo(wanKey);
             switch (kind)
             {
-                case WanVerdictKind.Total when !state.CoveredByRollup && state.OpenKind != WanVerdictKind.Total:
-                    // Opens fresh, or supersedes an open partial: publishing the total closes
-                    // the partial downstream (AlertProcessingService resolves it), so the two
-                    // never stack.
+                case WanVerdictKind.Total when !state.CoveredByRollup && !osCycling && state.OpenKind != WanVerdictKind.Total:
                     state.OpenKind = WanVerdictKind.Total;
                     await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
                     break;
 
-                case WanVerdictKind.Partial when !state.CoveredByRollup && state.OpenKind == WanVerdictKind.None:
-                    // A partial never downgrades an open total; the total stays open until
-                    // recovery closes it.
+                case WanVerdictKind.Partial when !state.CoveredByRollup && !osCycling && state.OpenKind == WanVerdictKind.None:
                     state.OpenKind = WanVerdictKind.Partial;
                     await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
                     break;

--- a/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/WanOutageEvaluator.cs
@@ -221,11 +221,16 @@ public class WanOutageEvaluator
             switch (kind)
             {
                 case WanVerdictKind.Total when !state.CoveredByRollup && !osCycling && state.OpenKind != WanVerdictKind.Total:
+                    // Opens fresh, or supersedes an open partial: publishing the total closes
+                    // the partial downstream (AlertProcessingService resolves it), so the two
+                    // never stack.
                     state.OpenKind = WanVerdictKind.Total;
                     await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
                     break;
 
                 case WanVerdictKind.Partial when !state.CoveredByRollup && !osCycling && state.OpenKind == WanVerdictKind.None:
+                    // A partial never downgrades an open total; the total stays open until
+                    // recovery closes it.
                     state.OpenKind = WanVerdictKind.Partial;
                     await _eventBus.PublishAsync(BuildOutageEvent(info, state, now), ct);
                     break;

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -901,7 +901,8 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 _liveStats.RecordHealth(device.Mac, cpu, memPct, temp, uptime, DateTime.UtcNow);
                 _rebootTracker.RecordUptimeSample(device.Mac, device.Name, device.DeviceType,
-                    device.Ip, uptime, device.Version, DateTime.UtcNow);
+                    device.Ip, uptime, device.Version, DateTime.UtcNow,
+                    model: device.Model);
 
                 if (customOids.TryGetValue(NormalizeMac(device.Mac), out var deviceCustomOids))
                     await PollCustomOidsAsync(poller, device.Mac, DescribeDeviceType(device.DeviceType), ip, deviceCustomOids, ct);
@@ -997,7 +998,8 @@ public class MonitoringCollectionAgent : BackgroundService
 
                 _liveStats.RecordHealth(device.Mac, cpu, mem, temp, uptime, now);
                 _rebootTracker.RecordUptimeSample(device.Mac, device.Name, device.DeviceType,
-                    device.Ip, uptime, device.Version, now);
+                    device.Ip, uptime, device.Version, now,
+                    model: device.Model);
 
                 await _deviceHealthAlertEvaluator.EvaluateAsync(
                     device.Mac, device.Name, DescribeDeviceType(device.DeviceType),

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1185,6 +1185,13 @@ a.stat-card-link:active {
     color: var(--primary-color);
 }
 
+.edit-bottom-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 4px 0;
+}
+
 .dashboard-card-editing {
     position: relative;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -1168,6 +1168,23 @@ a.stat-card-link:active {
     opacity: 0.4;
 }
 
+.add-card-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 120px;
+    border: 2px dashed var(--border-color);
+    background: transparent;
+    cursor: pointer;
+    color: var(--text-muted);
+    transition: border-color 0.15s, color 0.15s;
+}
+
+.add-card-placeholder:hover {
+    border-color: var(--primary-color);
+    color: var(--primary-color);
+}
+
 .dashboard-card-editing {
     position: relative;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
@@ -73,8 +73,8 @@ function foldedTooltip(marks) {
     const opts = days.size > 1 ? DATE_TIME : TIME_ONLY;
 
     const items = marks.map(mark => {
-        const parts = [mark.device, mark.port ? `port ${mark.port}` : null].filter(Boolean);
-        if (mark.firmware) parts.push(mark.firmware);
+        const extra = mark.firmware || mark.reading;
+        const parts = [mark.device, mark.port ? `port ${mark.port}` : null, extra].filter(Boolean);
         const where = parts.join(' · ');
         return `<div class="chart-mark-item">`
             + `<span class="chart-mark-item-time">${escapeHtml(formatTime(mark.time, opts))}</span>`

--- a/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/chart-event-marks.js
@@ -73,7 +73,9 @@ function foldedTooltip(marks) {
     const opts = days.size > 1 ? DATE_TIME : TIME_ONLY;
 
     const items = marks.map(mark => {
-        const where = [mark.device, mark.port ? `port ${mark.port}` : null].filter(Boolean).join(' . ');
+        const parts = [mark.device, mark.port ? `port ${mark.port}` : null].filter(Boolean);
+        if (mark.firmware) parts.push(mark.firmware);
+        const where = parts.join(' · ');
         return `<div class="chart-mark-item">`
             + `<span class="chart-mark-item-time">${escapeHtml(formatTime(mark.time, opts))}</span>`
             + `<span class="chart-mark-item-body">`

--- a/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/device-health-charts.js
@@ -5,7 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
-import { createMarkLayer } from './chart-event-marks.js?v=4';
+import { createMarkLayer } from './chart-event-marks.js?v=5';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';
 import { awaitContainer } from './chart-mount.js?v=1';

--- a/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/ont-charts.js
@@ -5,7 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
-import { createMarkLayer } from './chart-event-marks.js?v=4';
+import { createMarkLayer } from './chart-event-marks.js?v=5';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=3';
 import { syncIdentity } from './chart-sync.js?v=7';

--- a/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/sfp-charts.js
@@ -5,7 +5,7 @@ import ApexCharts from '/_content/Blazor-ApexCharts/js/apexcharts.esm.js';
 import { computeStats, renderStatsTable as renderTable } from './chart-stats.js?v=8';
 import { valueSortedTooltip, tooltipHeld, alignedPoints } from './chart-tooltip.js?v=15';
 import { renderFilterReset, isFiltered } from './chart-filter.js?v=6';
-import { createMarkLayer } from './chart-event-marks.js?v=4';
+import { createMarkLayer } from './chart-event-marks.js?v=5';
 import { createAxisDateCaption } from './chart-axis-date.js?v=3';
 import { syncIdentity, extentsOf, spanTo } from './chart-sync.js?v=7';
 import { ponSeriesFor, ponDetailsHtml, updatePonCard } from './pon-section.js?v=3';

--- a/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
+++ b/tests/NetworkOptimizer.Storage.Tests/NetworkOptimizer.Storage.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutSuppressionRegistryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutSuppressionRegistryTests.cs
@@ -105,6 +105,113 @@ public class RolloutSuppressionRegistryTests
         registry.IsInRolloutWindow(Site, Mac, Now).Should().BeFalse();
     }
 
+    // --- Console cycling (Network app or UniFi OS restart) ------------------------------------
+
+    [Fact]
+    public void ConsoleCycleSuppressesEveryDeviceOnTheSite()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshConsoleCycle(Site, Now);
+
+        registry.IsInRolloutWindow(Site, Mac, Now).Should().BeTrue();
+        registry.IsInRolloutWindow(Site, "ff:ff:ff:ff:ff:ff", Now).Should().BeTrue();
+        registry.IsInRolloutWindow(Site, null, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConsoleCycleImpliesSiteActiveRollout()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshConsoleCycle(Site, Now);
+
+        registry.IsSiteActiveRollout(Site, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConsoleCycleLapses()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshConsoleCycle(Site, Now);
+
+        var expired = Now + RolloutSuppressionRegistry.WindowFreshness + TimeSpan.FromSeconds(1);
+        registry.IsInRolloutWindow(Site, Mac, expired).Should().BeFalse();
+        registry.IsSiteActiveRollout(Site, expired).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearSiteDropsConsoleCycle()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshConsoleCycle(Site, Now);
+        registry.ClearSite(Site);
+
+        registry.IsInRolloutWindow(Site, Mac, Now).Should().BeFalse();
+        registry.IsSiteActiveRollout(Site, Now).Should().BeFalse();
+    }
+
+    // --- OS cycling (UniFi OS update specifically) --------------------------------------------
+
+    [Fact]
+    public void OsCycleIsTrackedSeparately()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshOsCycle(Site, Now);
+
+        registry.IsOsCycling(Site, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ConsoleCycleAloneDoesNotImplyOsCycling()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshConsoleCycle(Site, Now);
+
+        registry.IsOsCycling(Site, Now).Should().BeFalse();
+    }
+
+    [Fact]
+    public void OsCycleLapses()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshOsCycle(Site, Now);
+
+        var expired = Now + RolloutSuppressionRegistry.WindowFreshness + TimeSpan.FromSeconds(1);
+        registry.IsOsCycling(Site, expired).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearSiteDropsOsCycle()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshOsCycle(Site, Now);
+        registry.ClearSite(Site);
+
+        registry.IsOsCycling(Site, Now).Should().BeFalse();
+    }
+
+    // --- Site-active rollout (device steps in flight) -----------------------------------------
+
+    [Fact]
+    public void SiteActiveRolloutFromDeviceSteps()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshSiteActive(Site, Now);
+
+        registry.IsSiteActiveRollout(Site, Now).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SiteActiveRolloutLapses()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        registry.RefreshSiteActive(Site, Now);
+
+        var expired = Now + RolloutSuppressionRegistry.WindowFreshness + TimeSpan.FromSeconds(1);
+        registry.IsSiteActiveRollout(Site, expired).Should().BeFalse();
+    }
+
+    // --- Evaluator integration ----------------------------------------------------------------
+
     [Fact]
     public async Task DeviceOfflineIsNotAnnouncedForADeviceTheRolloutIsUpgrading()
     {

--- a/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GlModemTransportTests.cs
@@ -56,6 +56,49 @@ public class GlModemTransportTests
                 "description": "OpenWrt 23.05.4 r24012-d8dd03c46f"
         }
 }
+===MHI===
+no
+""";
+
+    // XE3000P01 with RM520N-GL on PCIe/MHI: ubus returns valid JSON with all fields empty,
+    // and /dev/mhi_DUN is the AT port. Trimmed from a real device running firmware 4.9.0.
+    private const string MhiModemDiscovery = """
+===INFO===
+{
+        "bus": "",
+        "name": "",
+        "version": "",
+        "vendor": "",
+        "sim_slot_num": 0,
+        "signal_support": false,
+        "sms_support": false
+}
+===STATUS===
+{
+        "bus": "",
+        "status": 0,
+        "current_sim_slot": "",
+        "slot_switch_status": 0,
+        "slot_switch_count": 0
+}
+===GLVER===
+4.9.0
+===BOARD===
+{
+        "kernel": "5.4.211",
+        "hostname": "GL-XE3000P01",
+        "system": "ARMv8 Processor rev 4",
+        "model": "GL.iNet GL-XE3000",
+        "board_name": "glinet,xe3000-emmc",
+        "release": {
+                "distribution": "OpenWrt",
+                "version": "21.02-SNAPSHOT",
+                "target": "mediatek/mt7981",
+                "description": "OpenWrt 21.02-SNAPSHOT "
+        }
+}
+===MHI===
+yes
 """;
 
     [Fact]
@@ -177,6 +220,76 @@ public class GlModemTransportTests
     public void BuildAtCommand_RejectsBusThatIsNotAPath(string bus)
     {
         var act = () => GlModemTransport.BuildAtCommand(new GlModemEndpoint(bus, null), "AT");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void ParseDiscovery_MhiModem_UsesMhiDevice()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(MhiModemDiscovery, configuredBus: "");
+
+        endpoint.IsMhi.Should().BeTrue();
+        endpoint.MhiDevice.Should().Be("/dev/mhi_DUN");
+        endpoint.Bus.Should().BeNull();
+        endpoint.Sub.Should().BeNull();
+        endpoint.HostVersion.Should().Be("4.9.0");
+        endpoint.Product.Should().Be("GL-XE3000");
+    }
+
+    [Fact]
+    public void ParseDiscovery_MhiModem_ConfiguredBusIgnored()
+    {
+        var endpoint = GlModemTransport.ParseDiscovery(MhiModemDiscovery, configuredBus: "1-1.2");
+
+        endpoint.IsMhi.Should().BeTrue("MHI wins over a configured bus when gl_modem can't reach the modem");
+        endpoint.MhiDevice.Should().Be("/dev/mhi_DUN");
+    }
+
+    [Fact]
+    public void ParseDiscovery_EmptyUbusNoMhi_FallsThrough()
+    {
+        // Same as the MHI fixture but without /dev/mhi_DUN present.
+        var output = MhiModemDiscovery.Replace("yes", "no");
+
+        var endpoint = GlModemTransport.ParseDiscovery(output, configuredBus: "");
+
+        endpoint.IsMhi.Should().BeFalse();
+        endpoint.Bus.Should().BeNull();
+        endpoint.Sub.Should().BeNull();
+        endpoint.HostVersion.Should().Be("4.9.0");
+        endpoint.Product.Should().Be("GL-XE3000");
+    }
+
+    [Fact]
+    public void ParseDiscovery_EmptyUbusNoMhi_UsesConfiguredBus()
+    {
+        var output = MhiModemDiscovery.Replace("yes", "no");
+
+        var endpoint = GlModemTransport.ParseDiscovery(output, configuredBus: "1-1.2");
+
+        endpoint.IsMhi.Should().BeFalse();
+        endpoint.Bus.Should().Be("1-1.2");
+    }
+
+    [Fact]
+    public void BuildMhiCommand_WritesAndReadsFromDevice()
+    {
+        var command = GlModemTransport.BuildMhiCommand("/dev/mhi_DUN", "AT+QENG=\"servingcell\"");
+
+        command.Should().Contain("> /dev/mhi_DUN");
+        command.Should().Contain("< /dev/mhi_DUN");
+        command.Should().Contain("AT+QENG=");
+        command.Should().Contain("timeout");
+    }
+
+    [Theory]
+    [InlineData("/dev/mhi_DUN; reboot")]
+    [InlineData("/dev/../etc/passwd")]
+    [InlineData("$(id)")]
+    public void BuildMhiCommand_RejectsInjection(string device)
+    {
+        var act = () => GlModemTransport.BuildMhiCommand(device, "AT");
 
         act.Should().Throw<ArgumentException>();
     }

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/AlertReadingArchitectureTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/AlertReadingArchitectureTests.cs
@@ -1,0 +1,96 @@
+using FluentAssertions;
+using NetworkOptimizer.Web.Endpoints;
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Guards that every health alert event type published by <see cref="DeviceHealthAlertEvaluator"/>
+/// has a corresponding extractor in <see cref="DeviceHealthChartEndpoints.AlertReading"/> and
+/// a label in <see cref="DeviceHealthChartEndpoints.AlertLabel"/>. A new event type added to one
+/// side without the other fails here rather than silently showing a blank subtitle or raw title
+/// in the collapsed chart tooltip.
+/// </summary>
+public class AlertReadingArchitectureTests
+{
+    /// <summary>
+    /// Every health alert event type constant on <see cref="DeviceHealthAlertEvaluator"/> must
+    /// produce a non-null reading from a representative message.
+    /// </summary>
+    public static TheoryData<string, string, string> HealthAlertMessages => new()
+    {
+        { DeviceHealthAlertEvaluator.HighCpuEventType,
+          "Gateway TestDevice CPU averaged 70.4% over the last 5 samples, exceeding the 70% threshold.",
+          "70.4%" },
+        { DeviceHealthAlertEvaluator.HighCpuEventType,
+          "Gateway TestDevice CPU averaged 85% over the last 5 samples, exceeding the 70% threshold.",
+          "85%" },
+        { DeviceHealthAlertEvaluator.HighMemoryEventType,
+          "Gateway TestDevice memory usage at 95.3%, exceeding the 95% threshold.",
+          "95.3%" },
+        { DeviceHealthAlertEvaluator.HighMemoryEventType,
+          "Gateway TestDevice memory usage at 99%, exceeding the 95% threshold.",
+          "99%" },
+        // New format with degree symbol
+        { DeviceHealthAlertEvaluator.HighTemperatureEventType,
+          "Gateway TestDevice temperature at 65.3 °C, exceeding the 60 °C threshold.",
+          "65.3 °C" },
+        { DeviceHealthAlertEvaluator.HighTemperatureEventType,
+          "Switch TestDevice temperature at 85 °C, exceeding the 85 °C threshold.",
+          "85 °C" },
+        // Old format without degree symbol (already in DB)
+        { DeviceHealthAlertEvaluator.HighTemperatureEventType,
+          "Gateway TestDevice temperature at 65.3 C, exceeding the 60 C threshold.",
+          "65.3 °C" },
+        { DeviceHealthAlertEvaluator.HighTemperatureEventType,
+          "Switch TestDevice temperature at 85 C, exceeding the 85 C threshold.",
+          "85 °C" },
+    };
+
+    [Theory]
+    [MemberData(nameof(HealthAlertMessages))]
+    public void AlertReading_extracts_reading_from_health_alert_message(
+        string eventType, string message, string expected)
+    {
+        DeviceHealthChartEndpoints.AlertReading(eventType, message)
+            .Should().Be(expected);
+    }
+
+    [Fact]
+    public void Every_health_event_type_has_an_AlertLabel()
+    {
+        var eventTypes = new[]
+        {
+            DeviceHealthAlertEvaluator.HighCpuEventType,
+            DeviceHealthAlertEvaluator.HighMemoryEventType,
+            DeviceHealthAlertEvaluator.HighTemperatureEventType,
+        };
+
+        foreach (var eventType in eventTypes)
+        {
+            var label = DeviceHealthChartEndpoints.AlertLabel(eventType, "fallback");
+            label.Should().NotBe("fallback",
+                $"AlertLabel must have an entry for {eventType} - add one when adding a new health alert type");
+        }
+    }
+
+    [Fact]
+    public void Every_health_event_type_has_an_AlertReading_extractor()
+    {
+        var eventTypes = new[]
+        {
+            DeviceHealthAlertEvaluator.HighCpuEventType,
+            DeviceHealthAlertEvaluator.HighMemoryEventType,
+            DeviceHealthAlertEvaluator.HighTemperatureEventType,
+        };
+
+        foreach (var eventType in eventTypes)
+        {
+            // A message with a number+unit must extract; null means the event type is unhandled.
+            var reading = DeviceHealthChartEndpoints.AlertReading(eventType, "Test value at 50% above 40% threshold.");
+            reading.Should().NotBeNull(
+                $"AlertReading must handle {eventType} - add it to the switch when adding a new health alert type");
+        }
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
@@ -4,6 +4,7 @@ using NetworkOptimizer.Alerts.Events;
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Monitoring.Probes;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Firmware;
 using NetworkOptimizer.Web.Services.Monitoring;
 using Xunit;
 
@@ -83,12 +84,13 @@ public class WanOutageEvaluatorTests
         _evaluator = BuildEvaluator(BuildContext());
     }
 
-    private MonitoringAlertEvaluator BuildEvaluator(WanOutageContext context)
+    private MonitoringAlertEvaluator BuildEvaluator(WanOutageContext context,
+        RolloutSuppressionRegistry? rolloutWindows = null)
     {
         var wanOutages = new WanOutageEvaluator(_bus, NullLogger<WanOutageEvaluator>.Instance,
-            new FakeContextSource(context), timeProvider: _time);
+            new FakeContextSource(context), rolloutWindows: rolloutWindows, timeProvider: _time);
         return new MonitoringAlertEvaluator(_bus, NullLogger<MonitoringAlertEvaluator>.Instance,
-            new DeviceTransitionTracker(), wanOutages);
+            new DeviceTransitionTracker(), wanOutages, rolloutWindows: rolloutWindows);
     }
 
     #region Per-WAN outages
@@ -296,6 +298,93 @@ public class WanOutageEvaluatorTests
         await RoundsAsync(RoundsToConfirm, failing: NoTargets, passing: Wan2Targets);
 
         _bus.Published.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A UniFi OS update reboots the gateway, which takes WAN with it. The outage is expected
+    /// and the rollout's own alerts cover it. WAN alerts must stay quiet.
+    /// </summary>
+    [Fact]
+    public async Task WanOutageDuringOsCycle_IsSuppressed()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        var evaluator = BuildEvaluator(BuildContext(), registry);
+        registry.RefreshOsCycle("main", _time.GetUtcNow().UtcDateTime);
+
+        for (var round = 0; round < RoundsToConfirm; round++)
+        {
+            foreach (var target in WanTargets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: false));
+            foreach (var target in Wan2Targets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            registry.RefreshOsCycle("main", _time.GetUtcNow().UtcDateTime);
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+
+        _bus.Published.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// A Network app update restarts the console but the gateway stays up. WAN outages during
+    /// one are real and must NOT be suppressed.
+    /// </summary>
+    [Fact]
+    public async Task WanOutageDuringConsoleCycleOnly_IsNotSuppressed()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        var evaluator = BuildEvaluator(BuildContext(), registry);
+        registry.RefreshConsoleCycle("main", _time.GetUtcNow().UtcDateTime);
+
+        for (var round = 0; round < RoundsToConfirm; round++)
+        {
+            foreach (var target in WanTargets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: false));
+            foreach (var target in Wan2Targets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            registry.RefreshConsoleCycle("main", _time.GetUtcNow().UtcDateTime);
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+
+        _bus.Published.Should().ContainSingle()
+            .Which.EventType.Should().Be("monitoring.wan_outage");
+    }
+
+    /// <summary>
+    /// If a WAN outage was already open before the OS update started, its recovery must still
+    /// close it. Suppression gates opens, never closes.
+    /// </summary>
+    [Fact]
+    public async Task WanRecoveryDuringOsCycle_StillFlows()
+    {
+        var registry = new RolloutSuppressionRegistry();
+        var evaluator = BuildEvaluator(BuildContext(), registry);
+
+        for (var round = 0; round < RoundsToConfirm; round++)
+        {
+            foreach (var target in WanTargets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: false));
+            foreach (var target in Wan2Targets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+
+        _bus.Published.Should().ContainSingle()
+            .Which.EventType.Should().Be("monitoring.wan_outage");
+
+        registry.RefreshOsCycle("main", _time.GetUtcNow().UtcDateTime);
+
+        for (var round = 0; round < RoundsToConfirm; round++)
+        {
+            foreach (var target in WanTargets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            foreach (var target in Wan2Targets)
+                await evaluator.EvaluateAsync(target, Probe(target, success: true));
+            registry.RefreshOsCycle("main", _time.GetUtcNow().UtcDateTime);
+            _time.Advance(TimeSpan.FromSeconds(SecondsPerPass));
+        }
+
+        _bus.Published.Select(e => e.EventType).Should()
+            .Equal("monitoring.wan_outage", "monitoring.wan_recovered");
     }
 
     #endregion

--- a/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
+++ b/tests/NetworkOptimizer.Web.Tests/NetworkOptimizer.Web.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.11" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

- **GL.iNet cellular**: reach PCIe/MHI modems and fix empty-bus discovery (#1172)
- **Dashboard**: add [+] card to enter edit mode, scroll to bottom on click, hover-only tooltip
- **Firmware Rollout**: add Mem column to Rollout Report device table, check console cycling window for active rollout suppression
- **Device Stats**: fix collapsed event tooltip redundancy, show readings with degree symbol and shared constants
- **AlertReading**: fix regex for `%` formatting (`\b` fails after `%` since it's non-word)
- **WAN monitoring**: warn when a non-primary WAN vantage has no probe binding (#1174)
- **WAN outage evaluator**: restore comments, add OS cycling integration tests
- **Firmware Rollout autopilot**: stamp site timezone on plan documents
- **Pipeline**: push `:preview` tag on every tag, not just prereleases
- **Security**: bump System.Security.Cryptography.Xml to 10.0.11 in test projects
- **PWA**: fix resume getting stuck on reconnect spinner forever on iOS/Android; retry server probe with backoff
- **Reboot tracking**: skip SSH probe on Flex and Ultra switches (no SSH daemon) (#1178)
