### PR TITLE
Override reboot reason on commanded restart crash; de-dup device offline alerts

### DIFF
--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceOfflineDeduplicator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceOfflineDeduplicator.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+
+namespace NetworkOptimizer.Web.Services.Monitoring;
+
+/// <summary>
+/// Suppresses duplicate device offline/recovered notifications when both the monitoring target
+/// evaluator (ICMP probes on Fabric targets) and the device state evaluator (UniFi API state)
+/// fire for the same device within a short window. Whichever fires first wins; the second is
+/// suppressed.
+/// </summary>
+public class DeviceOfflineDeduplicator
+{
+    /// <summary>
+    /// Two alerts for the same device within this window are the same physical event seen by
+    /// two detection paths. Wide enough to cover any poll-interval lag between them, tight
+    /// enough that a genuinely separate event (device recovers then goes down again) is not
+    /// suppressed.
+    /// </summary>
+    public static readonly TimeSpan Window = TimeSpan.FromMinutes(1);
+
+    private readonly ConcurrentDictionary<string, DateTime> _lastOffline = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, DateTime> _lastRecovered = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Try to claim the right to publish an offline or recovered alert for a device. Returns
+    /// true when this is the first alert for this device within the window (publish it), false
+    /// when another source already fired for the same device (suppress it).
+    /// </summary>
+    /// <param name="deviceMac">Device MAC, the stable cross-source identifier.</param>
+    /// <param name="isRecovery">True for a recovered alert, false for an offline alert.</param>
+    /// <param name="now">Current time, injectable for tests.</param>
+    public bool TryClaimSlot(string? deviceMac, bool isRecovery, DateTime now)
+    {
+        if (string.IsNullOrWhiteSpace(deviceMac))
+            return true;
+
+        var dict = isRecovery ? _lastRecovered : _lastOffline;
+        var key = NormalizeMac(deviceMac);
+
+        while (true)
+        {
+            if (dict.TryGetValue(key, out var existing))
+            {
+                if ((now - existing).Duration() < Window)
+                    return false;
+
+                if (dict.TryUpdate(key, now, existing))
+                    return true;
+            }
+            else
+            {
+                if (dict.TryAdd(key, now))
+                    return true;
+            }
+        }
+    }
+
+    private static string NormalizeMac(string mac) =>
+        mac.Replace(":", "").Replace("-", "").ToLowerInvariant();
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/DeviceStateAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/DeviceStateAlertEvaluator.cs
@@ -34,6 +34,7 @@ public class DeviceStateAlertEvaluator
 
     private readonly IAlertEventBus _eventBus;
     private readonly DeviceTransitionTracker _transitions;
+    private readonly DeviceOfflineDeduplicator _dedup;
     private readonly Firmware.RolloutSuppressionRegistry? _rolloutWindows;
     private readonly ILogger<DeviceStateAlertEvaluator> _logger;
     private readonly ConcurrentDictionary<string, DeviceAlertState> _states = new(StringComparer.OrdinalIgnoreCase);
@@ -42,6 +43,7 @@ public class DeviceStateAlertEvaluator
 
     /// <param name="eventBus">Site-stamped alert bus.</param>
     /// <param name="transitions">Which devices UniFi reports as mid-transition.</param>
+    /// <param name="dedup">Shared de-dup tracker for device offline/recovered alerts.</param>
     /// <param name="logger">Logger.</param>
     /// <param name="siteSlug">Site this instance evaluates for (one per site, owned by the registry).</param>
     /// <param name="rolloutWindows">
@@ -52,12 +54,14 @@ public class DeviceStateAlertEvaluator
     public DeviceStateAlertEvaluator(
         IAlertEventBus eventBus,
         DeviceTransitionTracker transitions,
+        DeviceOfflineDeduplicator dedup,
         ILogger<DeviceStateAlertEvaluator> logger,
         string siteSlug = SiteManagementService.DefaultSiteSlug,
         Firmware.RolloutSuppressionRegistry? rolloutWindows = null)
     {
         _eventBus = eventBus;
         _transitions = transitions;
+        _dedup = dedup;
         _rolloutWindows = rolloutWindows;
         _logger = logger;
         _siteSlug = siteSlug ?? SiteManagementService.DefaultSiteSlug;
@@ -141,6 +145,15 @@ public class DeviceStateAlertEvaluator
                 return;
 
             state.Announced = true;
+
+            if (!_dedup.TryClaimSlot(deviceMac, isRecovery: false, DateTime.UtcNow))
+            {
+                _logger.LogDebug(
+                    "Suppressing device.offline for {Device} ({Mac}): monitoring target_offline already fired",
+                    label, deviceMac);
+                return;
+            }
+
             await _eventBus.PublishAsync(new AlertEvent
             {
                 EventType = OfflineEventType,
@@ -176,6 +189,14 @@ public class DeviceStateAlertEvaluator
     private async ValueTask PublishRecoveredAsync(
         string deviceMac, string label, string? deviceIp, DeviceType deviceType, string message, CancellationToken ct)
     {
+        if (!_dedup.TryClaimSlot(deviceMac, isRecovery: true, DateTime.UtcNow))
+        {
+            _logger.LogDebug(
+                "Suppressing device.recovered for {Device} ({Mac}): monitoring target_recovered already fired",
+                label, deviceMac);
+            return;
+        }
+
         await _eventBus.PublishAsync(new AlertEvent
         {
             EventType = RecoveredEventType,

--- a/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/MonitoringAlertEvaluator.cs
@@ -38,6 +38,7 @@ public class MonitoringAlertEvaluator
     private readonly ILogger<MonitoringAlertEvaluator> _logger;
     private readonly DeviceTransitionTracker _transitions;
     private readonly WanOutageEvaluator _wanOutages;
+    private readonly DeviceOfflineDeduplicator _dedup;
     private readonly Firmware.RolloutSuppressionRegistry? _rolloutWindows;
     private readonly ConcurrentDictionary<string, TargetAlertState> _states = new();
     private readonly string _siteSuffix;
@@ -51,6 +52,7 @@ public class MonitoringAlertEvaluator
     /// </param>
     public MonitoringAlertEvaluator(IAlertEventBus eventBus, ILogger<MonitoringAlertEvaluator> logger,
         DeviceTransitionTracker transitions, WanOutageEvaluator wanOutages,
+        DeviceOfflineDeduplicator dedup,
         string siteSlug = SiteManagementService.DefaultSiteSlug,
         Firmware.RolloutSuppressionRegistry? rolloutWindows = null)
     {
@@ -58,6 +60,7 @@ public class MonitoringAlertEvaluator
         _logger = logger;
         _transitions = transitions;
         _wanOutages = wanOutages;
+        _dedup = dedup;
         _rolloutWindows = rolloutWindows;
         _siteSlug = siteSlug ?? SiteManagementService.DefaultSiteSlug;
         _siteSuffix = string.IsNullOrEmpty(siteSlug) || siteSlug == SiteManagementService.DefaultSiteSlug
@@ -93,7 +96,19 @@ public class MonitoringAlertEvaluator
             {
                 state.IsOffline = false;
                 if (publishPerTarget)
-                    await _eventBus.PublishAsync(BuildRecoveredEvent(target, result), ct);
+                {
+                    if (target.TargetType == MonitoringTargetType.Fabric
+                        && !_dedup.TryClaimSlot(target.DeviceMac, isRecovery: true, DateTime.UtcNow))
+                    {
+                        _logger.LogDebug(
+                            "Suppressing target_recovered for {Target}: device.recovered already fired for the same device",
+                            target.Name);
+                    }
+                    else
+                    {
+                        await _eventBus.PublishAsync(BuildRecoveredEvent(target, result), ct);
+                    }
+                }
             }
 
             // Sustained-loss detection only matters while the target is nominally up.
@@ -151,7 +166,19 @@ public class MonitoringAlertEvaluator
                 state.LossWindow.Clear();
                 state.TransitionSuppressionLogged = false;
                 if (publishPerTarget)
-                    await _eventBus.PublishAsync(BuildOfflineEvent(target), ct);
+                {
+                    if (target.TargetType == MonitoringTargetType.Fabric
+                        && !_dedup.TryClaimSlot(target.DeviceMac, isRecovery: false, DateTime.UtcNow))
+                    {
+                        _logger.LogDebug(
+                            "Suppressing target_offline for {Target}: device.offline already fired for the same device",
+                            target.Name);
+                    }
+                    else
+                    {
+                        await _eventBus.PublishAsync(BuildOfflineEvent(target), ct);
+                    }
+                }
             }
         }
     }

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootReason.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootReason.cs
@@ -88,13 +88,16 @@ public enum RebootReasonSource
 /// and firmware upgrades name the version from the UniFi device data when the evidence cannot.
 /// v7: a kernel crash dump only explains this boot when the console ring did NOT end deliberately
 /// and the dump dates to this boot - dumps outlive the boot that produced them.
-/// v8: an unexpected probe result is overridden to CommandedReboot when a UniFi Network restart
-/// event sits within the window - catches devices that crash during a commanded shutdown.
 /// </summary>
+/// <remarks>
+/// The commanded-restart override (UniFi event overriding an unexpected pstore classification)
+/// is a runtime signal, not a parser rule change - the same evidence classifies identically,
+/// so no version bump is needed and stored v7 records are not re-probed.
+/// </remarks>
 public static class RebootClassifier
 {
     /// <summary>Current rule-set version.</summary>
-    public const int Version = 8;
+    public const int Version = 7;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootReason.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootReason.cs
@@ -88,11 +88,13 @@ public enum RebootReasonSource
 /// and firmware upgrades name the version from the UniFi device data when the evidence cannot.
 /// v7: a kernel crash dump only explains this boot when the console ring did NOT end deliberately
 /// and the dump dates to this boot - dumps outlive the boot that produced them.
+/// v8: an unexpected probe result is overridden to CommandedReboot when a UniFi Network restart
+/// event sits within the window - catches devices that crash during a commanded shutdown.
 /// </summary>
 public static class RebootClassifier
 {
     /// <summary>Current rule-set version.</summary>
-    public const int Version = 7;
+    public const int Version = 8;
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
@@ -48,6 +48,22 @@ public class DeviceRebootTracker
     private readonly ConcurrentDictionary<string, byte> _inFlight = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
+    /// Recent UniFi Network restart events, keyed by normalized MAC. When a device crashes
+    /// during a commanded restart, the SSH probe sees an unclean shutdown and classifies it
+    /// as unexpected. Checking this lets the probe result be corrected when UniFi Network
+    /// says the restart was initiated, not spontaneous.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, CommandedRestartEvent> _commandedRestarts = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// A restart event must sit within this window of the boot time to override an unexpected
+    /// probe result.
+    /// </summary>
+    internal static readonly TimeSpan CommandedRestartWindow = TimeSpan.FromMinutes(2);
+
+    private record CommandedRestartEvent(string EventKey, string? AdminName, DateTime ReceivedAt);
+
+    /// <summary>
     /// Caps concurrent probes for this site. Uptime samples arrive for every device in one pass, so
     /// a first run - or any classifier bump, which re-probes the fleet - would otherwise open an SSH
     /// session to every device at once, frequently through a single agent tunnel. Probes are rare
@@ -286,8 +302,15 @@ public class DeviceRebootTracker
     }
 
     /// <summary>
-    /// Apply a UniFi Network event as the fallback reason for a device's current boot. Only used
-    /// when the on-device probe found nothing, since these events are generic and often wrong.
+    /// Record that UniFi Network issued a restart event for a device. Called as events arrive,
+    /// before the SSH probe resolves. Two roles:
+    /// <list type="number">
+    /// <item>Fallback: if the probe finds nothing, the event becomes the reason.</item>
+    /// <item>Override: if the probe classifies the boot as unexpected but a commanded restart
+    /// event sits near the boot time, the classification is corrected to CommandedReboot. This
+    /// catches devices that crash during a commanded shutdown sequence (the driver goes wrong,
+    /// pstore shows no clean shutdown marker, but the restart was initiated).</item>
+    /// </list>
     /// </summary>
     /// <param name="deviceMac">Device MAC.</param>
     /// <param name="eventKey">UniFi event key, e.g. <c>EVT_SW_RestartedUnknown</c>.</param>
@@ -297,12 +320,61 @@ public class DeviceRebootTracker
         if (string.IsNullOrWhiteSpace(deviceMac)) return;
 
         var mac = Normalize(deviceMac);
-        if (!_records.TryGetValue(mac, out var record) || record.Reason != null) return;
+        var parsedEvent = RebootReasonParser.ParseUniFiEvent(eventKey, adminName);
+        if (parsedEvent == null) return;
 
-        var reason = RebootReasonParser.ParseUniFiEvent(eventKey, adminName);
-        if (reason == null) return;
+        // Always record the event so the probe can check it when it resolves later.
+        if (parsedEvent.Category == RebootCategory.CommandedReboot)
+            _commandedRestarts[mac] = new CommandedRestartEvent(eventKey!, adminName, DateTime.UtcNow);
 
-        await StoreAsync(mac, record.BootedAt, reason, DeviceType.Unknown);
+        if (!_records.TryGetValue(mac, out var record)) return;
+
+        // Role 1: fallback when probe has not resolved yet.
+        if (record.Reason == null)
+        {
+            await StoreAsync(mac, record.BootedAt, parsedEvent, DeviceType.Unknown);
+            return;
+        }
+
+        // Role 2: override an unexpected probe result with a commanded restart.
+        if (record.Reason.IsUnexpected && parsedEvent.Category == RebootCategory.CommandedReboot)
+        {
+            var overridden = OverrideWithCommandedRestart(record.Reason, adminName);
+            _logger.LogInformation(
+                "Overriding {OldCategory} with {NewCategory} for {Mac}: UniFi Network says the restart was commanded",
+                record.Reason.Category, overridden.Category, mac);
+            await StoreAsync(mac, record.BootedAt, overridden, DeviceType.Unknown);
+        }
+    }
+
+    /// <summary>
+    /// Check whether a recently recorded UniFi restart event explains this boot, and if so
+    /// override an unexpected probe result with CommandedReboot. Called from the probe path
+    /// after it resolves.
+    /// </summary>
+    private DeviceRebootReason? TryOverrideFromCommandedRestart(
+        string mac, DeviceRebootReason probeResult, DateTime bootedAt)
+    {
+        if (!probeResult.IsUnexpected) return null;
+        if (!_commandedRestarts.TryGetValue(mac, out var evt)) return null;
+
+        if ((evt.ReceivedAt - bootedAt).Duration() > CommandedRestartWindow)
+            return null;
+
+        return OverrideWithCommandedRestart(probeResult, evt.AdminName);
+    }
+
+    private static DeviceRebootReason OverrideWithCommandedRestart(
+        DeviceRebootReason original, string? adminName)
+    {
+        var by = string.IsNullOrWhiteSpace(adminName)
+            ? "Restarted via UniFi Network"
+            : $"Restarted by {adminName}";
+        return new DeviceRebootReason(
+            RebootCategory.CommandedReboot,
+            "Restarted",
+            $"{by} (shutdown was not clean: {original.Summary.ToLowerInvariant()})",
+            RebootReasonSource.UniFiEvent);
     }
 
     private async Task ResolveInBackgroundAsync(
@@ -368,12 +440,22 @@ public class DeviceRebootTracker
 
             if (reason == null)
             {
-                // Probe logs why (unreachable vs. reachable but no evidence); this line ties it
-                // back to the device and says what the UI will show until the next attempt.
                 _logger.LogDebug(
                     "No reboot reason established for {Device} ({Mac}); will retry in {Retry} and fall back to the UniFi Network event if one arrives",
                     deviceName ?? "unknown", mac, ProbeRetryDelay);
                 return;
+            }
+
+            // A device that crashed during a commanded restart (the driver went wrong during
+            // shutdown) reads as unexpected from pstore alone. If UniFi Network says it was
+            // told to restart, the classification is corrected.
+            var overridden = TryOverrideFromCommandedRestart(mac, reason, bootedAt);
+            if (overridden != null)
+            {
+                _logger.LogInformation(
+                    "Overriding {OldCategory} with CommandedReboot for {Device} ({Mac}): UniFi Network event within window",
+                    reason.Category, deviceName ?? "unknown", mac);
+                reason = overridden;
             }
 
             // The boot may have rolled over while the probe ran; only store against the boot we probed.

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/DeviceRebootTracker.cs
@@ -336,8 +336,12 @@ public class DeviceRebootTracker
             return;
         }
 
-        // Role 2: override an unexpected probe result with a commanded restart.
-        if (record.Reason.IsUnexpected && parsedEvent.Category == RebootCategory.CommandedReboot)
+        // Role 2: override an unexpected probe result with a commanded restart, but only
+        // when the boot it describes is recent. Without this check, an AP that crashed days
+        // ago then gets a routine restart command today would have its old crash record
+        // rewritten - the event explains the next boot, not the recorded one.
+        if (record.Reason.IsUnexpected && parsedEvent.Category == RebootCategory.CommandedReboot
+            && (DateTime.UtcNow - record.BootedAt).Duration() <= CommandedRestartWindow)
         {
             var overridden = OverrideWithCommandedRestart(record.Reason, adminName);
             _logger.LogInformation(
@@ -361,6 +365,7 @@ public class DeviceRebootTracker
         if ((evt.ReceivedAt - bootedAt).Duration() > CommandedRestartWindow)
             return null;
 
+        _commandedRestarts.TryRemove(mac, out _);
         return OverrideWithCommandedRestart(probeResult, evt.AdminName);
     }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringAlertRegistry.cs
@@ -49,8 +49,11 @@ public class MonitoringAlertRegistry : ISiteScopedRegistry
             // per-target events for the WAN categories in its favor), so it is created first
             // and handed in rather than exposed on the bundle.
             var wanOutages = ActivatorUtilities.CreateInstance<WanOutageEvaluator>(_serviceProvider, s, bus);
+            // Shared across both evaluators that can fire device offline/recovered so
+            // whichever fires first wins and the other is suppressed.
+            var dedup = new Monitoring.DeviceOfflineDeduplicator();
             return new SiteAlertEvaluators(
-                ActivatorUtilities.CreateInstance<MonitoringAlertEvaluator>(_serviceProvider, s, bus, wanOutages),
+                ActivatorUtilities.CreateInstance<MonitoringAlertEvaluator>(_serviceProvider, s, bus, wanOutages, dedup),
                 ActivatorUtilities.CreateInstance<DeviceHealthAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<SfpAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<CableModemAlertEvaluator>(_serviceProvider, s, bus),
@@ -58,7 +61,7 @@ public class MonitoringAlertRegistry : ISiteScopedRegistry
                 ActivatorUtilities.CreateInstance<CellularAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<StarlinkAlertEvaluator>(_serviceProvider, s, bus),
                 ActivatorUtilities.CreateInstance<DeviceRebootAlertEvaluator>(_serviceProvider, s, bus),
-                ActivatorUtilities.CreateInstance<DeviceStateAlertEvaluator>(_serviceProvider, s, bus));
+                ActivatorUtilities.CreateInstance<DeviceStateAlertEvaluator>(_serviceProvider, s, bus, dedup));
         });
 
     /// <summary>The default site's evaluators.</summary>

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutSuppressionRegistryTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutSuppressionRegistryTests.cs
@@ -218,7 +218,7 @@ public class RolloutSuppressionRegistryTests
         var bus = new CapturingBus();
         var registry = new RolloutSuppressionRegistry();
         var evaluator = new DeviceStateAlertEvaluator(
-            bus, new DeviceTransitionTracker(), NullLogger<DeviceStateAlertEvaluator>.Instance, Site, registry);
+            bus, new DeviceTransitionTracker(), new DeviceOfflineDeduplicator(), NullLogger<DeviceStateAlertEvaluator>.Instance, Site, registry);
         registry.Refresh(Site, Mac, Now);
 
         await evaluator.EvaluateAsync(Mac, "AP 1", "192.0.2.10", DeviceType.AccessPoint, 0, Now);
@@ -233,7 +233,7 @@ public class RolloutSuppressionRegistryTests
         var bus = new CapturingBus();
         var registry = new RolloutSuppressionRegistry();
         var evaluator = new DeviceStateAlertEvaluator(
-            bus, new DeviceTransitionTracker(), NullLogger<DeviceStateAlertEvaluator>.Instance, Site, registry);
+            bus, new DeviceTransitionTracker(), new DeviceOfflineDeduplicator(), NullLogger<DeviceStateAlertEvaluator>.Instance, Site, registry);
         registry.Refresh(Site, Mac, Now);
 
         var late = Now + RolloutSuppressionRegistry.WindowFreshness + TimeSpan.FromMinutes(1);

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceOfflineDeduplicatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceOfflineDeduplicatorTests.cs
@@ -1,0 +1,81 @@
+using NetworkOptimizer.Web.Services.Monitoring;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+public class DeviceOfflineDeduplicatorTests
+{
+    private static readonly DateTime Now = new(2026, 8, 25, 18, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void FirstCaller_Wins()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now));
+    }
+
+    [Fact]
+    public void SecondCaller_WithinWindow_IsSuppressed()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now));
+        Assert.False(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now.AddSeconds(8)));
+    }
+
+    [Fact]
+    public void SecondCaller_AfterWindow_IsNotSuppressed()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now));
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false,
+            Now + DeviceOfflineDeduplicator.Window + TimeSpan.FromSeconds(1)));
+    }
+
+    [Fact]
+    public void OfflineAndRecovery_AreIndependent()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now));
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: true, Now.AddSeconds(30)));
+    }
+
+    [Fact]
+    public void DifferentDevices_AreIndependent()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("aa:bb:cc:dd:ee:ff", isRecovery: false, Now));
+        Assert.True(dedup.TryClaimSlot("11:22:33:44:55:66", isRecovery: false, Now.AddSeconds(5)));
+    }
+
+    [Fact]
+    public void MacNormalization_MatchesDifferentFormats()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("AA:BB:CC:DD:EE:FF", isRecovery: false, Now));
+        Assert.False(dedup.TryClaimSlot("aabbccddeeff", isRecovery: false, Now.AddSeconds(5)));
+    }
+
+    [Fact]
+    public void NullMac_AlwaysAllowed()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot(null, isRecovery: false, Now));
+        Assert.True(dedup.TryClaimSlot(null, isRecovery: false, Now.AddSeconds(5)));
+    }
+
+    [Fact]
+    public void EmptyMac_AlwaysAllowed()
+    {
+        var dedup = new DeviceOfflineDeduplicator();
+
+        Assert.True(dedup.TryClaimSlot("", isRecovery: false, Now));
+        Assert.True(dedup.TryClaimSlot("", isRecovery: false, Now.AddSeconds(5)));
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceRebootCommandedOverrideTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceRebootCommandedOverrideTests.cs
@@ -1,0 +1,191 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NetworkOptimizer.Alerts.Events;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.Web.Services.Monitoring;
+using NetworkOptimizer.Web.Services.Monitoring.RebootReason;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.Monitoring;
+
+/// <summary>
+/// Tests that a UniFi Network restart event overrides an unexpected SSH probe result when
+/// the device crashed during a commanded shutdown sequence.
+/// </summary>
+public class DeviceRebootCommandedOverrideTests
+{
+    private sealed class CapturingBus : IAlertEventBus
+    {
+        public List<AlertEvent> Published { get; } = [];
+
+        public ValueTask PublishAsync(AlertEvent alertEvent, CancellationToken ct = default)
+        {
+            Published.Add(alertEvent);
+            return ValueTask.CompletedTask;
+        }
+
+        public async IAsyncEnumerable<AlertEvent> ConsumeAsync(
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+    }
+
+    private sealed class NullProbe : DeviceRebootProbe
+    {
+        public NullProbe() : base(null!, null!, NullLogger<DeviceRebootProbe>.Instance) { }
+    }
+
+    private sealed class NullInflux : MonitoringInfluxClient
+    {
+        public NullInflux() : base(null!, null!, NullLogger<MonitoringInfluxClient>.Instance) { }
+    }
+
+    private static readonly DateTime Now = new(2026, 8, 25, 18, 0, 0, DateTimeKind.Utc);
+    private const string Mac = "aa:bb:cc:dd:ee:ff";
+
+    private static DeviceRebootTracker BuildTracker(CapturingBus? bus = null)
+    {
+        bus ??= new CapturingBus();
+        var alertEvaluator = new DeviceRebootAlertEvaluator(
+            bus, NullLogger<DeviceRebootAlertEvaluator>.Instance);
+        return new DeviceRebootTracker(
+            new NullProbe(), new NullInflux(), alertEvaluator,
+            NullLogger<DeviceRebootTracker>.Instance);
+    }
+
+    [Fact]
+    public async Task UniFiRestartEvent_OverridesAbruptStop()
+    {
+        var bus = new CapturingBus();
+        var tracker = BuildTracker(bus);
+
+        // Simulate: device booted, probe resolved AbruptStop, then UniFi event arrives
+        tracker.RecordUptimeSample(Mac, "AP 2", DeviceType.AccessPoint, "192.0.2.22",
+            uptimeSeconds: 120, firmwareVersion: "7.1.2", observedAt: Now);
+
+        // Manually set the reason as if the probe resolved AbruptStop
+        var bootedAt = Now.AddSeconds(-120);
+        var abruptStop = new DeviceRebootReason(
+            RebootCategory.AbruptStop, "Unexpected stop",
+            "The device stopped without shutting down, so it either lost power or hung",
+            RebootReasonSource.PstoreConsole);
+
+        // Access the internal state to simulate probe completion
+        var recordField = typeof(DeviceRebootTracker)
+            .GetField("_records", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var records = (System.Collections.Concurrent.ConcurrentDictionary<string, DeviceRebootTracker.DeviceBootRecord>)recordField.GetValue(tracker)!;
+        records[Mac.Replace(":", "").ToLowerInvariant()] =
+            new DeviceRebootTracker.DeviceBootRecord(bootedAt, abruptStop, "7.1.2");
+
+        // Now a UniFi restart event arrives
+        await tracker.ApplyUniFiEventFallbackAsync(Mac, "EVT_AP_Restarted");
+
+        // The reason should be overridden to CommandedReboot
+        var reason = tracker.GetReasonForReportedUptime(Mac, 120, Now);
+        Assert.NotNull(reason);
+        Assert.Equal(RebootCategory.CommandedReboot, reason!.Category);
+        Assert.Equal("Restarted", reason.Summary);
+        Assert.Contains("not clean", reason.Detail);
+    }
+
+    [Fact]
+    public async Task UniFiRestartUnknown_DoesNotOverride()
+    {
+        var tracker = BuildTracker();
+
+        tracker.RecordUptimeSample(Mac, "AP 2", DeviceType.AccessPoint, "192.0.2.22",
+            uptimeSeconds: 120, firmwareVersion: "7.1.2", observedAt: Now);
+
+        var bootedAt = Now.AddSeconds(-120);
+        var abruptStop = new DeviceRebootReason(
+            RebootCategory.AbruptStop, "Unexpected stop", "evidence",
+            RebootReasonSource.PstoreConsole);
+
+        var recordField = typeof(DeviceRebootTracker)
+            .GetField("_records", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var records = (System.Collections.Concurrent.ConcurrentDictionary<string, DeviceRebootTracker.DeviceBootRecord>)recordField.GetValue(tracker)!;
+        records[Mac.Replace(":", "").ToLowerInvariant()] =
+            new DeviceRebootTracker.DeviceBootRecord(bootedAt, abruptStop, "7.1.2");
+
+        // EVT_AP_RestartedUnknown is NOT a commanded restart - it's UniFi saying "I don't know"
+        await tracker.ApplyUniFiEventFallbackAsync(Mac, "EVT_AP_RestartedUnknown");
+
+        var reason = tracker.GetReasonForReportedUptime(Mac, 120, Now);
+        Assert.NotNull(reason);
+        Assert.Equal(RebootCategory.AbruptStop, reason!.Category);
+    }
+
+    [Fact]
+    public async Task UniFiRestartEvent_FallbackWhenNoProbeResult()
+    {
+        var tracker = BuildTracker();
+
+        tracker.RecordUptimeSample(Mac, "Switch 1", DeviceType.Switch, "192.0.2.30",
+            uptimeSeconds: 60, firmwareVersion: "7.5.6", observedAt: Now);
+
+        // No probe result yet - the event should be applied as the fallback reason
+        await tracker.ApplyUniFiEventFallbackAsync(Mac, "EVT_SW_Restarted");
+
+        var reason = tracker.GetReasonForReportedUptime(Mac, 60, Now);
+        Assert.NotNull(reason);
+        Assert.Equal(RebootCategory.CommandedReboot, reason!.Category);
+        Assert.Equal(RebootReasonSource.UniFiEvent, reason.Source);
+    }
+
+    [Fact]
+    public async Task UniFiRestartEvent_DoesNotOverrideConclusive_NonUnexpected()
+    {
+        var tracker = BuildTracker();
+
+        tracker.RecordUptimeSample(Mac, "Switch 1", DeviceType.Switch, "192.0.2.30",
+            uptimeSeconds: 60, firmwareVersion: "7.5.6", observedAt: Now);
+
+        var bootedAt = Now.AddSeconds(-60);
+        var commanded = new DeviceRebootReason(
+            RebootCategory.CommandedReboot, "Restarted",
+            "The device shut down cleanly",
+            RebootReasonSource.PstoreConsole);
+
+        var recordField = typeof(DeviceRebootTracker)
+            .GetField("_records", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var records = (System.Collections.Concurrent.ConcurrentDictionary<string, DeviceRebootTracker.DeviceBootRecord>)recordField.GetValue(tracker)!;
+        records[Mac.Replace(":", "").ToLowerInvariant()] =
+            new DeviceRebootTracker.DeviceBootRecord(bootedAt, commanded, "7.5.6");
+
+        // An already-correct CommandedReboot should not be touched
+        await tracker.ApplyUniFiEventFallbackAsync(Mac, "EVT_SW_Restarted");
+
+        var reason = tracker.GetReasonForReportedUptime(Mac, 60, Now);
+        Assert.Equal(RebootCategory.CommandedReboot, reason!.Category);
+        Assert.Equal(RebootReasonSource.PstoreConsole, reason.Source);
+    }
+
+    [Fact]
+    public async Task UniFiRestartEvent_OverridesWithAdminName()
+    {
+        var tracker = BuildTracker();
+
+        tracker.RecordUptimeSample(Mac, "AP 1", DeviceType.AccessPoint, "192.0.2.22",
+            uptimeSeconds: 90, firmwareVersion: "7.1.2", observedAt: Now);
+
+        var bootedAt = Now.AddSeconds(-90);
+        var abruptStop = new DeviceRebootReason(
+            RebootCategory.AbruptStop, "Unexpected stop", "evidence",
+            RebootReasonSource.PstoreConsole);
+
+        var recordField = typeof(DeviceRebootTracker)
+            .GetField("_records", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var records = (System.Collections.Concurrent.ConcurrentDictionary<string, DeviceRebootTracker.DeviceBootRecord>)recordField.GetValue(tracker)!;
+        records[Mac.Replace(":", "").ToLowerInvariant()] =
+            new DeviceRebootTracker.DeviceBootRecord(bootedAt, abruptStop, "7.1.2");
+
+        await tracker.ApplyUniFiEventFallbackAsync(Mac, "EVT_AP_Restarted", adminName: "TJ");
+
+        var reason = tracker.GetReasonForReportedUptime(Mac, 90, Now);
+        Assert.Equal(RebootCategory.CommandedReboot, reason!.Category);
+        Assert.Contains("Restarted by TJ", reason.Detail);
+        Assert.Contains("not clean", reason.Detail);
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceStateAlertEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/DeviceStateAlertEvaluatorTests.cs
@@ -42,7 +42,7 @@ public class DeviceStateAlertEvaluatorTests
     {
         var bus = new CapturingBus();
         var transitions = new DeviceTransitionTracker();
-        return (new DeviceStateAlertEvaluator(bus, transitions,
+        return (new DeviceStateAlertEvaluator(bus, transitions, new DeviceOfflineDeduplicator(),
             NullLogger<DeviceStateAlertEvaluator>.Instance), bus, transitions);
     }
 
@@ -163,7 +163,7 @@ public class DeviceStateAlertEvaluatorTests
     public async Task NonDefaultSite_StampsSlugInTitle()
     {
         var bus = new CapturingBus();
-        var evaluator = new DeviceStateAlertEvaluator(bus, new DeviceTransitionTracker(),
+        var evaluator = new DeviceStateAlertEvaluator(bus, new DeviceTransitionTracker(), new DeviceOfflineDeduplicator(),
             NullLogger<DeviceStateAlertEvaluator>.Instance, "branch-office");
 
         await evaluator.EvaluateAsync(Mac, "AP 1", "192.0.2.11", DeviceType.AccessPoint, Disconnected, Now);

--- a/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Monitoring/WanOutageEvaluatorTests.cs
@@ -90,7 +90,7 @@ public class WanOutageEvaluatorTests
         var wanOutages = new WanOutageEvaluator(_bus, NullLogger<WanOutageEvaluator>.Instance,
             new FakeContextSource(context), rolloutWindows: rolloutWindows, timeProvider: _time);
         return new MonitoringAlertEvaluator(_bus, NullLogger<MonitoringAlertEvaluator>.Instance,
-            new DeviceTransitionTracker(), wanOutages, rolloutWindows: rolloutWindows);
+            new DeviceTransitionTracker(), wanOutages, new DeviceOfflineDeduplicator(), rolloutWindows: rolloutWindows);
     }
 
     #region Per-WAN outages


### PR DESCRIPTION
## Summary

- **Reboot reasons - commanded restart override**: when a device crashes during a commanded restart (the WiFi driver panics during shutdown, pstore shows no clean shutdown marker), the SSH probe classifies it as AbruptStop. Now the tracker checks whether a UniFi Network restart event was recently recorded for the same device, and if so overrides the classification to CommandedReboot with a detail noting the unclean shutdown path. Handles both orderings (event before or after probe). The override is a runtime signal, not a parser rule change, so no classifier version bump and no fleet-wide re-probe on startup.

- **Alerts & Schedule - device offline de-dup**: a Fabric device going offline fires from two independent detection paths (ICMP monitoring target and UniFi device state), producing duplicate offline and duplicate recovery notifications. A shared `DeviceOfflineDeduplicator` per site gives both evaluators a 1-minute window: whichever fires first wins, the other is suppressed. Only applies to Fabric targets (the overlap case); non-Fabric monitoring targets and non-monitored devices are unaffected.