### PR TITLE
Multi-Site: Run It for Me - install or upgrade the gateway agent over SSH

### DIFF
--- a/src/NetworkOptimizer.Storage/Models/Identity/AuditEvent.cs
+++ b/src/NetworkOptimizer.Storage/Models/Identity/AuditEvent.cs
@@ -169,6 +169,7 @@ public static class AuditActions
     public const string LicenseChanged = "license.changed";
     public const string AgentEnrolled = "agent.enrolled";
     public const string AgentRemoved = "agent.removed";
+    public const string AgentGatewayInstallRun = "agent.gateway_install.run";
 
     // Meta
     public const string MigrationPerformed = "audit.migration";

--- a/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Settings.razor
@@ -3665,6 +3665,7 @@
                                                                         {
                                                                             <p class="form-help">On the UniFi gateway - enrollment is preserved, only the binary updates:</p>
                                                                             <CopyableCommand Text="@GatewayUpgradeCommand()" Tooltip="Copy the gateway upgrade command" />
+                                                                            <GatewayAgentRunPanel SiteSlug="@site.Slug" IsUpgrade="true" />
                                                                         }
                                                                         else
                                                                         {
@@ -3722,7 +3723,7 @@
                                                                     <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Hosts an OpenSpeedTest page and an iperf3 server at the site for the site's own clients" @onclick:stopPropagation="true" @onclick:preventDefault="true">?</span>
                                                                     - lets the site's clients run speed tests against the agent.</span>
                                                             </label>
-                                                            <AgentInstallInstructions Token="@_newAgentToken" LanSpeedTest="@_newAgentLanSpeedTest" />
+                                                            <AgentInstallInstructions Token="@_newAgentToken" LanSpeedTest="@_newAgentLanSpeedTest" SiteSlug="@site.Slug" />
                                                         }
                                                     </div>
 
@@ -4677,11 +4678,9 @@
     private string ProxmoxUpgradeCommand() =>
         $"pct exec <CT_ID> -- bash -c '{NativeUpgradeCommand().Replace("sudo ", "")}'";
 
-    // Monitoring-only gateway installer: no --lan-speed-test (the router must not
-    // host a speed-test server) and no sudo (UniFi gateways SSH in as root).
-    private string GatewayUpgradeCommand() =>
-        "curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/release/2.8/scripts/agent/install-agent-gateway.sh"
-        + $" | bash -s -- --server \"{AgentServerBase()}\"";
+    // Monitoring-only gateway installer, via the shared builder that also feeds the
+    // "Run It for Me" SSH run, so the displayed command and the executed one cannot drift.
+    private string GatewayUpgradeCommand() => GatewayAgentCommands.Upgrade(AgentServerUrl.Url);
 
     // Placeholder shows what a blank override resolves to - the online agent's
     // detected LAN IP on the agent's https port (same pick as

--- a/src/NetworkOptimizer.Web/Components/Shared/AgentInstallInstructions.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/AgentInstallInstructions.razor
@@ -54,6 +54,10 @@
         directly:
     </p>
     <CopyableCommand Text="@GatewayOneLiner()" Tooltip="Copy the gateway install command" />
+    @if (!string.IsNullOrWhiteSpace(SiteSlug))
+    {
+        <GatewayAgentRunPanel SiteSlug="@SiteSlug" EnrollmentToken="@Token" />
+    }
     @if (LanSpeedTest)
     {
         <p class="form-hint">
@@ -80,6 +84,14 @@
     /// <summary>Whether the agent should also host the LAN speed test server at the site.</summary>
     [Parameter]
     public bool LanSpeedTest { get; set; }
+
+    /// <summary>
+    /// The site the agent is being installed for. Enables "Run It for Me" under the gateway
+    /// one-liner when that site's gateway SSH is configured and dialable; without it the
+    /// commands are copy-paste only.
+    /// </summary>
+    [Parameter]
+    public string? SiteSlug { get; set; }
 
     /// <summary>The agent-facing HTTPS base URL, derived from REVERSE_PROXIED_HOST_NAME.</summary>
     private string? ServerUrl => AgentServerUrl.Url;
@@ -125,15 +137,7 @@
         return sb.ToString();
     }
 
-    // Monitoring-only gateway installer: no --lan-speed-test (the router must not
-    // host a speed-test server), and no sudo (UniFi gateways SSH in as root).
-    private string GatewayOneLiner()
-    {
-        var sb = new StringBuilder();
-        // PREVIEW-CYCLE PIN (2.8.0) - REVERT BEFORE STABLE.
-        sb.Append("curl -fsSL https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/release/2.8/scripts/agent/install-agent-gateway.sh | bash -s -- \\\n");
-        sb.Append($"  --server \"{ServerValue}\" \\\n");
-        sb.Append($"  --token \"{Token}\"");
-        return sb.ToString();
-    }
+    // The shared builder also feeds the "Run It for Me" SSH run, so the displayed
+    // command and the executed one cannot drift.
+    private string GatewayOneLiner() => GatewayAgentCommands.Install(ServerUrl, Token);
 }

--- a/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
@@ -15,7 +15,7 @@
             @if (_run.Status == GatewayAgentInstallStatus.Running)
             {
                 <span class="spinner spinner-sm"></span>
-                <span>Running on the gateway. The agent download can look idle for a few minutes.</span>
+                <span>Running on the gateway. The download step can look idle for a bit.</span>
                 <button type="button" class="btn btn-secondary btn-sm" @onclick="CancelAsync">Cancel</button>
             }
             else if (_run.Status == GatewayAgentInstallStatus.Succeeded)
@@ -27,13 +27,13 @@
             }
             else if (_run.Status == GatewayAgentInstallStatus.Canceled)
             {
-                <span>Canceled. Running it again is safe - the installer is idempotent and keeps the agent's enrollment.</span>
+                <span>Canceled. Safe to run again - the installer picks up cleanly and keeps the agent's enrollment.</span>
             }
             else
             {
                 <span class="gw-run-fail">&#x2715;</span>
                 <span>@(_run.ExitCode is int code
-                    ? $"The command exited with code {code} - the output below has the details."
+                    ? $"The {(_run.IsUpgrade ? "upgrade" : "install")} failed (exit code {code}). See the output below."
                     : _run.Error ?? "The run failed.")</span>
             }
         </div>
@@ -41,7 +41,7 @@
     </div>
 }
 
-@if (_available && _run?.Status != GatewayAgentInstallStatus.Running)
+@if (_available && ShowRunButton)
 {
     <div class="gw-run-action">
         <button type="button" class="btn btn-primary btn-sm" @onclick="Start">
@@ -112,7 +112,16 @@
     public string? EnrollmentToken { get; set; }
 
     private bool _available;
+    private bool _startedHere;
     private GatewayAgentInstallRun? _run;
+
+    // A success that just happened here needs no second click, so the button stays gone until
+    // the panel is next opened; failure and cancel keep the retry path, and a finished run
+    // found on open (started elsewhere or earlier) still offers one.
+    private bool ShowRunButton =>
+        _run == null
+        || (_run.Status != GatewayAgentInstallStatus.Running
+            && !(_run.Status == GatewayAgentInstallStatus.Succeeded && _startedHere));
     private GatewayAgentInstallRun? _subscribed;
     private string? _message;
     private int _renderPending;
@@ -144,6 +153,7 @@
     private void OnRunStarted(GatewayAgentInstallRun run)
     {
         _run = run;
+        _startedHere = true;
         Subscribe(run);
         _ = InvokeAsync(StateHasChanged);
     }

--- a/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
@@ -3,10 +3,11 @@
 @inject IGatewayAgentInstallService GatewayInstall
 
 @* "Run It for Me" under a gateway agent one-liner: executes that exact command on the
-   site's gateway over SSH and streams the output here. The button exists only once the
-   availability gate resolves (gateway SSH configured, directly dialable) - it never
-   renders disabled. Run state is server-side and per site, so navigating away leaves the
-   run finishing and coming back shows the transcript. *@
+   site's gateway over SSH (detached on the gateway, output polled back) and streams the
+   output here. The button exists only once the availability gate resolves (gateway SSH
+   configured, dial succeeds) - it never renders disabled. Run state is server-side and
+   per site, so navigating away leaves the run finishing and coming back shows the
+   transcript. *@
 
 @if (_run != null)
 {

--- a/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
@@ -1,0 +1,215 @@
+@using NetworkOptimizer.Web.Services
+@implements IDisposable
+@inject IGatewayAgentInstallService GatewayInstall
+
+@* "Run It for Me" under a gateway agent one-liner: executes that exact command on the
+   site's gateway over SSH and streams the output here. The button exists only once the
+   availability gate resolves (gateway SSH configured, directly dialable) - it never
+   renders disabled. Run state is server-side and per site, so navigating away leaves the
+   run finishing and coming back shows the transcript. *@
+
+@if (_run != null)
+{
+    <div class="gw-run-panel">
+        <div class="gw-run-status">
+            @if (_run.Status == GatewayAgentInstallStatus.Running)
+            {
+                <span class="spinner spinner-sm"></span>
+                <span>Running on the gateway. The agent download can look idle for a few minutes.</span>
+                <button type="button" class="btn btn-secondary btn-sm" @onclick="CancelAsync">Cancel</button>
+            }
+            else if (_run.Status == GatewayAgentInstallStatus.Succeeded)
+            {
+                <span class="gw-run-ok">&#x2713;</span>
+                <span>@(_run.IsUpgrade
+                    ? "Finished - the agent restarted on the new binary."
+                    : "Finished - the agent is installed and should come Online within a minute or two.")</span>
+            }
+            else if (_run.Status == GatewayAgentInstallStatus.Canceled)
+            {
+                <span>Canceled. Running it again is safe - the installer is idempotent and keeps the agent's enrollment.</span>
+            }
+            else
+            {
+                <span class="gw-run-fail">&#x2715;</span>
+                <span>@(_run.ExitCode is int code
+                    ? $"The command exited with code {code} - the output below has the details."
+                    : _run.Error ?? "The run failed.")</span>
+            }
+        </div>
+        <CopyableCommand Text="@_run.Transcript" Tooltip="Copy the output" />
+    </div>
+}
+
+@if (_available && _run?.Status != GatewayAgentInstallStatus.Running)
+{
+    <div class="gw-run-action">
+        <button type="button" class="btn btn-primary btn-sm" @onclick="Start">
+            @(_run == null ? "Run It for Me" : "Run It Again")
+        </button>
+        <span class="gw-run-hint">Runs this command on the gateway over SSH and shows the output here.</span>
+    </div>
+}
+
+@if (_message != null)
+{
+    <div class="alert alert-warning">@_message</div>
+}
+
+<style>
+    .gw-run-action {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin: 0.5rem 0;
+    }
+
+    .gw-run-hint {
+        color: var(--text-muted);
+        font-size: 0.8rem;
+    }
+
+    .gw-run-panel {
+        margin-top: 0.5rem;
+    }
+
+    .gw-run-status {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-bottom: 0.5rem;
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+    }
+
+    .gw-run-ok {
+        color: var(--success-color);
+    }
+
+    .gw-run-fail {
+        color: var(--danger-color);
+    }
+
+    .gw-run-panel .code-copy-block pre {
+        max-height: 320px;
+        overflow-y: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+    }
+</style>
+
+@code {
+    /// <summary>The site whose gateway the command runs on.</summary>
+    [Parameter, EditorRequired]
+    public string SiteSlug { get; set; } = "";
+
+    /// <summary>True under the upgrade one-liner (no token), false under the install one.</summary>
+    [Parameter]
+    public bool IsUpgrade { get; set; }
+
+    /// <summary>The enrollment token embedded in the displayed install command.</summary>
+    [Parameter]
+    public string? EnrollmentToken { get; set; }
+
+    private bool _available;
+    private GatewayAgentInstallRun? _run;
+    private GatewayAgentInstallRun? _subscribed;
+    private string? _message;
+    private int _renderPending;
+    private bool _disposed;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (string.IsNullOrWhiteSpace(SiteSlug))
+            return;
+
+        // A run from earlier in the process (finished, or still going after a navigation)
+        // renders immediately; the button waits for the availability gate to resolve so it
+        // never flashes in and disables.
+        _run = await GatewayInstall.GetRunAsync(SiteSlug);
+        if (_run != null)
+            Subscribe(_run);
+        _available = await GatewayInstall.IsAvailableAsync(SiteSlug);
+    }
+
+    private void Start()
+    {
+        _message = null;
+        var task = IsUpgrade
+            ? GatewayInstall.RunUpgradeAsync(SiteSlug, OnRunStarted)
+            : GatewayInstall.RunInstallAsync(SiteSlug, EnrollmentToken ?? "", OnRunStarted);
+        _ = ObserveAsync(task);
+    }
+
+    private void OnRunStarted(GatewayAgentInstallRun run)
+    {
+        _run = run;
+        Subscribe(run);
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private async Task ObserveAsync(Task runTask)
+    {
+        try
+        {
+            await runTask;
+        }
+        catch (Exception ex)
+        {
+            // A refusal (run already active) or a denial arrives before any run exists; a run
+            // that got going carries its own failure state in the panel instead.
+            if (_run is null or { Status: GatewayAgentInstallStatus.Running })
+                _message = ex.Message;
+        }
+        if (_disposed)
+            return;
+        // InvalidOperationException also covers ObjectDisposedException from a torn-down circuit.
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (InvalidOperationException) { }
+    }
+
+    private async Task CancelAsync() => await GatewayInstall.CancelRunAsync(SiteSlug);
+
+    private void Subscribe(GatewayAgentInstallRun run)
+    {
+        if (_subscribed == run)
+            return;
+        if (_subscribed != null)
+            _subscribed.Updated -= OnRunUpdated;
+        _subscribed = run;
+        run.Updated += OnRunUpdated;
+    }
+
+    private void OnRunUpdated()
+    {
+        if (Interlocked.Exchange(ref _renderPending, 1) == 1)
+            return;
+        _ = ThrottledRenderAsync();
+    }
+
+    // ~200 ms batches: streamed chunks arrive several times a second and each would
+    // otherwise be a full circuit render.
+    private async Task ThrottledRenderAsync()
+    {
+        await Task.Delay(200);
+        Interlocked.Exchange(ref _renderPending, 0);
+        if (_disposed)
+            return;
+        // InvalidOperationException also covers ObjectDisposedException from a torn-down circuit.
+        try
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+        catch (InvalidOperationException) { }
+    }
+
+    public void Dispose()
+    {
+        _disposed = true;
+        if (_subscribed != null)
+            _subscribed.Updated -= OnRunUpdated;
+    }
+}

--- a/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/GatewayAgentRunPanel.razor
@@ -33,9 +33,12 @@
             else
             {
                 <span class="gw-run-fail">&#x2715;</span>
-                <span>@(_run.ExitCode is int code
-                    ? $"The {(_run.IsUpgrade ? "upgrade" : "install")} failed (exit code {code}). See the output below."
-                    : _run.Error ?? "The run failed.")</span>
+                @* Error first: a failure can carry both a message and an exit code (the
+                   no-output guard), and the message is the one that says what to do. *@
+                <span>@(_run.Error
+                    ?? (_run.ExitCode is int code
+                        ? $"The {(_run.IsUpgrade ? "upgrade" : "install")} failed (exit code {code}). See the output below."
+                        : "The run failed."))</span>
             }
         </div>
         <CopyableCommand Text="@_run.Transcript" Tooltip="Copy the output" />
@@ -145,10 +148,11 @@
     private void Start()
     {
         _message = null;
+        var prior = _run;
         var task = IsUpgrade
             ? GatewayInstall.RunUpgradeAsync(SiteSlug, OnRunStarted)
             : GatewayInstall.RunInstallAsync(SiteSlug, EnrollmentToken ?? "", OnRunStarted);
-        _ = ObserveAsync(task);
+        _ = ObserveAsync(task, prior);
     }
 
     private void OnRunStarted(GatewayAgentInstallRun run)
@@ -159,7 +163,7 @@
         _ = InvokeAsync(StateHasChanged);
     }
 
-    private async Task ObserveAsync(Task runTask)
+    private async Task ObserveAsync(Task runTask, GatewayAgentInstallRun? prior)
     {
         try
         {
@@ -167,9 +171,10 @@
         }
         catch (Exception ex)
         {
-            // A refusal (run already active) or a denial arrives before any run exists; a run
-            // that got going carries its own failure state in the panel instead.
-            if (_run is null or { Status: GatewayAgentInstallStatus.Running })
+            // Show the error only when no new run got going (a refusal or a denial) - a run
+            // that started carries its own failure state in the panel instead. Compared by
+            // identity: a finished earlier run may still be on display when a start is refused.
+            if (ReferenceEquals(_run, prior))
                 _message = ex.Message;
         }
         if (_disposed)
@@ -182,7 +187,19 @@
         catch (InvalidOperationException) { }
     }
 
-    private async Task CancelAsync() => await GatewayInstall.CancelRunAsync(SiteSlug);
+    // Caught rather than thrown into the event pipeline: an unhandled exception here (a
+    // denial, a dropped circuit) would take the whole circuit down mid-run.
+    private async Task CancelAsync()
+    {
+        try
+        {
+            await GatewayInstall.CancelRunAsync(SiteSlug);
+        }
+        catch (Exception ex)
+        {
+            _message = ex.Message;
+        }
+    }
 
     private void Subscribe(GatewayAgentInstallRun run)
     {

--- a/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SiteSetupWizard.razor
@@ -236,7 +236,7 @@
         }
         else
         {
-            <AgentInstallInstructions Token="@_agentToken" LanSpeedTest="_featureLanSpeedTest" />
+            <AgentInstallInstructions Token="@_agentToken" LanSpeedTest="_featureLanSpeedTest" SiteSlug="@_site?.Slug" />
             <div class="action-buttons">
                 <button type="button" class="btn btn-primary" @onclick="() => _step = 4">Continue</button>
             </div>

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -274,6 +274,11 @@ builder.Services.AddMutatingService<IAgentEnrollmentService>(sp => sp.GetRequire
 // Detects agents running on the site's UniFi gateway itself (monitoring-only
 // installs) so speed-test surfaces can gate accordingly.
 builder.Services.AddSiteScopedRegistry<AgentOnGatewayDetector>();
+// "Run It for Me": executes the gateway agent install/upgrade one-liner over the site's
+// gateway SSH. Run state lives in the singleton state holder so a run outlives the circuit
+// that started it; the gated service stays scoped for audit-detail enrichment.
+builder.Services.AddSingleton<GatewayAgentInstallState>();
+builder.Services.AddMutatingService<IGatewayAgentInstallService, GatewayAgentInstallService>();
 
 // Licensing: singleton state machine, activation and phone-home loop. All
 // licensing data is instance-wide registry data in the main database.

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentCommands.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentCommands.cs
@@ -1,0 +1,31 @@
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Builds the on-gateway agent install/upgrade one-liners. The single source for both the
+/// command text the UI displays and the command "Run It for Me" executes over SSH, so the
+/// two can never drift.
+/// </summary>
+public static class GatewayAgentCommands
+{
+    /// <summary>Shown in place of the server URL when REVERSE_PROXIED_HOST_NAME is not set.</summary>
+    public const string PlaceholderServerUrl = "https://your-network-optimizer";
+
+    // PREVIEW-CYCLE PIN (2.8.0) - REVERT BEFORE STABLE: release/2.8 script fetches preview binaries.
+    private const string ScriptUrl =
+        "https://raw.githubusercontent.com/Ozark-Connect/NetworkOptimizer/release/2.8/scripts/agent/install-agent-gateway.sh";
+
+    /// <summary>The --server value: the configured agent-facing URL, or the placeholder.</summary>
+    public static string ServerValue(string? serverUrl) =>
+        string.IsNullOrWhiteSpace(serverUrl) ? PlaceholderServerUrl : serverUrl.TrimEnd('/');
+
+    /// <summary>
+    /// First-time install one-liner. Monitoring-only gateway installer: no --lan-speed-test (the
+    /// router must not host a speed-test server) and no sudo (UniFi gateways SSH in as root).
+    /// </summary>
+    public static string Install(string? serverUrl, string token) =>
+        $"curl -fsSL {ScriptUrl} | bash -s -- \\\n  --server \"{ServerValue(serverUrl)}\" \\\n  --token \"{token}\"";
+
+    /// <summary>Upgrade one-liner: same script, no token - an enrolled agent.json is kept.</summary>
+    public static string Upgrade(string? serverUrl) =>
+        $"curl -fsSL {ScriptUrl} | bash -s -- --server \"{ServerValue(serverUrl)}\"";
+}

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentInstallRun.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentInstallRun.cs
@@ -1,0 +1,76 @@
+using System.Text;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>Lifecycle of one "Run It for Me" gateway agent install/upgrade run.</summary>
+public enum GatewayAgentInstallStatus
+{
+    Running,
+    Succeeded,
+    Failed,
+    Canceled,
+}
+
+/// <summary>
+/// Live state of one "Run It for Me" gateway agent install/upgrade: the transcript as it
+/// streams in, the final status, and the script's exit code. The latest run per site is held
+/// by <see cref="GatewayAgentInstallState"/> for the lifetime of the process, so a page
+/// reopened mid-run or after completion can still show the transcript.
+/// </summary>
+public class GatewayAgentInstallRun
+{
+    private readonly StringBuilder _transcript = new();
+    private readonly object _lock = new();
+
+    public GatewayAgentInstallRun(string siteSlug, bool isUpgrade)
+    {
+        SiteSlug = siteSlug;
+        IsUpgrade = isUpgrade;
+    }
+
+    /// <summary>The site whose gateway the run targets.</summary>
+    public string SiteSlug { get; }
+
+    /// <summary>True for the upgrade one-liner (no token), false for a first-time install.</summary>
+    public bool IsUpgrade { get; }
+
+    /// <summary>When the run started.</summary>
+    public DateTime StartedAtUtc { get; } = DateTime.UtcNow;
+
+    /// <summary>Where the run is in its lifecycle.</summary>
+    public GatewayAgentInstallStatus Status { get; private set; } = GatewayAgentInstallStatus.Running;
+
+    /// <summary>The script's exit code, when it ran to an exit at all.</summary>
+    public int? ExitCode { get; private set; }
+
+    /// <summary>Failure summary when the run ended without a clean exit (SSH drop, timeout).</summary>
+    public string? Error { get; private set; }
+
+    /// <summary>Raised on every transcript append and once on completion. May fire on any thread.</summary>
+    public event Action? Updated;
+
+    /// <summary>Cancels the SSH channel when the user clicks Cancel.</summary>
+    internal CancellationTokenSource UserCancellation { get; } = new();
+
+    internal bool CancelRequested => UserCancellation.IsCancellationRequested;
+
+    /// <summary>Everything the command has written so far (stdout and stderr interleaved).</summary>
+    public string Transcript
+    {
+        get { lock (_lock) return _transcript.ToString(); }
+    }
+
+    internal void Append(string chunk)
+    {
+        lock (_lock) _transcript.Append(chunk);
+        Updated?.Invoke();
+    }
+
+    internal void Complete(GatewayAgentInstallStatus status, int? exitCode, string? error)
+    {
+        Status = status;
+        ExitCode = exitCode;
+        Error = error;
+        Updated?.Invoke();
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
@@ -1,0 +1,171 @@
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Gates;
+using NetworkOptimizer.Web.Services.Ssh;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Runs the gateway agent install/upgrade one-liner over the site's existing gateway SSH
+/// plumbing, streaming output into the per-site run held by
+/// <see cref="GatewayAgentInstallState"/>. The run method spans the whole execution, so the
+/// audit envelope the interceptor writes carries the final exit code - and because everything
+/// it touches is singleton-owned or plain objects, the run keeps going to completion even
+/// when the circuit that started it is disposed mid-install.
+/// </summary>
+public class GatewayAgentInstallService : IGatewayAgentInstallService
+{
+    /// <summary>
+    /// Overall cap per run - the ~100 MB agent binary is pulled from GitHub on the gateway's
+    /// WAN. Deliberately no inactivity timeout: that download is a silent curl that can
+    /// produce nothing for minutes.
+    /// </summary>
+    public static readonly TimeSpan RunTimeout = TimeSpan.FromMinutes(10);
+
+    private static readonly TimeSpan DialTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>Shown when a second start is refused while a run is active (never queued).</summary>
+    public const string AlreadyRunningMessage =
+        "A run is already in progress on this site's gateway - wait for it to finish.";
+
+    private readonly GatewayAgentInstallState _state;
+    private readonly GatewaySshRegistry _gatewaySsh;
+    private readonly SiteTunnelRouting _tunnelRouting;
+    private readonly AgentServerUrlProvider _serverUrl;
+    private readonly IAuditContext _auditContext;
+    private readonly ILogger<GatewayAgentInstallService> _logger;
+
+    public GatewayAgentInstallService(
+        GatewayAgentInstallState state,
+        GatewaySshRegistry gatewaySsh,
+        SiteTunnelRouting tunnelRouting,
+        AgentServerUrlProvider serverUrl,
+        IAuditContext auditContext,
+        ILogger<GatewayAgentInstallService> logger)
+    {
+        _state = state;
+        _gatewaySsh = gatewaySsh;
+        _tunnelRouting = tunnelRouting;
+        _serverUrl = serverUrl;
+        _auditContext = auditContext;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public Task<bool> IsAvailableAsync(string siteSlug)
+    {
+        if (_state.TryGetAvailability(siteSlug, out var cached))
+            return Task.FromResult(cached);
+
+        return _state.GetOrStartAvailabilityCheck(siteSlug, () => CheckAvailabilityAsync(siteSlug));
+    }
+
+    /// <inheritdoc />
+    public Task<GatewayAgentInstallRun?> GetRunAsync(string siteSlug) =>
+        Task.FromResult(_state.GetRun(siteSlug));
+
+    /// <inheritdoc />
+    public Task RunInstallAsync(string siteSlug, string enrollmentToken, Action<GatewayAgentInstallRun>? onStarted = null) =>
+        RunAsync(siteSlug, GatewayAgentCommands.Install(_serverUrl.Url, enrollmentToken), isUpgrade: false, onStarted);
+
+    /// <inheritdoc />
+    public Task RunUpgradeAsync(string siteSlug, Action<GatewayAgentInstallRun>? onStarted = null) =>
+        RunAsync(siteSlug, GatewayAgentCommands.Upgrade(_serverUrl.Url), isUpgrade: true, onStarted);
+
+    /// <inheritdoc />
+    public Task CancelRunAsync(string siteSlug)
+    {
+        var run = _state.GetRun(siteSlug);
+        if (run is { Status: GatewayAgentInstallStatus.Running })
+            run.UserCancellation.Cancel();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// The gate's configuration half, kept static and pure for the unit tests: whether the
+    /// site is even a candidate before the dial is attempted. Tunnel-routed sites are out of
+    /// v1 - their copy-paste command remains the path - and an unset server URL means the
+    /// displayed command holds a placeholder no gateway could call back on.
+    /// </summary>
+    public static bool IsCandidate(bool serverUrlConfigured, bool routedViaAgent, GatewaySshSettings? settings) =>
+        serverUrlConfigured
+        && !routedViaAgent
+        && settings is { Enabled: true }
+        && !string.IsNullOrEmpty(settings.Host)
+        && settings.HasCredentials;
+
+    private async Task<bool> CheckAvailabilityAsync(string siteSlug)
+    {
+        try
+        {
+            var ssh = _gatewaySsh.GetFor(siteSlug);
+            var settings = await ssh.GetSettingsAsync();
+            if (!IsCandidate(
+                    !string.IsNullOrWhiteSpace(_serverUrl.Url),
+                    await _tunnelRouting.IsViaAgentAsync(siteSlug),
+                    settings))
+                return false;
+
+            // The dial itself: a no-op command instead of TestConnectionAsync, which writes
+            // its result back to the settings row on every success.
+            var (ok, _) = await ssh.RunCommandAsync("true", DialTimeout);
+            return ok;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Gateway agent install availability check failed for site {Slug}", siteSlug);
+            return false;
+        }
+    }
+
+    private async Task RunAsync(string siteSlug, string command, bool isUpgrade, Action<GatewayAgentInstallRun>? onStarted)
+    {
+        var mode = isUpgrade ? "upgrade" : "install";
+        var run = _state.StartRun(siteSlug, isUpgrade, AlreadyRunningMessage);
+        onStarted?.Invoke(run);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(run.UserCancellation.Token);
+        timeout.CancelAfter(RunTimeout);
+
+        try
+        {
+            var ssh = _gatewaySsh.GetFor(siteSlug);
+            _auditContext.SetTarget((await ssh.GetSettingsAsync()).Host);
+
+            var result = await ssh.RunCommandStreamingAsync(command, run.Append, RunTimeout, timeout.Token);
+
+            if (result.Success)
+            {
+                run.Complete(GatewayAgentInstallStatus.Succeeded, result.ExitCode, null);
+            }
+            else
+            {
+                // Exit -1 is our own sentinel for "never ran to an exit" (dial refused, SSH
+                // dropped mid-run); the Error then says why and belongs in the transcript.
+                var exitCode = result.ExitCode >= 0 ? result.ExitCode : (int?)null;
+                if (exitCode == null && !string.IsNullOrWhiteSpace(result.Error))
+                    run.Append((run.Transcript.Length > 0 ? "\n" : "") + result.Error + "\n");
+                run.Complete(GatewayAgentInstallStatus.Failed, exitCode, exitCode == null ? result.Error : null);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            run.Complete(
+                run.CancelRequested ? GatewayAgentInstallStatus.Canceled : GatewayAgentInstallStatus.Failed,
+                null,
+                run.CancelRequested ? null : $"Timed out after {RunTimeout.TotalMinutes:0} minutes.");
+        }
+        catch (Exception ex)
+        {
+            // A run must never be left Running - it would block every future start for the site.
+            run.Complete(GatewayAgentInstallStatus.Failed, null, ex.Message);
+            throw;
+        }
+        finally
+        {
+            _auditContext.SetDetails(new { mode, status = run.Status.ToString(), exitCode = run.ExitCode });
+            _logger.LogInformation(
+                "Gateway agent {Mode} on site {Slug}: {Status} (exit code {ExitCode}). Transcript:\n{Transcript}",
+                mode, siteSlug, run.Status, run.ExitCode?.ToString() ?? "n/a", run.Transcript);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
@@ -5,12 +5,20 @@ using NetworkOptimizer.Web.Services.Ssh;
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
-/// Runs the gateway agent install/upgrade one-liner over the site's existing gateway SSH
-/// plumbing, streaming output into the per-site run held by
-/// <see cref="GatewayAgentInstallState"/>. The run method spans the whole execution, so the
-/// audit envelope the interceptor writes carries the final exit code - and because everything
-/// it touches is singleton-owned or plain objects, the run keeps going to completion even
-/// when the circuit that started it is disposed mid-install.
+/// Runs the gateway agent install/upgrade one-liner on the site's gateway, streaming output
+/// into the per-site run held by <see cref="GatewayAgentInstallState"/>.
+///
+/// The command runs DETACHED on the gateway (nohup into a log file plus an exit-code file)
+/// and the server polls the log back over short SSH dials. Never a live exec channel: the
+/// installer's final step restarts the agent, and on an agent-tunnel-routed site that tears
+/// down the very tunnel a live channel would be riding - the detached run just keeps going
+/// locally, and the polls retry through the few seconds the tunnel takes to come back. One
+/// mechanism for every site, tunnel-routed or directly dialed.
+///
+/// The run method spans the whole execution, so the audit envelope the interceptor writes
+/// carries the final exit code - and because everything it touches is singleton-owned or
+/// plain objects, the run keeps going to completion even when the circuit that started it
+/// is disposed mid-install.
 /// </summary>
 public class GatewayAgentInstallService : IGatewayAgentInstallService
 {
@@ -21,15 +29,44 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
     /// </summary>
     public static readonly TimeSpan RunTimeout = TimeSpan.FromMinutes(10);
 
+    /// <summary>
+    /// How long consecutive poll failures are tolerated before the run is declared lost.
+    /// Generous on purpose: the agent restart at the end of the installer drops a tunnel
+    /// for seconds, not minutes.
+    /// </summary>
+    public static readonly TimeSpan PollFailureGrace = TimeSpan.FromMinutes(2);
+
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(2);
+    private static readonly TimeSpan PollSshTimeout = TimeSpan.FromSeconds(15);
     private static readonly TimeSpan DialTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>Shown when a second start is refused while a run is active (never queued).</summary>
     public const string AlreadyRunningMessage =
         "A run is already in progress on this site's gateway - wait for it to finish.";
 
+    // The detached run's files on the gateway. /tmp is tmpfs, so a reboot clears them, and
+    // fixed names are safe because runs are serialized per site (one gateway per site).
+    private const string RemoteLogFile = "/tmp/netopt-gateway-run.log";
+    private const string RemoteExitFile = "/tmp/netopt-gateway-run.exit";
+    private const string RemotePidFile = "/tmp/netopt-gateway-run.pid";
+
+    // Poll-output fences: some gateways print a banner ahead of exec output, so the log is
+    // read between markers rather than from the start of the reply.
+    private const string LogMarker = "__NETOPT_LOG__";
+    private const string ExitMarker = "__NETOPT_EXIT__:";
+
+    private const string PollCommand =
+        "echo " + LogMarker + "; cat " + RemoteLogFile + " 2>/dev/null; " +
+        "printf '\\n" + ExitMarker + "%s\\n' \"$(cat " + RemoteExitFile + " 2>/dev/null)\"";
+
+    // Kill the detached run's whole process group (set -m at start makes it a group leader),
+    // falling back to the leader alone; ends in true so a missing pid file is not a failure.
+    private const string KillCommand =
+        "if [ -f " + RemotePidFile + " ]; then p=$(cat " + RemotePidFile + "); " +
+        "kill -s TERM -- \"-$p\" 2>/dev/null; kill -s TERM \"$p\" 2>/dev/null; fi; true";
+
     private readonly GatewayAgentInstallState _state;
     private readonly GatewaySshRegistry _gatewaySsh;
-    private readonly SiteTunnelRouting _tunnelRouting;
     private readonly AgentServerUrlProvider _serverUrl;
     private readonly IAuditContext _auditContext;
     private readonly ILogger<GatewayAgentInstallService> _logger;
@@ -37,14 +74,12 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
     public GatewayAgentInstallService(
         GatewayAgentInstallState state,
         GatewaySshRegistry gatewaySsh,
-        SiteTunnelRouting tunnelRouting,
         AgentServerUrlProvider serverUrl,
         IAuditContext auditContext,
         ILogger<GatewayAgentInstallService> logger)
     {
         _state = state;
         _gatewaySsh = gatewaySsh;
-        _tunnelRouting = tunnelRouting;
         _serverUrl = serverUrl;
         _auditContext = auditContext;
         _logger = logger;
@@ -82,16 +117,65 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
 
     /// <summary>
     /// The gate's configuration half, kept static and pure for the unit tests: whether the
-    /// site is even a candidate before the dial is attempted. Tunnel-routed sites are out of
-    /// v1 - their copy-paste command remains the path - and an unset server URL means the
-    /// displayed command holds a placeholder no gateway could call back on.
+    /// site is even a candidate before the dial is attempted. An unset server URL means the
+    /// displayed command holds a placeholder no gateway could call back on. Agent-tunnel-routed
+    /// sites are candidates like any other - the dial and the run both ride the tunnel.
     /// </summary>
-    public static bool IsCandidate(bool serverUrlConfigured, bool routedViaAgent, GatewaySshSettings? settings) =>
+    public static bool IsCandidate(bool serverUrlConfigured, GatewaySshSettings? settings) =>
         serverUrlConfigured
-        && !routedViaAgent
         && settings is { Enabled: true }
         && !string.IsNullOrEmpty(settings.Host)
         && settings.HasCredentials;
+
+    /// <summary>
+    /// Wraps the one-liner for a detached run: the payload is embedded verbatim, its output
+    /// goes to the log file, its exit code to the exit file, and the pid file holds the
+    /// group leader (set -m) so cancel can kill the whole tree.
+    /// </summary>
+    public static string BuildDetachedStart(string command)
+    {
+        var inner = command + "\necho $? > " + RemoteExitFile;
+        var escaped = inner.Replace("'", "'\\''");
+        return "rm -f " + RemoteLogFile + " " + RemoteExitFile + " " + RemotePidFile + "\n" +
+               "set -m\n" +
+               "nohup bash -c '" + escaped + "' </dev/null >" + RemoteLogFile + " 2>&1 &\n" +
+               "echo $! >" + RemotePidFile;
+    }
+
+    /// <summary>
+    /// Pulls the log text and exit code out of one poll reply. Null when the reply does not
+    /// carry the markers (the poll command did not run). A null exit code means the run is
+    /// still going.
+    /// </summary>
+    public static (string Log, int? ExitCode)? ParsePollOutput(string output)
+    {
+        var startIdx = output.IndexOf(LogMarker, StringComparison.Ordinal);
+        var exitIdx = output.LastIndexOf(ExitMarker, StringComparison.Ordinal);
+        if (startIdx < 0 || exitIdx < startIdx)
+            return null;
+
+        var logStart = output.IndexOf('\n', startIdx);
+        if (logStart < 0 || logStart > exitIdx)
+            return null;
+        logStart += 1;
+
+        // The poll's printf always contributes exactly one newline ahead of the exit marker,
+        // so stripping one preserves whether the log itself ended with a newline.
+        var logEnd = exitIdx;
+        if (logEnd > logStart && output[logEnd - 1] == '\n')
+            logEnd -= 1;
+        if (logEnd > logStart && output[logEnd - 1] == '\r')
+            logEnd -= 1;
+        var log = logEnd > logStart ? output[logStart..logEnd] : "";
+
+        var valueStart = exitIdx + ExitMarker.Length;
+        var valueEnd = output.IndexOf('\n', valueStart);
+        if (valueEnd < 0)
+            valueEnd = output.Length;
+        var value = output[valueStart..valueEnd].Trim();
+
+        return (log, int.TryParse(value, out var code) ? code : null);
+    }
 
     private async Task<bool> CheckAvailabilityAsync(string siteSlug)
     {
@@ -99,10 +183,7 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
         {
             var ssh = _gatewaySsh.GetFor(siteSlug);
             var settings = await ssh.GetSettingsAsync();
-            if (!IsCandidate(
-                    !string.IsNullOrWhiteSpace(_serverUrl.Url),
-                    await _tunnelRouting.IsViaAgentAsync(siteSlug),
-                    settings))
+            if (!IsCandidate(!string.IsNullOrWhiteSpace(_serverUrl.Url), settings))
                 return false;
 
             // The dial itself: a no-op command instead of TestConnectionAsync, which writes
@@ -123,36 +204,20 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
         var run = _state.StartRun(siteSlug, isUpgrade, AlreadyRunningMessage);
         onStarted?.Invoke(run);
 
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(run.UserCancellation.Token);
-        timeout.CancelAfter(RunTimeout);
-
         try
         {
             var ssh = _gatewaySsh.GetFor(siteSlug);
             _auditContext.SetTarget((await ssh.GetSettingsAsync()).Host);
 
-            var result = await ssh.RunCommandStreamingAsync(command, run.Append, RunTimeout, timeout.Token);
+            var (started, startError) = await ssh.RunCommandAsync(BuildDetachedStart(command), TimeSpan.FromSeconds(30));
+            if (!started)
+            {
+                run.Append(startError + "\n");
+                run.Complete(GatewayAgentInstallStatus.Failed, null, startError);
+                return;
+            }
 
-            if (result.Success)
-            {
-                run.Complete(GatewayAgentInstallStatus.Succeeded, result.ExitCode, null);
-            }
-            else
-            {
-                // Exit -1 is our own sentinel for "never ran to an exit" (dial refused, SSH
-                // dropped mid-run); the Error then says why and belongs in the transcript.
-                var exitCode = result.ExitCode >= 0 ? result.ExitCode : (int?)null;
-                if (exitCode == null && !string.IsNullOrWhiteSpace(result.Error))
-                    run.Append((run.Transcript.Length > 0 ? "\n" : "") + result.Error + "\n");
-                run.Complete(GatewayAgentInstallStatus.Failed, exitCode, exitCode == null ? result.Error : null);
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            run.Complete(
-                run.CancelRequested ? GatewayAgentInstallStatus.Canceled : GatewayAgentInstallStatus.Failed,
-                null,
-                run.CancelRequested ? null : $"Timed out after {RunTimeout.TotalMinutes:0} minutes.");
+            await PollToCompletionAsync(ssh, run);
         }
         catch (Exception ex)
         {
@@ -166,6 +231,73 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
             _logger.LogInformation(
                 "Gateway agent {Mode} on site {Slug}: {Status} (exit code {ExitCode}). Transcript:\n{Transcript}",
                 mode, siteSlug, run.Status, run.ExitCode?.ToString() ?? "n/a", run.Transcript);
+        }
+    }
+
+    private async Task PollToCompletionAsync(GatewaySshService ssh, GatewayAgentInstallRun run)
+    {
+        var deadline = run.StartedAtUtc + RunTimeout;
+        DateTime? failingSince = null;
+        var lastError = "";
+        var seen = 0;
+
+        while (true)
+        {
+            if (run.CancelRequested || DateTime.UtcNow > deadline)
+            {
+                await KillDetachedRunAsync(ssh);
+                run.Complete(
+                    run.CancelRequested ? GatewayAgentInstallStatus.Canceled : GatewayAgentInstallStatus.Failed,
+                    null,
+                    run.CancelRequested ? null : $"Timed out after {RunTimeout.TotalMinutes:0} minutes.");
+                return;
+            }
+
+            var (ok, output) = await ssh.RunCommandAsync(PollCommand, PollSshTimeout);
+            var parsed = ok ? ParsePollOutput(output) : null;
+            if (parsed is { } poll)
+            {
+                failingSince = null;
+                if (poll.Log.Length > seen)
+                {
+                    run.Append(poll.Log[seen..]);
+                    seen = poll.Log.Length;
+                }
+                if (poll.ExitCode is int code)
+                {
+                    run.Complete(
+                        code == 0 ? GatewayAgentInstallStatus.Succeeded : GatewayAgentInstallStatus.Failed,
+                        code, null);
+                    return;
+                }
+            }
+            else
+            {
+                // A tunnel dropping while the installer restarts the agent lands here for a
+                // few polls; only a sustained outage fails the run.
+                failingSince ??= DateTime.UtcNow;
+                lastError = ok ? "unexpected poll reply" : output;
+                if (DateTime.UtcNow - failingSince > PollFailureGrace)
+                {
+                    run.Complete(GatewayAgentInstallStatus.Failed, null,
+                        $"Lost contact with the gateway: {lastError}");
+                    return;
+                }
+            }
+
+            await Task.Delay(PollInterval, CancellationToken.None);
+        }
+    }
+
+    private async Task KillDetachedRunAsync(GatewaySshService ssh)
+    {
+        try
+        {
+            await ssh.RunCommandAsync(KillCommand, TimeSpan.FromSeconds(10));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Best-effort kill of the detached gateway run failed");
         }
     }
 }

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentInstallService.cs
@@ -258,6 +258,16 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
             if (parsed is { } poll)
             {
                 failingSince = null;
+
+                // A shorter log than already streamed means the run's files were reset out
+                // from under us - a fast gateway reboot, most likely. Its exit can never
+                // arrive, so fail now instead of sitting out the overall cap.
+                if (poll.Log.Length < seen)
+                {
+                    run.Complete(GatewayAgentInstallStatus.Failed, null,
+                        "Lost contact with the run on the gateway - the output below is what was captured.");
+                    return;
+                }
                 if (poll.Log.Length > seen)
                 {
                     run.Append(poll.Log[seen..]);
@@ -265,6 +275,15 @@ public class GatewayAgentInstallService : IGatewayAgentInstallService
                 }
                 if (poll.ExitCode is int code)
                 {
+                    // Exit 0 with an empty transcript is curl failing to fetch the script:
+                    // -fsSL without -S prints nothing, and bash -s on an empty stdin exits 0.
+                    // A real run always prints its steps, so this is never a success.
+                    if (code == 0 && string.IsNullOrWhiteSpace(run.Transcript))
+                    {
+                        run.Complete(GatewayAgentInstallStatus.Failed, 0,
+                            "The run produced no output - the gateway may not have been able to download the install script. Check its internet access.");
+                        return;
+                    }
                     run.Complete(
                         code == 0 ? GatewayAgentInstallStatus.Succeeded : GatewayAgentInstallStatus.Failed,
                         code, null);

--- a/src/NetworkOptimizer.Web/Services/GatewayAgentInstallState.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayAgentInstallState.cs
@@ -1,0 +1,77 @@
+using System.Collections.Concurrent;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Process-wide state behind <see cref="IGatewayAgentInstallService"/>: the latest run per
+/// site and the short-lived availability verdicts. A singleton so a run keeps streaming and
+/// finishing after the circuit that started it is gone; the gated service itself stays scoped
+/// because audit-detail enrichment rides the caller's scope.
+/// </summary>
+public class GatewayAgentInstallState
+{
+    private readonly ConcurrentDictionary<string, GatewayAgentInstallRun> _runs = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, (DateTime At, bool Available)> _availability = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, Lazy<Task<bool>>> _pendingChecks = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _startLock = new();
+
+    /// <summary>How long an availability verdict is trusted before the gateway is dialed again.</summary>
+    public static readonly TimeSpan AvailabilityCacheTtl = TimeSpan.FromSeconds(30);
+
+    /// <summary>The site's latest run (running or finished), or null when none this process.</summary>
+    public GatewayAgentInstallRun? GetRun(string siteSlug) =>
+        _runs.TryGetValue(siteSlug, out var run) ? run : null;
+
+    /// <summary>
+    /// Registers a new run for the site, refusing while one is still running - a second start
+    /// is rejected, not queued.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">A run is already active for the site.</exception>
+    public GatewayAgentInstallRun StartRun(string siteSlug, bool isUpgrade, string refusalMessage)
+    {
+        lock (_startLock)
+        {
+            if (_runs.TryGetValue(siteSlug, out var existing) && existing.Status == GatewayAgentInstallStatus.Running)
+                throw new InvalidOperationException(refusalMessage);
+
+            var run = new GatewayAgentInstallRun(siteSlug, isUpgrade);
+            _runs[siteSlug] = run;
+            return run;
+        }
+    }
+
+    /// <summary>
+    /// The cached availability verdict for a site, when one is fresh enough to trust.
+    /// </summary>
+    public bool TryGetAvailability(string siteSlug, out bool available)
+    {
+        available = false;
+        if (!_availability.TryGetValue(siteSlug, out var cached) || DateTime.UtcNow - cached.At >= AvailabilityCacheTtl)
+            return false;
+        available = cached.Available;
+        return true;
+    }
+
+    /// <summary>
+    /// Runs one availability check per site at a time: concurrent callers (the install panel
+    /// and an upgrade row on the same page) share a single dial, and the verdict is cached.
+    /// </summary>
+    public Task<bool> GetOrStartAvailabilityCheck(string siteSlug, Func<Task<bool>> check)
+    {
+        return _pendingChecks.GetOrAdd(siteSlug, _ => new Lazy<Task<bool>>(RunAsync)).Value;
+
+        async Task<bool> RunAsync()
+        {
+            try
+            {
+                var available = await check();
+                _availability[siteSlug] = (DateTime.UtcNow, available);
+                return available;
+            }
+            finally
+            {
+                _pendingChecks.TryRemove(siteSlug, out _);
+            }
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/IGatewayAgentInstallService.cs
+++ b/src/NetworkOptimizer.Web/Services/IGatewayAgentInstallService.cs
@@ -1,0 +1,57 @@
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// "Run It for Me": executes the displayed on-gateway agent install/upgrade one-liner on a
+/// site's gateway over the existing gateway SSH plumbing, streaming the output live.
+///
+/// Slug-parameterized rather than site-scoped: the Multi-Site settings panel starts runs for
+/// the site row being acted on, not the site in context, so authorization must follow the
+/// target site - the same shape as <see cref="IAgentEnrollmentService"/>. Run state is per
+/// site and lives in the singleton <see cref="GatewayAgentInstallState"/>, so a run survives
+/// the circuit that started it.
+/// </summary>
+[MutatingService]
+public interface IGatewayAgentInstallService
+{
+    /// <summary>
+    /// Whether the run button should exist for this site: agent-facing server URL configured,
+    /// gateway SSH configured, the gateway directly dialable (agent-tunnel-routed sites are
+    /// excluded - relayed SSH would ride the tunnel of the very agent being replaced), and a
+    /// test dial succeeding. Cached briefly; the button renders only after this resolves.
+    /// </summary>
+    [RequireSiteRole(SiteRole.SiteViewer)]
+    Task<bool> IsAvailableAsync([SiteSlug] string siteSlug);
+
+    /// <summary>The site's latest run (running or finished), or null when none this process.</summary>
+    [RequireSiteRole(SiteRole.SiteViewer)]
+    Task<GatewayAgentInstallRun?> GetRunAsync([SiteSlug] string siteSlug);
+
+    /// <summary>
+    /// Runs the gateway install one-liner (with the given enrollment token) to completion -
+    /// the returned task spans the whole run, so the audit envelope carries the outcome.
+    /// <paramref name="onStarted"/> fires with the live run as streaming begins, letting the
+    /// caller render the transcript while awaiting. Throws <see cref="InvalidOperationException"/>
+    /// while another run is active for the site (refused, not queued).
+    /// </summary>
+    [RequireSiteRole(SiteRole.SiteAdmin)]
+    [AuditAction(AuditActions.AgentGatewayInstallRun, TargetType = "gateway")]
+    Task RunInstallAsync([SiteSlug] string siteSlug, string enrollmentToken, Action<GatewayAgentInstallRun>? onStarted = null);
+
+    /// <summary>
+    /// Runs the gateway upgrade one-liner (no token - an enrolled agent.json is kept).
+    /// Same contract as <see cref="RunInstallAsync"/>.
+    /// </summary>
+    [RequireSiteRole(SiteRole.SiteAdmin)]
+    [AuditAction(AuditActions.AgentGatewayInstallRun, TargetType = "gateway")]
+    Task RunUpgradeAsync([SiteSlug] string siteSlug, Action<GatewayAgentInstallRun>? onStarted = null);
+
+    /// <summary>
+    /// Cancels the site's running install, if any, by killing the SSH channel. Safe: the
+    /// installer is idempotent, so running it again heals a canceled install.
+    /// </summary>
+    [RequireSiteRole(SiteRole.SiteAdmin)]
+    Task CancelRunAsync([SiteSlug] string siteSlug);
+}

--- a/src/NetworkOptimizer.Web/Services/IGatewayAgentInstallService.cs
+++ b/src/NetworkOptimizer.Web/Services/IGatewayAgentInstallService.cs
@@ -5,7 +5,9 @@ namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
 /// "Run It for Me": executes the displayed on-gateway agent install/upgrade one-liner on a
-/// site's gateway over the existing gateway SSH plumbing, streaming the output live.
+/// site's gateway over the existing gateway SSH plumbing. The command runs detached on the
+/// gateway and its output is polled back, so the agent restart at the end of the installer
+/// cannot kill the run - which is what makes agent-tunnel-routed sites workable.
 ///
 /// Slug-parameterized rather than site-scoped: the Multi-Site settings panel starts runs for
 /// the site row being acted on, not the site in context, so authorization must follow the
@@ -18,9 +20,9 @@ public interface IGatewayAgentInstallService
 {
     /// <summary>
     /// Whether the run button should exist for this site: agent-facing server URL configured,
-    /// gateway SSH configured, the gateway directly dialable (agent-tunnel-routed sites are
-    /// excluded - relayed SSH would ride the tunnel of the very agent being replaced), and a
-    /// test dial succeeding. Cached briefly; the button renders only after this resolves.
+    /// gateway SSH configured, and a test dial succeeding (through the site's agent tunnel
+    /// when it is routed that way). Cached briefly; the button renders only after this
+    /// resolves.
     /// </summary>
     [RequireSiteRole(SiteRole.SiteViewer)]
     Task<bool> IsAvailableAsync([SiteSlug] string siteSlug);
@@ -49,8 +51,9 @@ public interface IGatewayAgentInstallService
     Task RunUpgradeAsync([SiteSlug] string siteSlug, Action<GatewayAgentInstallRun>? onStarted = null);
 
     /// <summary>
-    /// Cancels the site's running install, if any, by killing the SSH channel. Safe: the
-    /// installer is idempotent, so running it again heals a canceled install.
+    /// Cancels the site's running install, if any, by killing the detached process on the
+    /// gateway. Safe: the installer is idempotent, so running it again heals a canceled
+    /// install.
     /// </summary>
     [RequireSiteRole(SiteRole.SiteAdmin)]
     Task CancelRunAsync([SiteSlug] string siteSlug);

--- a/src/NetworkOptimizer.Web/Services/Ssh/GatewaySshService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/GatewaySshService.cs
@@ -342,6 +342,34 @@ public class GatewaySshService : IGatewaySshService
     }
 
     /// <inheritdoc />
+    public async Task<SshCommandResult> RunCommandStreamingAsync(
+        string command,
+        Action<string> onOutput,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var settings = await GetSettingsAsync();
+
+        if (!settings.Enabled)
+            return StreamingPreconditionFailure("Gateway SSH access is disabled");
+
+        if (string.IsNullOrEmpty(settings.Host))
+            return StreamingPreconditionFailure("Gateway host not configured");
+
+        if (!settings.HasCredentials)
+            return StreamingPreconditionFailure("SSH credentials not configured");
+
+        if (await IsAwaitingAgentAsync())
+            return StreamingPreconditionFailure(AwaitingAgentMessage);
+
+        var connection = await CreateConnectionInfoAsync(settings);
+        return await _sshClient.ExecuteCommandStreamingAsync(connection, command, onOutput, timeout, cancellationToken);
+    }
+
+    private static SshCommandResult StreamingPreconditionFailure(string message) =>
+        new() { Success = false, ExitCode = -1, Error = message };
+
+    /// <inheritdoc />
     public async Task<SshConnectionInfo?> GetConnectionInfoAsync()
     {
         var settings = await GetSettingsAsync();

--- a/src/NetworkOptimizer.Web/Services/Ssh/IGatewaySshService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/IGatewaySshService.cs
@@ -63,6 +63,23 @@ public interface IGatewaySshService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Run an SSH command on the gateway, streaming its stdout/stderr to
+    /// <paramref name="onOutput"/> as it arrives. For long-running commands whose progress
+    /// the UI shows live (the gateway agent installer). The result carries the exit code but
+    /// no output; a precondition failure (SSH disabled, unconfigured, agent tunnel down)
+    /// comes back as a failed result whose Error says why.
+    /// </summary>
+    /// <param name="command">Command to execute</param>
+    /// <param name="onOutput">Receives output chunks; may be called on any thread</param>
+    /// <param name="timeout">Overall command timeout</param>
+    /// <param name="cancellationToken">Cancels the run (kills the channel)</param>
+    Task<SshCommandResult> RunCommandStreamingAsync(
+        string command,
+        Action<string> onOutput,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Ready-to-use connection info for direct SSH.NET operations (SFTP uploads),
     /// with decrypted credentials and any agent-tunnel routing applied.
     /// Null when gateway SSH is disabled or not configured.

--- a/src/NetworkOptimizer.Web/Services/Ssh/SshClientService.cs
+++ b/src/NetworkOptimizer.Web/Services/Ssh/SshClientService.cs
@@ -125,6 +125,132 @@ public class SshClientService
     }
 
     /// <summary>
+    /// Execute a command over SSH, streaming stdout and stderr to <paramref name="onOutput"/>
+    /// as they arrive (drained every 200 ms). For long-running commands whose progress the UI
+    /// shows live (the gateway agent installer). The callback may fire on any thread. The
+    /// returned result carries the exit code but no output - it already went to the callback.
+    /// Cancellation (user cancel or the caller's overall timeout) kills the channel and
+    /// surfaces as <see cref="OperationCanceledException"/>.
+    /// </summary>
+    public async Task<SshCommandResult> ExecuteCommandStreamingAsync(
+        SshConnectionInfo connection,
+        string command,
+        Action<string> onOutput,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        using var client = CreateSshClient(connection);
+
+        try
+        {
+            await Task.Run(() => client.Connect(), cancellationToken);
+
+            using var cmd = client.CreateCommand(command);
+            cmd.CommandTimeout = timeout;
+
+            var exec = cmd.ExecuteAsync(cancellationToken);
+            var stdout = new StreamTextDrainer(() => cmd.OutputStream, onOutput);
+            var stderr = new StreamTextDrainer(() => cmd.ExtendedOutputStream, onOutput);
+
+            while (!exec.IsCompleted)
+            {
+                // The delay is deliberately not cancellable: exec observes the token, and the
+                // loop must reach the final drain below so what arrived before a cancel is kept.
+                await Task.Delay(200, CancellationToken.None);
+                stdout.Drain();
+                stderr.Drain();
+            }
+            stdout.Drain();
+            stderr.Drain();
+
+            await exec;
+
+            _logger.LogDebug("SSH streaming command to {Host}: '{Command}' -> exit {ExitCode}",
+                connection.Host, TruncateForLog(command), cmd.ExitStatus);
+
+            return new SshCommandResult
+            {
+                Success = cmd.ExitStatus == 0,
+                ExitCode = cmd.ExitStatus ?? -1,
+                Error = cmd.Error ?? ""
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (SshAuthenticationException ex)
+        {
+            _logger.LogError("SSH authentication failed for {Host}: {Error}", connection.Host, ex.Message);
+            return new SshCommandResult { Success = false, ExitCode = -1, Error = $"Authentication failed: {ex.Message}" };
+        }
+        catch (SshConnectionException ex)
+        {
+            var explained = ExplainConnectionFailure(connection, ex.Message);
+            _logger.LogError("SSH connection failed for {Host}: {Error}", connection.Host, explained);
+            return new SshCommandResult { Success = false, ExitCode = -1, Error = $"Connection failed: {explained}" };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "SSH error executing streaming command on {Host}", connection.Host);
+            return new SshCommandResult { Success = false, ExitCode = -1, Error = ex.Message };
+        }
+        finally
+        {
+            if (client.IsConnected)
+            {
+                client.Disconnect();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drains whatever bytes a command output stream has buffered, without ever blocking on it,
+    /// and hands them on as decoded text. The stream is resolved per drain because SSH.NET only
+    /// materializes a command's streams once execution starts.
+    /// </summary>
+    private sealed class StreamTextDrainer
+    {
+        private readonly Func<Stream?> _stream;
+        private readonly Action<string> _onOutput;
+        private readonly Decoder _decoder = Encoding.UTF8.GetDecoder();
+        private readonly byte[] _buffer = new byte[8192];
+        private readonly char[] _chars = new char[8200];
+
+        public StreamTextDrainer(Func<Stream?> stream, Action<string> onOutput)
+        {
+            _stream = stream;
+            _onOutput = onOutput;
+        }
+
+        public void Drain()
+        {
+            while (true)
+            {
+                Stream? stream;
+                int available;
+                try
+                {
+                    stream = _stream();
+                    if (stream == null) return;
+                    available = (int)Math.Min(stream.Length, _buffer.Length);
+                }
+                catch (ObjectDisposedException)
+                {
+                    return;
+                }
+                if (available <= 0) return;
+
+                var read = stream.Read(_buffer, 0, available);
+                if (read <= 0) return;
+
+                var charCount = _decoder.GetChars(_buffer, 0, read, _chars, 0);
+                if (charCount > 0) _onOutput(new string(_chars, 0, charCount));
+            }
+        }
+    }
+
+    /// <summary>
     /// Test SSH connection to the host.
     /// </summary>
     /// <param name="connection">SSH connection information</param>

--- a/tests/NetworkOptimizer.Web.Tests/GatewayAgentInstallTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GatewayAgentInstallTests.cs
@@ -80,45 +80,33 @@ public class GatewayAgentInstallGateTests
     [Fact]
     public void IsCandidate_AllConditionsMet_True()
     {
-        GatewayAgentInstallService.IsCandidate(
-            serverUrlConfigured: true, routedViaAgent: false, ConfiguredSettings())
+        GatewayAgentInstallService.IsCandidate(serverUrlConfigured: true, ConfiguredSettings())
             .Should().BeTrue();
     }
 
     [Fact]
     public void IsCandidate_NoServerUrl_False()
     {
-        GatewayAgentInstallService.IsCandidate(
-            serverUrlConfigured: false, routedViaAgent: false, ConfiguredSettings())
-            .Should().BeFalse();
-    }
-
-    [Fact]
-    public void IsCandidate_RoutedViaAgent_False()
-    {
-        // Tunnel-relayed SSH is out of v1: the run would ride the tunnel of the very agent
-        // the installer restarts.
-        GatewayAgentInstallService.IsCandidate(
-            serverUrlConfigured: true, routedViaAgent: true, ConfiguredSettings())
+        GatewayAgentInstallService.IsCandidate(serverUrlConfigured: false, ConfiguredSettings())
             .Should().BeFalse();
     }
 
     [Fact]
     public void IsCandidate_SshNotConfigured_False()
     {
-        GatewayAgentInstallService.IsCandidate(true, false, null).Should().BeFalse();
+        GatewayAgentInstallService.IsCandidate(true, null).Should().BeFalse();
 
         var disabled = ConfiguredSettings();
         disabled.Enabled = false;
-        GatewayAgentInstallService.IsCandidate(true, false, disabled).Should().BeFalse();
+        GatewayAgentInstallService.IsCandidate(true, disabled).Should().BeFalse();
 
         var noHost = ConfiguredSettings();
         noHost.Host = null;
-        GatewayAgentInstallService.IsCandidate(true, false, noHost).Should().BeFalse();
+        GatewayAgentInstallService.IsCandidate(true, noHost).Should().BeFalse();
 
         var noCredentials = ConfiguredSettings();
         noCredentials.Password = null;
-        GatewayAgentInstallService.IsCandidate(true, false, noCredentials).Should().BeFalse();
+        GatewayAgentInstallService.IsCandidate(true, noCredentials).Should().BeFalse();
     }
 
     [Fact]
@@ -128,7 +116,80 @@ public class GatewayAgentInstallGateTests
         settings.Password = null;
         settings.HasStoredKey = true;
 
-        GatewayAgentInstallService.IsCandidate(true, false, settings).Should().BeTrue();
+        GatewayAgentInstallService.IsCandidate(true, settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildDetachedStart_EmbedsThePayloadVerbatim()
+    {
+        var command = GatewayAgentCommands.Install("https://optimizer.example.com", "noa_abc123");
+
+        var start = GatewayAgentInstallService.BuildDetachedStart(command);
+
+        // The whole point of the detach wrapper: the displayed command runs unchanged inside it.
+        start.Should().Contain(command);
+        start.Should().Contain("nohup bash -c");
+        start.Should().Contain("/tmp/netopt-gateway-run.exit");
+        start.Should().Contain("/tmp/netopt-gateway-run.pid");
+    }
+
+    [Fact]
+    public void BuildDetachedStart_EscapesSingleQuotesForTheWrapper()
+    {
+        var start = GatewayAgentInstallService.BuildDetachedStart("echo 'hi'");
+
+        start.Should().Contain("echo '\\''hi'\\''");
+    }
+
+    [Fact]
+    public void ParsePollOutput_StillRunning_ReturnsLogWithoutExit()
+    {
+        var reply = "__NETOPT_LOG__\n==> Downloading agent binary\n\n__NETOPT_EXIT__:\n";
+
+        var parsed = GatewayAgentInstallService.ParsePollOutput(reply);
+
+        parsed.Should().NotBeNull();
+        parsed!.Value.Log.Should().Be("==> Downloading agent binary\n");
+        parsed.Value.ExitCode.Should().BeNull();
+    }
+
+    [Fact]
+    public void ParsePollOutput_Finished_ReturnsExitCode()
+    {
+        var reply = "__NETOPT_LOG__\nDone\n\n__NETOPT_EXIT__:0\n";
+
+        var parsed = GatewayAgentInstallService.ParsePollOutput(reply);
+
+        parsed!.Value.Log.Should().Be("Done\n");
+        parsed.Value.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public void ParsePollOutput_BannerAheadOfMarker_IsIgnored()
+    {
+        var reply = "Welcome to UniFi OS\n__NETOPT_LOG__\nline\n\n__NETOPT_EXIT__:1\n";
+
+        var parsed = GatewayAgentInstallService.ParsePollOutput(reply);
+
+        parsed!.Value.Log.Should().Be("line\n");
+        parsed.Value.ExitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public void ParsePollOutput_NoMarkers_ReturnsNull()
+    {
+        GatewayAgentInstallService.ParsePollOutput("Connection failed: banner").Should().BeNull();
+        GatewayAgentInstallService.ParsePollOutput("").Should().BeNull();
+    }
+
+    [Fact]
+    public void ParsePollOutput_EmptyLogAtRunStart_IsRunning()
+    {
+        var parsed = GatewayAgentInstallService.ParsePollOutput("__NETOPT_LOG__\n\n__NETOPT_EXIT__:\n");
+
+        parsed.Should().NotBeNull();
+        parsed!.Value.Log.Should().Be("");
+        parsed.Value.ExitCode.Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/GatewayAgentInstallTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/GatewayAgentInstallTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests;
+
+/// <summary>
+/// The "Run It for Me" shared command builder - the one source for both the displayed
+/// gateway one-liners and the SSH run, so what these assert is exactly what executes.
+/// </summary>
+public class GatewayAgentCommandsTests
+{
+    [Fact]
+    public void Install_IncludesServerAndToken()
+    {
+        var command = GatewayAgentCommands.Install("https://optimizer.example.com", "noa_abc123");
+
+        command.Should().Contain("scripts/agent/install-agent-gateway.sh");
+        command.Should().Contain("--server \"https://optimizer.example.com\"");
+        command.Should().Contain("--token \"noa_abc123\"");
+    }
+
+    [Fact]
+    public void Install_TrimsTrailingSlashFromServerUrl()
+    {
+        var command = GatewayAgentCommands.Install("https://optimizer.example.com/", "noa_abc123");
+
+        command.Should().Contain("--server \"https://optimizer.example.com\"");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Install_UnsetServerUrl_UsesPlaceholder(string? serverUrl)
+    {
+        var command = GatewayAgentCommands.Install(serverUrl, "noa_abc123");
+
+        command.Should().Contain($"--server \"{GatewayAgentCommands.PlaceholderServerUrl}\"");
+    }
+
+    [Fact]
+    public void Install_IsMonitoringOnlyAndRootRun()
+    {
+        var command = GatewayAgentCommands.Install("https://optimizer.example.com", "noa_abc123");
+
+        // The gateway installer must never host the LAN speed test, and UniFi gateways SSH in
+        // as root, so neither flag nor sudo may creep in.
+        command.Should().NotContain("--lan-speed-test");
+        command.Should().NotContain("sudo");
+        command.Should().NotContain("--insecure");
+    }
+
+    [Fact]
+    public void Upgrade_HasServerButNoToken()
+    {
+        var command = GatewayAgentCommands.Upgrade("https://optimizer.example.com");
+
+        command.Should().Contain("scripts/agent/install-agent-gateway.sh");
+        command.Should().Contain("--server \"https://optimizer.example.com\"");
+        command.Should().NotContain("--token");
+    }
+}
+
+/// <summary>
+/// The availability gate's configuration half (the dial is exercised live) and the per-site
+/// run bookkeeping: one run at a time, a second start refused rather than queued.
+/// </summary>
+public class GatewayAgentInstallGateTests
+{
+    private static GatewaySshSettings ConfiguredSettings() => new()
+    {
+        Enabled = true,
+        Host = "192.0.2.1",
+        Username = "root",
+        Password = "encrypted",
+    };
+
+    [Fact]
+    public void IsCandidate_AllConditionsMet_True()
+    {
+        GatewayAgentInstallService.IsCandidate(
+            serverUrlConfigured: true, routedViaAgent: false, ConfiguredSettings())
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsCandidate_NoServerUrl_False()
+    {
+        GatewayAgentInstallService.IsCandidate(
+            serverUrlConfigured: false, routedViaAgent: false, ConfiguredSettings())
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCandidate_RoutedViaAgent_False()
+    {
+        // Tunnel-relayed SSH is out of v1: the run would ride the tunnel of the very agent
+        // the installer restarts.
+        GatewayAgentInstallService.IsCandidate(
+            serverUrlConfigured: true, routedViaAgent: true, ConfiguredSettings())
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCandidate_SshNotConfigured_False()
+    {
+        GatewayAgentInstallService.IsCandidate(true, false, null).Should().BeFalse();
+
+        var disabled = ConfiguredSettings();
+        disabled.Enabled = false;
+        GatewayAgentInstallService.IsCandidate(true, false, disabled).Should().BeFalse();
+
+        var noHost = ConfiguredSettings();
+        noHost.Host = null;
+        GatewayAgentInstallService.IsCandidate(true, false, noHost).Should().BeFalse();
+
+        var noCredentials = ConfiguredSettings();
+        noCredentials.Password = null;
+        GatewayAgentInstallService.IsCandidate(true, false, noCredentials).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsCandidate_StoredKeyCountsAsCredentials()
+    {
+        var settings = ConfiguredSettings();
+        settings.Password = null;
+        settings.HasStoredKey = true;
+
+        GatewayAgentInstallService.IsCandidate(true, false, settings).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartRun_SecondStartWhileRunning_IsRefused()
+    {
+        var state = new GatewayAgentInstallState();
+        state.StartRun("site-a", isUpgrade: false, "busy");
+
+        var refusal = () => state.StartRun("site-a", isUpgrade: true, "busy");
+
+        refusal.Should().Throw<InvalidOperationException>().WithMessage("busy");
+    }
+
+    [Fact]
+    public void StartRun_OtherSiteOrFinishedRun_IsAllowed()
+    {
+        var state = new GatewayAgentInstallState();
+        var first = state.StartRun("site-a", isUpgrade: false, "busy");
+
+        // Another site is independent.
+        state.StartRun("site-b", isUpgrade: false, "busy");
+
+        // A finished run frees the site.
+        first.Complete(GatewayAgentInstallStatus.Failed, 1, null);
+        var second = state.StartRun("site-a", isUpgrade: true, "busy");
+
+        state.GetRun("site-a").Should().BeSameAs(second);
+    }
+
+    [Fact]
+    public void Run_TranscriptAccumulatesAndUpdatesFire()
+    {
+        var run = new GatewayAgentInstallRun("site-a", isUpgrade: false);
+        var updates = 0;
+        run.Updated += () => updates++;
+
+        run.Append("==> Downloading agent binary\n");
+        run.Append("  ✓ agent (linux-arm64)\n");
+        run.Complete(GatewayAgentInstallStatus.Succeeded, 0, null);
+
+        run.Transcript.Should().Be("==> Downloading agent binary\n  ✓ agent (linux-arm64)\n");
+        run.Status.Should().Be(GatewayAgentInstallStatus.Succeeded);
+        run.ExitCode.Should().Be(0);
+        updates.Should().Be(3);
+    }
+}


### PR DESCRIPTION
## Multi-Site

- **Run It for Me** - when a site's gateway SSH is configured and the gateway answers a dial, the On-Site Agent gateway install and upgrade one-liners gain a button that runs that exact command on the gateway and streams the installer's output into the page. One run at a time per site, a 10-minute overall cap (no inactivity timeout - the agent binary download is a silent curl), and a Cancel that kills the run on the gateway; the installer is idempotent, so a canceled run heals by running again. The run finishes server-side even if the page is closed, and returning shows the transcript.
- **Works on agent-tunnel-routed sites too.** The command runs detached on the gateway (nohup into a log file plus an exit-code file) and the server polls the output back over short SSH dials, so the agent restart at the end of the installer - which drops the tunnel that site's SSH rides - cannot kill the run; polls just retry through the reconnect window. One mechanism for every site, direct or tunnel-routed.
- The displayed command and the executed one come from one shared builder (`GatewayAgentCommands`), and the payload inside the detach wrapper is byte-identical to the displayed one-liner. The PREVIEW-CYCLE PIN comment moved into the builder with the string; marker inventory is unchanged.
- Availability resolves before the button renders: agent-facing server URL set, gateway SSH configured, and a test dial succeeding (cached 30 s, deduped). Sites that fail the gate keep the copy-paste command as their path.
- RBAC: new `IGatewayAgentInstallService`, gated per target site - availability and transcript reads at Site Viewer, run and cancel at Site Admin - with an audit event (`agent.gateway_install.run`) recording install vs upgrade, the exit code, and the gateway host.
- Plumbing: streaming command execution added to the existing SSH layer (`SshClientService` / `IGatewaySshService`) as general capability for long-running gateway commands - no new SSH stack, no agent or protocol changes, no migrations.

## Tests

- Shared command builder (server URL handling, token presence, monitoring-only flags), the availability gate matrix, the detach wrapper (payload embedded verbatim, quote escaping), the poll-reply parser, and the one-run-per-site bookkeeping, in `NetworkOptimizer.Web.Tests`.