### PR TITLE
AP Agent: probe transfer capability, fall back to SCP then direct copy (#1182)

### DIFF
--- a/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
@@ -28,12 +28,11 @@
     </div>
     <div class="card-body">
         <p class="section-description">
-            The AP Agent is a small service Network Optimizer installs on each UniFi access point over
-            SSH. It reads what the UniFi Console does not expose: per-client retries, TCP stalls, and
-            airtime, plus roam timing and radio health. That sharpens channel recommendations, catches
-            a wedged radio before clients give up on the band, and lets Client Performance provide
-            truly real-time signal and roaming data. Any AP without it falls back to UniFi Console
-            data, so nothing breaks when one is missing.
+            A small service Network Optimizer installs on each access point over SSH to read what the
+            UniFi Console doesn't expose: per-client retries, TCP stalls, airtime, roam timing, and
+            radio health. That sharpens channel recommendations, catches a wedged radio before clients
+            give up on the band, and makes Client Performance truly real-time. Any AP without it falls
+            back to UniFi Console data.
         </p>
 
         @if (!_loaded)

--- a/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
@@ -144,7 +144,7 @@
                             @foreach (var entry in _fleet)
                             {
                                 var mac = entry.DeviceMac;
-                                var busy = _busyMacs.Contains(mac);
+                                var busy = _busyMacs.Contains(mac) || entry.DeployInProgress;
                                 var view = StatusView(entry);
                                 <tr class="@RowClass(entry)"
                                     @onclick="@(() => IsRowOpen(mac) ? CollapsePanelsAsync() : Task.CompletedTask)">
@@ -550,6 +550,39 @@
         {
             Logger.LogDebug(ex, "AP Agent fleet refresh failed");
         }
+        QueueFastRefresh();
+    }
+
+    private bool _fastRefreshQueued;
+
+    /// <summary>
+    /// Re-polls the fleet on a short cadence while the server has work in flight, so server-driven
+    /// deploys show live progress without waiting for the 30 s timer. One refresh is queued at a
+    /// time and the chain stops on the first poll that finds nothing in flight.
+    /// </summary>
+    private void QueueFastRefresh(bool force = false)
+    {
+        if (_fastRefreshQueued || (!force && !_fleet.Any(e => e.DeployInProgress))) return;
+        _fastRefreshQueued = true;
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(3000);
+                await InvokeAsync(async () =>
+                {
+                    _fastRefreshQueued = false;
+                    if (!Active || !_deviceSshConfigured) return;
+                    await RefreshFleetAsync();
+                    StateHasChanged();
+                });
+            }
+            catch
+            {
+                // A disposed circuit ends the chain; the 30 s timer covers anything left.
+                _fastRefreshQueued = false;
+            }
+        });
     }
 
     private void ShowMessage(string text, string cssClass)
@@ -569,9 +602,9 @@
     private static bool IsDeployable(ApAgentFleetEntry e) =>
         e.DeviceOnline && e.State is ApAgentState.Unknown or ApAgentState.NotListening;
 
-    /// <summary>Rows Deploy to All Eligible picks up. Filtered and offline APs are deliberately not eligible.</summary>
+    /// <summary>Rows Deploy to All Eligible picks up. Filtered, offline, and mid-deploy APs are deliberately not eligible.</summary>
     private bool IsEligible(ApAgentFleetEntry e) =>
-        e.Enabled && IsDeployable(e) && !_busyMacs.Contains(e.DeviceMac);
+        e.Enabled && IsDeployable(e) && !_busyMacs.Contains(e.DeviceMac) && !e.DeployInProgress;
 
     private int EligibleCount => _fleet.Count(IsEligible);
     private int RunningCount => _fleet.Count(IsRunning);
@@ -629,7 +662,9 @@
 
     private (string Dot, string Label, string? Note) StatusView(ApAgentFleetEntry e)
     {
-        if (_busyMacs.Contains(e.DeviceMac))
+        // DeployInProgress covers server-driven deploys (the pass after enabling the site,
+        // supervision redeploys), so those show as Deploying without the user pressing anything.
+        if (_busyMacs.Contains(e.DeviceMac) || e.DeployInProgress)
             return ("", "Deploying", _rowProgress.TryGetValue(e.DeviceMac, out var p) ? p : null);
 
         if (e.State != ApAgentState.Unsupported && !e.Enabled)
@@ -729,6 +764,13 @@
         try
         {
             await ApAgents.SetSiteEnabledAsync(_siteEnabled);
+            // Enabling kicks a server-side deploy pass; force one fast poll so its Deploying rows
+            // appear right away, and the chain keeps refreshing while work is in flight.
+            if (_siteEnabled)
+            {
+                await RefreshFleetAsync();
+                QueueFastRefresh(force: true);
+            }
         }
         catch (Exception ex)
         {
@@ -775,7 +817,9 @@
                     StateHasChanged();
                 }));
             var result = await ApAgents.DeployAsync(mac, progress);
-            if (!result.Success)
+            // An in-flight refusal is benign - the server is already deploying to this AP, and the
+            // refresh below renders that work's own Deploying row instead of an error.
+            if (!result.Success && !result.AlreadyInProgress)
                 ShowMessage($"Deploying to {entry.DeviceName} failed: {result.Error}", "danger");
         }
         catch (Exception ex)

--- a/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/ApTelemetryPanel.razor
@@ -2,6 +2,7 @@
    sites-table pattern, the firmware-wipe alert above it, and the per-AP capability report expanding
    inline through the same collapse machinery the Sites table uses. *@
 
+@using NetworkOptimizer.Core.Helpers
 @using NetworkOptimizer.Web.Services.ApAgent
 @using NetworkOptimizer.Web.Services.Ssh
 @implements IDisposable
@@ -269,11 +270,19 @@
                                                             {
                                                                 <span class="ap-agent-note">The capability report did not load; the AP Agent may be mid-restart. Check Status to try again.</span>
                                                             }
+                                                            else if (entry.State == ApAgentState.TransferFailed && !string.IsNullOrEmpty(entry.Detail))
+                                                            {
+                                                                <span class="ap-agent-note">@TransferFailureLead(entry)</span>
+                                                                @foreach (var line in TransferFailureLines(entry))
+                                                                {
+                                                                    <span class="ap-agent-note">@line</span>
+                                                                }
+                                                            }
                                                             else if (!string.IsNullOrEmpty(entry.Detail))
                                                             {
                                                                 <span class="ap-agent-note">@entry.Detail</span>
                                                             }
-                                                            @if (!string.IsNullOrEmpty(entry.LastError) && entry.LastError != entry.Detail)
+                                                            @if (!string.IsNullOrEmpty(entry.LastError) && entry.LastError != entry.Detail && entry.State != ApAgentState.TransferFailed)
                                                             {
                                                                 <span class="ap-agent-note">Last error: @entry.LastError</span>
                                                             }
@@ -307,6 +316,10 @@
                                                                     </div>
                                                                 }
                                                             </div>
+                                                        }
+                                                        @if (!string.IsNullOrEmpty(entry.TransferNote))
+                                                        {
+                                                            <span class="ap-agent-note">@entry.TransferNote</span>
                                                         }
                                                         <div class="ap-agent-cap-footer">
                                                             <label class="checkbox-toggle" @onclick:stopPropagation="true">
@@ -466,6 +479,23 @@
 
     private static string Ago(DateTime utc) => TimeFormatHelper.FormatRelativeTime(utc);
 
+    /// <summary>
+    /// The transfer-failure lead line. The model and firmware are rendered from the fleet entry at
+    /// display time rather than baked into the persisted error, so a replaced device never shows a
+    /// stale model name.
+    /// </summary>
+    private static string TransferFailureLead(ApAgentFleetEntry e)
+    {
+        var firmware = FirmwareVersionFormat.ShortOrNull(e.Firmware);
+        return firmware == null
+            ? "Could not copy the AP Agent to this access point."
+            : $"Could not copy the AP Agent to this access point. {e.Model} on firmware {firmware}.";
+    }
+
+    /// <summary>The per-method lines of the transfer-failure detail, after its lead sentence.</summary>
+    private static IEnumerable<string> TransferFailureLines(ApAgentFleetEntry e)
+        => (e.Detail ?? "").Split('\n').Skip(1);
+
     protected override async Task OnParametersSetAsync()
     {
         if (Active && !_loaded && !_loading)
@@ -609,7 +639,8 @@
         {
             ApAgentState.Healthy => ("online", "Running", null),
             ApAgentState.OutOfDate => ("online", "Running", null),
-            ApAgentState.Unsupported => ("offline", "Unsupported model", e.Detail),
+            ApAgentState.Unsupported => ("offline", "Unsupported hardware", e.Detail),
+            ApAgentState.TransferFailed => ("error", "Transfer failed", null),
             ApAgentState.ApOffline => ("offline", "AP offline", "Deployment waits for the access point to come back."),
             ApAgentState.Wedged => ("error", "Stalled", "Answering, but its probes stopped; it is restarted in place automatically."),
             ApAgentState.Unauthorized => ("error", "Token mismatch", "The AP Agent rejected this server's token; the token is re-pushed automatically."),

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentBinaryTransfer.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentBinaryTransfer.cs
@@ -5,15 +5,16 @@ namespace NetworkOptimizer.Web.Services.ApAgent;
 /// <summary>
 /// How the agent binary crosses the wire to an access point.
 ///
-/// This is a seam rather than a call because the method is not settled. SFTP, SCP, and streaming
-/// into <c>cat</c> were all measured working on a real AP (dropbear v2025.89), but with the OpenSSH
-/// CLI - not with SSH.NET, which is what actually runs here. SFTP is the default; if SSH.NET trips
-/// on dropbear, SCP is the drop-in and cat-over-exec is the floor, and swapping is a setting rather
-/// than a code change at every call site.
+/// Capability varies by firmware - dropbear's scp comes free as a multi-call symlink while
+/// sftp-server is a separate optional binary - so the status probe tests for each and
+/// <see cref="ApAgentTransferSelector"/> orders the chain from what the AP actually has, ending at
+/// cat-over-exec, which needs nothing but a shell. A present binary is still not proof SSH.NET can
+/// drive dropbear's implementation of it (all three were measured working with the OpenSSH CLI,
+/// not SSH.NET), so a failed attempt falls through to the next method rather than failing the deploy.
 /// </summary>
 public interface IApAgentBinaryTransfer
 {
-    /// <summary>Setting value that selects this implementation.</summary>
+    /// <summary>Method name, matched when ordering the chain and named in logs.</summary>
     string Name { get; }
 
     /// <summary>Uploads a local file to the AP.</summary>
@@ -54,24 +55,34 @@ public sealed class ExecApAgentBinaryTransfer(SshClientService sshClient) : IApA
 }
 
 /// <summary>
-/// Picks the transfer implementation. The default is SFTP; a site sets
-/// <see cref="TransferMethodSettingKey"/> to "scp" or "exec" to swap it without a code change.
+/// Orders the transfer chain from what the status probe measured on the access point: SFTP when
+/// the firmware ships sftp-server, then SCP when it ships scp, and cat-over-exec always last.
+/// Resolution is per-AP from the probe rather than a stored preference, which is what lets a
+/// mixed fleet put each AP on the fastest path its firmware supports.
 /// </summary>
 public sealed class ApAgentTransferSelector(IEnumerable<IApAgentBinaryTransfer> transfers)
 {
-    /// <summary>Per-site setting key naming the transfer method.</summary>
-    public const string TransferMethodSettingKey = "ap_agent.transfer";
+    /// <summary>The SFTP transfer, the fast default when the firmware supports it.</summary>
+    public const string SftpMethod = "sftp";
 
-    /// <summary>The method used when nothing has been configured.</summary>
-    public const string DefaultMethod = "sftp";
+    /// <summary>The SCP transfer.</summary>
+    public const string ScpMethod = "scp";
+
+    /// <summary>The cat-over-exec transfer, the floor that needs nothing but a shell.</summary>
+    public const string ExecMethod = "exec";
 
     private readonly IReadOnlyList<IApAgentBinaryTransfer> _transfers = transfers.ToList();
 
-    /// <summary>The transfer for a configured method name, falling back to the default.</summary>
-    public IApAgentBinaryTransfer Resolve(string? method)
+    /// <summary>The transfers to attempt in order for what the probe found, always ending in exec.</summary>
+    public IReadOnlyList<IApAgentBinaryTransfer> Resolve(ApAgentSshStatus status)
     {
-        var wanted = string.IsNullOrWhiteSpace(method) ? DefaultMethod : method.Trim();
-        return _transfers.FirstOrDefault(t => string.Equals(t.Name, wanted, StringComparison.OrdinalIgnoreCase))
-            ?? _transfers.First(t => t.Name == DefaultMethod);
+        var chain = new List<IApAgentBinaryTransfer>(3);
+        if (status.SftpAvailable) chain.Add(ByName(SftpMethod));
+        if (status.ScpAvailable) chain.Add(ByName(ScpMethod));
+        chain.Add(ByName(ExecMethod));
+        return chain;
     }
+
+    private IApAgentBinaryTransfer ByName(string name)
+        => _transfers.First(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase));
 }

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentDeploymentService.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Microsoft.EntityFrameworkCore;
 using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Core.Helpers;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
 using NetworkOptimizer.UniFi;
@@ -55,6 +56,12 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
 
     private readonly ApAgentRetryPolicy _retry = new();
     private readonly Dictionary<string, ApAgentAssessment> _lastAssessment = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>How the binary last crossed the wire per AP, when not over SFTP. In-memory like the assessments.</summary>
+    private readonly Dictionary<string, string> _transferNotes = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Firmware last probed per AP, rendered into the transfer-failure detail at display time.</summary>
+    private readonly Dictionary<string, string> _lastFirmware = new(StringComparer.OrdinalIgnoreCase);
     private DeviceRebootTracker? _rebootTracker;
     private bool _disposed;
 
@@ -206,6 +213,10 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
             records.TryGetValue(mac, out var record);
             ApAgentAssessment? assessment;
             lock (_lastAssessment) _lastAssessment.TryGetValue(mac, out assessment);
+            string? transferNote;
+            lock (_transferNotes) _transferNotes.TryGetValue(mac, out transferNote);
+            string? firmware;
+            lock (_lastFirmware) _lastFirmware.TryGetValue(mac, out firmware);
 
             fleet.Add(new ApAgentFleetEntry
             {
@@ -219,6 +230,8 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
                 RecommendedAction = assessment?.Action ?? ApAgentAction.None,
                 Detail = assessment?.Detail,
                 Architecture = record?.Architecture,
+                Firmware = firmware,
+                TransferNote = transferNote,
                 DeployedVersion = record?.DeployedVersion,
                 DeployedBinaryVersion = record?.DeployedBinaryVersion,
                 LastDeployedAt = record?.LastDeployedAt,
@@ -348,6 +361,7 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
 
         _retry.Forget(mac);
         lock (_lastAssessment) _lastAssessment.Remove(mac);
+        lock (_transferNotes) _transferNotes.Remove(mac);
         _directory.Invalidate(_siteSlug);
 
         _logger.LogInformation("AP Agent removed from {Host} on site {Site}", ap.DisplayIpAddress, _siteSlug);
@@ -544,6 +558,9 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
 
         await UpdateRecordAsync(mac, r => r.Architecture = status.Machine, ct);
 
+        if (!string.IsNullOrEmpty(status.Firmware))
+            lock (_lastFirmware) _lastFirmware[mac] = status.Firmware;
+
         if (!status.SupportedArchitecture)
         {
             var reason = ApAgentScripts.UnsupportedReason(status.Machine);
@@ -574,9 +591,11 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         if (!binaryIsCurrent)
         {
             progress?.Report("Transferring the agent...");
-            var transferred = await TransferBinaryAsync(ap.DisplayIpAddress, localPath, ct);
+            var transferred = await TransferBinaryAsync(mac, ap.DisplayIpAddress, localPath, localMd5, status, ct);
             if (!transferred.Success)
             {
+                if (transferred.State == ApAgentState.TransferFailed)
+                    lock (_lastAssessment) _lastAssessment[mac] = new ApAgentAssessment(ApAgentState.TransferFailed, ApAgentAction.None, transferred.Error!);
                 await RecordFailureAsync(mac, transferred.Error, ct);
                 return transferred;
             }
@@ -620,7 +639,14 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         return ApAgentOperationResult.Ok();
     }
 
-    private async Task<ApAgentOperationResult> TransferBinaryAsync(string host, string localPath, CancellationToken ct)
+    /// <summary>
+    /// Pushes the binary over the probed transfer chain, attempting each method in order until one
+    /// both uploads and verifies. The md5 comparison is the only integrity check in the path:
+    /// without it a truncated binary surfaces as "The agent did not start" and burns a retry cycle
+    /// before the next pass's md5 catches it.
+    /// </summary>
+    private async Task<ApAgentOperationResult> TransferBinaryAsync(
+        string mac, string host, string localPath, string localMd5, ApAgentSshStatus status, CancellationToken ct)
     {
         var connection = await BuildConnectionAsync(host);
         if (connection == null)
@@ -630,21 +656,101 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         if (!mkdir.success)
             return ApAgentOperationResult.Fail($"Could not create the install directory: {mkdir.output}");
 
-        var transfer = await ResolveTransferAsync();
-        try
+        var failures = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var transfer in _transferSelector.Resolve(status))
         {
-            await transfer.UploadAsync(connection, localPath, ApAgentPaths.RemoteBinaryPath, ct);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "AP Agent transfer to {Host} failed over {Method}", host, transfer.Name);
-            return ApAgentOperationResult.Fail($"Transferring the agent over {transfer.Name} failed: {ex.Message}");
+            string? error = null;
+            try
+            {
+                await transfer.UploadAsync(connection, localPath, ApAgentPaths.RemoteBinaryPath, ct);
+
+                var check = await _siteSsh.RunCommandAsync(host,
+                    $"md5sum {ApAgentPaths.RemoteBinaryPath} 2>/dev/null | cut -d' ' -f1", null, SshTimeout, ct);
+                if (!check.success || !string.Equals(check.output.Trim(), localMd5, StringComparison.OrdinalIgnoreCase))
+                    error = "The copied file did not match the original (md5 mismatch).";
+            }
+            catch (OperationCanceledException) when (ct.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+            }
+
+            if (error != null)
+            {
+                failures[transfer.Name] = error;
+                _logger.LogDebug("AP Agent transfer to {Host} over {Method} failed: {Error}", host, transfer.Name, error);
+                continue;
+            }
+
+            var chmod = await _siteSsh.RunCommandAsync(host, $"chmod +x {ApAgentPaths.RemoteBinaryPath}", null, SshTimeout, ct);
+            if (!chmod.success)
+                return ApAgentOperationResult.Fail($"Could not make the agent executable: {chmod.output}");
+
+            // Information rather than Debug on a non-default method, so an AP sitting on a slower
+            // path is visible in the log rather than silently slow.
+            if (transfer.Name != ApAgentTransferSelector.SftpMethod)
+                _logger.LogInformation("AP Agent transferred to {Host} over {Method} on site {Site}", host, transfer.Name, _siteSlug);
+
+            var note = TransferNoteFor(transfer.Name, status);
+            lock (_transferNotes)
+            {
+                if (note == null) _transferNotes.Remove(mac);
+                else _transferNotes[mac] = note;
+            }
+
+            return ApAgentOperationResult.Ok();
         }
 
-        var chmod = await _siteSsh.RunCommandAsync(host, $"chmod +x {ApAgentPaths.RemoteBinaryPath}", null, SshTimeout, ct);
-        return chmod.success
-            ? ApAgentOperationResult.Ok()
-            : ApAgentOperationResult.Fail($"Could not make the agent executable: {chmod.output}");
+        var detail = string.Join("\n",
+            "Could not copy the AP Agent to this access point.",
+            "- SFTP: " + (failures.TryGetValue(ApAgentTransferSelector.SftpMethod, out var sftpError) ? sftpError : "not available on this firmware"),
+            "- SCP: " + (failures.TryGetValue(ApAgentTransferSelector.ScpMethod, out var scpError) ? scpError : "not available on this firmware"),
+            "- Direct copy: " + failures[ApAgentTransferSelector.ExecMethod]);
+        _logger.LogWarning("AP Agent transfer to {Host} on site {Site} failed over every method: {Detail}", host, _siteSlug, detail);
+        return ApAgentOperationResult.Fail(detail, ApAgentState.TransferFailed);
+    }
+
+    /// <summary>
+    /// The detail-panel note for a deploy that did not go over SFTP. Curated copy - do not reword.
+    /// "doesn't support" is only true of a method whose binary was genuinely absent; one that was
+    /// present and failed anyway was refused.
+    /// </summary>
+    private static string? TransferNoteFor(string method, ApAgentSshStatus status)
+    {
+        if (method == ApAgentTransferSelector.SftpMethod) return null;
+
+        bool unsupported;
+        string note;
+        if (method == ApAgentTransferSelector.ScpMethod)
+        {
+            unsupported = !status.SftpAvailable;
+            note = unsupported
+                ? "Copied over SCP: this firmware doesn't support SFTP."
+                : "Copied over SCP: SFTP was refused.";
+        }
+        else
+        {
+            unsupported = !status.SftpAvailable && !status.ScpAvailable;
+            note = unsupported
+                ? "Copied directly: this firmware doesn't support SFTP or SCP."
+                : "Copied directly: SFTP and SCP were refused.";
+        }
+
+        // Arch-gated ARM plus pre-8 firmware is a U6-class AP without needing a model list; the
+        // model is never a decision input here.
+        if (unsupported && FirmwareMajorBelow8(status.Firmware))
+            note += " U6 gets SFTP on the 8.8.5+ shared U7 stack firmware.";
+        return note;
+    }
+
+    private static bool FirmwareMajorBelow8(string? firmware)
+    {
+        var shortForm = FirmwareVersionFormat.ShortOrNull(firmware);
+        if (shortForm == null) return false;
+        return int.TryParse(shortForm.Split('.')[0], out var major) && major < 8;
     }
 
     private async Task<ApAgentOperationResult> WriteSupportFilesAsync(string host, string token, bool procdAvailable, CancellationToken ct)
@@ -707,14 +813,6 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
 
         (connection.Host, connection.Port) = await _tunnelRouting.RouteAsync(_siteSlug, connection.Host, connection.Port);
         return connection;
-    }
-
-    private async Task<IApAgentBinaryTransfer> ResolveTransferAsync()
-    {
-        using var scope = CreateSiteScope();
-        var db = scope.ServiceProvider.GetRequiredService<NetworkOptimizerDbContext>();
-        var setting = await db.SystemSettings.FindAsync(ApAgentTransferSelector.TransferMethodSettingKey);
-        return _transferSelector.Resolve(setting?.Value);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentDeploymentService.cs
@@ -226,6 +226,7 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
                 Host = ap.DisplayIpAddress,
                 DeviceOnline = IsOnline(ap),
                 Enabled = record?.Enabled ?? true,
+                DeployInProgress = _retry.IsWorkInFlight(mac),
                 State = assessment?.State ?? ApAgentState.Unknown,
                 RecommendedAction = assessment?.Action ?? ApAgentAction.None,
                 Detail = assessment?.Detail,
@@ -290,7 +291,7 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         // of a slow deploy would open a second SSH session and a second transfer to the same AP.
         using var claim = _retry.TryBeginWork(mac);
         if (claim == null)
-            return ApAgentOperationResult.Fail("A deployment is already running for this access point.");
+            return ApAgentOperationResult.InProgress();
 
         await _deployGate.WaitAsync(ct);
         try
@@ -312,7 +313,7 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         var mac = NormalizeMac(ap.Mac);
         using var claim = _retry.TryBeginWork(mac);
         if (claim == null)
-            return ApAgentOperationResult.Fail("A deployment is already running for this access point.");
+            return ApAgentOperationResult.InProgress();
 
         var status = await ProbeStatusAsync(ap.DisplayIpAddress, ct);
         if (!status.Reachable)
@@ -342,7 +343,7 @@ public sealed class ApAgentDeploymentService : IApAgentDeploymentService, IDispo
         var mac = NormalizeMac(ap.Mac);
         using var claim = _retry.TryBeginWork(mac);
         if (claim == null)
-            return ApAgentOperationResult.Fail("A deployment is already running for this access point.");
+            return ApAgentOperationResult.InProgress();
 
         var status = await ProbeStatusAsync(ap.DisplayIpAddress, ct);
         var result = await _siteSsh.RunCommandAsync(

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentModels.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentModels.cs
@@ -189,11 +189,21 @@ public sealed class ApAgentSshStatus
 /// <param name="State">The AP's state after the operation.</param>
 public sealed record ApAgentOperationResult(bool Success, string? Error = null, ApAgentState State = ApAgentState.Unknown)
 {
+    /// <summary>
+    /// True when the only failure is that work is already running for this AP. Benign: the UI shows
+    /// that work's progress rather than an error.
+    /// </summary>
+    public bool AlreadyInProgress { get; init; }
+
     /// <summary>A successful operation, with the state it left the AP in.</summary>
     public static ApAgentOperationResult Ok(ApAgentState state = ApAgentState.Healthy) => new(true, null, state);
 
     /// <summary>A failed operation, with the reason and the state it left the AP in.</summary>
     public static ApAgentOperationResult Fail(string error, ApAgentState state = ApAgentState.Unknown) => new(false, error, state);
+
+    /// <summary>The in-flight guard refused the operation because one is already running.</summary>
+    public static ApAgentOperationResult InProgress() =>
+        new(false, "A deployment is already running for this access point.") { AlreadyInProgress = true };
 }
 
 /// <summary>One access point's row in the AP Telemetry fleet table.</summary>
@@ -216,6 +226,9 @@ public sealed class ApAgentFleetEntry
 
     /// <summary>False when the operator has opted this AP out.</summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>Whether the server is deploying to (or otherwise working on) this AP right now.</summary>
+    public bool DeployInProgress { get; set; }
 
     /// <summary>The AP's last observed agent state.</summary>
     public ApAgentState State { get; set; } = ApAgentState.Unknown;

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentModels.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentModels.cs
@@ -32,6 +32,9 @@ public enum ApAgentState
 
     /// <summary>Reached, but the answer was not one the server can act on.</summary>
     Unhealthy,
+
+    /// <summary>Every transfer method failed to copy the binary onto the AP. Set by the deploy path, never the classifier.</summary>
+    TransferFailed,
 }
 
 /// <summary>What the server should do about an <see cref="ApAgentState"/>.</summary>
@@ -170,6 +173,12 @@ public sealed class ApAgentSshStatus
     /// <summary>MD5 of the deployed binary, used to skip a transfer that would change nothing.</summary>
     public string? BinaryMd5 { get; set; }
 
+    /// <summary>Whether the firmware ships dropbear's sftp-server binary, which serves the SFTP subsystem.</summary>
+    public bool SftpAvailable { get; set; }
+
+    /// <summary>Whether the firmware ships an scp binary.</summary>
+    public bool ScpAvailable { get; set; }
+
     /// <summary>Why the probe failed, when it did.</summary>
     public string? Error { get; set; }
 }
@@ -219,6 +228,12 @@ public sealed class ApAgentFleetEntry
 
     /// <summary>Machine architecture last read over SSH.</summary>
     public string? Architecture { get; set; }
+
+    /// <summary>Firmware string last read over SSH. In-memory only, so it can be absent after a restart.</summary>
+    public string? Firmware { get; set; }
+
+    /// <summary>How the binary last crossed the wire, when that was not the default SFTP path.</summary>
+    public string? TransferNote { get; set; }
 
     /// <summary>Agent release version last seen running.</summary>
     public string? DeployedVersion { get; set; }

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentPaths.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentPaths.cs
@@ -29,6 +29,22 @@ public static class ApAgentPaths
     /// <summary>Presence of this file is how the server knows procd is available to supervise with.</summary>
     public const string ProcdIncludePath = "/lib/functions/procd.sh";
 
+    /// <summary>
+    /// Where dropbear's sftp-server binary lives. It is a separate optional binary that only some
+    /// firmware ships, and dropbear serves the SFTP subsystem by exec'ing it - so its presence is
+    /// the same fact the SFTP transfer depends on.
+    /// </summary>
+    public const string SftpServerPath = "/usr/lib/sftp-server";
+
+    /// <summary>Alternate sftp-server location on firmware that puts it under libexec.</summary>
+    public const string SftpServerAltPath = "/usr/libexec/sftp-server";
+
+    /// <summary>Where scp lives. It comes free with dropbear as a multi-call symlink.</summary>
+    public const string ScpPath = "/usr/sbin/scp";
+
+    /// <summary>Alternate scp location.</summary>
+    public const string ScpAltPath = "/usr/bin/scp";
+
     /// <summary>Listener port. Must match <c>defaultPort</c> in src/apagent/config.go.</summary>
     public const int AgentPort = 8899;
 

--- a/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentScripts.cs
+++ b/src/NetworkOptimizer.Web/Services/ApAgent/ApAgentScripts.cs
@@ -47,7 +47,12 @@ public static class ApAgentScripts
             $"echo '---PROCESS---'; pgrep -f {ApAgentPaths.ProcessPattern} > /dev/null 2>&1 && echo running || echo stopped; " +
             $"echo '---VERSION---'; {ApAgentPaths.RemoteWrapperPath} -version 2>/dev/null; " +
             $"echo '---BINARY_VERSION---'; {ApAgentPaths.RemoteWrapperPath} -binary-version 2>/dev/null; " +
-            $"echo '---MD5---'; md5sum {ApAgentPaths.RemoteBinaryPath} 2>/dev/null | cut -d' ' -f1";
+            $"echo '---MD5---'; md5sum {ApAgentPaths.RemoteBinaryPath} 2>/dev/null | cut -d' ' -f1; " +
+            // Braceless on purpose: at equal precedence "a || b && c || d" parses as ((a || b) && c) || d
+            // on busybox ash, which is what we want. POSIX marks -o obsolescent, and braces would have
+            // to be written {{ }} inside this interpolated string.
+            $"echo '---SFTP---'; test -f {ApAgentPaths.SftpServerPath} || test -f {ApAgentPaths.SftpServerAltPath} && echo present || echo absent; " +
+            $"echo '---SCP---'; test -x {ApAgentPaths.ScpPath} || test -x {ApAgentPaths.ScpAltPath} && echo present || echo absent";
     }
 
     /// <summary>Reads the status probe's delimited output.</summary>
@@ -74,6 +79,8 @@ public static class ApAgentScripts
         status.IsRunning = Section(sections, "PROCESS") == "running";
         status.Version = Section(sections, "VERSION");
         status.BinaryMd5 = Section(sections, "MD5");
+        status.SftpAvailable = Section(sections, "SFTP") == "present";
+        status.ScpAvailable = Section(sections, "SCP") == "present";
 
         if (int.TryParse(Section(sections, "BINARY_VERSION"), out var binaryVersion))
             status.DeployedBinaryVersion = binaryVersion;

--- a/tests/NetworkOptimizer.Web.Tests/ApAgent/ApAgentScriptsTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ApAgent/ApAgentScriptsTests.cs
@@ -31,6 +31,10 @@ public class ApAgentScriptsTests
         1
         ---MD5---
         3366043c8f699cf4aabbccddeeff0011
+        ---SFTP---
+        present
+        ---SCP---
+        present
         """;
 
     [Theory]
@@ -70,6 +74,8 @@ public class ApAgentScriptsTests
         status.Version.Should().Be("2.7.1");
         status.DeployedBinaryVersion.Should().Be(1);
         status.BinaryMd5.Should().Be("3366043c8f699cf4aabbccddeeff0011");
+        status.SftpAvailable.Should().BeTrue();
+        status.ScpAvailable.Should().BeTrue();
     }
 
     [Fact]
@@ -91,6 +97,10 @@ public class ApAgentScriptsTests
             ---VERSION---
             ---BINARY_VERSION---
             ---MD5---
+            ---SFTP---
+            absent
+            ---SCP---
+            absent
             """;
 
         var status = ApAgentScripts.ParseStatus(output, success: true);
@@ -101,6 +111,17 @@ public class ApAgentScriptsTests
         status.DeployedBinaryVersion.Should().BeNull();
         status.BinaryMd5.Should().BeNull();
         status.SupportedArchitecture.Should().BeTrue();
+        status.SftpAvailable.Should().BeFalse();
+        status.ScpAvailable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AProbeMissingTheCapabilitySections_reads_both_transfers_as_absent()
+    {
+        var status = ApAgentScripts.ParseStatus("---ARCH---\narmv7l", success: true);
+
+        status.SftpAvailable.Should().BeFalse();
+        status.ScpAvailable.Should().BeFalse();
     }
 
     [Fact]
@@ -119,8 +140,19 @@ public class ApAgentScriptsTests
     {
         var command = ApAgentScripts.StatusProbeCommand();
 
-        foreach (var section in new[] { "ARCH", "MODEL", "FIRMWARE", "PROCD", "BINARY", "WRAPPER", "PROCESS", "VERSION", "BINARY_VERSION", "MD5" })
+        foreach (var section in new[] { "ARCH", "MODEL", "FIRMWARE", "PROCD", "BINARY", "WRAPPER", "PROCESS", "VERSION", "BINARY_VERSION", "MD5", "SFTP", "SCP" })
             command.Should().Contain($"---{section}---");
+    }
+
+    [Fact]
+    public void TheCapabilityProbes_pin_the_braceless_shell_form_measured_on_busybox_ash()
+    {
+        // At equal precedence "a || b && c || d" parses as ((a || b) && c) || d, which is what we
+        // want. Do not "tidy" this with -o (POSIX-obsolescent) or braces.
+        var command = ApAgentScripts.StatusProbeCommand();
+
+        command.Should().Contain("test -f /usr/lib/sftp-server || test -f /usr/libexec/sftp-server && echo present || echo absent");
+        command.Should().Contain("test -x /usr/sbin/scp || test -x /usr/bin/scp && echo present || echo absent");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/ApAgent/ApAgentTransferSelectorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/ApAgent/ApAgentTransferSelectorTests.cs
@@ -6,8 +6,10 @@ using Xunit;
 namespace NetworkOptimizer.Web.Tests.ApAgent;
 
 /// <summary>
-/// The transfer seam. SFTP, SCP, and cat-over-exec were all measured working on a real AP with the
-/// OpenSSH CLI, but not with SSH.NET, so the method has to be swappable without touching callers.
+/// The transfer chain. The status probe measures which transfer binaries an AP's firmware ships,
+/// the selector orders the chain from that, and cat-over-exec is always the floor: a present binary
+/// is still not proof SSH.NET can drive dropbear's implementation of it, so the chain is attempted
+/// in order rather than trusted.
 /// </summary>
 public class ApAgentTransferSelectorTests
 {
@@ -26,33 +28,33 @@ public class ApAgentTransferSelectorTests
         new StubTransfer("exec"),
     ]);
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void NothingConfigured_uses_sftp(string? configured)
-    {
-        Selector().Resolve(configured).Name.Should().Be("sftp");
-    }
+    private static ApAgentSshStatus Status(bool sftp, bool scp)
+        => new() { SftpAvailable = sftp, ScpAvailable = scp };
 
     [Theory]
-    [InlineData("scp", "scp")]
-    [InlineData("exec", "exec")]
-    [InlineData("SCP", "scp")]
-    [InlineData(" exec ", "exec")]
-    public void AConfiguredMethod_wins(string configured, string expected)
+    [InlineData(true, true, new[] { "sftp", "scp", "exec" })]
+    [InlineData(true, false, new[] { "sftp", "exec" })]
+    [InlineData(false, true, new[] { "scp", "exec" })]
+    [InlineData(false, false, new[] { "exec" })]
+    public void TheChain_is_ordered_from_what_the_probe_found(bool sftp, bool scp, string[] expected)
     {
-        Selector().Resolve(configured).Name.Should().Be(expected);
+        Selector().Resolve(Status(sftp, scp)).Select(t => t.Name).Should().Equal(expected);
     }
 
     [Fact]
-    public void AnUnknownMethod_falls_back_rather_than_failing_a_deploy()
+    public void Exec_is_always_last_and_always_present()
     {
-        Selector().Resolve("rsync").Name.Should().Be("sftp");
+        foreach (var sftp in new[] { false, true })
+        foreach (var scp in new[] { false, true })
+        {
+            var chain = Selector().Resolve(Status(sftp, scp));
+            chain.Should().NotBeEmpty();
+            chain[^1].Name.Should().Be("exec");
+        }
     }
 
     [Fact]
-    public void EveryShippedTransfer_is_reachable_by_name()
+    public void EveryShippedTransfer_appears_in_the_chain_for_some_combination()
     {
         var shipped = new IApAgentBinaryTransfer[]
         {
@@ -62,7 +64,15 @@ public class ApAgentTransferSelectorTests
         };
         var selector = new ApAgentTransferSelector(shipped);
 
+        var reachable = new HashSet<IApAgentBinaryTransfer>();
+        foreach (var sftp in new[] { false, true })
+        foreach (var scp in new[] { false, true })
+        {
+            foreach (var transfer in selector.Resolve(Status(sftp, scp)))
+                reachable.Add(transfer);
+        }
+
         foreach (var transfer in shipped)
-            selector.Resolve(transfer.Name).Should().BeSameAs(transfer);
+            reachable.Should().Contain(transfer);
     }
 }


### PR DESCRIPTION
Fixes the AP Agent deploy failing on U6 access points running pre-8.8.5 firmware, which doesn't ship dropbear's sftp-server (`Subsystem 'sftp' could not be executed`). Server-side only: no AP Agent binary change, no binary-version bump.

## Settings - AP Telemetry

- **AP Agent deploys without SFTP** - the status probe now tests each access point for dropbear's sftp-server and scp binaries (two shell builtins inside the existing single-round-trip probe), and the transfer attempts SFTP, then SCP, then a direct copy over the SSH exec channel, in the order the probe found supported. A U6 that later upgrades to 8.8.5+ reports sftp-server present on its next pass and returns to the fast path on its own - no stored method, no firmware constant, no model list (#1182, thanks @cypherstream and @keith-richard for the reports). U7s and 8.8.5+ U6s resolve to SFTP first, so their path is unchanged.
- **Every transfer is verified** - the copied binary's md5 is compared against the local one before the agent starts, so a truncated copy is a named failure on the method that produced it instead of "The agent did not start" plus a burned retry cycle.
- **The detail panel says how the binary got there** when it was not over SFTP ("Copied over SCP: this firmware doesn't support SFTP."), pointing pre-8 firmware at the 8.8.5+ shared U7 stack. When every method fails the row shows **Transfer failed** and the panel carries a per-method breakdown, with the model and firmware rendered at display time so a replaced device never shows a stale name.
- **Unsupported hardware** - the row status for an access point with no agent build, replacing "Unsupported model": it's the architecture that has no build, not the model.
- **Server-driven deploys show live progress** - rows the server is already deploying to (the pass right after enabling the site, supervision redeploys) show the spinner and **Deploying** on their own, with the fleet fast-polled while work is in flight. **Deploy to All Eligible** skips mid-deploy rows, and racing it against a server deploy no longer surfaces a benign "already installing" error alongside the progress.
- Also: the tab's description copy is tightened.
- The site-wide `ap_agent.transfer` setting is removed: the probe measures per access point what the setting could only guess site-wide, and it would have dragged every AP on a mixed fleet onto one method. Nothing ever wrote the key, so there are no rows to clean up and the deploy path now does strictly less database work.

Tests: probe parsing for the new sections (present/absent/missing), the chain ordering for all four capability combinations with exec always last, and every registered transfer reachable for some combination. `dotnet test tests/NetworkOptimizer.Web.Tests`: 3176 passed, 0 warnings.

