### PR TITLE
Mesh MLO STR backhaul: derive child-side links from the parent and evaluate the aggregate

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
+++ b/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
@@ -98,6 +98,19 @@ public class NetworkHop
     /// <summary>RX rate in Mbps for wireless link (from uplink to device)</summary>
     public int? WirelessRxRateMbps { get; set; }
 
+    /// <summary>
+    /// Whether the wireless mesh backhaul at this hop is an MLO (Wi-Fi 7 multi-link) pairing.
+    /// The Wireless*RateMbps fields then carry the AGGREGATE across links (STR runs them
+    /// concurrently), and <see cref="MeshMloLinks"/> carries the per-link breakdown.
+    /// </summary>
+    public bool IsMloMeshBackhaul { get; set; }
+
+    /// <summary>
+    /// Per-link detail of an MLO mesh backhaul, child AP's perspective (TX toward the parent).
+    /// Read from the parent's downlink_table - the only end UniFi reports per link.
+    /// </summary>
+    public List<MeshBackhaulLink>? MeshMloLinks { get; set; }
+
     /// <summary>Whether the ingress port is part of a Link Aggregation Group</summary>
     public bool IsLagIngress { get; set; }
 
@@ -118,6 +131,26 @@ public class NetworkHop
 
     /// <summary>Additional notes (e.g., "L3 routing", "Wireless uplink")</summary>
     public string? Notes { get; set; }
+}
+
+/// <summary>
+/// One radio link of an MLO mesh backhaul on a <see cref="NetworkHop"/>, child AP's perspective
+/// (TX toward the parent). Signal is the parent's reading - the only end reported per link.
+/// </summary>
+public class MeshBackhaulLink
+{
+    /// <summary>Radio band (ng=2.4GHz, na=5GHz, 6e=6GHz), matching Wireless*Band conventions</summary>
+    public string? Band { get; set; }
+
+    public int? Channel { get; set; }
+
+    public int? SignalDbm { get; set; }
+
+    /// <summary>Link rate in Mbps, child toward parent</summary>
+    public int? TxRateMbps { get; set; }
+
+    /// <summary>Link rate in Mbps, parent toward child</summary>
+    public int? RxRateMbps { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
+++ b/src/NetworkOptimizer.UniFi/Models/NetworkHop.cs
@@ -144,6 +144,9 @@ public class MeshBackhaulLink
 
     public int? Channel { get; set; }
 
+    /// <summary>Channel width in MHz, from the parent's radio for this band</summary>
+    public int? WidthMhz { get; set; }
+
     public int? SignalDbm { get; set; }
 
     /// <summary>Link rate in Mbps, child toward parent</summary>

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1600,6 +1600,17 @@ public class DownlinkTableEntry
     [JsonPropertyName("serialno")]
     public string? SerialNo { get; set; }
 
+    /// <summary>
+    /// MLD (multi-link device) MAC of the mesh child, i.e. its base MAC. On an MLO mesh
+    /// backhaul the parent lists one entry PER LINK, all sharing this value.
+    /// </summary>
+    [JsonPropertyName("mld_mac")]
+    public string? MldMac { get; set; }
+
+    /// <summary>Whether this entry is one link of an MLO (Wi-Fi 7 multi-link) mesh backhaul</summary>
+    [JsonPropertyName("is_mlo")]
+    public bool? IsMlo { get; set; }
+
     /// <summary>Signal strength as seen by the parent AP (dBm)</summary>
     [JsonPropertyName("signal")]
     [JsonConverter(typeof(FlexibleIntConverter))]

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -1609,6 +1609,7 @@ public class DownlinkTableEntry
 
     /// <summary>Whether this entry is one link of an MLO (Wi-Fi 7 multi-link) mesh backhaul</summary>
     [JsonPropertyName("is_mlo")]
+    [JsonConverter(typeof(FlexibleNullableBoolConverter))]
     public bool? IsMlo { get; set; }
 
     /// <summary>Signal strength as seen by the parent AP (dBm)</summary>

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1565,6 +1565,7 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         {
             Band = l.Radio,
             Channel = l.Channel,
+            WidthMhz = l.WidthMhz,
             SignalDbm = l.Signal,
             TxRateMbps = l.RxRateKbps > 0 ? (int)(l.RxRateKbps / 1000) : null,
             RxRateMbps = l.TxRateKbps > 0 ? (int)(l.TxRateKbps / 1000) : null,

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -881,6 +881,12 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                     var rxKbps = FilterIdleRate(targetDevice.UplinkRxRateKbps);
                     deviceHop.WirelessTxRateMbps = txKbps > 0 ? (int)(txKbps / 1000) : null;
                     deviceHop.WirelessRxRateMbps = rxKbps > 0 ? (int)(rxKbps / 1000) : null;
+                    var mloAggregate = ApplySelfReportedMloOverlay(deviceHop, targetDevice, meshParents);
+                    if (mloAggregate.HasValue)
+                    {
+                        deviceHop.IngressSpeedMbps = mloAggregate.Value;
+                        deviceHop.EgressSpeedMbps = mloAggregate.Value;
+                    }
                 }
                 else if (!string.IsNullOrEmpty(currentMac) && currentPort.HasValue)
                 {
@@ -982,6 +988,11 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                         var uplinkRx = FilterIdleRate(device.UplinkRxRateKbps);
                         hop.WirelessTxRateMbps = uplinkTx > 0 ? (int)(uplinkTx / 1000) : null;
                         hop.WirelessRxRateMbps = uplinkRx > 0 ? (int)(uplinkRx / 1000) : null;
+                        var mloAggregate = ApplySelfReportedMloOverlay(hop, device, meshParents);
+                        if (mloAggregate.HasValue)
+                        {
+                            hop.EgressSpeedMbps = mloAggregate.Value;
+                        }
                     }
                     else
                     {
@@ -1538,6 +1549,53 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         hop.EgressSpeedMbps = txKbps > 0 ? (int)(txKbps / 1000) : 0;
         hop.WirelessTxRateMbps = txKbps > 0 ? (int)(txKbps / 1000) : null;
         hop.WirelessRxRateMbps = rxKbps > 0 ? (int)(rxKbps / 1000) : null;
+        ApplyMloBackhaulDetail(hop, claim);
+    }
+
+    /// <summary>
+    /// Attaches the per-link MLO breakdown of a mesh backhaul to a hop, child's perspective
+    /// (the parent transmitting is the child receiving). Rates on the hop itself are the
+    /// caller's concern; this only records the flag and the links for display.
+    /// </summary>
+    private static void ApplyMloBackhaulDetail(NetworkHop hop, UniFiDiscovery.MeshParentClaim claim)
+    {
+        if (!claim.IsMlo || claim.Links.Count == 0) return;
+        hop.IsMloMeshBackhaul = true;
+        hop.MeshMloLinks = claim.Links.Select(l => new MeshBackhaulLink
+        {
+            Band = l.Radio,
+            Channel = l.Channel,
+            SignalDbm = l.Signal,
+            TxRateMbps = l.RxRateKbps > 0 ? (int)(l.RxRateKbps / 1000) : null,
+            RxRateMbps = l.TxRateKbps > 0 ? (int)(l.TxRateKbps / 1000) : null,
+        }).ToList();
+    }
+
+    /// <summary>
+    /// Overlays the aggregate MLO capacity on a mesh hop the child described itself. The child's
+    /// uplink block names only its STA link, so its rates under-report an MLO backhaul; when the
+    /// parent's claim agrees on who the parent is and is MLO, the parent's per-link sum replaces
+    /// them. Returns the aggregate child-toward-parent Mbps (the hop's egress), or null when the
+    /// overlay does not apply.
+    /// </summary>
+    private static int? ApplySelfReportedMloOverlay(
+        NetworkHop hop,
+        DiscoveredDevice device,
+        IReadOnlyDictionary<string, UniFiDiscovery.MeshParentClaim> meshParents)
+    {
+        if (!meshParents.TryGetValue(device.Mac, out var claim)
+            || claim.Contradicts(device.UplinkMac)
+            || !claim.IsMlo || claim.Links.Count == 0)
+        {
+            return null;
+        }
+
+        ApplyMloBackhaulDetail(hop, claim);
+        var txKbps = FilterIdleRate(claim.RxRateKbps);
+        var rxKbps = FilterIdleRate(claim.TxRateKbps);
+        if (txKbps > 0) hop.WirelessTxRateMbps = (int)(txKbps / 1000);
+        if (rxKbps > 0) hop.WirelessRxRateMbps = (int)(rxKbps / 1000);
+        return txKbps > 0 ? (int)(txKbps / 1000) : null;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1591,6 +1591,14 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         }
 
         ApplyMloBackhaulDetail(hop, claim);
+        // The child measures its own STA link, so its signal outranks the parent's for
+        // that link; the other links are only reported by the parent.
+        if (hop.MeshMloLinks != null && device.UplinkSignalDbm.HasValue)
+        {
+            var ownLink = hop.MeshMloLinks.FirstOrDefault(l =>
+                string.Equals(l.Band, device.UplinkRadioBand, StringComparison.OrdinalIgnoreCase));
+            if (ownLink != null) ownLink.SignalDbm = device.UplinkSignalDbm;
+        }
         var txKbps = FilterIdleRate(claim.RxRateKbps);
         var rxKbps = FilterIdleRate(claim.TxRateKbps);
         if (txKbps > 0) hop.WirelessTxRateMbps = (int)(txKbps / 1000);

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -1599,11 +1599,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                 string.Equals(l.Band, device.UplinkRadioBand, StringComparison.OrdinalIgnoreCase));
             if (ownLink != null) ownLink.SignalDbm = device.UplinkSignalDbm;
         }
+        // Never lower a rate already on the hop: a load-time snapshot may have caught a link
+        // negotiated higher than the parent's table shows.
         var txKbps = FilterIdleRate(claim.RxRateKbps);
         var rxKbps = FilterIdleRate(claim.TxRateKbps);
-        if (txKbps > 0) hop.WirelessTxRateMbps = (int)(txKbps / 1000);
-        if (rxKbps > 0) hop.WirelessRxRateMbps = (int)(rxKbps / 1000);
-        return txKbps > 0 ? (int)(txKbps / 1000) : null;
+        if (txKbps > 0) hop.WirelessTxRateMbps = Math.Max(hop.WirelessTxRateMbps ?? 0, (int)(txKbps / 1000));
+        if (rxKbps > 0) hop.WirelessRxRateMbps = Math.Max(hop.WirelessRxRateMbps ?? 0, (int)(rxKbps / 1000));
+        return txKbps > 0 ? hop.WirelessTxRateMbps : null;
     }
 
     /// <summary>
@@ -1966,6 +1968,13 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
 
                 deviceHop.WirelessTxRateMbps = currentTxKbps > 0 ? (int)(currentTxKbps / 1000) : null;
                 deviceHop.WirelessRxRateMbps = currentRxKbps > 0 ? (int)(currentRxKbps / 1000) : null;
+
+                var mloAggregate = ApplySelfReportedMloOverlay(deviceHop, targetDevice, meshParents);
+                if (mloAggregate.HasValue)
+                {
+                    deviceHop.IngressSpeedMbps = mloAggregate.Value;
+                    deviceHop.EgressSpeedMbps = mloAggregate.Value;
+                }
 
                 _logger.LogDebug("Wireless mesh device {Name}: UplinkType={UplinkType}, TxRate={Tx}Mbps, RxRate={Rx}Mbps, Band={Band}, Ch={Ch}, Signal={Sig}dBm",
                     targetDevice.Name, targetDevice.UplinkType,
@@ -2356,6 +2365,11 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
                         }
                         hop.WirelessTxRateMbps = hopTxKbps > 0 ? (int)(hopTxKbps / 1000) : null;
                         hop.WirelessRxRateMbps = hopRxKbps > 0 ? (int)(hopRxKbps / 1000) : null;
+                        var hopMloAggregate = ApplySelfReportedMloOverlay(hop, device, meshParents);
+                        if (hopMloAggregate.HasValue)
+                        {
+                            hop.EgressSpeedMbps = hopMloAggregate.Value;
+                        }
                     }
                     else
                     {

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -179,18 +179,45 @@ public class UniFiDiscovery
         foreach (var parent in all)
         {
             if (string.IsNullOrEmpty(parent.Mac)) continue;
-            foreach (var link in parent.DownlinkTable ?? [])
+            // serialno (mld_mac on MLO links) is the child's base MAC; mac is its vwire BSSID,
+            // which matches nothing. An MLO backhaul is one entry PER LINK sharing that base MAC,
+            // so group first: the claim's rates are the sum over links (STR runs them
+            // concurrently), and each link is kept for per-band display.
+            foreach (var group in (parent.DownlinkTable ?? [])
+                .Select(l => (Key: (l.SerialNo ?? l.MldMac)?.ToLowerInvariant(), Link: l))
+                .Where(x => !string.IsNullOrEmpty(x.Key))
+                .GroupBy(x => x.Key!))
             {
-                // serialno is the child's base MAC; mac is its vwire BSSID, which matches nothing.
-                if (string.IsNullOrEmpty(link.SerialNo)) continue;
-                var childMac = link.SerialNo.ToLowerInvariant();
-                if (known.Contains(childMac))
-                    parentByChild[childMac] = new MeshParentClaim(parent.Mac.ToLowerInvariant(), link.TxRate, link.RxRate);
+                if (!known.Contains(group.Key)) continue;
+                // Aggregate ONLY is_mlo-flagged entries: a future firmware that also keeps a
+                // legacy combined row for the same child must not be double-counted, and a
+                // duplicate non-MLO listing keeps the pre-grouping last-entry-wins behavior
+                // rather than summing capacity that does not exist.
+                var members = group.Select(x => x.Link).ToList();
+                var mloMembers = members.Where(l => l.IsMlo == true).ToList();
+                members = mloMembers.Count > 0 ? mloMembers : [members[^1]];
+                var links = members.Select(l => new MeshLinkClaim(
+                    l.Radio, l.Channel, l.Signal, l.TxRate, l.RxRate)).ToList();
+                parentByChild[group.Key] = new MeshParentClaim(
+                    parent.Mac.ToLowerInvariant(),
+                    links.Sum(l => l.TxRateKbps),
+                    links.Sum(l => l.RxRateKbps))
+                {
+                    IsMlo = mloMembers.Count > 0,
+                    Links = links,
+                };
             }
         }
 
         return parentByChild;
     }
+
+    /// <summary>
+    /// One link of a mesh backhaul as the parent reports it in its downlink_table. Rates follow
+    /// <see cref="MeshParentClaim"/>'s convention: Tx is parent to child (the child's downstream).
+    /// Signal is the PARENT's reading of the link; the child's end is not reported anywhere.
+    /// </summary>
+    public readonly record struct MeshLinkClaim(string? Radio, int? Channel, int? Signal, long TxRateKbps, long RxRateKbps);
 
     /// <summary>
     /// A parent's account of one mesh child. Rates are the PARENT's perspective and are therefore
@@ -199,10 +226,18 @@ public class UniFiDiscovery
     /// round the child's fields are read reports the link backwards.
     /// </summary>
     /// <param name="ParentMac">The parent's MAC, lower case.</param>
-    /// <param name="TxRateKbps">Parent to child, i.e. downstream.</param>
-    /// <param name="RxRateKbps">Child to parent, i.e. upstream.</param>
+    /// <param name="TxRateKbps">Parent to child, i.e. downstream. Summed over links on MLO.</param>
+    /// <param name="RxRateKbps">Child to parent, i.e. upstream. Summed over links on MLO.</param>
     public readonly record struct MeshParentClaim(string ParentMac, long TxRateKbps, long RxRateKbps)
     {
+        /// <summary>Whether the backhaul is an MLO (Wi-Fi 7 multi-link) pairing.</summary>
+        public bool IsMlo { get; init; }
+
+        /// <summary>Per-link detail, one entry per radio link. A classic backhaul has one.
+        /// Never null, including on a default-constructed claim.</summary>
+        public IReadOnlyList<MeshLinkClaim> Links { get => _links ?? []; init => _links = value; }
+        private readonly IReadOnlyList<MeshLinkClaim>? _links;
+
         /// <summary>
         /// True when the child's own uplink field does NOT name this parent - empty, or a
         /// different device. Only then may a consumer absorb the claim; an agreeing child's own

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -103,6 +103,7 @@ public class UniFiDiscovery
                 UplinkTxRateKbps = d.Uplink?.TxRate ?? 0,
                 UplinkRxRateKbps = d.Uplink?.RxRate ?? 0,
                 UplinkType = d.Uplink?.Type,
+                UplinkIsMlo = d.Uplink?.IsMlo == true,
                 // Active uplink interface name. For a wireless mesh child this is the
                 // wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways
                 // it's the wired/WAN iface. Callers must validate the "vwiresta" prefix before
@@ -948,6 +949,14 @@ public class DiscoveredDevice
     /// <summary>RX rate in Kbps for wireless uplinks</summary>
     public long UplinkRxRateKbps { get; set; }
     public string? UplinkType { get; set; }  // "wire" or "wireless"
+
+    /// <summary>
+    /// Whether the device's own uplink block flags MLO (uplink.is_mlo). UniFi does not set this
+    /// for mesh children today - the per-link truth lives on the parent - but a firmware that
+    /// starts reporting the child side is expected to reuse its standard MLO station shape,
+    /// and this flag is the cheapest half of it.
+    /// </summary>
+    public bool UplinkIsMlo { get; set; }
     /// <summary>
     /// Active uplink interface name (uplink.name). For a wireless mesh child this is the
     /// wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways it's the

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -158,7 +158,7 @@ public class UniFiDiscovery
     public static Dictionary<string, MeshParentClaim> BuildMeshParentByChild(IEnumerable<DiscoveredDevice> devices)
     {
         var all = devices as IList<DiscoveredDevice> ?? devices.ToList();
-        return BuildMeshParentByChild(all.Select(d => (d.Mac, d.DownlinkTable)));
+        return BuildMeshParentByChild(all.Select(d => (d.Mac, d.DownlinkTable, d.RadioTableStats, d.RadioTable)));
     }
 
     /// <summary>Raw-device overload for callers that hold <see cref="UniFiDeviceResponse"/>
@@ -166,13 +166,13 @@ public class UniFiDiscovery
     public static Dictionary<string, MeshParentClaim> BuildMeshParentByChild(IEnumerable<UniFiDeviceResponse> devices)
     {
         var all = devices as IList<UniFiDeviceResponse> ?? devices.ToList();
-        return BuildMeshParentByChild(all.Select(d => (d.Mac, d.DownlinkTable)));
+        return BuildMeshParentByChild(all.Select(d => (d.Mac, d.DownlinkTable, d.RadioTableStats, d.RadioTable)));
     }
 
     private static Dictionary<string, MeshParentClaim> BuildMeshParentByChild(
-        IEnumerable<(string Mac, List<DownlinkTableEntry>? DownlinkTable)> devices)
+        IEnumerable<(string Mac, List<DownlinkTableEntry>? DownlinkTable, List<RadioTableStats>? RadioStats, List<RadioTableEntry>? RadioTable)> devices)
     {
-        var all = devices as IList<(string Mac, List<DownlinkTableEntry>? DownlinkTable)> ?? devices.ToList();
+        var all = devices as IList<(string Mac, List<DownlinkTableEntry>? DownlinkTable, List<RadioTableStats>? RadioStats, List<RadioTableEntry>? RadioTable)> ?? devices.ToList();
         var known = new HashSet<string>(all.Where(d => !string.IsNullOrEmpty(d.Mac)).Select(d => d.Mac.ToLowerInvariant()));
         var parentByChild = new Dictionary<string, MeshParentClaim>(StringComparer.OrdinalIgnoreCase);
 
@@ -197,7 +197,10 @@ public class UniFiDiscovery
                 var mloMembers = members.Where(l => l.IsMlo == true).ToList();
                 members = mloMembers.Count > 0 ? mloMembers : [members[^1]];
                 var links = members.Select(l => new MeshLinkClaim(
-                    l.Radio, l.Channel, l.Signal, l.TxRate, l.RxRate)).ToList();
+                    l.Radio, l.Channel, l.Signal, l.TxRate, l.RxRate)
+                {
+                    WidthMhz = ResolveRadioWidth(parent.RadioStats, parent.RadioTable, l.Radio),
+                }).ToList();
                 parentByChild[group.Key] = new MeshParentClaim(
                     parent.Mac.ToLowerInvariant(),
                     links.Sum(l => l.TxRateKbps),
@@ -217,7 +220,23 @@ public class UniFiDiscovery
     /// <see cref="MeshParentClaim"/>'s convention: Tx is parent to child (the child's downstream).
     /// Signal is the PARENT's reading of the link; the child's end is not reported anywhere.
     /// </summary>
-    public readonly record struct MeshLinkClaim(string? Radio, int? Channel, int? Signal, long TxRateKbps, long RxRateKbps);
+    public readonly record struct MeshLinkClaim(string? Radio, int? Channel, int? Signal, long TxRateKbps, long RxRateKbps)
+    {
+        /// <summary>Channel width in MHz, read off the parent's radio for the link's band -
+        /// the downlink entries themselves report chwidth 0.</summary>
+        public int? WidthMhz { get; init; }
+    }
+
+    /// <summary>The parent radio's width for a link's band: the operating width (stats bw)
+    /// when reported, else the configured width (radio_table ht).</summary>
+    private static int? ResolveRadioWidth(List<RadioTableStats>? stats, List<RadioTableEntry>? table, string? radio)
+    {
+        if (string.IsNullOrEmpty(radio)) return null;
+        var bw = stats?.FirstOrDefault(s => string.Equals(s.Radio, radio, StringComparison.OrdinalIgnoreCase))?.Bw;
+        if (bw is > 0) return bw;
+        var ht = table?.FirstOrDefault(t => string.Equals(t.Radio, radio, StringComparison.OrdinalIgnoreCase))?.ChannelWidth;
+        return ht is > 0 ? ht : null;
+    }
 
     /// <summary>
     /// A parent's account of one mesh child. Rates are the PARENT's perspective and are therefore

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -643,7 +643,33 @@
                                                     }
                                                 </button>
                                             </SiteOperatorOnly>
-                                            @if (ap.MeshUplinkSignalDbm.HasValue)
+                                            @if (ap.MeshUplinkIsMlo && ap.MeshUplinkLinks.Count > 0)
+                                            {
+                                                @* UniFi reports the MLO links only from the parent's end; these rows are
+                                                   built from the parent's downlink_table with direction flipped to the
+                                                   child's perspective. *@
+                                                @foreach (var link in ap.MeshUplinkLinks.OrderByDescending(l => l.Band))
+                                                {
+                                                    <div class="mesh-signal mesh-mlo-link">
+                                                        <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
+                                                        @if (link.SignalDbm.HasValue)
+                                                        {
+                                                            <span class="mesh-signal-value mesh-mlo-signal"><span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
+                                                        }
+                                                        <span class="mesh-rates">
+                                                            @if (link.TxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
+                                                            }
+                                                            @if (link.RxRateMbps.HasValue)
+                                                            {
+                                                                <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
+                                                            }
+                                                        </span>
+                                                    </div>
+                                                }
+                                            }
+                                            else if (ap.MeshUplinkSignalDbm.HasValue)
                                             {
                                                 <div class="mesh-signal">
                                                     <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(ap.MeshUplinkSignalDbm.Value, ap.MeshUplinkBand ?? RadioBand.Band5GHz)">@ap.MeshUplinkSignalDbm</span> <span class="mesh-unit">dBm</span></span>
@@ -662,7 +688,7 @@
                                                     }
                                                 </div>
                                             }
-                                            <span class="ap-stat-label"><strong>Mesh Uplink</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
+                                            <span class="ap-stat-label"><strong>Mesh Uplink@(ap.MeshUplinkIsMlo ? " (MLO)" : "")</strong>@(ap.MeshParentName != null ? $" to {ap.MeshParentName}" : "")</span>
                                         </div>
                                     }
                                     @if (ap.MeshChildren.Count > 0)
@@ -670,26 +696,52 @@
                                         @foreach (var child in ap.MeshChildren)
                                         {
                                             <div class="ap-mesh-info">
-                                                <div class="mesh-signal">
-                                                    @if (child.SignalDbm.HasValue)
+                                                @if (child.IsMlo && child.Links.Count > 0)
+                                                {
+                                                    @foreach (var link in child.Links.OrderByDescending(l => l.Band))
                                                     {
-                                                        <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(child.SignalDbm.Value, child.UplinkBand ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(child.SignalDbm.Value, child.UplinkBand ?? RadioBand.Band5GHz)">@child.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
-                                                    }
-                                                    @if (child.TxRateMbps.HasValue || child.RxRateMbps.HasValue)
-                                                    {
-                                                        <span class="mesh-rates">
-                                                            @if (child.TxRateMbps.HasValue)
+                                                        <div class="mesh-signal mesh-mlo-link">
+                                                            <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
+                                                            @if (link.SignalDbm.HasValue)
                                                             {
-                                                                <span class="mesh-rate wifi-speed-tx">TX @child.TxRateMbps</span>
+                                                                <span class="mesh-signal-value mesh-mlo-signal"><span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
                                                             }
-                                                            @if (child.RxRateMbps.HasValue)
-                                                            {
-                                                                <span class="mesh-rate wifi-speed-rx">RX @child.RxRateMbps</span>
-                                                            }
-                                                        </span>
+                                                            <span class="mesh-rates">
+                                                                @if (link.TxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
+                                                                }
+                                                                @if (link.RxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
+                                                                }
+                                                            </span>
+                                                        </div>
                                                     }
-                                                </div>
-                                                <span class="ap-stat-label"><strong>Mesh Child:</strong> @child.Name</span>
+                                                }
+                                                else
+                                                {
+                                                    <div class="mesh-signal">
+                                                        @if (child.SignalDbm.HasValue)
+                                                        {
+                                                            <span class="mesh-signal-value"><span class="@SignalClassification.GetSignalClass(child.SignalDbm.Value, child.UplinkBand ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(child.SignalDbm.Value, child.UplinkBand ?? RadioBand.Band5GHz)">@child.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
+                                                        }
+                                                        @if (child.TxRateMbps.HasValue || child.RxRateMbps.HasValue)
+                                                        {
+                                                            <span class="mesh-rates">
+                                                                @if (child.TxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-tx">TX @child.TxRateMbps</span>
+                                                                }
+                                                                @if (child.RxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-rx">RX @child.RxRateMbps</span>
+                                                                }
+                                                            </span>
+                                                        }
+                                                    </div>
+                                                }
+                                                <span class="ap-stat-label"><strong>Mesh Child@(child.IsMlo ? " (MLO)" : ""):</strong> @child.Name</span>
                                             </div>
                                         }
                                     }

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -615,7 +615,7 @@
                                         <span class="ap-status-text">@ap.Status.Label</span>
                                     </div>
                                 </div>
-                                <div class="ap-stats @(ap.IsMeshChild || ap.MeshChildren.Count > 0 ? "ap-stats-mesh" : "")">
+                                <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "") @(ap.MeshUplinkIsMlo || ap.MeshChildren.Any(c => c.IsMlo) ? "ap-stats-mlo" : "")">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
                                         <span class="ap-stat-value">@ap.TotalClients</span>
                                         <span class="ap-stat-label">Clients</span>

--- a/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/WiFiOptimizer.razor
@@ -615,7 +615,7 @@
                                         <span class="ap-status-text">@ap.Status.Label</span>
                                     </div>
                                 </div>
-                                <div class="ap-stats @(ap.IsMeshChild ? "ap-stats-mesh" : "")">
+                                <div class="ap-stats @(ap.IsMeshChild || ap.MeshChildren.Count > 0 ? "ap-stats-mesh" : "")">
                                     <div class="ap-stat clickable" @onclick="@(() => NavigateToTab("client", ap.Mac))" @onclick:stopPropagation="true">
                                         <span class="ap-stat-value">@ap.TotalClients</span>
                                         <span class="ap-stat-label">Clients</span>
@@ -647,27 +647,32 @@
                                             {
                                                 @* UniFi reports the MLO links only from the parent's end; these rows are
                                                    built from the parent's downlink_table with direction flipped to the
-                                                   child's perspective. *@
-                                                @foreach (var link in ap.MeshUplinkLinks.OrderByDescending(l => l.Band))
-                                                {
-                                                    <div class="mesh-signal mesh-mlo-link">
-                                                        <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
-                                                        @if (link.SignalDbm.HasValue)
-                                                        {
-                                                            <span class="mesh-signal-value mesh-mlo-signal"><span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
-                                                        }
-                                                        <span class="mesh-rates">
-                                                            @if (link.TxRateMbps.HasValue)
-                                                            {
-                                                                <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
-                                                            }
-                                                            @if (link.RxRateMbps.HasValue)
-                                                            {
-                                                                <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
-                                                            }
-                                                        </span>
-                                                    </div>
-                                                }
+                                                   child's perspective. The empty signal span keeps a row at three grid
+                                                   cells so the columns stay aligned. *@
+                                                <div class="mesh-mlo-links">
+                                                    @foreach (var link in ap.MeshUplinkLinks.OrderByDescending(l => l.Band))
+                                                    {
+                                                        <div class="mesh-mlo-link">
+                                                            <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
+                                                            <span class="mesh-signal-value mesh-mlo-signal">
+                                                                @if (link.SignalDbm.HasValue)
+                                                                {
+                                                                    <span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span>
+                                                                }
+                                                            </span>
+                                                            <span class="mesh-rates">
+                                                                @if (link.TxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
+                                                                }
+                                                                @if (link.RxRateMbps.HasValue)
+                                                                {
+                                                                    <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
+                                                                }
+                                                            </span>
+                                                        </div>
+                                                    }
+                                                </div>
                                             }
                                             else if (ap.MeshUplinkSignalDbm.HasValue)
                                             {
@@ -698,26 +703,30 @@
                                             <div class="ap-mesh-info">
                                                 @if (child.IsMlo && child.Links.Count > 0)
                                                 {
-                                                    @foreach (var link in child.Links.OrderByDescending(l => l.Band))
-                                                    {
-                                                        <div class="mesh-signal mesh-mlo-link">
-                                                            <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
-                                                            @if (link.SignalDbm.HasValue)
-                                                            {
-                                                                <span class="mesh-signal-value mesh-mlo-signal"><span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span></span>
-                                                            }
-                                                            <span class="mesh-rates">
-                                                                @if (link.TxRateMbps.HasValue)
-                                                                {
-                                                                    <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
-                                                                }
-                                                                @if (link.RxRateMbps.HasValue)
-                                                                {
-                                                                    <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
-                                                                }
-                                                            </span>
-                                                        </div>
-                                                    }
+                                                    <div class="mesh-mlo-links">
+                                                        @foreach (var link in child.Links.OrderByDescending(l => l.Band))
+                                                        {
+                                                            <div class="mesh-mlo-link">
+                                                                <span class="band-badge @GetBandCssClass(link.Band ?? RadioBand.Band5GHz)">@((link.Band ?? RadioBand.Band5GHz).ToDisplayString())</span>
+                                                                <span class="mesh-signal-value mesh-mlo-signal">
+                                                                    @if (link.SignalDbm.HasValue)
+                                                                    {
+                                                                        <span class="@SignalClassification.GetSignalClass(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)" style="color: @SignalClassification.GetSignalColor(link.SignalDbm.Value, link.Band ?? RadioBand.Band5GHz)">@link.SignalDbm</span> <span class="mesh-unit">dBm</span>
+                                                                    }
+                                                                </span>
+                                                                <span class="mesh-rates">
+                                                                    @if (link.TxRateMbps.HasValue)
+                                                                    {
+                                                                        <span class="mesh-rate wifi-speed-tx">TX @link.TxRateMbps</span>
+                                                                    }
+                                                                    @if (link.RxRateMbps.HasValue)
+                                                                    {
+                                                                        <span class="mesh-rate wifi-speed-rx">RX @link.RxRateMbps</span>
+                                                                    }
+                                                                </span>
+                                                            </div>
+                                                        }
+                                                    </div>
                                                 }
                                                 else
                                                 {

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1187,9 +1187,12 @@
 
         // For mesh/bridge wireless - use same styled format
         var meshHop = hop.IsWirelessEgress ? hop : nextHop;
+        var isMloMesh = meshHop.IsMloMeshBackhaul && meshHop.MeshMloLinks is { Count: > 0 };
         var lines2 = new List<string>();
 
-        lines2.Add("<div class='wifi-tooltip-header'>Wireless Mesh</div>");
+        lines2.Add(isMloMesh
+            ? "<div class='wifi-tooltip-header'>Wireless Mesh (MLO)</div>"
+            : "<div class='wifi-tooltip-header'>Wireless Mesh</div>");
 
         // RX/TX speeds from parent AP's perspective (RX = FromDevice, TX = ToDevice)
         // Mesh hop stores child's perspective, so flip: child TX → parent RX, child RX → parent TX
@@ -1216,24 +1219,59 @@
             lines2.Add($"<div class='wifi-tooltip-row wifi-tooltip-speed'>{string.Join(" · ", speedParts)}</div>");
         }
 
-        // Link info with band badge
-        if (!string.IsNullOrEmpty(band) || meshHop.WirelessChannel.HasValue)
+        if (isMloMesh)
         {
-            var linkParts = new List<string>();
-            if (!string.IsNullOrEmpty(band))
-                linkParts.Add($"<span class='wifi-band-badge wifi-band-{band}'>{FormatRadioBand(band)}</span>");
-            if (meshHop.WirelessChannel.HasValue)
-                linkParts.Add($"Ch {meshHop.WirelessChannel.Value}");
-            lines2.Add($"<div class='wifi-tooltip-link'>{string.Join(" ", linkParts)}</div>");
+            // The aggregate row above is the pair's capacity; break out each link. The single
+            // band/channel/signal fields describe only the STA link, so per-link rows replace them.
+            foreach (var link in meshHop.MeshMloLinks!.OrderByDescending(l => BandSortOrder(l.Band)))
+            {
+                var linkParts = new List<string>();
+                if (!string.IsNullOrEmpty(link.Band))
+                    linkParts.Add($"<span class='wifi-band-badge wifi-band-{link.Band}'>{FormatRadioBand(link.Band)}</span>");
+                if (link.Channel.HasValue)
+                    linkParts.Add($"Ch {link.Channel.Value}");
+                if (link.SignalDbm.HasValue)
+                    linkParts.Add($"{link.SignalDbm.Value} dBm");
+                // Same frame mapping as the aggregate row: child TX carries data away from the
+                // device, child RX carries data toward it.
+                if (DeviceFrame)
+                {
+                    if (link.RxRateMbps.HasValue)
+                        linkParts.Add($"<span class='wifi-speed-rx'>TX {link.RxRateMbps.Value}</span>");
+                    if (link.TxRateMbps.HasValue)
+                        linkParts.Add($"<span class='wifi-speed-tx'>RX {link.TxRateMbps.Value}</span>");
+                }
+                else
+                {
+                    if (link.TxRateMbps.HasValue)
+                        linkParts.Add($"<span class='wifi-speed-rx'>RX {link.TxRateMbps.Value}</span>");
+                    if (link.RxRateMbps.HasValue)
+                        linkParts.Add($"<span class='wifi-speed-tx'>TX {link.RxRateMbps.Value}</span>");
+                }
+                lines2.Add($"<div class='wifi-tooltip-link'>{string.Join(" ", linkParts)}</div>");
+            }
         }
-
-        // Signal line
-        if (meshHop.WirelessSignalDbm.HasValue)
+        else
         {
-            var sigParts = new List<string> { $"{meshHop.WirelessSignalDbm.Value} dBm" };
-            if (meshHop.WirelessNoiseDbm.HasValue)
-                sigParts.Add($"SNR {meshHop.WirelessSignalDbm.Value - meshHop.WirelessNoiseDbm.Value} dB");
-            lines2.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" · ", sigParts)}</div>");
+            // Link info with band badge
+            if (!string.IsNullOrEmpty(band) || meshHop.WirelessChannel.HasValue)
+            {
+                var linkParts = new List<string>();
+                if (!string.IsNullOrEmpty(band))
+                    linkParts.Add($"<span class='wifi-band-badge wifi-band-{band}'>{FormatRadioBand(band)}</span>");
+                if (meshHop.WirelessChannel.HasValue)
+                    linkParts.Add($"Ch {meshHop.WirelessChannel.Value}");
+                lines2.Add($"<div class='wifi-tooltip-link'>{string.Join(" ", linkParts)}</div>");
+            }
+
+            // Signal line
+            if (meshHop.WirelessSignalDbm.HasValue)
+            {
+                var sigParts = new List<string> { $"{meshHop.WirelessSignalDbm.Value} dBm" };
+                if (meshHop.WirelessNoiseDbm.HasValue)
+                    sigParts.Add($"SNR {meshHop.WirelessSignalDbm.Value - meshHop.WirelessNoiseDbm.Value} dB");
+                lines2.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" · ", sigParts)}</div>");
+            }
         }
 
         var meshTooltip = lines2.Count > 1 ? string.Join("", lines2) : "Wireless mesh";
@@ -1337,6 +1375,15 @@
     );
 
     private string FormatRadioBand(string? radio) => RadioFormatHelper.FormatBand(radio);
+
+    /// <summary>Sorts MLO backhaul links highest band first (6 GHz, 5 GHz, 2.4 GHz).</summary>
+    private static int BandSortOrder(string? band) => band switch
+    {
+        "6e" => 3,
+        "na" => 2,
+        "ng" => 1,
+        _ => 0
+    };
 
     private string FormatRadioProto(string? proto, string? radio = null) =>
         RadioFormatHelper.FormatProtocolSuffix(proto, radio);

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1229,9 +1229,14 @@
                 if (!string.IsNullOrEmpty(link.Band))
                     linkParts.Add($"<span class='wifi-band-badge wifi-band-{link.Band}'>{FormatRadioBand(link.Band)}</span>");
                 if (link.Channel.HasValue)
-                    linkParts.Add($"Ch {link.Channel.Value}");
+                {
+                    var chInfo = $"Ch {link.Channel.Value}";
+                    if (link.WidthMhz.HasValue)
+                        chInfo += $" <span class='text-muted'>{link.WidthMhz.Value} MHz</span>";
+                    linkParts.Add(chInfo);
+                }
                 if (link.SignalDbm.HasValue)
-                    linkParts.Add($"{link.SignalDbm.Value} dBm");
+                    linkParts.Add($"<span class='wifi-tooltip-signal-value'>{link.SignalDbm.Value} dBm</span>");
                 // Same frame mapping as the aggregate row: child TX carries data away from the
                 // device, child RX carries data toward it.
                 if (DeviceFrame)

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1154,10 +1154,10 @@
             // Signal line
             if (Result.WifiSignalDbm.HasValue)
             {
-                var sigParts = new List<string> { $"{Result.WifiSignalDbm.Value} dBm" };
+                var sigParts = new List<string> { $"<span class='wifi-tooltip-signal-value'>{Result.WifiSignalDbm.Value} dBm</span>" };
                 if (Result.WifiNoiseDbm.HasValue)
                     sigParts.Add($"SNR {Result.WifiSignalDbm.Value - Result.WifiNoiseDbm.Value} dB");
-                lines.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" · ", sigParts)}</div>");
+                lines.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" ", sigParts)}</div>");
             }
 
             var clientTooltip = lines.Count > 0 ? string.Join("", lines) : "Wireless connection";
@@ -1175,7 +1175,7 @@
             var pathOnlyLines = new List<string>();
             if (!string.IsNullOrEmpty(clientBand))
                 pathOnlyLines.Add($"<div class='wifi-tooltip-link'><span class='wifi-band-badge wifi-band-{clientBand}'>{FormatRadioBand(clientBand)}</span></div>");
-            pathOnlyLines.Add($"<div class='wifi-tooltip-link-signal'>{ClientSignalDbm.Value} dBm</div>");
+            pathOnlyLines.Add($"<div class='wifi-tooltip-link-signal'><span class='wifi-tooltip-signal-value'>{ClientSignalDbm.Value} dBm</span></div>");
             var tooltip = string.Join("", pathOnlyLines);
             if (isBottleneck)
                 tooltip += "<div class='wifi-tooltip-bottleneck'>Bottleneck: slowest link in path</div>";
@@ -1267,10 +1267,10 @@
             // Signal line
             if (meshHop.WirelessSignalDbm.HasValue)
             {
-                var sigParts = new List<string> { $"{meshHop.WirelessSignalDbm.Value} dBm" };
+                var sigParts = new List<string> { $"<span class='wifi-tooltip-signal-value'>{meshHop.WirelessSignalDbm.Value} dBm</span>" };
                 if (meshHop.WirelessNoiseDbm.HasValue)
                     sigParts.Add($"SNR {meshHop.WirelessSignalDbm.Value - meshHop.WirelessNoiseDbm.Value} dB");
-                lines2.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" · ", sigParts)}</div>");
+                lines2.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" ", sigParts)}</div>");
             }
         }
 
@@ -1348,10 +1348,10 @@
                 // Signal for this link
                 if (link.signal.HasValue)
                 {
-                    var sigParts = new List<string> { $"{link.signal.Value} dBm" };
+                    var sigParts = new List<string> { $"<span class='wifi-tooltip-signal-value'>{link.signal.Value} dBm</span>" };
                     if (link.signal.HasValue && link.noise.HasValue)
                         sigParts.Add($"SNR {link.signal.Value - link.noise.Value} dB");
-                    lines.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" · ", sigParts)}</div>");
+                    lines.Add($"<div class='wifi-tooltip-link-signal'>{string.Join(" ", sigParts)}</div>");
                 }
             }
 

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1248,7 +1248,7 @@
                     if (link.RxRateMbps.HasValue)
                         linkParts.Add($"<span class='wifi-speed-tx'>TX {link.RxRateMbps.Value}</span>");
                 }
-                lines2.Add($"<div class='wifi-tooltip-link'>{string.Join(" ", linkParts)}</div>");
+                lines2.Add($"<div class='wifi-tooltip-link wifi-tooltip-mlo-link'>{string.Join(" ", linkParts)}</div>");
             }
         }
         else

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestMap.razor
@@ -1713,7 +1713,7 @@
                 }
                 html += FormatChannelForTooltip(link.channel, link.channelWidth);
                 if (link.signal.HasValue)
-                    html += $"{(link.channel is > 0 ? " · " : "")}{link.signal} dBm";
+                    html += $"{(link.channel is > 0 ? " " : "")}<span class='wifi-tooltip-signal-value'>{link.signal} dBm</span>";
                 html += "</div>";
             }
         }
@@ -1728,7 +1728,7 @@
             html += FormatChannelForTooltip(result.WifiChannel, result.WifiChannelWidthMhz);
             if (result.WifiSignalDbm.HasValue)
             {
-                html += $"{(result.WifiChannel is > 0 ? " · " : "")}{result.WifiSignalDbm} dBm";
+                html += $"{(result.WifiChannel is > 0 ? " " : "")}<span class='wifi-tooltip-signal-value'>{result.WifiSignalDbm} dBm</span>";
             }
             html += "</div>";
         }

--- a/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/WiFi/ChannelAnalysis.razor
@@ -569,7 +569,7 @@
                                 <div class="ap-col ap-name-col">
                                     <span class="ap-name">
                                         <DeviceIcon Model="@ap.Model" Size="md" /> @ap.Name
-                                        @if (ap.IsMeshChild && ap.MeshUplinkBand == _selectedBand)
+                                        @if (ap.IsMeshChild && ap.MeshUplinkUsesBand(_selectedBand))
                                         {
                                             <span class="mesh-link-badge" data-tooltip="Mesh uplink - shares channel with parent">Mesh</span>
                                         }
@@ -900,8 +900,7 @@
         return apsOnChannel.Any(ap =>
             ap.IsMeshChild &&
             !string.IsNullOrEmpty(ap.MeshParentMac) &&
-            ap.MeshUplinkBand == band &&
-            ap.MeshUplinkChannel == channel.Value &&
+            ap.MeshUplinkUsesChannel(band, channel.Value) &&
             apsOnChannel.Any(parent => parent.Mac.Equals(ap.MeshParentMac, StringComparison.OrdinalIgnoreCase)));
     }
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -1253,7 +1253,11 @@ public class AgentProbeResultSink
                          && sample.IfDescr.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
                          && !sample.IfDescr.Contains('.'))
                 {
-                    meshUplink[NormalizeMac(sample.DeviceMac)] = (calc.RateInBps.Value, calc.RateOutBps.Value);
+                    // Summed, not assigned: an MLO backhaul has one vwiresta slave per link,
+                    // mirroring the fast tier's accumulation.
+                    var meshKey = NormalizeMac(sample.DeviceMac);
+                    var meshCur = meshUplink.TryGetValue(meshKey, out var mPrev) ? mPrev : (0.0, 0.0);
+                    meshUplink[meshKey] = (meshCur.Item1 + calc.RateInBps.Value, meshCur.Item2 + calc.RateOutBps.Value);
                 }
             }
 

--- a/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
+++ b/src/NetworkOptimizer.Web/Services/AgentProbeResultSink.cs
@@ -1354,6 +1354,9 @@ public class AgentProbeResultSink
             // resolver - identical to the directly-monitored fast tier (in-memory-only live path,
             // and a UDB has no SNMP interface series to re-derive from during playback).
             BridgeInterfaceRecorder.Record(fabric, console.Devices, influx, aggNow);
+            // Mesh backhaul PHY, identical to the fast tier, so agent-relayed sites scrub the
+            // maps' Link speed the same as directly-monitored ones.
+            MeshBackhaulPhyRecorder.Record(console.Devices, influx, aggNow);
             // A switch the agent's SNMP has not read within the hand-over gap has its port_table
             // counters recorded instead, as the directly-monitored fast tier does for the switches
             // it skips. The agent never streams a switch that does not answer, so unheard is the

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -113,6 +113,11 @@ public class LanNode
         : null;
     public long? PhyTxKbps { get; set; }
     public long? PhyRxKbps { get; set; }
+
+    /// <summary>Mesh AP whose backhaul is an MLO pairing; the Phy rates above are the
+    /// aggregate across links. Drives the "(MLO)" tag on the map tooltips.</summary>
+    public bool IsMloMesh { get; set; }
+
     public string? Ssid { get; set; }
 
     /// <summary>VLAN for client filtering ("Main", "IoT", "Guest", ...).</summary>

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapModels.cs
@@ -190,6 +190,10 @@ public class LanLink
     /// <summary>Upstream (toward the gateway/ISP) capacity in bps for asymmetric links.</summary>
     public long? CapacityUpBps { get; set; }
 
+    /// <summary>Mesh backhaul that is an MLO pairing; the capacities above are the aggregate
+    /// across links. Drives the "(MLO)" tag on the 3D map's link hover.</summary>
+    public bool IsMloMesh { get; set; }
+
     /// <summary>Wireless band ("2.4"/"5"/"6") for wifi-client and mesh links.</summary>
     public string? Band { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -1611,6 +1611,7 @@ public class LanFlowMapService
                 {
                     if (claim.TxRateKbps > 0) link.CapacityDownBps = claim.TxRateKbps * 1_000L;
                     if (claim.RxRateKbps > 0) link.CapacityUpBps = claim.RxRateKbps * 1_000L;
+                    link.IsMloMesh = claim.IsMlo;
                 }
                 else
                 {
@@ -1619,11 +1620,15 @@ public class LanFlowMapService
                     // The child's own uplink names only its STA link; an MLO pair's capacity is
                     // the parent-summed aggregate. Never lower what the child reported. (claim
                     // holds the agreeing parent claim here - a contradicting one took the
-                    // fromDownlinkTable branch above.)
+                    // fromDownlinkTable branch above.) CapacityBps drives the pipes' saturation
+                    // ramp, so it takes the aggregate too or MLO throughput reads oversaturated.
                     if (claim.IsMlo)
                     {
+                        link.IsMloMesh = true;
                         if (claim.TxRateKbps > 0) link.CapacityDownBps = Math.Max(link.CapacityDownBps ?? 0, claim.TxRateKbps * 1_000L);
                         if (claim.RxRateKbps > 0) link.CapacityUpBps = Math.Max(link.CapacityUpBps ?? 0, claim.RxRateKbps * 1_000L);
+                        var aggPeak = Math.Max(claim.TxRateKbps, claim.RxRateKbps) * 1_000L;
+                        if (aggPeak > 0) link.CapacityBps = Math.Max(link.CapacityBps ?? 0, aggPeak);
                     }
                 }
             }

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -860,11 +860,29 @@ public class LanFlowMapService
                         {
                             if (link.Kind == LanLinkKind.MeshBackhaul)
                             {
-                                resolved = cPts
+                                // One vwiresta series per MLO link; the backhaul is their sum at
+                                // the scrub instant (nearest point per series). A classic backhaul
+                                // has one series, so this is the old single read for it.
+                                var meshPts = cPts
                                     .Where(p => p.IfName.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
                                         && !p.IfName.Contains('.'))
-                                    .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
-                                    .FirstOrDefault();
+                                    .GroupBy(p => p.IfName, StringComparer.OrdinalIgnoreCase)
+                                    .Select(g => g.OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds)).First())
+                                    .ToList();
+                                if (meshPts.Count == 1)
+                                {
+                                    resolved = meshPts[0];
+                                }
+                                else if (meshPts.Count > 1)
+                                {
+                                    resolved = new MonitoringInfluxClient.InterfaceRatePoint
+                                    {
+                                        Time = meshPts.OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds)).First().Time,
+                                        IfName = "vwiresta",
+                                        RateInBps = meshPts.Sum(p => p.RateInBps ?? 0),
+                                        RateOutBps = meshPts.Sum(p => p.RateOutBps ?? 0),
+                                    };
+                                }
                                 // UDB single-port bridge: no vwiresta interface. Its downlink
                                 // port_table rate is persisted under a synthetic "bridge-downlink"
                                 // series (BridgeInterfaceRecorder), stored in the same rateIn =
@@ -1479,6 +1497,11 @@ public class LanFlowMapService
         LanFlowMapSnapshot snapshot,
         Dictionary<(string mac, int port), InterfaceNameMap> nameMaps)
     {
+        // A mesh child whose own uplink UniFi did not report still has a parent that named it.
+        // Without this the device gets no edge at all: gone from the 2D map, isolated on the 3D one.
+        // Built before the node pass because MLO node rates read it too.
+        var meshParentByChild = NetworkOptimizer.UniFi.UniFiDiscovery.BuildMeshParentByChild(topology.Devices);
+
         // First pass: emit nodes for every device.
         foreach (var d in topology.Devices)
         {
@@ -1501,6 +1524,16 @@ public class LanFlowMapService
                 node.PhyTxKbps = d.UplinkTxRateKbps > 0 ? d.UplinkTxRateKbps : null;
                 node.PhyRxKbps = d.UplinkRxRateKbps > 0 ? d.UplinkRxRateKbps : null;
                 node.Band = NormalizeBand(d.UplinkRadioBand);
+                // The child's own uplink names only its STA link; on an MLO backhaul the pair's
+                // rate is the parent-summed aggregate (claim rates are the parent's perspective,
+                // so they map inverted). Never lower what the child already reported.
+                if (meshParentByChild.TryGetValue(mac, out var mloClaim)
+                    && mloClaim.IsMlo && !mloClaim.Contradicts(d.UplinkMac))
+                {
+                    node.IsMloMesh = true;
+                    if (mloClaim.RxRateKbps > 0) node.PhyTxKbps = Math.Max(node.PhyTxKbps ?? 0, mloClaim.RxRateKbps);
+                    if (mloClaim.TxRateKbps > 0) node.PhyRxKbps = Math.Max(node.PhyRxKbps ?? 0, mloClaim.TxRateKbps);
+                }
             }
             snapshot.Nodes.Add(node);
         }
@@ -1512,10 +1545,6 @@ public class LanFlowMapService
         // Second pass: uplink edges. Build them as (child -> parent), so on the wire the
         // FromNodeId is the leaf side and the data flowing toward it (DownstreamBps) is
         // gateway -> device per spec 5.7.1.
-        // A mesh child whose own uplink UniFi did not report still has a parent that named it.
-        // Without this the device gets no edge at all: gone from the 2D map, isolated on the 3D one.
-        var meshParentByChild = NetworkOptimizer.UniFi.UniFiDiscovery.BuildMeshParentByChild(topology.Devices);
-
         // An uplink is only useful if it names a device that is actually on the map. UniFi has been
         // seen reporting a stale one after a reboot - present, so nothing looked wrong, but naming
         // something no node exists for. The edge then hangs off nothing and the client drops it,
@@ -1587,6 +1616,15 @@ public class LanFlowMapService
                 {
                     if (d.UplinkRxRateKbps > 0) link.CapacityDownBps = d.UplinkRxRateKbps * 1_000L;
                     if (d.UplinkTxRateKbps > 0) link.CapacityUpBps = d.UplinkTxRateKbps * 1_000L;
+                    // The child's own uplink names only its STA link; an MLO pair's capacity is
+                    // the parent-summed aggregate. Never lower what the child reported. (claim
+                    // holds the agreeing parent claim here - a contradicting one took the
+                    // fromDownlinkTable branch above.)
+                    if (claim.IsMlo)
+                    {
+                        if (claim.TxRateKbps > 0) link.CapacityDownBps = Math.Max(link.CapacityDownBps ?? 0, claim.TxRateKbps * 1_000L);
+                        if (claim.RxRateKbps > 0) link.CapacityUpBps = Math.Max(link.CapacityUpBps ?? 0, claim.RxRateKbps * 1_000L);
+                    }
                 }
             }
 

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -735,6 +735,21 @@ public class LanFlowMapService
                 RxRateKbps = described.RxRateKbps,
             };
         }
+        // Points whose MAC is an infrastructure node are the fast tier's mesh backhaul PHY
+        // readings, recorded per mesh child under its base MAC. They feed the DEVICE node's
+        // scrub stats below and must not read as clients (presence, measured sets, or
+        // rebuilt historic-only leaves).
+        var deviceNodeMacs = snapshot.Nodes
+            .Where(n => n.Id.StartsWith("dev-", StringComparison.Ordinal) && !string.IsNullOrEmpty(n.Mac))
+            .Select(n => NormalizeMac(n.Mac))
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var meshDevRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
+        foreach (var mac in wifiClientRates.Keys.Where(deviceNodeMacs.Contains).ToList())
+        {
+            meshDevRates[mac] = wifiClientRates[mac];
+            wifiClientRates.Remove(mac);
+        }
+
         var wiredClientRates = new Dictionary<string, MonitoringInfluxClient.ClientThroughputPoint>(StringComparer.OrdinalIgnoreCase);
         foreach (var p in cached.WiredClients)
         {
@@ -748,7 +763,7 @@ public class LanFlowMapService
         // outside it write no telemetry, so their absence proves nothing and playback leaves them be.
         foreach (var p in cached.WifiClients)
         {
-            if (!string.IsNullOrEmpty(p.ClientMac))
+            if (!string.IsNullOrEmpty(p.ClientMac) && !deviceNodeMacs.Contains(NormalizeMac(p.ClientMac)))
                 update.MeasuredClientIds.Add("cli-" + NormalizeMac(p.ClientMac));
         }
         foreach (var p in cached.WiredClients)
@@ -793,6 +808,19 @@ public class LanFlowMapService
                 PhyTxKbps = p.TxRateKbps,
                 PhyRxKbps = p.RxRateKbps,
                 ApNodeId = apNodeId,
+            };
+        }
+
+        // Mesh backhaul PHY at the scrub instant, keyed by the device node so the maps'
+        // Link speed rows follow the playhead like a client's connection stats do.
+        foreach (var (mac, p) in meshDevRates)
+        {
+            update.ClientStats["dev-" + NormalizeMac(mac)] = new NodeClientStats
+            {
+                Band = NormalizeBand(p.Band),
+                SignalDbm = p.SignalDbm,
+                PhyTxKbps = p.TxRateKbps,
+                PhyRxKbps = p.RxRateKbps,
             };
         }
 

--- a/src/NetworkOptimizer.Web/Services/MeshBackhaulPhyRecorder.cs
+++ b/src/NetworkOptimizer.Web/Services/MeshBackhaulPhyRecorder.cs
@@ -1,0 +1,64 @@
+using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.UniFi;
+using NetworkOptimizer.UniFi.Models;
+
+namespace NetworkOptimizer.Web.Services;
+
+/// <summary>
+/// Persists each mesh child's backhaul PHY as a wifi_client point keyed by its base MAC, so
+/// playback can scrub the maps' Link speed the way it scrubs a client's connection. The
+/// historic resolver routes these to the DEVICE node - a mesh AP is not a client. Shared by
+/// the directly-monitored fast tier and the agent-relayed path so both sites record
+/// identically.
+/// </summary>
+public static class MeshBackhaulPhyRecorder
+{
+    public static void Record(IReadOnlyList<UniFiDeviceResponse> devices, MonitoringInfluxClient influx, DateTime now)
+    {
+        var claims = UniFiDiscovery.BuildMeshParentByChild(devices);
+        foreach (var dev in devices)
+        {
+            if (string.IsNullOrEmpty(dev.Mac)) continue;
+            if (!string.Equals(dev.Uplink?.Type, "wireless", StringComparison.OrdinalIgnoreCase)) continue;
+
+            long txKbps = dev.Uplink?.TxRate ?? 0;
+            long rxKbps = dev.Uplink?.RxRate ?? 0;
+            var parentMac = dev.Uplink?.UplinkMac;
+            var bandCode = dev.Uplink?.RadioBand;
+            if (claims.TryGetValue(dev.Mac, out var meshClaim) && !string.IsNullOrEmpty(meshClaim.ParentMac))
+            {
+                if (meshClaim.Contradicts(dev.Uplink?.UplinkMac))
+                {
+                    // The child's own uplink block is stale; the parent's claim is the link.
+                    // Claim rates are the parent's perspective, so they map inverted.
+                    parentMac = meshClaim.ParentMac;
+                    txKbps = meshClaim.RxRateKbps;
+                    rxKbps = meshClaim.TxRateKbps;
+                    bandCode ??= meshClaim.Links.Count > 0 ? meshClaim.Links[0].Radio : null;
+                }
+                else if (meshClaim.IsMlo)
+                {
+                    txKbps = Math.Max(txKbps, meshClaim.RxRateKbps);
+                    rxKbps = Math.Max(rxKbps, meshClaim.TxRateKbps);
+                }
+            }
+            // A radio code MapBand doesn't know (a UDB Pro's 60 GHz, say) must not skip the
+            // write: "unknown" keeps the PHY scrubbable, and the reader normalizes it to null
+            // rather than fabricating a band.
+            var band = MonitoringCollectionAgent.MapBand(bandCode);
+            if (string.IsNullOrEmpty(band)) band = "unknown";
+            if ((txKbps <= 0 && rxKbps <= 0) || string.IsNullOrEmpty(parentMac)) continue;
+
+            _ = influx.WriteWifiClientThroughputAsync(
+                apMac: parentMac,
+                band: band,
+                clientMac: dev.Mac,
+                txThroughputBps: null,
+                rxThroughputBps: null,
+                signalDbm: dev.Uplink?.Signal,
+                timestamp: now,
+                txRateKbps: txKbps > 0 ? txKbps : null,
+                rxRateKbps: rxKbps > 0 ? rxKbps : null);
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/RebootReasonParser.cs
+++ b/src/NetworkOptimizer.Web/Services/Monitoring/RebootReason/RebootReasonParser.cs
@@ -155,7 +155,7 @@ public static class RebootReasonParser
             return new DeviceRebootReason(
                 RebootCategory.CommandedReboot,
                 "Restarted",
-                "The device shut down cleanly, so something asked it to restart",
+                "The device shut down cleanly, this was a planned restart",
                 RebootReasonSource.PstoreConsole);
         }
 

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -644,6 +644,51 @@ public class MonitoringCollectionAgent : BackgroundService
         // resolver can re-derive them (the live path above is in-memory only, and a UDB has no
         // SNMP interface series). Shared verbatim with the agent-relayed path.
         BridgeInterfaceRecorder.Record(_fabric, devices, _influx, aggNow);
+
+        // Persist each mesh child's backhaul PHY as a wifi_client point keyed by its base MAC,
+        // so playback can scrub the maps' Link speed the way it scrubs a client's connection.
+        // The historic resolver routes these to the DEVICE node - a mesh AP is not a client.
+        var meshPhyClaims = UniFiDiscovery.BuildMeshParentByChild(devices);
+        foreach (var dev in devices)
+        {
+            if (string.IsNullOrEmpty(dev.Mac)) continue;
+            if (!string.Equals(dev.Uplink?.Type, "wireless", StringComparison.OrdinalIgnoreCase)) continue;
+
+            long txKbps = dev.Uplink?.TxRate ?? 0;
+            long rxKbps = dev.Uplink?.RxRate ?? 0;
+            var parentMac = dev.Uplink?.UplinkMac;
+            var bandCode = dev.Uplink?.RadioBand;
+            if (meshPhyClaims.TryGetValue(dev.Mac, out var meshClaim) && !string.IsNullOrEmpty(meshClaim.ParentMac))
+            {
+                if (meshClaim.Contradicts(dev.Uplink?.UplinkMac))
+                {
+                    // The child's own uplink block is stale; the parent's claim is the link.
+                    // Claim rates are the parent's perspective, so they map inverted.
+                    parentMac = meshClaim.ParentMac;
+                    txKbps = meshClaim.RxRateKbps;
+                    rxKbps = meshClaim.TxRateKbps;
+                    bandCode ??= meshClaim.Links.Count > 0 ? meshClaim.Links[0].Radio : null;
+                }
+                else if (meshClaim.IsMlo)
+                {
+                    txKbps = Math.Max(txKbps, meshClaim.RxRateKbps);
+                    rxKbps = Math.Max(rxKbps, meshClaim.TxRateKbps);
+                }
+            }
+            var band = MapBand(bandCode);
+            if ((txKbps <= 0 && rxKbps <= 0) || string.IsNullOrEmpty(parentMac) || string.IsNullOrEmpty(band)) continue;
+
+            _ = _influx.WriteWifiClientThroughputAsync(
+                apMac: parentMac,
+                band: band,
+                clientMac: dev.Mac,
+                txThroughputBps: null,
+                rxThroughputBps: null,
+                signalDbm: dev.Uplink?.Signal,
+                timestamp: aggNow,
+                txRateKbps: txKbps > 0 ? txKbps : null,
+                rxRateKbps: rxKbps > 0 ? rxKbps : null);
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -552,8 +552,11 @@ public class MonitoringCollectionAgent : BackgroundService
                                 && iface.Description.StartsWith("vwiresta", StringComparison.OrdinalIgnoreCase)
                                 && !iface.Description.Contains('.'))
                             {
-                                apMeshUplinkInBps = rateIn.Value;
-                                apMeshUplinkOutBps = rateOut.Value;
+                                // An MLO backhaul runs one vwiresta slave per link under the mld
+                                // master; the backhaul total is their sum. A classic backhaul has
+                                // one, so the sum is the old single read for it.
+                                apMeshUplinkInBps = (apMeshUplinkInBps ?? 0) + rateIn.Value;
+                                apMeshUplinkOutBps = (apMeshUplinkOutBps ?? 0) + rateOut.Value;
                             }
                         }
                     }

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -645,54 +645,9 @@ public class MonitoringCollectionAgent : BackgroundService
         // SNMP interface series). Shared verbatim with the agent-relayed path.
         BridgeInterfaceRecorder.Record(_fabric, devices, _influx, aggNow);
 
-        // Persist each mesh child's backhaul PHY as a wifi_client point keyed by its base MAC,
-        // so playback can scrub the maps' Link speed the way it scrubs a client's connection.
-        // The historic resolver routes these to the DEVICE node - a mesh AP is not a client.
-        var meshPhyClaims = UniFiDiscovery.BuildMeshParentByChild(devices);
-        foreach (var dev in devices)
-        {
-            if (string.IsNullOrEmpty(dev.Mac)) continue;
-            if (!string.Equals(dev.Uplink?.Type, "wireless", StringComparison.OrdinalIgnoreCase)) continue;
-
-            long txKbps = dev.Uplink?.TxRate ?? 0;
-            long rxKbps = dev.Uplink?.RxRate ?? 0;
-            var parentMac = dev.Uplink?.UplinkMac;
-            var bandCode = dev.Uplink?.RadioBand;
-            if (meshPhyClaims.TryGetValue(dev.Mac, out var meshClaim) && !string.IsNullOrEmpty(meshClaim.ParentMac))
-            {
-                if (meshClaim.Contradicts(dev.Uplink?.UplinkMac))
-                {
-                    // The child's own uplink block is stale; the parent's claim is the link.
-                    // Claim rates are the parent's perspective, so they map inverted.
-                    parentMac = meshClaim.ParentMac;
-                    txKbps = meshClaim.RxRateKbps;
-                    rxKbps = meshClaim.TxRateKbps;
-                    bandCode ??= meshClaim.Links.Count > 0 ? meshClaim.Links[0].Radio : null;
-                }
-                else if (meshClaim.IsMlo)
-                {
-                    txKbps = Math.Max(txKbps, meshClaim.RxRateKbps);
-                    rxKbps = Math.Max(rxKbps, meshClaim.TxRateKbps);
-                }
-            }
-            // A radio code MapBand doesn't know (a UDB Pro's 60 GHz, say) must not skip the
-            // write: "unknown" keeps the PHY scrubbable, and the reader normalizes it to null
-            // rather than fabricating a band.
-            var band = MapBand(bandCode);
-            if (string.IsNullOrEmpty(band)) band = "unknown";
-            if ((txKbps <= 0 && rxKbps <= 0) || string.IsNullOrEmpty(parentMac)) continue;
-
-            _ = _influx.WriteWifiClientThroughputAsync(
-                apMac: parentMac,
-                band: band,
-                clientMac: dev.Mac,
-                txThroughputBps: null,
-                rxThroughputBps: null,
-                signalDbm: dev.Uplink?.Signal,
-                timestamp: aggNow,
-                txRateKbps: txKbps > 0 ? txKbps : null,
-                rxRateKbps: rxKbps > 0 ? rxKbps : null);
-        }
+        // Persist each mesh child's backhaul PHY so playback can scrub the maps' Link speed.
+        // Shared verbatim with the agent-relayed path.
+        MeshBackhaulPhyRecorder.Record(devices, _influx, aggNow);
     }
 
     /// <summary>
@@ -1602,7 +1557,7 @@ public class MonitoringCollectionAgent : BackgroundService
     /// the InfluxDB tag value to keep the wifi_client measurement's cardinality on
     /// 3 distinct values per AP.
     /// </summary>
-    private static string MapBand(string? radio) => radio switch
+    internal static string MapBand(string? radio) => radio switch
     {
         "ng" => "2.4ghz",
         "na" => "5ghz",

--- a/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
+++ b/src/NetworkOptimizer.Web/Services/MonitoringCollectionAgent.cs
@@ -675,8 +675,12 @@ public class MonitoringCollectionAgent : BackgroundService
                     rxKbps = Math.Max(rxKbps, meshClaim.TxRateKbps);
                 }
             }
+            // A radio code MapBand doesn't know (a UDB Pro's 60 GHz, say) must not skip the
+            // write: "unknown" keeps the PHY scrubbable, and the reader normalizes it to null
+            // rather than fabricating a band.
             var band = MapBand(bandCode);
-            if ((txKbps <= 0 && rxKbps <= 0) || string.IsNullOrEmpty(parentMac) || string.IsNullOrEmpty(band)) continue;
+            if (string.IsNullOrEmpty(band)) band = "unknown";
+            if ((txKbps <= 0 && rxKbps <= 0) || string.IsNullOrEmpty(parentMac)) continue;
 
             _ = _influx.WriteWifiClientThroughputAsync(
                 apMac: parentMac,

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9429,8 +9429,23 @@ a.path-hop.hop-clickable:hover {
     margin-left: 0.25rem;
 }
 
-.ap-stats-mesh {
-    gap: 1rem;
+.ap-stats-mesh .ap-stat {
+    justify-content: flex-end;
+}
+
+/* MLO mesh cards only: the multi-row link block reads top-down, so the client stat
+   aligns top like non-mesh cards, the row tightens to make width for the grid, and
+   the mesh block hugs the right edge as one unit (the grid keeps columns aligned). */
+.ap-stats-mlo {
+    gap: 1.25rem;
+}
+
+.ap-stats-mlo .ap-stat {
+    justify-content: flex-start;
+}
+
+.ap-stats-mlo .ap-mesh-info {
+    align-items: flex-end;
 }
 
 .ap-stat {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9490,6 +9490,10 @@ a.path-hop.hop-clickable:hover {
     justify-content: flex-end;
 }
 
+.mesh-mlo-link + .mesh-mlo-link {
+    margin-top: 0.3rem;
+}
+
 .mesh-mlo-link .band-badge {
     min-width: 54px;
     text-align: center;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9560,7 +9560,7 @@ a.path-hop.hop-clickable:hover {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    padding-top: 0.75rem;
+    padding-top: 0.4rem;
     border-top: 1px solid var(--border-color);
     /* Sink to the card bottom so radio lists align across a row when a taller
        MLO mesh card stretches its siblings. */

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6467,6 +6467,10 @@ tr:hover .snmp-row-chevron {
     gap: 0.4rem;
 }
 
+.wifi-tooltip-mlo-link + .wifi-tooltip-mlo-link {
+    margin-top: 0.35rem;
+}
+
 .wifi-tooltip-link-signal {
     font-size: 0.75rem;
     color: var(--text-muted);
@@ -9425,8 +9429,8 @@ a.path-hop.hop-clickable:hover {
     margin-left: 0.25rem;
 }
 
-.ap-stats-mesh .ap-stat {
-    justify-content: flex-end;
+.ap-stats-mesh {
+    gap: 1rem;
 }
 
 .ap-stat {
@@ -9485,22 +9489,29 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-secondary);
 }
 
-/* MLO mesh backhaul: one row per link, so the big single-link signal is scaled down */
+/* MLO mesh backhaul: link rows share a 3-column grid (badge / signal / rates) so the
+   columns align across rows; each row div flattens into it via display: contents. */
+.mesh-mlo-links {
+    display: grid;
+    grid-template-columns: auto auto auto;
+    column-gap: 0.5rem;
+    row-gap: 0.3rem;
+    align-items: baseline;
+    justify-content: start;
+}
+
 .mesh-mlo-link {
-    justify-content: flex-end;
+    display: contents;
 }
 
-.mesh-mlo-link + .mesh-mlo-link {
-    margin-top: 0.3rem;
-}
-
-.mesh-mlo-link .band-badge {
+.mesh-mlo-links .band-badge {
     min-width: 54px;
     text-align: center;
 }
 
 .mesh-mlo-signal {
     font-size: 0.875rem;
+    white-space: nowrap;
 }
 
 .mesh-rate {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9535,6 +9535,7 @@ a.path-hop.hop-clickable:hover {
 
 .ap-mesh-info .ap-stat-label {
     text-transform: none;
+    margin-top: 0.2rem;
 }
 
 .lock-icon {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -6478,6 +6478,11 @@ tr:hover .snmp-row-chevron {
     padding-left: 0.25rem;
 }
 
+/* The dBm reading is the payload of a signal line; only the SNR/channel context stays muted */
+.wifi-tooltip-signal-value {
+    color: var(--text-secondary);
+}
+
 .wifi-tooltip-ch {
     color: var(--text-secondary);
 }

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -17292,7 +17292,7 @@ tr.stats-row-filtered {
     color: var(--text-primary);
     pointer-events: none;
     z-index: 10;
-    max-width: 260px;
+    max-width: 300px;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.15s ease, visibility 0.15s ease;
@@ -17311,6 +17311,11 @@ tr.stats-row-filtered {
     gap: 0.75rem;
     color: var(--text-secondary);
     font-variant-numeric: tabular-nums;
+}
+
+/* Labels stay on one line ("Link speed (MLO)"); values may still wrap. */
+.lan-flow-map-tooltip-row span:first-child {
+    white-space: nowrap;
 }
 .lan-flow-map-tooltip-row .v {
     color: var(--text-primary);
@@ -17448,7 +17453,7 @@ tr.stats-row-filtered {
     color: var(--text-primary);
     pointer-events: none;
     z-index: 10;
-    max-width: 260px;
+    max-width: 300px;
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.15s ease, visibility 0.15s ease;

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9351,6 +9351,8 @@ a.path-hop.hop-clickable:hover {
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius-lg);
     padding: 1rem;
+    display: flex;
+    flex-direction: column;
 }
 
 .ap-card.ap-offline {
@@ -9560,6 +9562,9 @@ a.path-hop.hop-clickable:hover {
     gap: 0.5rem;
     padding-top: 0.75rem;
     border-top: 1px solid var(--border-color);
+    /* Sink to the card bottom so radio lists align across a row when a taller
+       MLO mesh card stretches its siblings. */
+    margin-top: auto;
 }
 
 .ap-radio {

--- a/src/NetworkOptimizer.Web/wwwroot/css/app.css
+++ b/src/NetworkOptimizer.Web/wwwroot/css/app.css
@@ -9485,6 +9485,20 @@ a.path-hop.hop-clickable:hover {
     color: var(--text-secondary);
 }
 
+/* MLO mesh backhaul: one row per link, so the big single-link signal is scaled down */
+.mesh-mlo-link {
+    justify-content: flex-end;
+}
+
+.mesh-mlo-link .band-badge {
+    min-width: 54px;
+    text-align: center;
+}
+
+.mesh-mlo-signal {
+    font-size: 0.875rem;
+}
+
 .mesh-rate {
     white-space: nowrap;
 }

--- a/src/NetworkOptimizer.Web/wwwroot/js/firmware-rollout-viz.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/firmware-rollout-viz.js
@@ -3,7 +3,7 @@
 // planned (preview: scrub or play the sequence over estimated times) and live
 // (actual step states with a now marker). No chart library - DOM + the map canvas.
 
-import * as map2d from './lan-flow-map-2d.js?v=44'; // bump v= when lan-flow-map-2d.js changes
+import * as map2d from './lan-flow-map-2d.js?v=45'; // bump v= when lan-flow-map-2d.js changes
 // KEEP IN SYNC with lan-flow-map-2d.js: the same specifier, so both share one store.
 import * as flowData from './lan-flow-data.js?v=16';
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/firmware-rollout-viz.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/firmware-rollout-viz.js
@@ -3,7 +3,7 @@
 // planned (preview: scrub or play the sequence over estimated times) and live
 // (actual step states with a now marker). No chart library - DOM + the map canvas.
 
-import * as map2d from './lan-flow-map-2d.js?v=45'; // bump v= when lan-flow-map-2d.js changes
+import * as map2d from './lan-flow-map-2d.js?v=46'; // bump v= when lan-flow-map-2d.js changes
 // KEEP IN SYNC with lan-flow-map-2d.js: the same specifier, so both share one store.
 import * as flowData from './lan-flow-data.js?v=16';
 

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1206,7 +1206,7 @@ class LanFlowMap2D {
             const upKbps=isMeshUplink?pTx:pRx;
             const dl=downKbps?`↓${formatSpeed(Math.round(downKbps/1000))}`:'';
             const ul=upKbps?`↑${formatSpeed(Math.round(upKbps/1000))}`:'';
-            rows.push(['Link speed',`${dl}${dl&&ul?'  ':''}${ul}`]);
+            rows.push([d.isMloMesh?'Link speed (MLO)':'Link speed',`${dl}${dl&&ul?'  ':''}${ul}`]);
         }
         if(any){
             // APs: uplink throughput flipped to the to-gateway (fabric) direction.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map-2d.js
@@ -1230,7 +1230,7 @@ class LanFlowMap2D {
         this._tooltip.innerHTML=
             `<div style="font-weight:600;margin-bottom:3px">${esc(m(d.name||d.mac||''))}</div>`
             +(ovTip?`<div style="margin-bottom:3px">${esc(String(ovTip))}</div>`:'')
-            +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted}">${k}</span><span>${esc(String(v))}</span></div>`).join('')
+            +rows.map(([k,v])=>`<div style="display:flex;justify-content:space-between;gap:12px"><span style="color:${C.textMuted};white-space:nowrap">${k}</span><span>${esc(String(v))}</span></div>`).join('')
             +(hint?`<div style="color:${C.textMuted};margin-top:4px">${hint}</div>`:'');
         this._tooltip.style.opacity='1';
         this._tooltip.style.visibility='visible';

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3948,7 +3948,7 @@ export class LanFlowMap {
             const upKbps = isMeshUplink ? pTx : pRx;
             const dl = downKbps ? `↓${formatLinkSpeed(Math.round(downKbps / 1000))}` : '';
             const ul = upKbps ? `↑${formatLinkSpeed(Math.round(upKbps / 1000))}` : '';
-            rows.push(['Link speed', `${dl}${dl && ul ? '  ' : ''}${ul}`]);
+            rows.push([node.isMloMesh ? 'Link speed (MLO)' : 'Link speed', `${dl}${dl && ul ? '  ' : ''}${ul}`]);
         }
         if (anyData) {
             if (node.kind === NODE_KIND.AccessPoint) {

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -1651,7 +1651,20 @@ export class LanFlowMap {
 
     _refreshLinkLabels() {
         if (!this._linkLabels || this._linkLabels.size === 0) return;
-        for (const [linkId, { el, kind }] of this._linkLabels) {
+        for (const [linkId, { el, kind, link }] of this._linkLabels) {
+            // The negotiated-speed hover follows the tick for a mesh backhaul, as the node
+            // tooltips do: the scrubbed PHY for the child node wins over the snapshot
+            // capacities. The app's tooltip sweep rebinds when the attribute changes.
+            if (kind === LINK_KIND.MeshBackhaul && link) {
+                const mcs = this._currentClientStats?.[link.toNodeId];
+                const capDown = mcs?.phyRxKbps > 0 ? mcs.phyRxKbps * 1000 : link.capacityDownBps;
+                const capUp = mcs?.phyTxKbps > 0 ? mcs.phyTxKbps * 1000 : link.capacityUpBps;
+                const capLabel = link.isMloMesh ? 'Link speed (MLO)' : 'Link speed';
+                let tip = null;
+                if (capDown > 0 && capUp > 0) tip = `${capLabel}: ↓ ${formatCapacity(capDown)} / ↑ ${formatCapacity(capUp)}`;
+                else if (capDown > 0 || capUp > 0) tip = `${capLabel}: ${formatCapacity(capDown > 0 ? capDown : capUp)}`;
+                if (tip) el.setAttribute('data-tooltip', tip);
+            }
             const r = this._currentRates?.[linkId];
             const down = r?.downstreamBps || 0;
             const up = r?.upstreamBps || 0;
@@ -3382,7 +3395,7 @@ export class LanFlowMap {
                 this.canvas.dispatchEvent(new WheelEvent('wheel', e));
             }, { passive: false });
             this._labelsLayer.appendChild(el);
-            this._linkLabels.set(link.id, { el, kind: link.kind });
+            this._linkLabels.set(link.id, { el, kind: link.kind, link });
         }
 
         // Device labels: infrastructure devices (gateway, switch, AP) get DOM labels.

--- a/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
+++ b/src/NetworkOptimizer.Web/wwwroot/js/lan-flow-map.js
@@ -3361,13 +3361,14 @@ export class LanFlowMap {
             // Directional capacities always win over the symmetric PHY figure -
             // a symmetric ISP plan must still show the plan, not the port speed.
             const capDown = link.capacityDownBps, capUp = link.capacityUpBps;
+            const capLabel = link.isMloMesh ? 'Link speed (MLO)' : 'Link speed';
             let capTip = null;
             if (capDown > 0 && capUp > 0) {
-                capTip = `Link speed: ↓ ${formatCapacity(capDown)} / ↑ ${formatCapacity(capUp)}`;
+                capTip = `${capLabel}: ↓ ${formatCapacity(capDown)} / ↑ ${formatCapacity(capUp)}`;
             } else if (capDown > 0 || capUp > 0) {
-                capTip = `Link speed: ${formatCapacity(capDown > 0 ? capDown : capUp)}`;
+                capTip = `${capLabel}: ${formatCapacity(capDown > 0 ? capDown : capUp)}`;
             } else if (Number.isFinite(link.capacityBps) && link.capacityBps > 0) {
-                capTip = `Link speed: ${formatCapacity(link.capacityBps)}`;
+                capTip = `${capLabel}: ${formatCapacity(link.capacityBps)}`;
             }
             if (capTip) {
                 el.setAttribute('data-tooltip', capTip);

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -118,6 +118,14 @@ public class AccessPointSnapshot
         MeshUplinkBandChannels.Any(x => x.Band == band && x.Channel == channel);
 
     /// <summary>
+    /// Whether a mesh backhaul this AP participates in - as child or as parent - occupies the
+    /// given band. The parent side reads its children's links; the child side its own uplink.
+    /// </summary>
+    public bool MeshBackhaulUsesBand(RadioBand band) =>
+        MeshUplinkUsesBand(band) ||
+        MeshChildren.Any(c => c.UplinkBand == band || c.Links.Any(l => l.Band == band));
+
+    /// <summary>
     /// Per-link detail of the mesh uplink, child's perspective (TX toward the parent). The child's
     /// own uplink block describes at most one link, so on MLO these are read from the parent's
     /// downlink_table; empty when the parent reports nothing.

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -92,6 +92,32 @@ public class AccessPointSnapshot
     public bool MeshUplinkIsMlo { get; set; }
 
     /// <summary>
+    /// Every band/channel the mesh uplink occupies: the self-reported STA link plus any
+    /// parent-derived MLO links. A classic backhaul yields one entry; non-mesh APs none.
+    /// </summary>
+    public IEnumerable<(RadioBand Band, int? Channel)> MeshUplinkBandChannels
+    {
+        get
+        {
+            if (MeshUplinkBand.HasValue)
+                yield return (MeshUplinkBand.Value, MeshUplinkChannel);
+            foreach (var link in MeshUplinkLinks)
+            {
+                if (link.Band.HasValue && link.Band != MeshUplinkBand)
+                    yield return (link.Band.Value, link.Channel);
+            }
+        }
+    }
+
+    /// <summary>Whether the mesh uplink occupies the given band (any link, on MLO).</summary>
+    public bool MeshUplinkUsesBand(RadioBand band) =>
+        MeshUplinkBandChannels.Any(x => x.Band == band);
+
+    /// <summary>Whether the mesh uplink occupies the given band and channel (any link, on MLO).</summary>
+    public bool MeshUplinkUsesChannel(RadioBand band, int channel) =>
+        MeshUplinkBandChannels.Any(x => x.Band == band && x.Channel == channel);
+
+    /// <summary>
     /// Per-link detail of the mesh uplink, child's perspective (TX toward the parent). The child's
     /// own uplink block describes at most one link, so on MLO these are read from the parent's
     /// downlink_table; empty when the parent reports nothing.

--- a/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
+++ b/src/NetworkOptimizer.WiFi/Models/AccessPointSnapshot.cs
@@ -88,6 +88,16 @@ public class AccessPointSnapshot
     /// <summary>Name of the mesh parent AP (resolved from MAC, if mesh child)</summary>
     public string? MeshParentName { get; set; }
 
+    /// <summary>Whether the mesh uplink is an MLO (Wi-Fi 7 multi-link) backhaul</summary>
+    public bool MeshUplinkIsMlo { get; set; }
+
+    /// <summary>
+    /// Per-link detail of the mesh uplink, child's perspective (TX toward the parent). The child's
+    /// own uplink block describes at most one link, so on MLO these are read from the parent's
+    /// downlink_table; empty when the parent reports nothing.
+    /// </summary>
+    public List<MeshLinkInfo> MeshUplinkLinks { get; set; } = new();
+
     /// <summary>Mesh children connected to this AP (if mesh parent)</summary>
     public List<MeshChildInfo> MeshChildren { get; set; } = new();
 
@@ -109,6 +119,26 @@ public class MeshChildInfo
     public int? TxRateMbps { get; set; }
     public int? RxRateMbps { get; set; }
     public RadioBand? UplinkBand { get; set; }
+
+    /// <summary>Whether the backhaul to this child is an MLO (Wi-Fi 7 multi-link) pairing</summary>
+    public bool IsMlo { get; set; }
+
+    /// <summary>Per-link detail, parent's perspective (TX toward the child). Empty when the
+    /// parent's downlink_table reported nothing and the values above came from the child.</summary>
+    public List<MeshLinkInfo> Links { get; set; } = new();
+}
+
+/// <summary>
+/// One radio link of a mesh backhaul. TX/RX direction follows the owning collection's
+/// perspective; signal is always the parent's reading (the only end reported).
+/// </summary>
+public class MeshLinkInfo
+{
+    public RadioBand? Band { get; set; }
+    public int? Channel { get; set; }
+    public int? SignalDbm { get; set; }
+    public int? TxRateMbps { get; set; }
+    public int? RxRateMbps { get; set; }
 }
 
 /// <summary>

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -123,7 +123,11 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     }
                 }
 
-                snapshot.MeshUplinkIsMlo = isMlo;
+                // The child's own uplink.is_mlo counts too: UniFi does not set it today, but a
+                // firmware that starts reporting the child side is expected to reuse its standard
+                // MLO station shape, and the flag must not depend on the parent's table alone.
+                snapshot.MeshUplinkIsMlo = isMlo ||
+                    (devicesByMac.TryGetValue(snapshot.Mac, out var selfDevice) && selfDevice.UplinkIsMlo);
                 // Child's perspective flips direction: the parent transmitting is the child
                 // receiving. The child measures its own STA link, so its signal outranks the
                 // parent's for that link; the other links are only reported by the parent.
@@ -146,7 +150,7 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     TxRateMbps = parentTxRateMbps ?? snapshot.MeshUplinkRxRateMbps, // child RX = parent TX
                     RxRateMbps = parentRxRateMbps ?? snapshot.MeshUplinkTxRateMbps, // child TX = parent RX
                     UplinkBand = snapshot.MeshUplinkBand,
-                    IsMlo = isMlo,
+                    IsMlo = snapshot.MeshUplinkIsMlo,
                     Links = parentLinks
                 });
             }

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -125,12 +125,15 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
 
                 snapshot.MeshUplinkIsMlo = isMlo;
                 // Child's perspective flips direction: the parent transmitting is the child
-                // receiving. Signal stays the parent's reading - the only end reported per link.
+                // receiving. The child measures its own STA link, so its signal outranks the
+                // parent's for that link; the other links are only reported by the parent.
                 snapshot.MeshUplinkLinks = parentLinks.Select(l => new MeshLinkInfo
                 {
                     Band = l.Band,
                     Channel = l.Channel,
-                    SignalDbm = l.SignalDbm,
+                    SignalDbm = l.Band.HasValue && l.Band == snapshot.MeshUplinkBand && snapshot.MeshUplinkSignalDbm.HasValue
+                        ? snapshot.MeshUplinkSignalDbm
+                        : l.SignalDbm,
                     TxRateMbps = l.RxRateMbps,
                     RxRateMbps = l.TxRateMbps,
                 }).ToList();

--- a/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
+++ b/src/NetworkOptimizer.WiFi/Providers/UniFiLiveDataProvider.cs
@@ -82,24 +82,58 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
             {
                 snapshot.MeshParentName = parent.Name;
 
-                // Try to get the parent's view from its downlink_table
+                // Try to get the parent's view from its downlink_table. It is the fuller account:
+                // one entry PER LINK, so on an MLO backhaul it holds links the child's own uplink
+                // block never mentions (the child names only its STA link).
                 int? parentSignal = null;
                 int? parentTxRateMbps = null;
                 int? parentRxRateMbps = null;
+                var isMlo = false;
+                var parentLinks = new List<MeshLinkInfo>();
                 if (devicesByMac.TryGetValue(snapshot.MeshParentMac, out var parentDevice) &&
                     parentDevice.DownlinkTable != null)
                 {
-                    var childMacLower = snapshot.Mac.ToLowerInvariant();
-                    var downlink = parentDevice.DownlinkTable.FirstOrDefault(d =>
-                        string.Equals(d.SerialNo, childMacLower, StringComparison.OrdinalIgnoreCase) ||
-                        string.Equals(d.SerialNo, snapshot.Mac, StringComparison.OrdinalIgnoreCase));
-                    if (downlink != null)
+                    var matches = parentDevice.DownlinkTable
+                        .Where(d => string.Equals(d.SerialNo ?? d.MldMac, snapshot.Mac, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                    // Aggregate ONLY is_mlo-flagged entries; a non-MLO child keeps the original
+                    // single-entry read so nothing about existing mesh pairs changes.
+                    var mloEntries = matches.Where(e => e.IsMlo == true).ToList();
+                    isMlo = mloEntries.Count > 0;
+                    var entries = isMlo ? mloEntries : matches.Take(1).ToList();
+                    if (isMlo)
                     {
-                        parentSignal = downlink.Signal;
-                        parentTxRateMbps = downlink.TxRate > 0 ? (int)(downlink.TxRate / 1000) : null;
-                        parentRxRateMbps = downlink.RxRate > 0 ? (int)(downlink.RxRate / 1000) : null;
+                        parentLinks = mloEntries.Select(e => new MeshLinkInfo
+                        {
+                            Band = RadioBandExtensions.FromUniFiCode(e.Radio),
+                            Channel = e.Channel,
+                            SignalDbm = e.Signal,
+                            TxRateMbps = e.TxRate > 0 ? (int)(e.TxRate / 1000) : null,
+                            RxRateMbps = e.RxRate > 0 ? (int)(e.RxRate / 1000) : null,
+                        }).ToList();
+                    }
+                    if (entries.Count > 0)
+                    {
+                        // STR MLO runs its links concurrently, so the pair's capacity is the sum.
+                        parentSignal = entries.Max(e => e.Signal);
+                        var txSum = entries.Sum(e => e.TxRate);
+                        var rxSum = entries.Sum(e => e.RxRate);
+                        parentTxRateMbps = txSum > 0 ? (int)(txSum / 1000) : null;
+                        parentRxRateMbps = rxSum > 0 ? (int)(rxSum / 1000) : null;
                     }
                 }
+
+                snapshot.MeshUplinkIsMlo = isMlo;
+                // Child's perspective flips direction: the parent transmitting is the child
+                // receiving. Signal stays the parent's reading - the only end reported per link.
+                snapshot.MeshUplinkLinks = parentLinks.Select(l => new MeshLinkInfo
+                {
+                    Band = l.Band,
+                    Channel = l.Channel,
+                    SignalDbm = l.SignalDbm,
+                    TxRateMbps = l.RxRateMbps,
+                    RxRateMbps = l.TxRateMbps,
+                }).ToList();
 
                 parent.MeshChildren.Add(new MeshChildInfo
                 {
@@ -108,7 +142,9 @@ public class UniFiLiveDataProvider : IWiFiDataProvider
                     SignalDbm = parentSignal ?? snapshot.MeshUplinkSignalDbm,
                     TxRateMbps = parentTxRateMbps ?? snapshot.MeshUplinkRxRateMbps, // child RX = parent TX
                     RxRateMbps = parentRxRateMbps ?? snapshot.MeshUplinkTxRateMbps, // child TX = parent RX
-                    UplinkBand = snapshot.MeshUplinkBand
+                    UplinkBand = snapshot.MeshUplinkBand,
+                    IsMlo = isMlo,
+                    Links = parentLinks
                 });
             }
         }

--- a/src/NetworkOptimizer.WiFi/Rules/WideChannelWidthRule.cs
+++ b/src/NetworkOptimizer.WiFi/Rules/WideChannelWidthRule.cs
@@ -54,9 +54,13 @@ public class WideChannelWidthRule : IWiFiOptimizerRule
                     hasWeakSignal = weakPct >= WeakClientPctThreshold;
                 }
 
-                // 6 GHz 320 MHz: always flag (unconditional - better performance + co-channel separation)
+                // 6 GHz 320 MHz: always flag (unconditional - better performance + co-channel
+                // separation) - EXCEPT when the band carries a mesh backhaul: 320 MHz there is
+                // paying for backhaul capacity, and "Apply to All APs" would narrow both ends.
                 if (radio.Band == RadioBand.Band6GHz && currentWidth >= 320)
                 {
+                    if (ap.MeshBackhaulUsesBand(RadioBand.Band6GHz))
+                        continue;
                     yield return hasWeakSignal
                         ? BuildWeakSignalIssue(ap.Name, bandName, currentWidth, 160, weakClients, totalClients, weakPct)
                         : BuildInfoIssue(ap.Name, bandName, currentWidth, 160);

--- a/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
+++ b/src/NetworkOptimizer.WiFi/Services/ChannelRecommendationService.cs
@@ -2703,12 +2703,9 @@ public class ChannelRecommendationService
         {
             if (!ap.IsMeshChild || string.IsNullOrEmpty(ap.MeshParentMac))
                 continue;
-            // TODO(MLO): MeshUplinkBand is a single RadioBand. No AP-to-AP MLO STR backhaul
-            // hardware exists yet (today's MLO STR is client/bridge only), but when it ships a
-            // backhaul can span multiple bands at once (e.g. 5 + 6 GHz). Make this a set and emit
-            // one constraint per participating band once UniFi exposes per-link bands. The
-            // reconciliation logic keys off MeshGroupLeader and needs no change - only this.
-            if (ap.MeshUplinkBand != band)
+            // An MLO STR backhaul spans several bands at once (per-link bands derived from the
+            // parent's downlink_table), so each participating band emits its own constraint.
+            if (!ap.MeshUplinkUsesBand(band))
                 continue;
 
             if (macToIndex.TryGetValue(ap.Mac, out var childIdx) &&

--- a/src/NetworkOptimizer.WiFi/WiFiAnalysisHelpers.cs
+++ b/src/NetworkOptimizer.WiFi/WiFiAnalysisHelpers.cs
@@ -75,8 +75,7 @@ public static class WiFiAnalysisHelpers
         {
             if (ap.IsMeshChild &&
                 !string.IsNullOrEmpty(ap.MeshParentMac) &&
-                ap.MeshUplinkBand == band &&
-                ap.MeshUplinkChannel == channel)
+                ap.MeshUplinkUsesChannel(band, channel))
             {
                 meshPairs.Add((ap.Mac.ToLowerInvariant(), ap.MeshParentMac.ToLowerInvariant()));
             }

--- a/tests/NetworkOptimizer.UniFi.Tests/MeshParentDerivationTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/MeshParentDerivationTests.cs
@@ -112,4 +112,89 @@ public class MeshParentDerivationTests
 
         claim.Contradicts(reported).Should().Be(expected);
     }
+
+    // --- MLO: an MLO backhaul is one downlink entry PER LINK, all sharing the child's base MAC ---
+
+    private static DownlinkTableEntry MloLink(string radio, long txRate, long rxRate, int? signal = null) => new()
+    {
+        Mac = $"vwire-{radio}",
+        SerialNo = ChildMac,
+        MldMac = ChildMac,
+        IsMlo = true,
+        Radio = radio,
+        Signal = signal,
+        TxRate = txRate,
+        RxRate = rxRate,
+    };
+
+    [Fact]
+    public void BuildMeshParentByChild_MloLinks_AggregateIntoOneClaim()
+    {
+        // STR runs the links concurrently, so the pair's capacity is the sum, and each link
+        // is kept for per-band display.
+        var parent = Device(ParentMac);
+        parent.DownlinkTable = [MloLink("6e", 2_594_200, 2_161_800, -62), MloLink("na", 2_161_800, 1_201_000, -50)];
+
+        var claim = UniFiDiscovery.BuildMeshParentByChild([parent, Device(ChildMac)])[ChildMac];
+
+        claim.ParentMac.Should().Be(ParentMac);
+        claim.IsMlo.Should().BeTrue();
+        claim.TxRateKbps.Should().Be(2_594_200 + 2_161_800);
+        claim.RxRateKbps.Should().Be(2_161_800 + 1_201_000);
+        claim.Links.Should().HaveCount(2);
+        claim.Links.Select(l => l.Radio).Should().BeEquivalentTo(["6e", "na"]);
+    }
+
+    [Fact]
+    public void BuildMeshParentByChild_MloEntriesOutrankAnUnflaggedRowForTheSameChild()
+    {
+        // A firmware that keeps a legacy combined row next to the per-link entries must not be
+        // double-counted: only is_mlo-flagged entries are ever aggregated.
+        var parent = Device(ParentMac);
+        parent.DownlinkTable =
+        [
+            new DownlinkTableEntry { Mac = "vwire-combined", SerialNo = ChildMac, TxRate = 4_756_000, RxRate = 3_362_800 },
+            MloLink("6e", 2_594_200, 2_161_800),
+            MloLink("na", 2_161_800, 1_201_000),
+        ];
+
+        var claim = UniFiDiscovery.BuildMeshParentByChild([parent, Device(ChildMac)])[ChildMac];
+
+        claim.TxRateKbps.Should().Be(2_594_200 + 2_161_800);
+        claim.Links.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void BuildMeshParentByChild_DuplicateUnflaggedEntries_KeepLastEntryWins()
+    {
+        // Pre-MLO behavior, preserved exactly: duplicate non-MLO listings are never summed.
+        var parent = Device(ParentMac);
+        parent.DownlinkTable =
+        [
+            new DownlinkTableEntry { Mac = "vwire-stale", SerialNo = ChildMac, TxRate = 866_000, RxRate = 585_000 },
+            new DownlinkTableEntry { Mac = "vwire-fresh", SerialNo = ChildMac, TxRate = 1_201_000, RxRate = 866_000 },
+        ];
+
+        var claim = UniFiDiscovery.BuildMeshParentByChild([parent, Device(ChildMac)])[ChildMac];
+
+        claim.IsMlo.Should().BeFalse();
+        claim.TxRateKbps.Should().Be(1_201_000);
+        claim.RxRateKbps.Should().Be(866_000);
+        claim.Links.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void BuildMeshParentByChild_FallsBackToMldMacWhenSerialNoIsAbsent()
+    {
+        var parent = Device(ParentMac);
+        parent.DownlinkTable = [new DownlinkTableEntry { Mac = "vwire-bssid", MldMac = ChildMac, IsMlo = true, TxRate = 866_000 }];
+
+        UniFiDiscovery.BuildMeshParentByChild([parent, Device(ChildMac)]).Should().ContainKey(ChildMac);
+    }
+
+    [Fact]
+    public void MeshParentClaim_DefaultInstance_HasEmptyLinksNotNull()
+    {
+        default(UniFiDiscovery.MeshParentClaim).Links.Should().NotBeNull().And.BeEmpty();
+    }
 }

--- a/tests/NetworkOptimizer.WiFi.Tests/WiFiAnalysisHelpersTests.cs
+++ b/tests/NetworkOptimizer.WiFi.Tests/WiFiAnalysisHelpersTests.cs
@@ -215,6 +215,32 @@ public class WiFiAnalysisHelpersTests
             result.Should().HaveCount(2);
         }
 
+        [Fact]
+        public void FiltersMeshPairs_OnDerivedMloLinkBand()
+        {
+            // The child self-reports only its 5 GHz STA link; the 6 GHz MLO link is derived from
+            // the parent's downlink_table. Sharing the 6 GHz channel is the backhaul, not
+            // co-channel interference.
+            var parentMac = "aa:bb:cc:dd:ee:01";
+            var childMac = "aa:bb:cc:dd:ee:02";
+
+            var parent = CreateAp("Parent", parentMac);
+            var child = CreateMeshChild("Child", childMac, parentMac, RadioBand.Band5GHz, 40);
+            child.MeshUplinkIsMlo = true;
+            child.MeshUplinkLinks =
+            [
+                new MeshLinkInfo { Band = RadioBand.Band6GHz, Channel = 5 },
+                new MeshLinkInfo { Band = RadioBand.Band5GHz, Channel = 40 },
+            ];
+
+            var input = new List<AccessPointSnapshot> { parent, child };
+
+            WiFiAnalysisHelpers.FilterOutMeshPairs(input, RadioBand.Band6GHz, 5).Should().BeEmpty();
+            WiFiAnalysisHelpers.FilterOutMeshPairs(input, RadioBand.Band5GHz, 40).Should().BeEmpty();
+            // A 6 GHz channel the backhaul does not occupy still counts as interference.
+            WiFiAnalysisHelpers.FilterOutMeshPairs(input, RadioBand.Band6GHz, 37).Should().HaveCount(2);
+        }
+
         private static AccessPointSnapshot CreateAp(string name, string mac) => new()
         {
             Name = name,


### PR DESCRIPTION
UniFi Network reports an MLO STR mesh backhaul only from the parent's end: the parent's downlink_table carries one entry per link (is_mlo, mld_mac), while the child's own uplink block names just its STA link - no is_mlo, no second link, and an AP restart does not change that. This derives the full pair from the parent's per-link entries (the same downlink_table fill already used when a child's uplink goes missing) and feeds it everywhere the backhaul is shown or evaluated. If UniFi Network starts reporting the child side (expected to reuse its standard MLO station shape), everything here keeps working: the child's uplink is_mlo flag is honored, unknown keys are ignored, and only is_mlo-flagged entries ever aggregate.

Non-MLO mesh pairs are unchanged - duplicate unflagged rows keep last-entry-wins, empty-serialno entries stay skipped, and every new display branch gates on MLO. Locked in by new derivation and filter tests.

## Wi-Fi Optimizer

- **Overview** - The **Mesh Uplink** and **Mesh Child** blocks show one row per MLO link (band badge, signal, TX/RX) with "(MLO)" on the label, laid out as a 3-column grid so the columns align. The child's own reading supplies the signal for its STA link; the other links carry the parent's readings, the only end UniFi reports. MLO cards top-align the client count and right-align the mesh block; non-MLO mesh cards keep their existing layout. Radio lists sink to the card bottom so rows align across siblings when a taller MLO card stretches the row.
- **Channels** - **Co-Channel Interference** and **High Power Overlap** no longer flag the backhaul's shared channel on any MLO band (a third AP genuinely colliding there still is), and the **Mesh** badges light on every band the backhaul occupies, not just the STA link's.
- **Channel Recommendation** - mesh same-channel constraints are emitted per participating band, so a recommendation cannot move one end of an MLO link independently of the other.
- **Fix: 320 MHz narrowing advice on mesh backhaul APs** - the 6 GHz 320 MHz narrowing suggestion is suppressed for APs on either end of a 6 GHz mesh backhaul (MLO or classic): narrowing that band halves the backhaul, and "Apply to All APs" would narrow both ends at once. Other APs at 320 MHz are still flagged.

## Monitoring - Live View

- The 2D and 3D maps rate a mesh backhaul at the pair's aggregate: the 2D link badge, the node hovers, and the 3D link hover, with the Link speed rows tagged "(MLO)". The pipe saturation ramp uses the aggregate capacity so MLO throughput doesn't read oversaturated.
- Backhaul throughput counts every link: an MLO backhaul runs one vwiresta slave interface per link under the mld master, and the vwiresta accumulation kept one link's rate per AP in the fast tier, the agent relay, and the historic playback resolver. All three sum the links now, so live and playback agree - verified against the AP's interface counters (mld0 equals the sum of its vwiresta slaves). A classic backhaul has one slave, so nothing changes there.
- **Mesh Link speed scrubs in playback** - PHY history was never recorded for mesh backhauls, so the maps' Link speed was snapshot-frozen at every historic instant (throughput always scrubbed; PHY never did). A shared MeshBackhaulPhyRecorder now records a wifi_client point per mesh child (base MAC, parent as the AP, child-perspective rates with the MLO aggregate; unknown radio codes such as a UDB Pro's 60 GHz record under an "unknown" band rather than being skipped), called by BOTH the directly-monitored fast tier and the agent-relay sink - mutually exclusive per site via the existing AgentCoversCollection gate, so no site double-writes. The historic resolver feeds it to the DEVICE node while keeping it out of everything client-shaped - no presence, no measured set, no rebuilt client leaves. Node hovers, the 2D badge, and the 3D link hover all follow the playhead from the deploy onward.
- **Fix: the 3D map's mesh link hover froze at the live value during playback** - the negotiated-speed tooltip was built once from the snapshot; it now follows the scrub, reading the same per-tick PHY the node tooltips do. Pre-existing, surfaced by the MLO work.

## Speed Test Path Trace

On WAN Speed Test and LAN Speed Test result details:

- The AP-to-AP mesh hop carries the STR aggregate (links run concurrently, so the pair's capacity is the sum) in the link speed, bottleneck capping, and directional evaluation.
- The link tooltip reads **Wireless Mesh (MLO)**: the aggregate rate row plus one row per link (band, channel and width, signal, TX/RX). Per-link channel width is read off the parent's radio for that band (the downlink entries report chwidth 0) and is persisted with each result's path, so historical traces keep the width the backhaul ran at.
- This works both when the child reports its uplink and on the parent-derived fallback used when it does not, and rates a load-time snapshot already raised are never lowered by the aggregate.

## Speed test tooltips (map and details)

- The dBm signal value renders in the regular text color on the Speed Test map tooltips and all details-tooltip signal lines (client, mesh, and MLO per-link); channel and SNR context stay muted, and the dot separator around the value is dropped.
