### PR TITLE
Put UniFi Building Bridge pairs on the 2D and 3D maps

### DIFF
--- a/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
+++ b/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
@@ -177,7 +177,9 @@ public class PathAnalysisResult
             if (meshSpeedMbps <= 0)
                 return Path.TargetIsAccessPoint ? MeshBackhaulOverheadFactor : ClientWifiOverheadFactor;
 
-            if (meshSpeedMbps <= Path.TheoreticalMaxMbps)
+            // Read off the hops, not the stored path max: results whose client hop was re-rated
+            // after the trace carry a path max from the trace-time PHY.
+            if (meshSpeedMbps <= SlowestLinkMbps())
                 return MeshBackhaulOverheadFactor;
 
             // A mesh AP has no client Wi-Fi link: past the mesh, only wire is left to bound it.
@@ -207,8 +209,11 @@ public class PathAnalysisResult
     /// </summary>
     /// <param name="wifiRxRateKbps">AP RX rate in Kbps (limits FromDevice direction)</param>
     /// <param name="wifiTxRateKbps">AP TX rate in Kbps (limits ToDevice direction)</param>
-    /// <returns>Tuple of (fromDeviceMaxMbps, toDeviceMaxMbps, fromEfficiency%, toEfficiency%, overheadPercent)</returns>
-    public (double fromDeviceMaxMbps, double toDeviceMaxMbps, double fromEfficiency, double toEfficiency, int overheadPercent)
+    /// <returns>Tuple of (fromDeviceMaxMbps, toDeviceMaxMbps, fromEfficiency%, toEfficiency%,
+    /// fromOverheadPercent, toOverheadPercent). Overhead is per direction because each direction is
+    /// bounded by whichever link leaves it the least: a wire can bind one direction while the
+    /// wireless link still binds the other.</returns>
+    public (double fromDeviceMaxMbps, double toDeviceMaxMbps, double fromEfficiency, double toEfficiency, int fromOverheadPercent, int toOverheadPercent)
         GetDirectionalEfficiency(long? wifiRxRateKbps, long? wifiTxRateKbps)
     {
         // Use stored directional rates if available (wireless clients with TX/RX data, or WAN/VPN)
@@ -255,7 +260,6 @@ public class PathAnalysisResult
             {
                 overheadFactor = ClientWifiOverheadFactor;
             }
-            var overheadPercent = (int)Math.Round((1 - overheadFactor) * 100);
 
             // RX = AP receives from client = FromDevice direction limit
             // TX = AP transmits to client = ToDevice direction limit
@@ -288,26 +292,38 @@ public class PathAnalysisResult
                     toDeviceMaxMbps = Math.Min(toDeviceMaxMbps, meshHop.WirelessRxRateMbps.Value);
             }
 
-            // A wireless link faster in BOTH directions than the path's slowest link is not what
-            // bounds the test - a wired hop is (an MLO mesh backhaul over a 2.5 GbE uplink), so
-            // the wire's speed and overhead apply. When the wireless link is the bottleneck the
-            // path max IS one of its two directions and this stays inert.
-            var pathMax = Path.TheoreticalMaxMbps;
-            if (!Path.IsExternalPath && pathMax > 0 && pathMax < fromDeviceMaxMbps && pathMax < toDeviceMaxMbps)
+            // A wireless link faster than the slowest wire on the path (an MLO mesh backhaul over
+            // a 2.5 GbE uplink) shares the test with that wire. Per direction, the binding link is
+            // whichever leaves less after its own overhead: the wire at wired overhead, or the
+            // wireless link at wireless overhead - a mesh at 4 Gbps PHY still bottoms out below a
+            // 2.5 GbE port once its 45% is taken. The wire is found on its own, never inferred
+            // from the path max: that can be the wireless hop's momentary PHY rate at trace time.
+            var fromOverheadFactor = overheadFactor;
+            var toOverheadFactor = overheadFactor;
+            var wiredCap = Path.IsExternalPath ? 0 : SlowestWiredLinkMbps();
+            if (wiredCap > 0)
             {
-                fromDeviceMaxMbps = pathMax;
-                toDeviceMaxMbps = pathMax;
-                overheadFactor = WiredOverheadFactor;
-                overheadPercent = (int)Math.Round((1 - overheadFactor) * 100);
+                var wiredRealistic = wiredCap * WiredOverheadFactor;
+                if (wiredRealistic < fromDeviceMaxMbps * fromOverheadFactor)
+                {
+                    fromDeviceMaxMbps = wiredCap;
+                    fromOverheadFactor = WiredOverheadFactor;
+                }
+                if (wiredRealistic < toDeviceMaxMbps * toOverheadFactor)
+                {
+                    toDeviceMaxMbps = wiredCap;
+                    toOverheadFactor = WiredOverheadFactor;
+                }
             }
 
-            var fromRealistic = fromDeviceMaxMbps * overheadFactor;
-            var toRealistic = toDeviceMaxMbps * overheadFactor;
+            var fromRealistic = fromDeviceMaxMbps * fromOverheadFactor;
+            var toRealistic = toDeviceMaxMbps * toOverheadFactor;
 
             var fromEfficiency = fromRealistic > 0 ? (MeasuredFromDeviceMbps / fromRealistic) * 100 : 0;
             var toEfficiency = toRealistic > 0 ? (MeasuredToDeviceMbps / toRealistic) * 100 : 0;
 
-            return (fromDeviceMaxMbps, toDeviceMaxMbps, fromEfficiency, toEfficiency, overheadPercent);
+            return (fromDeviceMaxMbps, toDeviceMaxMbps, fromEfficiency, toEfficiency,
+                OverheadPercent(fromOverheadFactor), OverheadPercent(toOverheadFactor));
         }
 
         // Fall back to symmetric calculation (legacy results or wired clients)
@@ -317,9 +333,45 @@ public class PathAnalysisResult
             Path.TheoreticalMaxMbps,
             FromDeviceEfficiencyPercent,
             ToDeviceEfficiencyPercent,
+            fallbackOverheadPercent,
             fallbackOverheadPercent
         );
     }
+
+    private static int OverheadPercent(double factor) => (int)Math.Round((1 - factor) * 100);
+
+    /// <summary>
+    /// The slowest rated wired link on the path, or 0 when none is. Only a link with a port
+    /// number counts: a wireless client or mesh hop carries none, and a mesh rate mirrored onto
+    /// the parent AP's ingress reads as port 0.
+    /// </summary>
+    private int SlowestWiredLinkMbps()
+    {
+        var min = 0;
+        foreach (var h in Path.Hops)
+        {
+            if (h.IngressPort is > 0 && !h.IsWirelessIngress && h.IngressSpeedMbps > 0 && !IsMeshPort(h.IngressPortName))
+                min = min == 0 ? h.IngressSpeedMbps : Math.Min(min, h.IngressSpeedMbps);
+            if (h.EgressPort is > 0 && !h.IsWirelessEgress && h.EgressSpeedMbps > 0 && !IsMeshPort(h.EgressPortName))
+                min = min == 0 ? h.EgressSpeedMbps : Math.Min(min, h.EgressSpeedMbps);
+        }
+        return min;
+    }
+
+    /// <summary>The slowest rated link on the path, wired or wireless, or 0 when none is.</summary>
+    private int SlowestLinkMbps()
+    {
+        var min = 0;
+        foreach (var h in Path.Hops)
+        {
+            if (h.IngressSpeedMbps > 0) min = min == 0 ? h.IngressSpeedMbps : Math.Min(min, h.IngressSpeedMbps);
+            if (h.EgressSpeedMbps > 0) min = min == 0 ? h.EgressSpeedMbps : Math.Min(min, h.EgressSpeedMbps);
+        }
+        return min;
+    }
+
+    private static bool IsMeshPort(string? portName) =>
+        portName?.Contains("mesh", StringComparison.OrdinalIgnoreCase) == true;
 
     /// <summary>
     /// Check if the link is asymmetric (>9% difference between TX and RX rates)

--- a/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
+++ b/src/NetworkOptimizer.UniFi/Models/PathAnalysisResult.cs
@@ -153,8 +153,9 @@ public class PathAnalysisResult
 
     /// <summary>
     /// Get the overhead factor for this path based on the bottleneck link type.
-    /// For Wi-Fi clients behind mesh, only uses mesh overhead (55%) if mesh is the bottleneck.
-    /// For mesh AP tests (target IS the mesh AP), always uses mesh overhead.
+    /// Mesh overhead (45%) applies only when the mesh backhaul is the bottleneck. A mesh AP
+    /// whose backhaul outruns its parent's wired uplink (an MLO backhaul over 2.5 GbE) is
+    /// bounded by that wire, at wired overhead.
     /// </summary>
     public double GetOverheadFactor()
     {
@@ -168,22 +169,20 @@ public class PathAnalysisResult
 
         if (meshHop != null)
         {
-            // If target IS the mesh AP, mesh IS the connection - always use mesh overhead
-            if (Path.TargetIsAccessPoint)
-            {
-                return MeshBackhaulOverheadFactor;
-            }
-
-            // For Wi-Fi clients behind mesh: check if mesh is the bottleneck
             var meshSpeedMbps = meshHop.IngressSpeedMbps > 0 && meshHop.EgressSpeedMbps > 0
                 ? Math.Min(meshHop.IngressSpeedMbps, meshHop.EgressSpeedMbps)
                 : Math.Max(meshHop.IngressSpeedMbps, meshHop.EgressSpeedMbps);
 
-            // Mesh overhead only if mesh is the bottleneck
-            if (meshSpeedMbps > 0 && meshSpeedMbps <= Path.TheoreticalMaxMbps)
-            {
+            // An unrated mesh link on a mesh AP test is still the connection under test.
+            if (meshSpeedMbps <= 0)
+                return Path.TargetIsAccessPoint ? MeshBackhaulOverheadFactor : ClientWifiOverheadFactor;
+
+            if (meshSpeedMbps <= Path.TheoreticalMaxMbps)
                 return MeshBackhaulOverheadFactor;
-            }
+
+            // A mesh AP has no client Wi-Fi link: past the mesh, only wire is left to bound it.
+            if (Path.TargetIsAccessPoint)
+                return WiredOverheadFactor;
         }
 
         return ClientWifiOverheadFactor;
@@ -287,6 +286,19 @@ public class PathAnalysisResult
                     fromDeviceMaxMbps = Math.Min(fromDeviceMaxMbps, meshHop.WirelessTxRateMbps.Value);
                 if (meshHop.WirelessRxRateMbps is > 0)
                     toDeviceMaxMbps = Math.Min(toDeviceMaxMbps, meshHop.WirelessRxRateMbps.Value);
+            }
+
+            // A wireless link faster in BOTH directions than the path's slowest link is not what
+            // bounds the test - a wired hop is (an MLO mesh backhaul over a 2.5 GbE uplink), so
+            // the wire's speed and overhead apply. When the wireless link is the bottleneck the
+            // path max IS one of its two directions and this stays inert.
+            var pathMax = Path.TheoreticalMaxMbps;
+            if (!Path.IsExternalPath && pathMax > 0 && pathMax < fromDeviceMaxMbps && pathMax < toDeviceMaxMbps)
+            {
+                fromDeviceMaxMbps = pathMax;
+                toDeviceMaxMbps = pathMax;
+                overheadFactor = WiredOverheadFactor;
+                overheadPercent = (int)Math.Round((1 - overheadFactor) * 100);
             }
 
             var fromRealistic = fromDeviceMaxMbps * overheadFactor;

--- a/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiDeviceResponse.cs
@@ -215,6 +215,24 @@ public class UniFiDeviceResponse
     public List<DownlinkTableEntry>? DownlinkTable { get; set; }
 
     /// <summary>
+    /// The wireless links this device holds as a station, one entry per radio, the device's own
+    /// perspective (tx toward the far end). A Building Bridge runs a 60 GHz link with a 5 GHz
+    /// fallback and its uplink block can describe the fallback while the 60 GHz link carries the
+    /// traffic; the entry flagged active is the live one.
+    /// </summary>
+    [JsonPropertyName("active_sta_table")]
+    public List<DownlinkTableEntry>? ActiveStaTable { get; set; }
+
+    /// <summary>
+    /// The other unit of a UniFi Building Bridge pair. The console lists one unit of a pair as a
+    /// device and nests the other here, so this is the only place the second unit exists. It has
+    /// a device's shape: its own uplink (the listed unit, or the switch it is wired to), and the
+    /// far building's switch names it as ITS uplink. Null on every other device.
+    /// </summary>
+    [JsonPropertyName("peer_ubb")]
+    public UniFiDeviceResponse? PeerUbb { get; set; }
+
+    /// <summary>
     /// Device satisfaction score (0-100). Higher is better.
     /// Represents overall Wi-Fi experience quality.
     /// </summary>
@@ -796,6 +814,16 @@ public class UplinkInfo
     /// </summary>
     [JsonPropertyName("noise")]
     public int? Noise { get; set; }
+
+    /// <summary>Cumulative bytes this device has sent over its uplink, toward the parent.</summary>
+    [JsonPropertyName("tx_bytes")]
+    [JsonConverter(typeof(FlexibleLongConverter))]
+    public long TxBytes { get; set; }
+
+    /// <summary>Cumulative bytes this device has received over its uplink, from the parent.</summary>
+    [JsonPropertyName("rx_bytes")]
+    [JsonConverter(typeof(FlexibleLongConverter))]
+    public long RxBytes { get; set; }
 
     /// <summary>
     /// Per-link detail of an MLO mesh backhaul, the child's own account: every link, with the
@@ -1671,6 +1699,14 @@ public class DownlinkTableEntry
     [JsonPropertyName("is_mlo")]
     [JsonConverter(typeof(FlexibleNullableBoolConverter))]
     public bool? IsMlo { get; set; }
+
+    /// <summary>
+    /// Whether this link carries traffic right now. A Building Bridge lists its 60 GHz link and
+    /// its 5 GHz fallback side by side; only one is active.
+    /// </summary>
+    [JsonPropertyName("active")]
+    [JsonConverter(typeof(FlexibleNullableBoolConverter))]
+    public bool? Active { get; set; }
 
     /// <summary>Signal strength as seen by the parent AP (dBm)</summary>
     [JsonPropertyName("signal")]

--- a/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiNetworkConfig.cs
@@ -103,6 +103,28 @@ public class FlexibleIntConverter : JsonConverter<int?>
 }
 
 /// <summary>
+/// Tolerant parser for 64-bit counters (byte and packet totals) that may arrive as a number, a
+/// stringified number, a float, or nothing. Mirrors FlexibleIntConverter; a value that cannot be
+/// read is 0, which the byte-delta readers treat as "no sample" rather than as a reset.
+/// </summary>
+public class FlexibleLongConverter : JsonConverter<long>
+{
+    public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.Number when reader.TryGetInt64(out var l) => l,
+            JsonTokenType.Number => (long)reader.GetDouble(),
+            JsonTokenType.String when long.TryParse(reader.GetString(), out var value) => value,
+            _ => 0,
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options)
+        => writer.WriteNumberValue(value);
+}
+
+/// <summary>
 /// Tolerant nullable-double parser for UniFi API fields that may arrive as a number, a
 /// stringified number, or an empty string. Mirrors FlexibleIntConverter but for floating
 /// point. SFP DDM values (rxpower, current, temperature, voltage) are the primary case;

--- a/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
+++ b/src/NetworkOptimizer.UniFi/NetworkPathAnalyzer.cs
@@ -3152,7 +3152,19 @@ public class NetworkPathAnalyzer : INetworkPathAnalyzer
         return (int)(theoreticalMbps * FallbackOverheadFactor);
     }
 
-    private void CalculateBottleneck(NetworkPath path)
+    /// <summary>
+    /// Re-derives the path's bottleneck, max, and realistic max from its hops as they stand now.
+    /// For a caller that re-rates a hop after the trace (the client Wi-Fi fit): without this the
+    /// stored max, realistic max, and description keep describing the trace-time rate.
+    /// </summary>
+    public static void RecalculateBottleneck(NetworkPath path)
+    {
+        foreach (var hop in path.Hops)
+            hop.IsBottleneck = false;
+        CalculateBottleneck(path);
+    }
+
+    private static void CalculateBottleneck(NetworkPath path)
     {
         if (path.Hops.Count == 0)
         {

--- a/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
+++ b/src/NetworkOptimizer.UniFi/UniFiDiscovery.cs
@@ -64,75 +64,9 @@ public class UniFiDiscovery
             devices.Where(d => !string.IsNullOrEmpty(d.Mac)).Select(d => d.Mac.ToLowerInvariant()),
             StringComparer.OrdinalIgnoreCase);
 
-        var discoveredDevices = devices.Select(d =>
-        {
-            var hardwareType = d.DeviceType;
-            var effectiveType = DetermineDeviceType(d, allDeviceMacs, _logger);
-
-            return new DiscoveredDevice
-            {
-                Id = d.Id,
-                Mac = d.Mac,
-                Name = d.Name,
-                Type = effectiveType,
-                HardwareType = hardwareType,
-                Model = d.Model,
-                Shortname = d.Shortname,
-                IpAddress = d.Ip,
-                // Set LAN IP for gateways from network config
-                LanIpAddress = effectiveType.IsGateway() ? defaultLanGatewayIp : null,
-                Firmware = d.DisplayableVersion ?? d.Version,
-                Adopted = d.Adopted,
-                State = d.State,
-                Uptime = TimeSpan.FromSeconds(d.Uptime),
-                LastSeen = DateTimeOffset.FromUnixTimeSeconds(d.LastSeen).DateTime,
-                Upgradable = d.Upgradable,
-                UpgradeToFirmware = d.UpgradeToFirmware,
-                SuricataVersion = d.SuricataVersion,
-                SupportedSuricataVersion = d.SupportedSuricataVersion,
-                SuricataUpgradePendingTarget = d.SuricataUpgradePendingTarget,
-                UplinkMac = d.Uplink?.UplinkMac,
-                UplinkPort = d.Uplink?.UplinkRemotePort,
-                LocalUplinkPort = d.Uplink?.PortIdx,
-                IsUplinkConnected = d.Uplink?.Up ?? false,
-                // For wireless uplinks, use tx_rate (Kbps -> Mbps); for wired, use speed (already Mbps)
-                UplinkSpeedMbps = d.Uplink?.Type == "wireless" && d.Uplink.TxRate > 0
-                    ? (int)(d.Uplink.TxRate / 1000)
-                    : d.Uplink?.Speed ?? 0,
-                // Wireless uplink rates in Kbps
-                UplinkTxRateKbps = d.Uplink?.TxRate ?? 0,
-                UplinkRxRateKbps = d.Uplink?.RxRate ?? 0,
-                UplinkType = d.Uplink?.Type,
-                UplinkIsMlo = d.Uplink?.IsMlo == true || (d.Uplink?.MloLinks?.Count ?? 0) > 1,
-                UplinkMloLinks = BuildSelfReportedMloLinks(d),
-                // Active uplink interface name. For a wireless mesh child this is the
-                // wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways
-                // it's the wired/WAN iface. Callers must validate the "vwiresta" prefix before
-                // treating it as a mesh backhaul interface.
-                UplinkInterface = d.Uplink?.Name,
-                UplinkRadioBand = d.Uplink?.RadioBand,
-                UplinkChannel = d.Uplink?.Channel,
-                UplinkSignalDbm = d.Uplink?.Signal,
-                UplinkNoiseDbm = d.Uplink?.Noise,
-                CpuUsage = d.SystemStats?.Cpu,
-                MemoryUsage = d.SystemStats?.Mem,
-                LoadAverage = d.SystemStats?.LoadAvg1?.ToString("F2"),
-                TxBytes = d.Stats?.TxBytes ?? 0,
-                RxBytes = d.Stats?.RxBytes ?? 0,
-                PortCount = d.PortTable?.Count ?? 0,
-                WanInterfaceNames = GetWanInterfaceNames(d),
-                // Wi-Fi specific (APs only)
-                RadioTable = d.RadioTable,
-                RadioTableStats = d.RadioTableStats,
-                AntennaTable = d.AntennaTable,
-                VapTable = d.VapTable,
-                Satisfaction = d.Satisfaction,
-                ScanRadioTable = d.ScanRadioTable,
-                DownlinkTable = d.DownlinkTable,
-                AfcEnabled = d.AfcEnabled,
-                AfcState = d.AfcState
-            };
-        }).ToList();
+        var discoveredDevices = devices
+            .Select(d => MapDevice(d, DetermineDeviceType(d, allDeviceMacs, _logger), defaultLanGatewayIp))
+            .ToList();
 
         // Log wireless uplink details for debugging
         foreach (var d in devices.Where(d => d.Uplink?.Type == "wireless"))
@@ -143,6 +77,122 @@ public class UniFiDiscovery
 
         return discoveredDevices;
     }
+
+    /// <summary>
+    /// The nested second unit of every UniFi Building Bridge pair in <paramref name="devices"/>.
+    /// The console lists one unit of a pair as a device and tucks the other into its
+    /// <c>peer_ubb</c>, so the far building's whole subtree uplinks to a MAC no device list
+    /// carries. Units that are also listed in their own right are left out.
+    /// </summary>
+    public static List<UniFiDeviceResponse> BuildingBridgePeers(IReadOnlyList<UniFiDeviceResponse> devices)
+    {
+        var listed = new HashSet<string>(
+            devices.Where(d => !string.IsNullOrEmpty(d.Mac)).Select(d => NormalizeMac(d.Mac)),
+            StringComparer.OrdinalIgnoreCase);
+        var peers = new List<UniFiDeviceResponse>();
+        foreach (var d in devices)
+        {
+            var peer = d.PeerUbb;
+            if (peer == null || string.IsNullOrEmpty(peer.Mac)) continue;
+            if (!listed.Add(NormalizeMac(peer.Mac))) continue;
+            peers.Add(peer);
+        }
+        return peers;
+    }
+
+    /// <summary>
+    /// A nested Building Bridge unit (<see cref="BuildingBridgePeers"/>) as a device of its own,
+    /// mapped exactly as the listed devices are. A bridge unit is never a gateway, so the
+    /// listed-device type adjustment does not apply.
+    /// </summary>
+    public static DiscoveredDevice MapBuildingBridgePeer(UniFiDeviceResponse peer)
+        => MapDevice(peer, peer.DeviceType, defaultLanGatewayIp: null);
+
+    private static DiscoveredDevice MapDevice(UniFiDeviceResponse d, DeviceType effectiveType, string? defaultLanGatewayIp)
+    {
+        var link = ActiveBridgeLink(d);
+        var txRateKbps = link?.TxRate > 0 ? link.TxRate : d.Uplink?.TxRate ?? 0;
+        var rxRateKbps = link?.RxRate > 0 ? link.RxRate : d.Uplink?.RxRate ?? 0;
+
+        return new DiscoveredDevice
+        {
+            Id = d.Id,
+            Mac = d.Mac,
+            Name = d.Name,
+            Type = effectiveType,
+            HardwareType = d.DeviceType,
+            Model = d.Model,
+            Shortname = d.Shortname,
+            IpAddress = d.Ip,
+            // Set LAN IP for gateways from network config
+            LanIpAddress = effectiveType.IsGateway() ? defaultLanGatewayIp : null,
+            Firmware = d.DisplayableVersion ?? d.Version,
+            Adopted = d.Adopted,
+            State = d.State,
+            Uptime = TimeSpan.FromSeconds(d.Uptime),
+            LastSeen = DateTimeOffset.FromUnixTimeSeconds(d.LastSeen).DateTime,
+            Upgradable = d.Upgradable,
+            UpgradeToFirmware = d.UpgradeToFirmware,
+            SuricataVersion = d.SuricataVersion,
+            SupportedSuricataVersion = d.SupportedSuricataVersion,
+            SuricataUpgradePendingTarget = d.SuricataUpgradePendingTarget,
+            UplinkMac = d.Uplink?.UplinkMac,
+            UplinkPort = d.Uplink?.UplinkRemotePort,
+            LocalUplinkPort = d.Uplink?.PortIdx,
+            IsUplinkConnected = d.Uplink?.Up ?? false,
+            // For wireless uplinks, use tx_rate (Kbps -> Mbps); for wired, use speed (already Mbps)
+            UplinkSpeedMbps = d.Uplink?.Type == "wireless" && txRateKbps > 0
+                ? (int)(txRateKbps / 1000)
+                : d.Uplink?.Speed ?? 0,
+            // Wireless uplink rates in Kbps
+            UplinkTxRateKbps = txRateKbps,
+            UplinkRxRateKbps = rxRateKbps,
+            UplinkType = d.Uplink?.Type,
+            UplinkIsMlo = d.Uplink?.IsMlo == true || (d.Uplink?.MloLinks?.Count ?? 0) > 1,
+            UplinkMloLinks = BuildSelfReportedMloLinks(d),
+            // Active uplink interface name. For a wireless mesh child this is the
+            // wpa_supplicant STA backhaul iface (e.g. "vwiresta7"); for wired APs/gateways
+            // it's the wired/WAN iface. Callers must validate the "vwiresta" prefix before
+            // treating it as a mesh backhaul interface.
+            UplinkInterface = d.Uplink?.Name,
+            UplinkRadioBand = link?.Radio ?? d.Uplink?.RadioBand,
+            UplinkChannel = link?.Channel ?? d.Uplink?.Channel,
+            UplinkSignalDbm = link?.Signal ?? d.Uplink?.Signal,
+            UplinkNoiseDbm = link?.Noise ?? d.Uplink?.Noise,
+            CpuUsage = d.SystemStats?.Cpu,
+            MemoryUsage = d.SystemStats?.Mem,
+            LoadAverage = d.SystemStats?.LoadAvg1?.ToString("F2"),
+            TxBytes = d.Stats?.TxBytes ?? 0,
+            RxBytes = d.Stats?.RxBytes ?? 0,
+            PortCount = d.PortTable?.Count ?? 0,
+            WanInterfaceNames = GetWanInterfaceNames(d),
+            // Wi-Fi specific (APs only)
+            RadioTable = d.RadioTable,
+            RadioTableStats = d.RadioTableStats,
+            AntennaTable = d.AntennaTable,
+            VapTable = d.VapTable,
+            Satisfaction = d.Satisfaction,
+            ScanRadioTable = d.ScanRadioTable,
+            DownlinkTable = d.DownlinkTable,
+            AfcEnabled = d.AfcEnabled,
+            AfcState = d.AfcState
+        };
+    }
+
+    /// <summary>
+    /// The link a wirelessly-uplinked Building Bridge unit is actually carrying traffic on. Its
+    /// uplink block can describe the 5 GHz fallback radio (flagged inactive) while the 60 GHz
+    /// link is up; active_sta_table lists both and flags the live one. Null for anything else,
+    /// so the uplink block stands as reported.
+    /// </summary>
+    private static DownlinkTableEntry? ActiveBridgeLink(UniFiDeviceResponse d)
+    {
+        if (d.DeviceType != DeviceType.BuildingBridge) return null;
+        if (!string.Equals(d.Uplink?.Type, "wireless", StringComparison.OrdinalIgnoreCase)) return null;
+        return d.ActiveStaTable?.FirstOrDefault(l => l.Active == true);
+    }
+
+    private static string NormalizeMac(string mac) => mac.ToLowerInvariant().Replace('-', ':');
 
     /// <summary>
     /// Mesh parent for each child that does not report one itself, read from the other end.

--- a/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
+++ b/src/NetworkOptimizer.Web/Components/Shared/SpeedTestDetails.razor
@@ -1645,11 +1645,11 @@
     /// - FromDevice (↓): Client SENDS → AP RECEIVES → uses RX rate
     /// - ToDevice (↑): Server SENDS → AP TRANSMITS → uses TX rate
     /// </summary>
-    private (double fromMaxMbps, double toMaxMbps, double fromEff, double toEff, int overheadPct) GetDirectionalEfficiencyData()
+    private (double fromMaxMbps, double toMaxMbps, double fromEff, double toEff, int fromOverheadPct, int toOverheadPct) GetDirectionalEfficiencyData()
     {
         if (PathAnalysis == null || Result == null)
         {
-            return (0, 0, 0, 0, 6); // Default overhead
+            return (0, 0, 0, 0, 6, 6); // Default overhead
         }
 
         var (rxKbps, txKbps) = GetDirectionalRates();
@@ -1671,12 +1671,13 @@
         if (PathAnalysis == null || Result == null)
             return directionText;
 
-        var (fromMax, toMax, fromEff, toEff, overheadPct) = GetDirectionalEfficiencyData();
+        var (fromMax, toMax, fromEff, toEff, fromOverheadPct, toOverheadPct) = GetDirectionalEfficiencyData();
 
         // Get the relevant values for this direction
         var maxMbps = isFromDevice ? fromMax : toMax;
         var measuredMbps = isFromDevice ? DownloadMbps : UploadMbps;
         var efficiency = isFromDevice ? fromEff : toEff;
+        var overheadPct = isFromDevice ? fromOverheadPct : toOverheadPct;
 
         // If we don't have valid data, return just the direction text
         if (maxMbps <= 0 || measuredMbps <= 0)
@@ -1781,7 +1782,7 @@
         }
 
         // Asymmetric wireless bottleneck: show both directions with colored arrows
-        var (fromMax, toMax, _, _, _) = GetDirectionalEfficiencyData();
+        var (fromMax, toMax, _, _, _, _) = GetDirectionalEfficiencyData();
 
         // Use Gbps if both are >= 1000, otherwise Mbps
         string fromVal, toVal, unit;
@@ -1895,7 +1896,7 @@
         if (PathAnalysis == null || !IsLinkAsymmetric())
             return (false, "Mbps");
 
-        var (fromMax, toMax, _, _, _) = GetDirectionalEfficiencyData();
+        var (fromMax, toMax, _, _, _, _) = GetDirectionalEfficiencyData();
         var useGbps = fromMax >= 1000 && toMax >= 1000;
         return (useGbps, useGbps ? "Gbps" : "Mbps");
     }
@@ -1913,7 +1914,7 @@
         var (rxKbps, txKbps) = GetDirectionalRates();
         if (rxKbps > 0 && txKbps > 0)
         {
-            var (_, _, fromEff, toEff, _) = GetDirectionalEfficiencyData();
+            var (_, _, fromEff, toEff, _, _) = GetDirectionalEfficiencyData();
             return isFromDevice ? fromEff : toEff;
         }
 

--- a/src/NetworkOptimizer.Web/Services/BridgeInterfaceRecorder.cs
+++ b/src/NetworkOptimizer.Web/Services/BridgeInterfaceRecorder.cs
@@ -1,37 +1,41 @@
 using NetworkOptimizer.Core.Enums;
 using NetworkOptimizer.Storage.Models;
 using NetworkOptimizer.Storage.Services;
+using NetworkOptimizer.UniFi;
 using NetworkOptimizer.UniFi.Models;
 
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
-/// Persists each UniFi Device Bridge (UDB) downlink port_table rate to the interface_counters
-/// InfluxDB measurement so the LAN Flow Map's HISTORIC resolver can re-derive it.
+/// Persists each UniFi bridge's flow to the interface_counters InfluxDB measurement so the LAN
+/// Flow Map's HISTORIC resolver can re-derive it: a Device Bridge (UDB) from its downlink
+/// port_table, a Building Bridge (UBB) from the wirelessly-uplinked unit's uplink counters.
 ///
-/// The live path reads a UDB's rate from <see cref="LanFabricAggregator"/> + MonitoringLiveStats,
+/// The live path reads a bridge's rate from <see cref="LanFabricAggregator"/> + MonitoringLiveStats,
 /// which are in-memory only. Every other device's boundary aggregate has a durable
 /// interface_counters series to re-derive from during playback (an SNMP uplink port, or a mesh
-/// AP's vwiresta interface). A UDB's throughput uniquely lives on its own port_table - a
-/// UniFi-API signal that is never SNMP-polled - so without this it has no durable series at all.
+/// AP's vwiresta interface). A bridge's throughput lives only in UniFi-API signals that are never
+/// SNMP-polled, so without this it has no durable series at all.
 ///
-/// One summed "bridge-downlink" series is written per UDB, matching the live WriteAggregates
+/// One "bridge-downlink" series is written per bridge, matching the live WriteAggregates
 /// aggregate. Shared by the directly-monitored fast tier (MonitoringCollectionAgent) and the
 /// agent-relayed path (AgentProbeResultSink) so both site types record identically.
 /// </summary>
 public static class BridgeInterfaceRecorder
 {
     /// <summary>
-    /// Synthetic interface name for a UDB's summed downlink port_table series in
-    /// interface_counters. The historic MeshBackhaul and WiredClient resolvers match on it.
+    /// Synthetic interface name for a bridge's single-flow series in interface_counters: a UDB's
+    /// summed downlink port_table, or a UBB unit's wireless span. The historic MeshBackhaul and
+    /// WiredClient resolvers match on it, and the fabric-sum badge excludes it.
     /// </summary>
     public const string DownlinkIfName = "bridge-downlink";
 
     /// <summary>
-    /// Writes the downlink port_table rate of every DeviceBridge in <paramref name="devices"/>
-    /// to interface_counters. Call right after <see cref="LanFabricAggregator.WriteAggregates"/>
-    /// (its live sibling), once <see cref="LanFabricAggregator.UpdateUnifiPortRates"/> has run so
-    /// PortRate is populated. No-op until a rate is available (needs a prior byte sample to delta).
+    /// Writes the bridged flow of every DeviceBridge and wirelessly-uplinked BuildingBridge unit
+    /// in <paramref name="devices"/> (nested UBB peers included) to interface_counters. Call right
+    /// after <see cref="LanFabricAggregator.WriteAggregates"/> (its live sibling), once
+    /// <see cref="LanFabricAggregator.UpdateUnifiPortRates"/> has run so the rates are populated.
+    /// No-op until a rate is available (needs a prior byte sample to delta).
     /// </summary>
     public static void Record(
         LanFabricAggregator fabric,
@@ -41,8 +45,13 @@ public static class BridgeInterfaceRecorder
     {
         if (!influx.IsConfigured) return;
 
-        foreach (var dev in devices)
+        foreach (var dev in devices.Concat(UniFiDiscovery.BuildingBridgePeers(devices)))
         {
+            if (LanFabricAggregator.IsWirelessBridgeUnit(dev))
+            {
+                RecordBuildingBridgeSpan(fabric, dev, influx, now);
+                continue;
+            }
             if (dev.DeviceType != DeviceType.DeviceBridge || dev.PortTable == null) continue;
 
             var devMac = dev.Mac.ToLowerInvariant().Replace("-", ":");
@@ -97,5 +106,43 @@ public static class BridgeInterfaceRecorder
                 bcastPktsOut: null,
                 timestamp: now);
         }
+    }
+
+    /// <summary>
+    /// A UBB unit's wireless span, from its own uplink counters (unit perspective: rx = from the
+    /// peer = downloads, tx = toward it = uploads), in interface_counters' rateIn = download
+    /// convention. Speed is the span's PHY rate so the series reads like a port.
+    /// </summary>
+    private static void RecordBuildingBridgeSpan(
+        LanFabricAggregator fabric, UniFiDeviceResponse dev, MonitoringInfluxClient influx, DateTime now)
+    {
+        var devMac = dev.Mac.ToLowerInvariant().Replace("-", ":");
+        var rate = fabric.UplinkRate(devMac);
+        if (!rate.HasValue || dev.Uplink == null) return;
+
+        var phyKbps = Math.Max(dev.Uplink.TxRate, dev.Uplink.RxRate);
+        _ = influx.WriteInterfaceCountersAsync(
+            deviceMac: devMac,
+            ifName: DownlinkIfName,
+            portId: null,
+            direction: InterfaceDirection.Unknown,
+            bytesIn: dev.Uplink.RxBytes,
+            bytesOut: dev.Uplink.TxBytes,
+            rateInBps: rate.Value.DownBps,
+            rateOutBps: rate.Value.UpBps,
+            speedBps: phyKbps > 0 ? phyKbps * 1_000L : null,
+            operStatus: 1,
+            errorsIn: 0,
+            errorsOut: 0,
+            discardsIn: 0,
+            discardsOut: 0,
+            hcCounters: true,
+            ucastPktsIn: null,
+            ucastPktsOut: null,
+            mcastPktsIn: null,
+            mcastPktsOut: null,
+            bcastPktsIn: null,
+            bcastPktsOut: null,
+            timestamp: now);
     }
 }

--- a/src/NetworkOptimizer.Web/Services/ClientSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/ClientSpeedTestService.cs
@@ -762,6 +762,9 @@ public class ClientSpeedTestService : IClientSpeedTestService
             }
 
             // The wireless hop is what the trace renders. Ingress is TX (To Device), egress is RX.
+            // The bottleneck, max, and grades were derived from the trace-time rate, so they are
+            // re-derived from the re-rated hop or the stored path keeps describing a link that
+            // was never the one tested.
             //
             // Assigned back deliberately: PathAnalysis caches the deserialized object, and only its
             // setter rewrites PathAnalysisJson. Mutating the hop alone changes what this instance
@@ -772,6 +775,9 @@ public class ClientSpeedTestService : IClientSpeedTestService
             {
                 if (best.TxIsPlausible && best.Candidate.TxRateKbps is > 0) hop.IngressSpeedMbps = (int)(best.Candidate.TxRateKbps.Value / 1000);
                 if (best.RxIsPlausible && best.Candidate.RxRateKbps is > 0) hop.EgressSpeedMbps = (int)(best.Candidate.RxRateKbps.Value / 1000);
+                NetworkPathAnalyzer.RecalculateBottleneck(analysis!.Path);
+                analysis.CalculateEfficiency();
+                analysis.GenerateInsights();
                 result.PathAnalysis = analysis;
             }
 

--- a/src/NetworkOptimizer.Web/Services/LanFabricAggregator.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFabricAggregator.cs
@@ -39,6 +39,11 @@ public sealed class LanFabricAggregator
     // fallback when no parent switch port rate is available.
     private readonly ConcurrentDictionary<string, PortByteSnapshot> _deviceBytePrev = new();
     private readonly ConcurrentDictionary<string, (double DownBps, double UpBps)> _deviceByteRateLatest = new();
+    // Byte counters of a Building Bridge unit's wireless uplink block (uplink.tx_bytes /
+    // rx_bytes). A UBB has no port_table and no vwiresta interface, so the only account of
+    // its bridged flow is this block on the wirelessly-uplinked unit. Keyed by device MAC.
+    private readonly ConcurrentDictionary<string, PortByteSnapshot> _uplinkBytePrev = new();
+    private readonly ConcurrentDictionary<string, (double DownBps, double UpBps)> _uplinkRateLatest = new();
 
     /// <summary>Latest computed rate for a switch port, or null.</summary>
     public (double DownBps, double UpBps)? PortRate(string switchMac, int portIdx) =>
@@ -47,6 +52,31 @@ public sealed class LanFabricAggregator
     /// <summary>UniFi device-level byte-counter delta. Fallback for mesh-uplinked APs.</summary>
     public (double DownBps, double UpBps)? DeviceRate(string deviceMac) =>
         _deviceByteRateLatest.TryGetValue(deviceMac, out var v) ? v : null;
+
+    /// <summary>
+    /// Byte-counter delta of a Building Bridge unit's wireless uplink, the unit's own perspective:
+    /// DownBps is what it received from its peer (downloads), UpBps what it sent (uploads).
+    /// </summary>
+    public (double DownBps, double UpBps)? UplinkRate(string deviceMac) =>
+        _uplinkRateLatest.TryGetValue(deviceMac, out var v) ? v : null;
+
+    /// <summary>
+    /// A Building Bridge unit whose uplink is the wireless span to its peer: the unit that
+    /// carries the pair's flow in its uplink counters, and the child end of the map's link.
+    /// </summary>
+    public static bool IsWirelessBridgeUnit(UniFiDeviceResponse d) =>
+        d.DeviceType == DeviceType.BuildingBridge
+        && string.Equals(d.Uplink?.Type, "wireless", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// <paramref name="devices"/> plus the nested second unit of every Building Bridge pair,
+    /// which the console lists only inside its listed sibling's peer_ubb.
+    /// </summary>
+    private static IReadOnlyList<UniFiDeviceResponse> WithBridgePeers(IReadOnlyList<UniFiDeviceResponse> devices)
+    {
+        var peers = UniFiDiscovery.BuildingBridgePeers(devices);
+        return peers.Count == 0 ? devices : devices.Concat(peers).ToList();
+    }
 
     /// <summary>
     /// Sets the SNMP-derived rate for a port (the primary, 5s-cadence source). The
@@ -64,8 +94,11 @@ public sealed class LanFabricAggregator
     /// </summary>
     public void UpdateUnifiPortRates(IReadOnlyList<UniFiDeviceResponse> devices, DateTime now)
     {
-        foreach (var device in devices)
+        foreach (var device in WithBridgePeers(devices))
         {
+            if (IsWirelessBridgeUnit(device) && device.Uplink != null)
+                UpdateBridgeUplinkRate(NormalizeMac(device.Mac), device.Uplink, now);
+
             if (device.PortTable == null || device.PortTable.Count == 0) continue;
             var mac = NormalizeMac(device.Mac);
             foreach (var port in device.PortTable)
@@ -147,14 +180,48 @@ public sealed class LanFabricAggregator
     }
 
     /// <summary>
+    /// Diff a Building Bridge unit's wireless uplink byte counters against the previous
+    /// reading. Same unchanged-counter handling as the port_table path: the console refreshes
+    /// these ~30 s, so a repeated sample keeps the previous snapshot rather than reading as zero.
+    /// </summary>
+    private void UpdateBridgeUplinkRate(string mac, UplinkInfo uplink, DateTime now)
+    {
+        var current = new PortByteSnapshot(now, uplink.TxBytes, uplink.RxBytes);
+        if (current.TxBytes == 0 && current.RxBytes == 0) return;
+        if (_uplinkBytePrev.TryGetValue(mac, out var prev))
+        {
+            var elapsed = (now - prev.Timestamp).TotalSeconds;
+            long deltaTx = current.TxBytes - prev.TxBytes;
+            long deltaRx = current.RxBytes - prev.RxBytes;
+            if (elapsed > 0.5 && deltaTx >= 0 && deltaRx >= 0 && (deltaTx > 0 || deltaRx > 0))
+            {
+                // Unit perspective: rx = from the peer = downloads, tx = toward it = uploads.
+                _uplinkRateLatest[mac] = (deltaRx * 8.0 / elapsed, deltaTx * 8.0 / elapsed);
+                _uplinkBytePrev[mac] = current;
+            }
+            else if (deltaTx < 0 || deltaRx < 0)
+            {
+                // Counter reset (unit rebooted): restart the baseline.
+                _uplinkBytePrev[mac] = current;
+            }
+        }
+        else
+        {
+            _uplinkBytePrev[mac] = current;
+        }
+    }
+
+    /// <summary>
     /// Writes each device's topology-boundary aggregate to live stats: AP/switch
-    /// uplink-port rates, mesh-AP synthesis, and gateway WAN rates, with the exact
-    /// fallbacks the directly-monitored fast tier uses. Call after the per-interface
-    /// loop has fed in SNMP port rates and UpdateUnifiPortRates has run. Fabric sums
-    /// (sum of physical interface rates) are written by the caller from its loop.
+    /// uplink-port rates, mesh-AP synthesis, Building Bridge spans, and gateway WAN rates,
+    /// with the exact fallbacks the directly-monitored fast tier uses. Call after the
+    /// per-interface loop has fed in SNMP port rates and UpdateUnifiPortRates has run.
+    /// Fabric sums (sum of physical interface rates) are written by the caller from its loop.
     /// </summary>
     public void WriteAggregates(IReadOnlyList<UniFiDeviceResponse> devices, MonitoringLiveStats liveStats, DateTime now)
     {
+        devices = WithBridgePeers(devices);
+
         // A parent's downlink_table claim contradicting a device's own uplink field means that
         // uplink block is stale and describes the wrong link - reading the port it names reports
         // the mesh backhaul backwards (and repeatedly overwrites the correct vwiresta aggregate).
@@ -173,10 +240,13 @@ public sealed class LanFabricAggregator
         // the topology cares about. The trunk/uplink port is the boundary between
         // the device and the rest of the network, which is what the topology pipe
         // actually carries.
+        // A Building Bridge unit wired to a switch is bounded by that port like any switch is;
+        // the wirelessly-uplinked unit of the pair names no port and is handled below.
         foreach (var dev in devices.Where(d => d.Uplink != null
                                                && !string.IsNullOrEmpty(d.Uplink.UplinkMac)
                                                && (d.DeviceType == DeviceType.AccessPoint
-                                                   || d.DeviceType == DeviceType.Switch)
+                                                   || d.DeviceType == DeviceType.Switch
+                                                   || d.DeviceType == DeviceType.BuildingBridge)
                                                && !HasContradictedUplink(d)))
         {
             var devMac = NormalizeMac(dev.Mac);
@@ -326,6 +396,17 @@ public sealed class LanFabricAggregator
                     liveStats.RecordInterfaceAggregate(dev.Mac, sumIn, sumOut, now);
                 }
             }
+        }
+
+        // Building Bridge span: the wirelessly-uplinked unit's own uplink counters are the one
+        // account of everything crossing the pair (no port_table, no vwiresta, and nothing else
+        // writes this unit). Uploads land in RateInBps and downloads in RateOutBps, as every
+        // other aggregate writer stores them.
+        foreach (var dev in devices.Where(IsWirelessBridgeUnit))
+        {
+            var rate = UplinkRate(NormalizeMac(dev.Mac));
+            if (rate.HasValue)
+                liveStats.RecordInterfaceAggregate(dev.Mac, rate.Value.UpBps, rate.Value.DownBps, now);
         }
 
         // Gateways are the top of the topology - no parent switch to read their

--- a/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
+++ b/src/NetworkOptimizer.Web/Services/LanFlowMap/LanFlowMapService.cs
@@ -166,6 +166,24 @@ public class LanFlowMapService
         {
             rawDevices = new List<NetworkOptimizer.UniFi.Models.UniFiDeviceResponse>();
         }
+
+        // The console nests the second unit of a Building Bridge pair inside the first, so it is
+        // on no device list - yet it is the device the far building's switch uplinks to. Without
+        // it the pair's wireless link has one end and everything behind it draws isolated.
+        var bridgePeers = UniFiDiscovery.BuildingBridgePeers(rawDevices);
+        if (bridgePeers.Count > 0)
+        {
+            var listed = new HashSet<string>(topology.Devices.Select(x => NormalizeMac(x.Mac)), StringComparer.OrdinalIgnoreCase);
+            rawDevices.AddRange(bridgePeers);
+            foreach (var peer in bridgePeers)
+            {
+                if (listed.Add(NormalizeMac(peer.Mac)))
+                    topology.Devices.Add(UniFiDiscovery.MapBuildingBridgePeer(peer));
+            }
+            _logger.LogDebug("LAN map [{Site}]: {Count} Building Bridge peer unit(s) added from peer_ubb",
+                _siteContext.Slug, bridgePeers.Count);
+        }
+
         var rawByMac = rawDevices
             .Where(d => !string.IsNullOrEmpty(d.Mac))
             .ToDictionary(d => NormalizeMac(d.Mac), d => d, StringComparer.OrdinalIgnoreCase);
@@ -911,10 +929,10 @@ public class LanFlowMapService
                                         RateOutBps = meshPts.Sum(p => p.RateOutBps ?? 0),
                                     };
                                 }
-                                // UDB single-port bridge: no vwiresta interface. Its downlink
-                                // port_table rate is persisted under a synthetic "bridge-downlink"
-                                // series (BridgeInterfaceRecorder), stored in the same rateIn =
-                                // downstream convention, so it maps through the block below.
+                                // UDB and UBB: no vwiresta interface. Their bridged flow is persisted
+                                // under a synthetic "bridge-downlink" series (BridgeInterfaceRecorder),
+                                // stored in the same rateIn = downstream convention, so it maps
+                                // through the block below.
                                 resolved ??= cPts
                                     .Where(p => string.Equals(p.IfName, BridgeInterfaceRecorder.DownlinkIfName, StringComparison.OrdinalIgnoreCase))
                                     .OrderBy(p => Math.Abs((p.Time - at).TotalMilliseconds))
@@ -2592,6 +2610,8 @@ public class LanFlowMapService
         DeviceType.Switch => LanNodeKind.Switch,
         DeviceType.SmartPower => LanNodeKind.Switch,
         DeviceType.AccessPoint => LanNodeKind.AccessPoint,
+        // A bridge unit (UDB, or either half of a UBB pair) is a one-port switch to the map.
+        DeviceType.DeviceBridge or DeviceType.BuildingBridge => LanNodeKind.Switch,
         _ => LanNodeKind.Switch,
     };
 
@@ -2788,6 +2808,8 @@ public class LanFlowMapService
         "ng" or "2.4ghz" or "2.4 GHz" or "2.4" => "2.4",
         "na" or "5ghz" or "5 GHz" or "5" => "5",
         "6e" or "6ghz" or "6 GHz" or "6" => "6",
+        // 802.11ad: the Building Bridge's 60 GHz link.
+        "ad" or "60ghz" or "60 GHz" or "60" => "60",
         _ => null,
     };
 

--- a/tests/NetworkOptimizer.UniFi.Tests/BuildingBridgePeerTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/BuildingBridgePeerTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using FluentAssertions;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// A UniFi Building Bridge pair is one listed device with the other unit nested in its peer_ubb.
+/// The far building's switch uplinks to the nested unit's MAC, so a device list without it has a
+/// wireless span with one end and a subtree hanging off nothing.
+/// </summary>
+public class BuildingBridgePeerTests
+{
+    private const string SwitchMac = "aa:bb:cc:00:00:01";
+    private const string ListedMac = "aa:bb:cc:00:00:10";
+    private const string PeerMac = "aa:bb:cc:00:00:20";
+
+    private static List<UniFiDeviceResponse> Parse(string json) =>
+        JsonSerializer.Deserialize<List<UniFiDeviceResponse>>(json)!;
+
+    // The listed unit is wired to the switch; the nested unit is the wireless end of the span.
+    private const string PairJson = """
+        [
+          { "type": "usw", "model": "USL8LP", "mac": "aa:bb:cc:00:00:01" },
+          {
+            "type": "ubb", "model": "UBB", "mac": "aa:bb:cc:00:00:10", "name": "HQ side",
+            "uplink": { "type": "wire", "uplink_mac": "aa:bb:cc:00:00:01", "uplink_remote_port": 17, "port_idx": 1, "speed": 1000 },
+            "peer_ubb": {
+              "type": "ubb", "model": "UBB", "mac": "aa:bb:cc:00:00:20", "name": "Far side", "state": 1, "ip": "192.0.2.20",
+              "uplink": {
+                "type": "wireless", "uplink_mac": "aa:bb:cc:00:00:10", "radio": "na", "channel": 100,
+                "signal": -60, "tx_rate": 274477, "rx_rate": 334799, "tx_bytes": "4076657960", "rx_bytes": 5753964353
+              },
+              "active_sta_table": [
+                { "name": "wlan0", "radio": "ad", "channel": 4, "signal": -73, "tx_rate": 336875, "rx_rate": 311000, "active": true, "mac": "aa:bb:cc:00:00:10" },
+                { "name": "ath0", "radio": "na", "channel": 100, "signal": -60, "tx_rate": 274477, "rx_rate": 334799, "active": false, "mac": "aa:bb:cc:00:00:10" }
+              ]
+            }
+          }
+        ]
+        """;
+
+    [Fact]
+    public void BuildingBridgePeers_SurfacesTheNestedUnit()
+    {
+        var peers = UniFiDiscovery.BuildingBridgePeers(Parse(PairJson));
+
+        peers.Should().ContainSingle().Which.Mac.Should().Be(PeerMac);
+    }
+
+    [Fact]
+    public void BuildingBridgePeers_LeavesOutAUnitTheConsoleAlsoLists()
+    {
+        var devices = Parse(PairJson);
+        devices.Add(new UniFiDeviceResponse { Type = "ubb", Model = "UBB", Mac = PeerMac.ToUpperInvariant() });
+
+        UniFiDiscovery.BuildingBridgePeers(devices).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildingBridgePeers_IsEmptyWithoutAPair()
+    {
+        UniFiDiscovery.BuildingBridgePeers(Parse("""[{ "type": "usw", "mac": "aa:bb:cc:00:00:01" }]"""))
+            .Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MapBuildingBridgePeer_IsABuildingBridgeUplinkedToItsSibling()
+    {
+        var peer = UniFiDiscovery.BuildingBridgePeers(Parse(PairJson))[0];
+
+        var device = UniFiDiscovery.MapBuildingBridgePeer(peer);
+
+        device.Type.Should().Be(DeviceType.BuildingBridge);
+        device.Mac.Should().Be(PeerMac);
+        device.Name.Should().Be("Far side");
+        device.UplinkMac.Should().Be(ListedMac);
+        device.UplinkType.Should().Be("wireless");
+        device.State.Should().Be(1);
+    }
+
+    [Fact]
+    public void WirelessUnit_TakesItsBandAndRatesFromTheActiveLink()
+    {
+        // The uplink block describes the 5 GHz fallback; the 60 GHz link is the one flagged
+        // active, and it is what the console's own link_capacity follows.
+        var peer = UniFiDiscovery.BuildingBridgePeers(Parse(PairJson))[0];
+
+        var device = UniFiDiscovery.MapBuildingBridgePeer(peer);
+
+        device.UplinkRadioBand.Should().Be("ad");
+        device.UplinkChannel.Should().Be(4);
+        device.UplinkSignalDbm.Should().Be(-73);
+        device.UplinkTxRateKbps.Should().Be(336875);
+        device.UplinkRxRateKbps.Should().Be(311000);
+        device.UplinkSpeedMbps.Should().Be(336);
+    }
+
+    [Fact]
+    public void WirelessUnit_KeepsTheUplinkBlockWhenNoLinkIsFlaggedActive()
+    {
+        var peer = UniFiDiscovery.BuildingBridgePeers(Parse(PairJson))[0];
+        foreach (var l in peer.ActiveStaTable!) l.Active = false;
+
+        var device = UniFiDiscovery.MapBuildingBridgePeer(peer);
+
+        device.UplinkRadioBand.Should().Be("na");
+        device.UplinkChannel.Should().Be(100);
+        device.UplinkTxRateKbps.Should().Be(274477);
+    }
+
+    [Fact]
+    public void UplinkByteCounters_ParseWhetherStringOrNumber()
+    {
+        var peer = UniFiDiscovery.BuildingBridgePeers(Parse(PairJson))[0];
+
+        peer.Uplink!.TxBytes.Should().Be(4076657960);
+        peer.Uplink.RxBytes.Should().Be(5753964353);
+    }
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
@@ -535,6 +535,98 @@ public class PathAnalysisResultTests
 
     #endregion
 
+    #region Directional efficiency - wired bottleneck under a faster wireless link
+
+    // A mesh AP whose MLO backhaul (6.5 / 7.2 Gbps) outruns its parent's 2.5 GbE uplink. The
+    // path's bottleneck is the wire, so the grade must be measured against 2.5 Gbps at wired
+    // overhead, not against the backhaul at mesh overhead.
+    private static PathAnalysisResult MeshApBehindSlowerWire() => new()
+    {
+        Path = new NetworkPath
+        {
+            TargetIsAccessPoint = true,
+            HasRealBottleneck = true,
+            TheoreticalMaxMbps = 2500,
+            RealisticMaxMbps = 2390,
+            Hops =
+            [
+                new()
+                {
+                    Type = HopType.AccessPoint,
+                    IngressPortName = "wireless mesh", IngressSpeedMbps = 6533, IsWirelessIngress = true,
+                    EgressPortName = "wireless mesh", EgressSpeedMbps = 6533, IsWirelessEgress = true,
+                    WirelessTxRateMbps = 6533, WirelessRxRateMbps = 7206,
+                },
+                new() { Type = HopType.AccessPoint, IngressSpeedMbps = 6533, EgressSpeedMbps = 2500, IsBottleneck = true },
+                new() { Type = HopType.Switch, IngressSpeedMbps = 2500, EgressSpeedMbps = 10000 },
+            ],
+        },
+        MeasuredFromDeviceMbps = 1262,
+        MeasuredToDeviceMbps = 1247,
+    };
+
+    [Fact]
+    public void GetDirectionalEfficiency_WireSlowerThanBothWirelessDirections_GradesAgainstTheWire()
+    {
+        var result = MeshApBehindSlowerWire();
+        var (rxKbps, txKbps) = result.GetDirectionalRatesFromPath();
+
+        var (fromMax, toMax, fromEff, toEff, overhead) = result.GetDirectionalEfficiency(rxKbps, txKbps);
+
+        fromMax.Should().Be(2500);
+        toMax.Should().Be(2500);
+        overhead.Should().Be(6, "a wired bottleneck carries wired overhead");
+        fromEff.Should().BeApproximately(1262 / (2500 * 0.94) * 100, 0.01);
+        toEff.Should().BeApproximately(1247 / (2500 * 0.94) * 100, 0.01);
+    }
+
+    [Fact]
+    public void GetOverheadFactor_MeshApBehindSlowerWire_IsWired()
+    {
+        MeshApBehindSlowerWire().GetOverheadFactor().Should().Be(PathAnalysisResult.WiredOverheadFactor);
+    }
+
+    [Fact]
+    public void GetDirectionalEfficiency_WirelessLinkIsTheBottleneck_KeepsItsOwnDirections()
+    {
+        // A phone's Wi-Fi link (2401 / 2161) on an AP with a faster uplink: the path max is
+        // one of the two directions, so each direction keeps its own rate at Wi-Fi overhead.
+        var result = new PathAnalysisResult
+        {
+            Path = new NetworkPath
+            {
+                HasRealBottleneck = true,
+                TheoreticalMaxMbps = 2161,
+                Hops =
+                [
+                    new() { Type = HopType.WirelessClient, IngressSpeedMbps = 2161, EgressSpeedMbps = 2401, IsWirelessIngress = true, IsBottleneck = true },
+                    new() { Type = HopType.AccessPoint, IngressSpeedMbps = 10000, EgressSpeedMbps = 10000 },
+                ],
+            },
+            MeasuredFromDeviceMbps = 1147,
+            MeasuredToDeviceMbps = 1190,
+        };
+
+        var (fromMax, toMax, _, _, overhead) = result.GetDirectionalEfficiency(2401_000, 2161_000);
+
+        fromMax.Should().Be(2401);
+        toMax.Should().Be(2161);
+        overhead.Should().Be(25);
+    }
+
+    [Fact]
+    public void GetOverheadFactor_MeshApWhoseMeshIsTheBottleneck_IsMesh()
+    {
+        var result = MeshApBehindSlowerWire();
+        result.Path.TheoreticalMaxMbps = 1200;
+        result.Path.Hops[0].IngressSpeedMbps = 1200;
+        result.Path.Hops[0].EgressSpeedMbps = 1200;
+
+        result.GetOverheadFactor().Should().Be(PathAnalysisResult.MeshBackhaulOverheadFactor);
+    }
+
+    #endregion
+
     #region PerformanceGrade Enum Tests
 
     [Fact]

--- a/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/PathAnalysisResultTests.cs
@@ -557,8 +557,9 @@ public class PathAnalysisResultTests
                     EgressPortName = "wireless mesh", EgressSpeedMbps = 6533, IsWirelessEgress = true,
                     WirelessTxRateMbps = 6533, WirelessRxRateMbps = 7206,
                 },
-                new() { Type = HopType.AccessPoint, IngressSpeedMbps = 6533, EgressSpeedMbps = 2500, IsBottleneck = true },
-                new() { Type = HopType.Switch, IngressSpeedMbps = 2500, EgressSpeedMbps = 10000 },
+                // The parent carries the mesh rate on its port-less ingress; only its port 3 is a wire.
+                new() { Type = HopType.AccessPoint, IngressPort = 0, IngressPortName = "Port 0", IngressSpeedMbps = 6533, EgressPort = 3, EgressSpeedMbps = 2500, IsBottleneck = true },
+                new() { Type = HopType.Switch, IngressPort = 3, IngressSpeedMbps = 2500, EgressPort = 10, EgressSpeedMbps = 10000 },
             ],
         },
         MeasuredFromDeviceMbps = 1262,
@@ -571,13 +572,35 @@ public class PathAnalysisResultTests
         var result = MeshApBehindSlowerWire();
         var (rxKbps, txKbps) = result.GetDirectionalRatesFromPath();
 
-        var (fromMax, toMax, fromEff, toEff, overhead) = result.GetDirectionalEfficiency(rxKbps, txKbps);
+        var (fromMax, toMax, fromEff, toEff, fromOverhead, toOverhead) = result.GetDirectionalEfficiency(rxKbps, txKbps);
 
         fromMax.Should().Be(2500);
         toMax.Should().Be(2500);
-        overhead.Should().Be(6, "a wired bottleneck carries wired overhead");
+        fromOverhead.Should().Be(6, "a wired bottleneck carries wired overhead");
+        toOverhead.Should().Be(6);
         fromEff.Should().BeApproximately(1262 / (2500 * 0.94) * 100, 0.01);
         toEff.Should().BeApproximately(1247 / (2500 * 0.94) * 100, 0.01);
+    }
+
+    [Fact]
+    public void GetDirectionalEfficiency_MeshOverheadStillBindsWhenItLeavesLessThanTheWire()
+    {
+        // Mesh at 4000 / 5000 Mbps PHY over a 2.5 GbE port. The wire is the slowest link, but
+        // 4000 x 0.55 = 2200 is under the wire's 2350, so the from-device direction stays mesh-
+        // bound at mesh overhead while the to-device direction (5000 x 0.55 = 2750) is wire-bound.
+        var result = MeshApBehindSlowerWire();
+        result.Path.Hops[0].WirelessTxRateMbps = 4000;
+        result.Path.Hops[0].WirelessRxRateMbps = 5000;
+        result.Path.Hops[0].IngressSpeedMbps = 4000;
+        result.Path.Hops[0].EgressSpeedMbps = 4000;
+        var (rxKbps, txKbps) = result.GetDirectionalRatesFromPath();
+
+        var (fromMax, toMax, _, _, fromOverhead, toOverhead) = result.GetDirectionalEfficiency(rxKbps, txKbps);
+
+        fromMax.Should().Be(4000);
+        fromOverhead.Should().Be(45);
+        toMax.Should().Be(2500);
+        toOverhead.Should().Be(6);
     }
 
     [Fact]
@@ -607,11 +630,12 @@ public class PathAnalysisResultTests
             MeasuredToDeviceMbps = 1190,
         };
 
-        var (fromMax, toMax, _, _, overhead) = result.GetDirectionalEfficiency(2401_000, 2161_000);
+        var (fromMax, toMax, _, _, fromOverhead, toOverhead) = result.GetDirectionalEfficiency(2401_000, 2161_000);
 
         fromMax.Should().Be(2401);
         toMax.Should().Be(2161);
-        overhead.Should().Be(25);
+        fromOverhead.Should().Be(25);
+        toOverhead.Should().Be(25);
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.UniFi.Tests/RecalculateBottleneckTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/RecalculateBottleneckTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using NetworkOptimizer.UniFi.Models;
+using Xunit;
+
+namespace NetworkOptimizer.UniFi.Tests;
+
+/// <summary>
+/// The client Wi-Fi fit re-rates the wireless hop after the trace. The path's bottleneck, max,
+/// and description were derived from the trace-time rate and must follow the hop, or a phone
+/// traced at 216 Mbps and tested at 2.2 Gbps keeps "216 Mbps link" in its stored path.
+/// </summary>
+public class RecalculateBottleneckTests
+{
+    private static NetworkPath PhoneBehindMeshTracedAtLowPhy() => new()
+    {
+        Hops =
+        [
+            new() { Order = 0, Type = HopType.WirelessClient, DeviceName = "Phone", IngressSpeedMbps = 216, EgressSpeedMbps = 216, IsWirelessIngress = true, IsWirelessEgress = true, IsBottleneck = true },
+            new() { Order = 1, Type = HopType.AccessPoint, DeviceName = "Child AP", EgressPort = 0, EgressPortName = "wireless mesh", EgressSpeedMbps = 6533, IsWirelessEgress = true },
+            new() { Order = 2, Type = HopType.AccessPoint, DeviceName = "Parent AP", IngressPort = 0, IngressPortName = "Port 0", IngressSpeedMbps = 6533, EgressPort = 3, EgressPortName = "AP Backhaul", EgressSpeedMbps = 2500, EgressPortDeviceName = "Switch" },
+            new() { Order = 3, Type = HopType.Switch, DeviceName = "Switch", IngressPort = 3, IngressPortName = "AP Backhaul", IngressSpeedMbps = 2500, EgressPort = 10, EgressSpeedMbps = 10000 },
+        ],
+        TheoreticalMaxMbps = 216,
+        RealisticMaxMbps = 162,
+        BottleneckDescription = "216 Mbps link at Phone (wireless)",
+        HasRealBottleneck = true,
+    };
+
+    [Fact]
+    public void ReRatedClientHop_MovesTheMaxAndDescriptionWithIt()
+    {
+        var path = PhoneBehindMeshTracedAtLowPhy();
+        path.Hops[0].IngressSpeedMbps = 2161;
+        path.Hops[0].EgressSpeedMbps = 2401;
+
+        NetworkPathAnalyzer.RecalculateBottleneck(path);
+
+        path.TheoreticalMaxMbps.Should().Be(2161);
+        path.RealisticMaxMbps.Should().Be((int)(2161 * 0.75), "the client Wi-Fi link is still the bottleneck");
+        path.BottleneckDescription.Should().Be("2.2 Gbps link at Phone (wireless)");
+        path.Hops.Single(h => h.IsBottleneck).DeviceName.Should().Be("Phone");
+    }
+
+    [Fact]
+    public void ReRatedClientHopAboveTheWire_MovesTheBottleneckToTheWire()
+    {
+        var path = PhoneBehindMeshTracedAtLowPhy();
+        path.Hops[0].IngressSpeedMbps = 2882;
+        path.Hops[0].EgressSpeedMbps = 2882;
+
+        NetworkPathAnalyzer.RecalculateBottleneck(path);
+
+        path.TheoreticalMaxMbps.Should().Be(2500);
+        path.BottleneckDescription.Should().Be("2.5 Gbps link at Switch (AP Backhaul)");
+        path.Hops.Single(h => h.IsBottleneck).DeviceName.Should().Be("Parent AP");
+        path.Hops[0].IsBottleneck.Should().BeFalse("the stale flag from the trace is cleared");
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/LanFabricAggregatorTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/LanFabricAggregatorTests.cs
@@ -154,4 +154,94 @@ public class LanFabricAggregatorTests
         stats.RateInBps.Should().Be(50, "the SNMP (vwiresta) aggregate wins for a healthy mesh child too");
         stats.RateOutBps.Should().Be(75);
     }
+
+    // ---- Building Bridge pairs ----
+    // One unit is listed and wired to a switch; the other is nested in its peer_ubb, uplinked
+    // wirelessly to the listed one, and is the unit the far building's switch hangs off.
+
+    private const string BridgeWiredMac = "aa:bb:cc:00:00:10";
+    private const string BridgeWirelessMac = "aa:bb:cc:00:00:20";
+
+    private static UniFiDeviceResponse BridgePair(long peerTxBytes, long peerRxBytes) => new()
+    {
+        Mac = BridgeWiredMac,
+        Type = "ubb",
+        Model = "UBB",
+        Uplink = new UplinkInfo { UplinkMac = SwitchMac, Type = "wire", UplinkRemotePort = 17 },
+        PeerUbb = new UniFiDeviceResponse
+        {
+            Mac = BridgeWirelessMac,
+            Type = "ubb",
+            Model = "UBB",
+            Uplink = new UplinkInfo
+            {
+                UplinkMac = BridgeWiredMac,
+                Type = "wireless",
+                TxBytes = peerTxBytes,
+                RxBytes = peerRxBytes,
+            },
+        },
+    };
+
+    [Fact]
+    public void WiredBridgeUnit_AggregateComesFromParentPort()
+    {
+        var fabric = new LanFabricAggregator();
+        var liveStats = NewLiveStats();
+        fabric.SetSnmpPortRate(SwitchMac, 17, rateInBps: 111, rateOutBps: 222);
+        var devices = new List<UniFiDeviceResponse> { Switch(SwitchMac, uplinkMac: null), BridgePair(0, 0) };
+
+        fabric.WriteAggregates(devices, liveStats, DateTime.UtcNow);
+
+        var stats = liveStats.GetForDevice(BridgeWiredMac)!;
+        stats.RateInBps.Should().Be(111, "parent port RX = the unit's uploads = RateInBps");
+        stats.RateOutBps.Should().Be(222);
+    }
+
+    [Fact]
+    public void WirelessBridgeUnit_AggregateComesFromItsUplinkCounters_RateInIsUploads()
+    {
+        // The nested unit is on no device list; its uplink counters are the only account of the
+        // span. Unit perspective: tx = toward the peer = uploads, rx = from it = downloads.
+        var fabric = new LanFabricAggregator();
+        var liveStats = NewLiveStats();
+        var t0 = DateTime.UtcNow;
+        var sw = Switch(SwitchMac, uplinkMac: null);
+
+        fabric.UpdateUnifiPortRates([sw, BridgePair(peerTxBytes: 1_000, peerRxBytes: 5_000)], t0);
+        fabric.UpdateUnifiPortRates([sw, BridgePair(peerTxBytes: 2_000, peerRxBytes: 9_000)], t0.AddSeconds(10));
+        fabric.WriteAggregates([sw, BridgePair(peerTxBytes: 2_000, peerRxBytes: 9_000)], liveStats, t0.AddSeconds(10));
+
+        var stats = liveStats.GetForDevice(BridgeWirelessMac)!;
+        stats.RateInBps.Should().Be(800, "1000 bytes sent in 10 s = 800 bps of uploads into RateInBps");
+        stats.RateOutBps.Should().Be(3200, "4000 bytes received in 10 s = 3200 bps of downloads into RateOutBps");
+    }
+
+    [Fact]
+    public void WirelessBridgeUnit_UnchangedCountersKeepTheLastRate()
+    {
+        // The console refreshes the block ~30 s; a repeated sample must not read as a zero rate.
+        var fabric = new LanFabricAggregator();
+        var t0 = DateTime.UtcNow;
+        var sw = Switch(SwitchMac, uplinkMac: null);
+
+        fabric.UpdateUnifiPortRates([sw, BridgePair(1_000, 5_000)], t0);
+        fabric.UpdateUnifiPortRates([sw, BridgePair(2_000, 9_000)], t0.AddSeconds(10));
+        fabric.UpdateUnifiPortRates([sw, BridgePair(2_000, 9_000)], t0.AddSeconds(15));
+
+        fabric.UplinkRate(BridgeWirelessMac).Should().Be((3200d, 800d));
+    }
+
+    [Fact]
+    public void WirelessBridgeUnit_HasNoAggregateBeforeASecondSample()
+    {
+        var fabric = new LanFabricAggregator();
+        var liveStats = NewLiveStats();
+        var devices = new List<UniFiDeviceResponse> { Switch(SwitchMac, uplinkMac: null), BridgePair(1_000, 5_000) };
+
+        fabric.UpdateUnifiPortRates(devices, DateTime.UtcNow);
+        fabric.WriteAggregates(devices, liveStats, DateTime.UtcNow);
+
+        liveStats.GetForDevice(BridgeWirelessMac).Should().BeNull();
+    }
 }


### PR DESCRIPTION
## Monitoring - Live View

- **UniFi Building Bridge pairs on the 3D LAN Flow Map and LAN Topology Flow Map** - UniFi Network lists one unit of a UBB pair as a device and nests the other inside it (`peer_ubb`), so the far building's switch uplinked to a MAC no device list carried: the listed unit drew isolated and everything behind the bridge hung off nothing. The nested unit is now a device of its own on both maps, so a pair renders as two nodes joined by a wireless link, the wired unit sits on its switch port, and the far building's switches, APs, and clients attach behind it.
- **Throughput across the span** - a UBB has no port table and no mesh station interface, so the span's live rate comes from the wirelessly-uplinked unit's own uplink byte counters, and it is persisted under the same series a Device Bridge's single flow uses so the timeline can play it back. The wired unit takes its parent switch port's rate like any switch.
- **60 GHz link details** - a UBB runs its 60 GHz link with a 5 GHz fallback, and UniFi Network can describe the fallback radio in the uplink block while the 60 GHz link is the one carrying traffic. The active link now supplies the band, channel, signal, and PHY rates, and the tooltip reads 60 GHz for it.

Verified against a captured device response from a site with two UBB pairs (one wired unit listed with the wireless unit nested, and the reverse); no test site has a UBB, so the rendering has not been seen live.

## LAN Speed Test

- **Fix: Efficiency grades on a mesh AP test graded against the backhaul when a wire was the bottleneck** - an MLO backhaul at 6.5 / 7.2 Gbps behind a 2.5 GbE uplink read "1262 of 6533 Mbps (~45% overhead)" and graded Poor, while the max box and the bottleneck line already named the 2.5 Gbps wire. The grades now find the slowest wire on the path and, per direction, grade against whichever link leaves less after its own overhead, reporting that link's overhead. A client Wi-Fi link that is the bottleneck keeps its own two directions. The wire is read off the hops, never the stored path max, so every existing result renders correctly.
- **Fix: Client Speed Test results stored a stale bottleneck** - the Wi-Fi fit re-rates the client hop after the trace but left the path's max, realistic max, and bottleneck line at the trace-time PHY (a phone traced at 216 Mbps and tested at 2.2 Gbps kept "216 Mbps link"). New results re-derive them after the fit; existing results are untouched and unaffected on screen.
