### PR TITLE
Adaptive SQM: 7-day congestion profile learning and dynamic upload shaping

### DIFF
--- a/src/NetworkOptimizer.Alerts/ScheduleService.cs
+++ b/src/NetworkOptimizer.Alerts/ScheduleService.cs
@@ -48,6 +48,16 @@ public class ScheduleService : BackgroundService
     /// </summary>
     public Func<string, string?, string?, CancellationToken, Task<(bool Success, string? Summary, string? Error)>>? LanSpeedTestExecutor { get; set; }
 
+    /// <summary>Task type of the one-time Adaptive SQM congestion learning schedule.</summary>
+    public const string SqmLearningTaskType = "sqm_learning";
+
+    /// <summary>
+    /// Delegate that the Web project registers to take one Adaptive SQM learning sample.
+    /// Takes (siteKey, taskId, targetId, targetConfig). Its outcome may name the next run (a busy
+    /// link retries within the hour) and whether the run deserves an alert.
+    /// </summary>
+    public Func<string, int, string?, string?, CancellationToken, Task<ScheduleRunOutcome>>? SqmLearningExecutor { get; set; }
+
     public ScheduleService(
         ILogger<ScheduleService> logger,
         IServiceScopeFactory scopeFactory,
@@ -216,22 +226,36 @@ public class ScheduleService : BackgroundService
 
         try
         {
-            var (success, summary, error) = taskType switch
+            // The learning executor steers its own next run and alerting; the others keep the
+            // plain (success, summary, error) contract and the default cadence.
+            ScheduleRunOutcome outcome;
+            if (taskType == SqmLearningTaskType)
             {
-                "audit" => AuditExecutor != null
-                    ? await AuditExecutor(siteKey, ct)
-                    : (false, null, "Audit executor not registered"),
-                "wan_speedtest" => WanSpeedTestExecutor != null
-                    ? await WanSpeedTestExecutor(siteKey, taskId, targetId, targetConfig, ct)
-                    : (false, null, "WAN speed test executor not registered"),
-                "lan_speedtest" => LanSpeedTestExecutor != null
-                    ? await LanSpeedTestExecutor(siteKey, targetId, targetConfig, ct)
-                    : (false, null, "LAN speed test executor not registered"),
-                _ => (false, (string?)null, $"Unknown task type: {taskType}")
-            };
+                outcome = SqmLearningExecutor != null
+                    ? await SqmLearningExecutor(siteKey, taskId, targetId, targetConfig, ct)
+                    : new ScheduleRunOutcome(false, null, "Adaptive SQM learning executor not registered");
+            }
+            else
+            {
+                var (s, m, e) = taskType switch
+                {
+                    "audit" => AuditExecutor != null
+                        ? await AuditExecutor(siteKey, ct)
+                        : (false, null, "Audit executor not registered"),
+                    "wan_speedtest" => WanSpeedTestExecutor != null
+                        ? await WanSpeedTestExecutor(siteKey, taskId, targetId, targetConfig, ct)
+                        : (false, null, "WAN speed test executor not registered"),
+                    "lan_speedtest" => LanSpeedTestExecutor != null
+                        ? await LanSpeedTestExecutor(siteKey, targetId, targetConfig, ct)
+                        : (false, null, "LAN speed test executor not registered"),
+                    _ => (false, (string?)null, $"Unknown task type: {taskType}")
+                };
+                outcome = new ScheduleRunOutcome(s, m, e);
+            }
+            var (success, summary, error) = (outcome.Success, outcome.Summary, outcome.Error);
 
             var status = success ? "success" : "failed";
-            var nextRun = CalculateNextRun(frequencyMinutes, startHour, startMinute, scheduledRunTime);
+            var nextRun = outcome.NextRunAt ?? CalculateNextRun(frequencyMinutes, startHour, startMinute, scheduledRunTime);
 
             // DB update - failure here shouldn't change the task's reported status
             try
@@ -249,7 +273,11 @@ public class ScheduleService : BackgroundService
                 taskId, taskType, status, summary ?? "no summary");
 
             // Alert publishing - based on actual task result, not DB update success
-            if (success)
+            if (!outcome.Notify)
+            {
+                // A quiet run (a learning sample, a busy-link retry) is recorded on the task only.
+            }
+            else if (success)
             {
                 await _alertEventBus.PublishAsync(new AlertEvent
                 {
@@ -414,6 +442,19 @@ public class ScheduleService : BackgroundService
         "audit" => "security audit",
         "wan_speedtest" => "WAN speed test",
         "lan_speedtest" => "LAN speed test",
+        SqmLearningTaskType => "Adaptive SQM learning",
         _ => taskType
     };
 }
+
+/// <summary>
+/// What a schedule executor reports back. <paramref name="NextRunAt"/> overrides the task's
+/// regular cadence for one cycle (null keeps it); <paramref name="Notify"/> false records the run
+/// on the task without raising the completed/failed alert.
+/// </summary>
+public sealed record ScheduleRunOutcome(
+    bool Success,
+    string? Summary,
+    string? Error,
+    DateTime? NextRunAt = null,
+    bool Notify = true);

--- a/src/NetworkOptimizer.Alerts/ScheduleService.cs
+++ b/src/NetworkOptimizer.Alerts/ScheduleService.cs
@@ -254,7 +254,7 @@ public class ScheduleService : BackgroundService
             }
             var (success, summary, error) = (outcome.Success, outcome.Summary, outcome.Error);
 
-            var status = success ? "success" : "failed";
+            var status = outcome.Status ?? (success ? "success" : "failed");
             var nextRun = outcome.NextRunAt ?? CalculateNextRun(frequencyMinutes, startHour, startMinute, scheduledRunTime);
 
             // DB update - failure here shouldn't change the task's reported status
@@ -450,11 +450,13 @@ public class ScheduleService : BackgroundService
 /// <summary>
 /// What a schedule executor reports back. <paramref name="NextRunAt"/> overrides the task's
 /// regular cadence for one cycle (null keeps it); <paramref name="Notify"/> false records the run
-/// on the task without raising the completed/failed alert.
+/// on the task without raising the completed/failed alert; <paramref name="Status"/> replaces the
+/// recorded "success"/"failed" (a deferred check is neither, and must not read as a result).
 /// </summary>
 public sealed record ScheduleRunOutcome(
     bool Success,
     string? Summary,
     string? Error,
     DateTime? NextRunAt = null,
-    bool Notify = true);
+    bool Notify = true,
+    string? Status = null);

--- a/src/NetworkOptimizer.Sqm/CongestionProfileInsights.cs
+++ b/src/NetworkOptimizer.Sqm/CongestionProfileInsights.cs
@@ -1,0 +1,133 @@
+using NetworkOptimizer.Sqm.Models;
+
+namespace NetworkOptimizer.Sqm;
+
+/// <summary>
+/// Reads a learned curve back in plain words: when the line is slow, by how much, and how that
+/// compares with the connection type's built-in assumption. Everything is hours and percentages
+/// of the best hour; nothing about the measuring.
+/// </summary>
+public static class CongestionProfileInsights
+{
+    /// <summary>Hours within this much of the worst hour count as part of the slow band.</summary>
+    public const double BandTolerance = 0.10;
+
+    /// <summary>A learned and default depth closer than this read as "about what the default expects".</summary>
+    public const double ComparisonTolerance = 0.08;
+
+    /// <summary>Below this much variation the line is flat enough that a schedule barely matters.</summary>
+    public const double FlatThreshold = 0.08;
+
+    /// <summary>How the learned dip compares with the built-in curve over the same hours.</summary>
+    public enum Comparison { Deeper, Shallower, Similar, Flat }
+
+    /// <summary>The slow band and its comparison, ready to render.</summary>
+    /// <param name="StartHour">First hour of the slow band (0-23).</param>
+    /// <param name="EndHour">Last hour of the slow band (0-23); the band can wrap midnight.</param>
+    /// <param name="Depth">How far below the best hour the band sits (0.3 = 30% below).</param>
+    /// <param name="DefaultDepth">The built-in curve's depth over the same hours.</param>
+    public sealed record Insight(
+        string SlowestLabel,
+        int StartHour,
+        int EndHour,
+        double Depth,
+        double DefaultDepth,
+        Comparison Comparison)
+    {
+        /// <summary>"weekday evenings (19:00 to 22:00), about 70% of your best hour"</summary>
+        public string SlowestSentence =>
+            $"{SlowestLabel} ({StartHour:00}:00 to {EndHour:00}:00), about {Math.Round((1 - Depth) * 100):F0}% of your best hour";
+
+        /// <summary>One sentence against the connection type's default curve.</summary>
+        public string ComparisonSentence(string connectionTypeName) => Comparison switch
+        {
+            Comparison.Flat => $"your line barely varies, so the {connectionTypeName} default was shaping it harder than it needed",
+            Comparison.Deeper => $"dips deeper than the {connectionTypeName} default expects (about {Pct(Depth)} vs {Pct(DefaultDepth)} below your best hour)",
+            Comparison.Shallower => $"dips less than the {connectionTypeName} default expects (about {Pct(Depth)} vs {Pct(DefaultDepth)} below your best hour)",
+            _ => $"close to what the {connectionTypeName} default expects (about {Pct(Depth)} below your best hour)",
+        };
+
+        private static string Pct(double depth) => $"{Math.Round(depth * 100):F0}%";
+    }
+
+    /// <summary>
+    /// Describes the learned download curve. Null when the curve is flat and so is the default,
+    /// which leaves nothing worth saying.
+    /// </summary>
+    public static Insight? Describe(LearnedCongestionProfile learned, ConnectionType type)
+    {
+        var hourly = LearnedCongestionProfile.HourOfDayAverages(learned.DownloadMultipliers);
+        var worst = Array.IndexOf(hourly, hourly.Min());
+        var variation = 1 - hourly[worst];
+
+        // Grow the band outward from the worst hour while neighbours stay within tolerance.
+        var limit = hourly[worst] + BandTolerance;
+        var start = worst;
+        var end = worst;
+        while (hourly[(start + 23) % 24] <= limit && Span(start, end) < 23) start = (start + 23) % 24;
+        while (hourly[(end + 1) % 24] <= limit && Span(start, end) < 23) end = (end + 1) % 24;
+
+        var bandHours = BandHours(start, end).ToList();
+        var depth = 1 - bandHours.Average(h => hourly[h]);
+
+        var defaults = new ConnectionProfile { Type = type, NominalDownloadMbps = 100 }.GetBaselinePatternPublic();
+        var defaultHourly = new double[24];
+        for (var h = 0; h < 24; h++)
+        {
+            double sum = 0;
+            for (var d = 0; d < 7; d++) sum += defaults[d, h];
+            defaultHourly[h] = sum / 7.0;
+        }
+        var defaultBest = defaultHourly.Max();
+        var defaultDepth = 1 - bandHours.Average(h => defaultHourly[h]) / defaultBest;
+        var defaultVariation = 1 - defaultHourly.Min() / defaultBest;
+
+        Comparison comparison;
+        if (variation < FlatThreshold)
+        {
+            if (defaultVariation < FlatThreshold) return null;
+            comparison = Comparison.Flat;
+        }
+        else if (depth > defaultDepth + ComparisonTolerance) comparison = Comparison.Deeper;
+        else if (defaultDepth > depth + ComparisonTolerance) comparison = Comparison.Shallower;
+        else comparison = Comparison.Similar;
+
+        return new Insight(Label(learned, bandHours, start, end), start, end, depth, Math.Max(0, defaultDepth), comparison);
+    }
+
+    private static int Span(int start, int end) => ((end - start) % 24 + 24) % 24;
+
+    private static IEnumerable<int> BandHours(int start, int end)
+    {
+        for (var h = start; ; h = (h + 1) % 24)
+        {
+            yield return h;
+            if (h == end) yield break;
+        }
+    }
+
+    /// <summary>"weekday evenings", "weekend afternoons", "overnight", from the band's centre and which days carry it.</summary>
+    private static string Label(LearnedCongestionProfile learned, List<int> bandHours, int start, int end)
+    {
+        var centre = (start + Span(start, end) / 2) % 24;
+        var timeOfDay = centre switch
+        {
+            >= 5 and <= 11 => "mornings",
+            >= 12 and <= 16 => "afternoons",
+            >= 17 and <= 22 => "evenings",
+            _ => "overnight",
+        };
+
+        double weekday = 0, weekend = 0;
+        foreach (var h in bandHours)
+        {
+            for (var d = 0; d < 5; d++) weekday += learned.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(d, h)];
+            for (var d = 5; d < 7; d++) weekend += learned.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(d, h)];
+        }
+        weekday /= 5 * bandHours.Count;
+        weekend /= 2 * bandHours.Count;
+
+        var days = weekend < weekday - BandTolerance ? "weekend " : weekday < weekend - BandTolerance ? "weekday " : "";
+        return timeOfDay == "overnight" ? $"{days}overnight".Trim() : $"{days}{timeOfDay}";
+    }
+}

--- a/src/NetworkOptimizer.Sqm/CongestionProfileInsights.cs
+++ b/src/NetworkOptimizer.Sqm/CongestionProfileInsights.cs
@@ -26,17 +26,23 @@ public static class CongestionProfileInsights
     /// <param name="EndHour">Last hour of the slow band (0-23); the band can wrap midnight.</param>
     /// <param name="Depth">How far below the best hour the band sits (0.3 = 30% below).</param>
     /// <param name="DefaultDepth">The built-in curve's depth over the same hours.</param>
+    /// <param name="Variation">How far the worst hour sits below the best (0.05 = 5%).</param>
     public sealed record Insight(
         string SlowestLabel,
         int StartHour,
         int EndHour,
         double Depth,
         double DefaultDepth,
-        Comparison Comparison)
+        Comparison Comparison,
+        double Variation = 0)
     {
-        /// <summary>"weekday evenings (19:00 to 22:00), about 70% of your best hour"</summary>
-        public string SlowestSentence =>
-            $"{SlowestLabel} ({StartHour:00}:00 to {EndHour:00}:00), about {Math.Round((1 - Depth) * 100):F0}% of your best hour";
+        /// <summary>
+        /// "weekday evenings (19:00 to 22:00), about 70% of your best hour". A flat line has no band
+        /// to name, so it says how little the line moves instead.
+        /// </summary>
+        public string SlowestSentence => Comparison == Comparison.Flat
+            ? $"no slow band yet, your line stays within about {Math.Max(1, Math.Round(Variation * 100)):F0}% all day"
+            : $"{SlowestLabel} ({StartHour:00}:00 to {EndHour:00}:00), about {Math.Round((1 - Depth) * 100):F0}% of your best hour";
 
         /// <summary>One sentence against the connection type's default curve.</summary>
         public string ComparisonSentence(string connectionTypeName) => Comparison switch
@@ -92,7 +98,7 @@ public static class CongestionProfileInsights
         else if (defaultDepth > depth + ComparisonTolerance) comparison = Comparison.Shallower;
         else comparison = Comparison.Similar;
 
-        return new Insight(Label(learned, bandHours, start, end), start, end, depth, Math.Max(0, defaultDepth), comparison);
+        return new Insight(Label(learned, bandHours, start, end), start, end, depth, Math.Max(0, defaultDepth), comparison, variation);
     }
 
     private static int Span(int start, int end) => ((end - start) % 24 + 24) % 24;

--- a/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
+++ b/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
@@ -136,7 +136,8 @@ public static class CongestionProfileLearner
         profile.PeakDownloadMbps = Math.Round(peakDown, 1);
         profile.PeakUploadMbps = Math.Round(peakUp, 1);
         profile.ProbeLimitedSampleCount = kept.Count - unclipped.Count;
-        profile.DaysSpanned = kept.Select(s => s.SampledAt.Date).Distinct().Count();
+        // Gateway-local weekdays, not SampledAt's UTC dates: those roll over mid-evening in the Americas.
+        profile.DaysSpanned = kept.Select(s => s.DayOfWeek).Distinct().Count();
         profile.IsReliable = kept.Count >= MinReliableSamples
             && profile.Coverage >= MinReliableCoverage
             && profile.DaysSpanned >= MinReliableDays;

--- a/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
+++ b/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
@@ -103,14 +103,39 @@ public static class CongestionProfileLearner
         var smoothDown = Smooth(sumDown, counts, HourOfDayMeans(kept, s => s.DownloadMbps), Median(kept.Select(s => s.DownloadMbps)));
         var smoothUp = Smooth(sumUp, counts, HourOfDayMeans(kept, s => s.UploadMbps), Median(kept.Select(s => s.UploadMbps)));
 
-        var peakDown = smoothDown.Max();
-        var peakUp = smoothUp.Max();
+        // The peak comes only from samples that measured the line. A probe-limited sample is a
+        // lower bound: it may pull the shape, but it must not become the ceiling everything is
+        // relative to, or the learned nominal is our own lift rate.
+        var unclipped = kept.Where(s => !s.ProbeLimited).ToList();
+        double peakDown, peakUp;
+        if (unclipped.Count > 0)
+        {
+            var uCounts = new int[LearnedCongestionProfile.Slots];
+            var uDown = new double[LearnedCongestionProfile.Slots];
+            var uUp = new double[LearnedCongestionProfile.Slots];
+            foreach (var s in unclipped)
+            {
+                var slot = LearnedCongestionProfile.SlotIndex(s.DayOfWeek, s.Hour);
+                uCounts[slot]++;
+                uDown[slot] += s.DownloadMbps;
+                uUp[slot] += s.UploadMbps;
+            }
+            peakDown = Smooth(uDown, uCounts, HourOfDayMeans(unclipped, s => s.DownloadMbps), Median(unclipped.Select(s => s.DownloadMbps))).Max();
+            peakUp = Smooth(uUp, uCounts, HourOfDayMeans(unclipped, s => s.UploadMbps), Median(unclipped.Select(s => s.UploadMbps))).Max();
+        }
+        else
+        {
+            peakDown = smoothDown.Max();
+            peakUp = smoothUp.Max();
+            profile.PeakIsLowerBound = true;
+        }
 
         profile.SampleCounts = counts;
         profile.DownloadMultipliers = smoothDown.Select(v => Normalize(v, peakDown)).ToArray();
         profile.UploadMultipliers = smoothUp.Select(v => Normalize(v, peakUp)).ToArray();
         profile.PeakDownloadMbps = Math.Round(peakDown, 1);
         profile.PeakUploadMbps = Math.Round(peakUp, 1);
+        profile.ProbeLimitedSampleCount = kept.Count - unclipped.Count;
         profile.DaysSpanned = kept.Select(s => s.SampledAt.Date).Distinct().Count();
         profile.IsReliable = kept.Count >= MinReliableSamples
             && profile.Coverage >= MinReliableCoverage

--- a/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
+++ b/src/NetworkOptimizer.Sqm/CongestionProfileLearner.cs
@@ -1,0 +1,180 @@
+using NetworkOptimizer.Sqm.Models;
+
+namespace NetworkOptimizer.Sqm;
+
+/// <summary>
+/// Turns a week of hourly throughput samples into a <see cref="LearnedCongestionProfile"/>.
+/// Rejects errant samples (a download that was running, a bad server), then smooths over the
+/// 168-hour ring so a single noisy sample cannot carve a hole into the schedule. Deterministic:
+/// the same samples always yield the same profile.
+/// </summary>
+public static class CongestionProfileLearner
+{
+    /// <summary>Valid samples needed before a profile is called reliable.</summary>
+    public const int MinReliableSamples = 100;
+
+    /// <summary>Fraction of the 168 slots that need a sample of their own for a reliable profile.</summary>
+    public const double MinReliableCoverage = 0.70;
+
+    /// <summary>Distinct days a reliable profile must span.</summary>
+    public const int MinReliableDays = 6;
+
+    /// <summary>Samples in an hour-of-day pool before outlier rejection is attempted.</summary>
+    public const int MinPoolForOutliers = 4;
+
+    /// <summary>A sample below this fraction of its hour's median is treated as errant (busy link, bad server).</summary>
+    public const double LowOutlierRatio = 0.45;
+
+    /// <summary>A sample above this multiple of its hour's median is treated as errant.</summary>
+    public const double HighOutlierRatio = 1.8;
+
+    /// <summary>Floor for any slot's multiplier, so the schedule never collapses a link to nothing.</summary>
+    public const double MinMultiplier = 0.2;
+
+    // Smoothing weights over the hour-of-week ring. With one week of hourly samples every slot
+    // holds a single reading; its own value keeps the largest say, the adjacent hours of the same
+    // day carry the shape of that day, and the same hour on other days anchors the time-of-day.
+    private const double OwnWeight = 1.0;
+    private const double AdjacentHourWeight = 0.5;
+    private const double SameHourOtherDayWeight = 0.25;
+    private const double AdjacentHourOtherDayWeight = 0.1;
+
+    /// <summary>A sample the learner left out, and why.</summary>
+    public sealed record Exclusion(long SampleId, string Reason);
+
+    /// <summary>The learned profile plus the samples that were excluded on the way.</summary>
+    public sealed record Result(LearnedCongestionProfile Profile, IReadOnlyList<Exclusion> Exclusions);
+
+    /// <summary>Learns a profile from raw samples.</summary>
+    public static Result Learn(IReadOnlyCollection<LearningSample> samples)
+    {
+        var exclusions = new List<Exclusion>();
+        var valid = new List<LearningSample>();
+        foreach (var s in samples)
+        {
+            if (s.DayOfWeek is < 0 or > 6 || s.Hour is < 0 or > 23)
+                exclusions.Add(new Exclusion(s.Id, "invalid time slot"));
+            else if (s.DownloadMbps <= 0 || s.UploadMbps <= 0)
+                exclusions.Add(new Exclusion(s.Id, "no throughput measured"));
+            else
+                valid.Add(s);
+        }
+
+        var kept = new List<LearningSample>();
+        foreach (var pool in valid.GroupBy(s => s.Hour))
+        {
+            var list = pool.ToList();
+            if (list.Count < MinPoolForOutliers)
+            {
+                kept.AddRange(list);
+                continue;
+            }
+
+            var medianDown = Median(list.Select(s => s.DownloadMbps));
+            var medianUp = Median(list.Select(s => s.UploadMbps));
+            foreach (var s in list)
+            {
+                if (IsOutlier(s.DownloadMbps, medianDown))
+                    exclusions.Add(new Exclusion(s.Id,
+                        $"download {s.DownloadMbps:F0} Mbps against {medianDown:F0} Mbps typical at {s.Hour:00}:00"));
+                else if (IsOutlier(s.UploadMbps, medianUp))
+                    exclusions.Add(new Exclusion(s.Id,
+                        $"upload {s.UploadMbps:F0} Mbps against {medianUp:F0} Mbps typical at {s.Hour:00}:00"));
+                else
+                    kept.Add(s);
+            }
+        }
+
+        var profile = new LearnedCongestionProfile { ValidSampleCount = kept.Count };
+        if (kept.Count == 0)
+            return new Result(profile, exclusions);
+
+        var counts = new int[LearnedCongestionProfile.Slots];
+        var sumDown = new double[LearnedCongestionProfile.Slots];
+        var sumUp = new double[LearnedCongestionProfile.Slots];
+        foreach (var s in kept)
+        {
+            var slot = LearnedCongestionProfile.SlotIndex(s.DayOfWeek, s.Hour);
+            counts[slot]++;
+            sumDown[slot] += s.DownloadMbps;
+            sumUp[slot] += s.UploadMbps;
+        }
+
+        var smoothDown = Smooth(sumDown, counts, HourOfDayMeans(kept, s => s.DownloadMbps), Median(kept.Select(s => s.DownloadMbps)));
+        var smoothUp = Smooth(sumUp, counts, HourOfDayMeans(kept, s => s.UploadMbps), Median(kept.Select(s => s.UploadMbps)));
+
+        var peakDown = smoothDown.Max();
+        var peakUp = smoothUp.Max();
+
+        profile.SampleCounts = counts;
+        profile.DownloadMultipliers = smoothDown.Select(v => Normalize(v, peakDown)).ToArray();
+        profile.UploadMultipliers = smoothUp.Select(v => Normalize(v, peakUp)).ToArray();
+        profile.PeakDownloadMbps = Math.Round(peakDown, 1);
+        profile.PeakUploadMbps = Math.Round(peakUp, 1);
+        profile.DaysSpanned = kept.Select(s => s.SampledAt.Date).Distinct().Count();
+        profile.IsReliable = kept.Count >= MinReliableSamples
+            && profile.Coverage >= MinReliableCoverage
+            && profile.DaysSpanned >= MinReliableDays;
+
+        return new Result(profile, exclusions);
+    }
+
+    private static bool IsOutlier(double value, double median) =>
+        median > 0 && (value < median * LowOutlierRatio || value > median * HighOutlierRatio);
+
+    private static double Normalize(double value, double peak) =>
+        peak <= 0 ? 1.0 : Math.Round(Math.Clamp(value / peak, MinMultiplier, 1.0), 4);
+
+    /// <summary>
+    /// Weighted mean over the ring for every slot; slots with no neighbours at all fall back to
+    /// the hour-of-day mean, then to the overall median.
+    /// </summary>
+    private static double[] Smooth(double[] sums, int[] counts, double?[] hourOfDayMeans, double overallMedian)
+    {
+        const int slots = LearnedCongestionProfile.Slots;
+        var result = new double[slots];
+        for (var slot = 0; slot < slots; slot++)
+        {
+            var day = slot / 24;
+            var hour = slot % 24;
+            double weight = 0, total = 0;
+
+            void Add(int s, double w)
+            {
+                if (counts[s] == 0) return;
+                weight += w * counts[s];
+                total += w * sums[s];
+            }
+
+            Add(slot, OwnWeight);
+            Add((slot + 1) % slots, AdjacentHourWeight);
+            Add((slot + slots - 1) % slots, AdjacentHourWeight);
+            for (var otherDay = 0; otherDay < 7; otherDay++)
+            {
+                if (otherDay == day) continue;
+                Add(LearnedCongestionProfile.SlotIndex(otherDay, hour), SameHourOtherDayWeight);
+                Add(LearnedCongestionProfile.SlotIndex(otherDay, (hour + 1) % 24), AdjacentHourOtherDayWeight);
+                Add(LearnedCongestionProfile.SlotIndex(otherDay, (hour + 23) % 24), AdjacentHourOtherDayWeight);
+            }
+
+            result[slot] = weight > 0 ? total / weight : hourOfDayMeans[hour] ?? overallMedian;
+        }
+        return result;
+    }
+
+    private static double?[] HourOfDayMeans(List<LearningSample> samples, Func<LearningSample, double> selector)
+    {
+        var result = new double?[24];
+        foreach (var pool in samples.GroupBy(s => s.Hour))
+            result[pool.Key] = pool.Average(selector);
+        return result;
+    }
+
+    private static double Median(IEnumerable<double> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        if (sorted.Count == 0) return 0;
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 0 ? (sorted[mid - 1] + sorted[mid]) / 2.0 : sorted[mid];
+    }
+}

--- a/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/ConnectionProfile.cs
@@ -125,6 +125,71 @@ public class ConnectionProfile
     private string? _preferredSpeedtestServerId;
 
     /// <summary>
+    /// A learned 7x24 download curve (day 0 = Monday) that replaces the connection type's built-in
+    /// pattern when set. Values are fractions of nominal, exactly like the built-in patterns.
+    /// </summary>
+    public double[,]? CustomDownloadPattern { get; set; }
+
+    /// <summary>
+    /// A learned 7x24 upload curve. When null the upload schedule follows the download curve.
+    /// </summary>
+    public double[,]? CustomUploadPattern { get; set; }
+
+    /// <summary>
+    /// Dynamic upload shaping never drops below this fraction of nominal upload: the schedule and
+    /// the ping loop together can take at most half the upstream away.
+    /// </summary>
+    public const double MinUploadFraction = 0.5;
+
+    /// <summary>
+    /// Whether the medium's upstream is shared and congestion-sensitive enough for dynamic upload
+    /// shaping. Fiber and DOCSIS are not upstream-constrained by contention in the same way, so
+    /// they stay on the static nominal upload rate.
+    /// </summary>
+    public static bool SupportsDynamicUpload(ConnectionType type) =>
+        type is ConnectionType.CellularHome or ConnectionType.Starlink or ConnectionType.FixedWireless;
+
+    /// <summary>Default upload shaping strength for a connection type: half strength on shared media, off elsewhere.</summary>
+    public static double DefaultUploadCongestionSeverity(ConnectionType type) =>
+        SupportsDynamicUpload(type) ? 0.5 : 0.0;
+
+    /// <summary>
+    /// Upload multiplier for one hour: the curve's dip scaled by <paramref name="uploadSeverity"/>
+    /// (0 = flat, 1 = the full dip), floored at <see cref="MinUploadFraction"/> and capped at 1.0.
+    /// The cap matters for curves that exceed nominal in places (Starlink's); upload never shapes
+    /// above the configured nominal.
+    /// </summary>
+    public static double EffectiveUploadMultiplier(double multiplier, double uploadSeverity) =>
+        Math.Clamp(1.0 - (1.0 - multiplier) * uploadSeverity, MinUploadFraction, 1.0);
+
+    /// <summary>The upload curve for UI display: learned upload, else learned download, else the built-in pattern.</summary>
+    public double[,] GetUploadPatternPublic() => GetUploadPattern();
+
+    /// <summary>
+    /// Get the 168-hour upload schedule scaled to nominal upload, in the same "day_hour" keyed form
+    /// as <see cref="GetHourlyBaseline"/>. Severity 0 yields nominal upload for every hour.
+    /// </summary>
+    public Dictionary<string, string> GetHourlyUploadBaseline(double uploadSeverity)
+    {
+        var baseline = new Dictionary<string, string>();
+        var pattern = GetUploadPattern();
+
+        for (int day = 0; day < 7; day++)
+        {
+            for (int hour = 0; hour < 24; hour++)
+            {
+                var multiplier = EffectiveUploadMultiplier(pattern[day, hour], uploadSeverity);
+                var speed = Math.Max(1, (int)(multiplier * NominalUploadMbps));
+                baseline[$"{day}_{hour}"] = speed.ToString();
+            }
+        }
+
+        return baseline;
+    }
+
+    private double[,] GetUploadPattern() => CustomUploadPattern ?? CustomDownloadPattern ?? GetBaselinePattern();
+
+    /// <summary>
     /// Get default speedtest server based on connection type
     /// </summary>
     private string? GetDefaultSpeedtestServer()
@@ -443,6 +508,9 @@ public class ConnectionProfile
     /// </summary>
     private double[,] GetBaselinePattern()
     {
+        if (CustomDownloadPattern != null)
+            return CustomDownloadPattern;
+
         return Type switch
         {
             // DOCSIS Cable: stable with predictable peak-hour congestion

--- a/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
@@ -37,6 +37,15 @@ public class LearnedCongestionProfile
     /// <summary>True once the sample count, coverage, and span are enough to shape from.</summary>
     public bool IsReliable { get; set; }
 
+    /// <summary>Samples that hit the measurement ceiling (the lifted shaper rate) rather than the line.</summary>
+    public int ProbeLimitedSampleCount { get; set; }
+
+    /// <summary>
+    /// True when every sample hit the measurement ceiling, so the peaks are the ceiling, not the line:
+    /// the real best hour is at least this fast.
+    /// </summary>
+    public bool PeakIsLowerBound { get; set; }
+
     /// <summary>Slot index for a day of week (0 = Monday) and hour.</summary>
     public static int SlotIndex(int dayOfWeek, int hour) => dayOfWeek * 24 + hour;
 
@@ -92,6 +101,8 @@ public class LearnedCongestionProfile
 /// <summary>
 /// One measured throughput sample feeding the learner. Day and hour are the gateway's local
 /// time at the moment of the test, so slots line up with the clock the deployed scripts read.
+/// A probe-limited sample ran into the lifted shaper rate: its figures are lower bounds, so it
+/// shapes the curve but never sets the peak.
 /// </summary>
 public sealed record LearningSample(
     long Id,
@@ -99,4 +110,5 @@ public sealed record LearningSample(
     int Hour,
     double DownloadMbps,
     double UploadMbps,
-    DateTime SampledAt);
+    DateTime SampledAt,
+    bool ProbeLimited = false);

--- a/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
@@ -28,8 +28,11 @@ public class LearnedCongestionProfile
     /// <summary>Samples that survived validation and outlier rejection.</summary>
     public int ValidSampleCount { get; set; }
 
-    /// <summary>Distinct calendar days with at least one valid sample.</summary>
+    /// <summary>Distinct gateway-local days of the week with at least one valid sample.</summary>
     public int DaysSpanned { get; set; }
+
+    /// <summary>Every hour of the day has been sampled on at least one day: the shape of a whole day is known.</summary>
+    public bool HasFullDayCycle => Enumerable.Range(0, 24).All(h => Enumerable.Range(0, 7).Any(d => SampleCounts[SlotIndex(d, h)] > 0));
 
     /// <summary>Fraction of the 168 slots that hold at least one valid sample of their own.</summary>
     public double Coverage => SampleCounts.Count(c => c > 0) / (double)Slots;

--- a/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
+++ b/src/NetworkOptimizer.Sqm/Models/LearnedCongestionProfile.cs
@@ -1,0 +1,102 @@
+namespace NetworkOptimizer.Sqm.Models;
+
+/// <summary>
+/// A 7-day congestion profile learned from measured throughput on one WAN: per hour of the week,
+/// download and upload as a fraction of that link's best hour. Slot index = day * 24 + hour with
+/// day 0 = Monday, the same layout the BASELINE arrays in the deployed scripts use.
+/// </summary>
+public class LearnedCongestionProfile
+{
+    /// <summary>Hours in a week.</summary>
+    public const int Slots = 168;
+
+    /// <summary>Download multipliers (0..1) per hour-of-week slot; the best hour is 1.0.</summary>
+    public double[] DownloadMultipliers { get; set; } = Flat();
+
+    /// <summary>Upload multipliers (0..1) per hour-of-week slot; the best hour is 1.0.</summary>
+    public double[] UploadMultipliers { get; set; } = Flat();
+
+    /// <summary>Valid samples that landed in each slot (before smoothing).</summary>
+    public int[] SampleCounts { get; set; } = new int[Slots];
+
+    /// <summary>Smoothed best-hour download throughput in Mbps; the multipliers are relative to it.</summary>
+    public double PeakDownloadMbps { get; set; }
+
+    /// <summary>Smoothed best-hour upload throughput in Mbps; the multipliers are relative to it.</summary>
+    public double PeakUploadMbps { get; set; }
+
+    /// <summary>Samples that survived validation and outlier rejection.</summary>
+    public int ValidSampleCount { get; set; }
+
+    /// <summary>Distinct calendar days with at least one valid sample.</summary>
+    public int DaysSpanned { get; set; }
+
+    /// <summary>Fraction of the 168 slots that hold at least one valid sample of their own.</summary>
+    public double Coverage => SampleCounts.Count(c => c > 0) / (double)Slots;
+
+    /// <summary>True once the sample count, coverage, and span are enough to shape from.</summary>
+    public bool IsReliable { get; set; }
+
+    /// <summary>Slot index for a day of week (0 = Monday) and hour.</summary>
+    public static int SlotIndex(int dayOfWeek, int hour) => dayOfWeek * 24 + hour;
+
+    /// <summary>The download curve as the 7x24 matrix <see cref="ConnectionProfile"/> consumes.</summary>
+    public double[,] DownloadPattern() => ToPattern(DownloadMultipliers);
+
+    /// <summary>The upload curve as the 7x24 matrix <see cref="ConnectionProfile"/> consumes.</summary>
+    public double[,] UploadPattern() => ToPattern(UploadMultipliers);
+
+    /// <summary>
+    /// The curve rescaled so the deployed scripts reproduce the learned absolute throughput under the
+    /// user's nominal speed: each hour becomes peak * multiplier / nominal, capped at 1.0 (nominal is
+    /// the ceiling) and floored so a slot can never shape to nothing. Identity when nominal equals
+    /// the learned peak.
+    /// </summary>
+    public static double[,] ScaledPattern(double[] multipliers, double peakMbps, int nominalMbps)
+    {
+        var scale = peakMbps > 0 && nominalMbps > 0 ? peakMbps / nominalMbps : 1.0;
+        var result = new double[7, 24];
+        for (var slot = 0; slot < Slots; slot++)
+        {
+            var m = slot < multipliers.Length ? multipliers[slot] : 1.0;
+            result[slot / 24, slot % 24] = Math.Clamp(m * scale, 0.05, 1.0);
+        }
+        return result;
+    }
+
+    /// <summary>Average multiplier per hour of day across the week, for compact display.</summary>
+    public static double[] HourOfDayAverages(double[] multipliers)
+    {
+        var result = new double[24];
+        for (var hour = 0; hour < 24; hour++)
+        {
+            double sum = 0;
+            for (var day = 0; day < 7; day++)
+                sum += multipliers[SlotIndex(day, hour)];
+            result[hour] = sum / 7.0;
+        }
+        return result;
+    }
+
+    private static double[,] ToPattern(double[] multipliers)
+    {
+        var result = new double[7, 24];
+        for (var slot = 0; slot < Slots; slot++)
+            result[slot / 24, slot % 24] = slot < multipliers.Length ? multipliers[slot] : 1.0;
+        return result;
+    }
+
+    private static double[] Flat() => Enumerable.Repeat(1.0, Slots).ToArray();
+}
+
+/// <summary>
+/// One measured throughput sample feeding the learner. Day and hour are the gateway's local
+/// time at the moment of the test, so slots line up with the clock the deployed scripts read.
+/// </summary>
+public sealed record LearningSample(
+    long Id,
+    int DayOfWeek,
+    int Hour,
+    double DownloadMbps,
+    double UploadMbps,
+    DateTime SampledAt);

--- a/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
+++ b/src/NetworkOptimizer.Sqm/Models/SqmConfiguration.cs
@@ -43,6 +43,25 @@ public class SqmConfiguration
     public bool RateProportionalDownloadBurst { get; set; } = false;
 
     /// <summary>
+    /// Upload shaping strength (0-1). 0 keeps the upload rate static at nominal, which is what
+    /// every deployment did before this setting existed. Above 0 the upload rate follows the
+    /// congestion schedule, its dips scaled by this value, never below <see cref="MinUploadSpeed"/>.
+    /// </summary>
+    public double UploadCongestionSeverity { get; set; } = 0.0;
+
+    /// <summary>Floor for dynamic upload shaping: half of nominal upload.</summary>
+    public int MinUploadSpeed => Math.Max(1, (int)(NominalUploadSpeed * ConnectionProfile.MinUploadFraction));
+
+    /// <summary>True when the generated scripts vary the upload rate over the week.</summary>
+    public bool DynamicUpload => ShapeUpload && UploadCongestionSeverity > 0;
+
+    /// <summary>Learned 7x24 download curve that replaces the connection type's pattern; null = built-in.</summary>
+    public double[,]? LearnedDownloadPattern { get; set; }
+
+    /// <summary>Learned 7x24 upload curve; null = follow the download curve.</summary>
+    public double[,]? LearnedUploadPattern { get; set; }
+
+    /// <summary>
     /// WAN interface name (e.g., "eth2", "eth4")
     /// </summary>
     public string Interface { get; set; } = "eth2";
@@ -193,7 +212,9 @@ public class SqmConfiguration
             NominalDownloadMbps = NominalDownloadSpeed,
             NominalUploadMbps = NominalUploadSpeed,
             PingHost = PingHost,
-            PreferredSpeedtestServerId = PreferredSpeedtestServerId
+            PreferredSpeedtestServerId = PreferredSpeedtestServerId,
+            CustomDownloadPattern = LearnedDownloadPattern,
+            CustomUploadPattern = LearnedUploadPattern
         };
     }
 
@@ -286,6 +307,8 @@ public class SqmConfiguration
             Overhead: {(OverheadMultiplier - 1) * 100:F0}%
             Latency: {BaselineLatency}ms baseline, {LatencyThreshold}ms threshold
             Rate Adjust: -{(1 - LatencyDecrease) * 100:F0}% / +{(LatencyIncrease - 1) * 100:F0}%
+            Upload: {(DynamicUpload ? $"dynamic, strength {UploadCongestionSeverity:F2}, floor {MinUploadSpeed} Mbps" : ShapeUpload ? "static" : "perf-tuned only")}
+            Profile: {(LearnedDownloadPattern != null ? "learned" : "connection type default")}
             """;
     }
 }

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -288,6 +288,11 @@ public class ScriptGenerator
         sb.AppendLine("echo \"[$(date)] Starting speedtest adjustment on $INTERFACE...\" >> $LOG_FILE");
         sb.AppendLine();
 
+        // A probe (congestion learning sample) may hold the shaper lifted for ~15 s; calibrating on
+        // top of it would measure against its lift and then write over its restore.
+        sb.AppendLine(GetProbeLockWait());
+        sb.AppendLine();
+
         // Verify IFB device exists (created by UniFi Smart Queues)
         sb.AppendLine("# Verify IFB device exists (created by UniFi Smart Queues)");
         sb.AppendLine("if ! ip link show \"$IFB_DEVICE\" &>/dev/null; then");
@@ -641,6 +646,22 @@ public class ScriptGenerator
 
     /// <summary>Seconds after which a lock left behind by a killed probe is ignored and removed.</summary>
     public const int ProbeLockMaxAgeSeconds = 120;
+
+    /// <summary>
+    /// Speedtest-script wait: let a fresh probe lock clear (up to 90 s) before calibrating, and
+    /// drop a stale one so a killed probe can never block calibration for good.
+    /// </summary>
+    private static string GetProbeLockWait()
+    {
+        return $@"# Wait for a probe (congestion learning sample) to release the shaper
+PROBE_LOCK=""/data/sqm/probe-${{INTERFACE}}.lock""
+for _ in $(seq 1 90); do
+    [ -f ""$PROBE_LOCK"" ] || break
+    lock_age=$(( $(date +%s) - $(stat -c %Y ""$PROBE_LOCK"" 2>/dev/null || echo 0) ))
+    if [ ""$lock_age"" -ge {ProbeLockMaxAgeSeconds} ]; then rm -f ""$PROBE_LOCK""; break; fi
+    sleep 1
+done";
+    }
 
     /// <summary>
     /// Ping-script guard: stand down while a fresh probe lock exists for this interface.

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -36,13 +36,19 @@ public class ScriptGenerator
     /// Generate all scripts required for SQM deployment.
     /// Returns a single self-contained boot script that creates everything else.
     /// </summary>
-    public Dictionary<string, string> GenerateAllScripts(Dictionary<string, string> baseline)
+    /// <param name="baseline">Download schedule keyed "day_hour".</param>
+    /// <param name="uploadBaseline">Upload schedule keyed "day_hour"; ignored unless the configuration shapes upload dynamically.</param>
+    public Dictionary<string, string> GenerateAllScripts(Dictionary<string, string> baseline, Dictionary<string, string>? uploadBaseline = null)
     {
         return new Dictionary<string, string>
         {
-            [$"20-sqm-{_name}.sh"] = GenerateBootScript(baseline)
+            [$"20-sqm-{_name}.sh"] = GenerateBootScript(baseline, uploadBaseline)
         };
     }
+
+    /// <summary>Whether the generated scripts carry an upload schedule at all.</summary>
+    private bool UsesDynamicUpload(Dictionary<string, string>? uploadBaseline) =>
+        _config.DynamicUpload && uploadBaseline is { Count: > 0 };
 
     /// <summary>
     /// Get the boot script filename for this configuration
@@ -57,7 +63,7 @@ public class ScriptGenerator
     /// 4. Sets up IFB device and TC classes
     /// 5. Configures crontab entries
     /// </summary>
-    public string GenerateBootScript(Dictionary<string, string> baseline)
+    public string GenerateBootScript(Dictionary<string, string> baseline, Dictionary<string, string>? uploadBaseline = null)
     {
         var sb = new StringBuilder();
 
@@ -135,7 +141,7 @@ public class ScriptGenerator
         sb.AppendLine("# ============================================");
         sb.AppendLine();
         sb.AppendLine("cat > \"$SPEEDTEST_SCRIPT\" << 'SPEEDTEST_EOF'");
-        sb.Append(GenerateSpeedtestScript(baseline));
+        sb.Append(GenerateSpeedtestScript(baseline, uploadBaseline));
         sb.AppendLine("SPEEDTEST_EOF");
         sb.AppendLine("chmod +x \"$SPEEDTEST_SCRIPT\"");
         sb.AppendLine();
@@ -146,7 +152,7 @@ public class ScriptGenerator
         sb.AppendLine("# ============================================");
         sb.AppendLine();
         sb.AppendLine("cat > \"$PING_SCRIPT\" << 'PING_EOF'");
-        sb.Append(GeneratePingScript(baseline));
+        sb.Append(GeneratePingScript(baseline, uploadBaseline));
         sb.AppendLine("PING_EOF");
         sb.AppendLine("chmod +x \"$PING_SCRIPT\"");
         sb.AppendLine();
@@ -225,8 +231,11 @@ public class ScriptGenerator
     /// <summary>
     /// Generate the speedtest adjustment script content (embedded in boot script)
     /// </summary>
-    private string GenerateSpeedtestScript(Dictionary<string, string> baseline)
+    private string GenerateSpeedtestScript(Dictionary<string, string> baseline, Dictionary<string, string>? uploadBaseline)
     {
+        var dynamicUpload = UsesDynamicUpload(uploadBaseline);
+        var uploadRateVar = dynamicUpload ? "$upload_rate" : "$UPLOAD_SPEED";
+
         var sb = new StringBuilder();
         sb.AppendLine("#!/bin/bash");
         sb.AppendLine();
@@ -244,6 +253,8 @@ public class ScriptGenerator
         sb.AppendLine($"MIN_DOWNLOAD_SPEED=\"{_config.MinDownloadSpeed}\"");
         sb.AppendLine($"UPLOAD_SPEED=\"{_config.NominalUploadSpeed}\"");
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
+        if (dynamicUpload)
+            sb.AppendLine($"MIN_UPLOAD_SPEED=\"{_config.MinUploadSpeed}\"");
         sb.AppendLine($"DOWNLOAD_BURST_MODE={(_config.RateProportionalDownloadBurst ? "1" : "0")}");
         sb.AppendLine($"DOWNLOAD_SPEED_MULTIPLIER=\"{Inv(_config.OverheadMultiplier)}\"");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
@@ -263,6 +274,8 @@ public class ScriptGenerator
             sb.AppendLine($"BASELINE[{key}]=\"{value}\"");
         }
         sb.AppendLine();
+        if (dynamicUpload)
+            AppendUploadBaseline(sb, uploadBaseline!);
 
         // Check for speedtest
         sb.AppendLine("# Check if speedtest is installed");
@@ -323,6 +336,11 @@ public class ScriptGenerator
         // Baseline blending
         sb.AppendLine(GetBaselineBlendingLogic());
         sb.AppendLine();
+        if (dynamicUpload)
+        {
+            sb.AppendLine(GetUploadRateLogic());
+            sb.AppendLine();
+        }
 
         // Apply ceiling
         sb.AppendLine("# Apply ceiling");
@@ -353,13 +371,13 @@ public class ScriptGenerator
         sb.AppendLine("update_all_tc_classes $IFB_DEVICE $download_speed_mbps $DOWNLOAD_BURST_MODE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
-        sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
+        sb.AppendLine($"    update_all_tc_classes $INTERFACE {uploadRateVar}");
         sb.AppendLine("else");
         sb.AppendLine("    tune_tc_performance $INTERFACE");
         sb.AppendLine("fi");
         sb.AppendLine();
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
-        sb.AppendLine("    echo \"[$(date)] Adjusted to $download_speed_mbps Mbps (down), $UPLOAD_SPEED Mbps (up)\" >> $LOG_FILE");
+        sb.AppendLine($"    echo \"[$(date)] Adjusted to $download_speed_mbps Mbps (down), {uploadRateVar} Mbps (up)\" >> $LOG_FILE");
         sb.AppendLine("else");
         sb.AppendLine("    echo \"[$(date)] Adjusted to $download_speed_mbps Mbps (down), upstream perf-tuned\" >> $LOG_FILE");
         sb.AppendLine("fi");
@@ -370,8 +388,11 @@ public class ScriptGenerator
     /// <summary>
     /// Generate the ping adjustment script content (embedded in boot script)
     /// </summary>
-    private string GeneratePingScript(Dictionary<string, string> baseline)
+    private string GeneratePingScript(Dictionary<string, string> baseline, Dictionary<string, string>? uploadBaseline)
     {
+        var dynamicUpload = UsesDynamicUpload(uploadBaseline);
+        var uploadRateVar = dynamicUpload ? "$upload_rate" : "$UPLOAD_SPEED";
+
         var sb = new StringBuilder();
         sb.AppendLine("#!/bin/bash");
         sb.AppendLine();
@@ -393,6 +414,8 @@ public class ScriptGenerator
         sb.AppendLine($"MAX_DOWNLOAD_SPEED_CONFIG=\"{_config.MaxDownloadSpeed}\"");
         sb.AppendLine($"UPLOAD_SPEED=\"{_config.NominalUploadSpeed}\"");
         sb.AppendLine($"SHAPE_UPLOAD={(_config.ShapeUpload ? "1" : "0")}");
+        if (dynamicUpload)
+            sb.AppendLine($"MIN_UPLOAD_SPEED=\"{_config.MinUploadSpeed}\"");
         sb.AppendLine($"DOWNLOAD_BURST_MODE={(_config.RateProportionalDownloadBurst ? "1" : "0")}");
         sb.AppendLine($"SAFETY_CAP=\"{Inv(_config.SafetyCapPercent)}\"");
         sb.AppendLine($"NOMINAL_SPEED=\"{_config.NominalDownloadSpeed}\"");
@@ -412,6 +435,8 @@ public class ScriptGenerator
             sb.AppendLine($"BASELINE[{key}]=\"{value}\"");
         }
         sb.AppendLine();
+        if (dynamicUpload)
+            AppendUploadBaseline(sb, uploadBaseline!);
 
         // Check for result file
         sb.AppendLine("# Check for speedtest result");
@@ -456,6 +481,11 @@ public class ScriptGenerator
         // Baseline lookup for ping
         sb.AppendLine(GetBaselineBlendingLogicForPing());
         sb.AppendLine();
+        if (dynamicUpload)
+        {
+            sb.AppendLine(GetUploadRateLogic());
+            sb.AppendLine();
+        }
 
         // Apply safety cap to MAX_DOWNLOAD_SPEED BEFORE latency adjustment.
         // This sets the schedule-derived ceiling as the starting point, then latency
@@ -551,6 +581,18 @@ public class ScriptGenerator
         sb.AppendLine("fi");
         sb.AppendLine();
 
+        if (dynamicUpload)
+        {
+            // The ping cannot tell which direction is saturated, so a latency cut scales upload
+            // by the same fraction it took off download. The floor still holds.
+            sb.AppendLine("# Latency cut applies to upload in the same proportion");
+            sb.AppendLine("if (( $(echo \"$new_rate < $MAX_DOWNLOAD_SPEED\" | bc) )); then");
+            sb.AppendLine("    upload_rate=$(echo \"scale=0; $upload_rate * $new_rate / $MAX_DOWNLOAD_SPEED\" | bc)");
+            sb.AppendLine("    if [ \"$upload_rate\" -lt \"$MIN_UPLOAD_SPEED\" ]; then upload_rate=$MIN_UPLOAD_SPEED; fi");
+            sb.AppendLine("fi");
+            sb.AppendLine();
+        }
+
         // TC update function and apply
         sb.AppendLine(GetTcUpdateFunction());
         sb.AppendLine();
@@ -558,7 +600,15 @@ public class ScriptGenerator
         // Skip tc update if rate hasn't changed (avoids no-op tc rewrites every minute)
         sb.AppendLine("# Skip tc update if rate unchanged");
         sb.AppendLine("current_rate=$(tc class show dev $IFB_DEVICE 2>/dev/null | grep \"class htb 1:1 root\" | grep -o \"rate [0-9]*Mbit\" | grep -o \"[0-9]*\")");
-        sb.AppendLine("if [ \"$new_rate_int\" = \"$current_rate\" ]; then");
+        if (dynamicUpload)
+        {
+            sb.AppendLine("current_up_rate=$(tc class show dev $INTERFACE 2>/dev/null | grep \"class htb 1:1 root\" | grep -o \"rate [0-9]*Mbit\" | grep -o \"[0-9]*\")");
+            sb.AppendLine("if [ \"$new_rate_int\" = \"$current_rate\" ] && [ \"$upload_rate\" = \"$current_up_rate\" ]; then");
+        }
+        else
+        {
+            sb.AppendLine("if [ \"$new_rate_int\" = \"$current_rate\" ]; then");
+        }
         sb.AppendLine("    exit 0");
         sb.AppendLine("fi");
         sb.AppendLine();
@@ -566,13 +616,13 @@ public class ScriptGenerator
         sb.AppendLine("update_all_tc_classes $IFB_DEVICE $new_rate_int $DOWNLOAD_BURST_MODE");
         sb.AppendLine("# Upstream: shape rate if enabled, otherwise just tune performance params");
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
-        sb.AppendLine("    update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
+        sb.AppendLine($"    update_all_tc_classes $INTERFACE {uploadRateVar}");
         sb.AppendLine("else");
         sb.AppendLine("    tune_tc_performance $INTERFACE");
         sb.AppendLine("fi");
         sb.AppendLine();
         sb.AppendLine("if [ \"$SHAPE_UPLOAD\" = \"1\" ]; then");
-        sb.AppendLine("    echo \"[$(date)] Ping adjusted to $new_rate_int Mbps (down), $UPLOAD_SPEED Mbps (up) (latency: ${latency}ms)\" >> $LOG_FILE");
+        sb.AppendLine($"    echo \"[$(date)] Ping adjusted to $new_rate_int Mbps (down), {uploadRateVar} Mbps (up) (latency: ${{latency}}ms)\" >> $LOG_FILE");
         sb.AppendLine("else");
         sb.AppendLine("    echo \"[$(date)] Ping adjusted to $new_rate_int Mbps (down), upstream perf-tuned (latency: ${latency}ms)\" >> $LOG_FILE");
         sb.AppendLine("fi");
@@ -581,11 +631,50 @@ public class ScriptGenerator
     }
 
     /// <summary>
+    /// Emit the upload schedule array (same "day_hour" keys as BASELINE).
+    /// </summary>
+    private static void AppendUploadBaseline(StringBuilder sb, Dictionary<string, string> uploadBaseline)
+    {
+        sb.AppendLine("# Upload schedule by day of week (0=Mon, 6=Sun) and hour");
+        sb.AppendLine("declare -A UPLOAD_BASELINE");
+        foreach (var (key, value) in uploadBaseline.OrderBy(b => b.Key))
+        {
+            sb.AppendLine($"UPLOAD_BASELINE[{key}]=\"{value}\"");
+        }
+        sb.AppendLine();
+    }
+
+    /// <summary>
+    /// Upload rate for the current quarter hour. Runs after the download baseline lookup, which
+    /// set lookup_key, next_key, and current_min; the same 15-minute interpolation applies.
+    /// </summary>
+    private static string GetUploadRateLogic()
+    {
+        return @"# Upload schedule (interpolated at the same quarter-hour breakpoints as the download baseline)
+upload_rate=$UPLOAD_SPEED
+upload_baseline=${UPLOAD_BASELINE[$lookup_key]}
+next_upload_baseline=${UPLOAD_BASELINE[$next_key]}
+if [ -n ""$upload_baseline"" ] && [ -n ""$next_upload_baseline"" ]; then
+    upload_weight=$(( (current_min / 15) * 25 ))
+    upload_rate=$(( (upload_baseline * (100 - upload_weight) + next_upload_baseline * upload_weight) / 100 ))
+elif [ -n ""$upload_baseline"" ]; then
+    upload_rate=$upload_baseline
+fi
+if [ ""$upload_rate"" -lt ""$MIN_UPLOAD_SPEED"" ]; then upload_rate=$MIN_UPLOAD_SPEED; fi
+if [ ""$upload_rate"" -gt ""$UPLOAD_SPEED"" ]; then upload_rate=$UPLOAD_SPEED; fi";
+    }
+
+    /// <summary>
     /// Get TC update function (common to both scripts)
     /// </summary>
-    private string GetTcUpdateFunction()
-    {
-        return @"# Burst sizing. Mode 0 (default) is the conservative sizing: 5KB burst eliminates
+    private string GetTcUpdateFunction() => TcFunctionsText;
+
+    /// <summary>
+    /// The shell functions that size burst and fq_codel memory and rewrite the HTB classes. Shared
+    /// with the shaper-lift wrapper so there is exactly one copy of the tc logic.
+    /// </summary>
+    internal static string TcFunctionsText =>
+        @"# Burst sizing. Mode 0 (default) is the conservative sizing: 5KB burst eliminates
 # downstream drop_overmemory for bulk flows at gig speeds, and 8KB+ creates bursty HTB
 # send patterns that increase queue depth variance in fq_codel.
 #
@@ -722,7 +811,6 @@ tune_tc_performance() {
 
     update_all_tc_classes $device $current_rate
 }";
-    }
 
     /// <summary>
     /// Get baseline blending logic for speedtest script

--- a/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
+++ b/src/NetworkOptimizer.Sqm/ScriptGenerator.cs
@@ -438,6 +438,12 @@ public class ScriptGenerator
         if (dynamicUpload)
             AppendUploadBaseline(sb, uploadBaseline!);
 
+        // A probe (congestion learning sample) holds the shaper lifted for ~15 s and leaves this
+        // lock while it does. Adjusting in that window would write a latency-driven cut over the
+        // lift and shorten the measurement; the probe restores the rates itself when it exits.
+        sb.AppendLine(GetProbeLockGuard());
+        sb.AppendLine();
+
         // Check for result file
         sb.AppendLine("# Check for speedtest result");
         sb.AppendLine("if [ ! -f \"$RESULT_FILE\" ]; then");
@@ -628,6 +634,28 @@ public class ScriptGenerator
         sb.AppendLine("fi");
 
         return sb.ToString();
+    }
+
+    /// <summary>Path of the lock a probe holds while it has the shaper lifted on an interface.</summary>
+    public static string ProbeLockPath(string interfaceName) => $"/data/sqm/probe-{interfaceName}.lock";
+
+    /// <summary>Seconds after which a lock left behind by a killed probe is ignored and removed.</summary>
+    public const int ProbeLockMaxAgeSeconds = 120;
+
+    /// <summary>
+    /// Ping-script guard: stand down while a fresh probe lock exists for this interface.
+    /// </summary>
+    private static string GetProbeLockGuard()
+    {
+        return $@"# Stand down while a probe (congestion learning sample) has the shaper lifted
+PROBE_LOCK=""/data/sqm/probe-${{INTERFACE}}.lock""
+if [ -f ""$PROBE_LOCK"" ]; then
+    lock_age=$(( $(date +%s) - $(stat -c %Y ""$PROBE_LOCK"" 2>/dev/null || echo 0) ))
+    if [ ""$lock_age"" -lt {ProbeLockMaxAgeSeconds} ]; then
+        exit 0
+    fi
+    rm -f ""$PROBE_LOCK""
+fi";
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
+++ b/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
@@ -1,0 +1,98 @@
+using System.Text;
+
+namespace NetworkOptimizer.Sqm;
+
+/// <summary>
+/// Wraps a gateway command so it runs with the WAN's shaper lifted to a probe rate, then puts the
+/// rates back. One script, one SSH session: the restore runs from an EXIT trap so a killed or
+/// failed test cannot leave the link unshaped. Used for congestion profile learning, which needs
+/// to measure the line rather than whatever rate Adaptive SQM is holding at that hour.
+/// </summary>
+public static class SqmShaperLiftScript
+{
+    /// <summary>
+    /// Builds the wrapper script. Only the root rates that exist are touched: no IFB means Smart
+    /// Queues is off and the download side is left alone; no egress HTB likewise.
+    /// </summary>
+    /// <param name="testCommand">The command whose stdout is the script's output.</param>
+    /// <param name="interfaceName">Data-path WAN interface (validated by the caller).</param>
+    /// <param name="downloadProbeMbps">Rate to hold on the IFB while the command runs.</param>
+    /// <param name="uploadProbeMbps">Rate to hold on the egress HTB while the command runs.</param>
+    /// <param name="rateProportionalDownloadBurst">The WAN's configured download burst mode, so the restore matches the deploy.</param>
+    public static string Wrap(string testCommand, string interfaceName, int downloadProbeMbps, int uploadProbeMbps, bool rateProportionalDownloadBurst)
+    {
+        var validation = InputSanitizer.ValidateInterface(interfaceName);
+        if (!validation.isValid)
+            throw new ArgumentException(validation.error, nameof(interfaceName));
+        if (downloadProbeMbps <= 0) throw new ArgumentOutOfRangeException(nameof(downloadProbeMbps));
+        if (uploadProbeMbps <= 0) throw new ArgumentOutOfRangeException(nameof(uploadProbeMbps));
+
+        var sb = new StringBuilder();
+        sb.Append("#!/bin/bash\n");
+        sb.Append("# Runs a WAN measurement with Adaptive SQM lifted out of the way, then restores it.\n");
+        sb.Append($"INTERFACE=\"{interfaceName}\"\n");
+        sb.Append($"IFB_DEVICE=\"ifb{interfaceName}\"\n");
+        sb.Append($"DOWN_PROBE=\"{downloadProbeMbps}\"\n");
+        sb.Append($"UP_PROBE=\"{uploadProbeMbps}\"\n");
+        sb.Append($"BURST_MODE={(rateProportionalDownloadBurst ? "1" : "0")}\n");
+        sb.Append('\n');
+        sb.Append(ScriptGenerator.TcFunctionsText.Replace("\r\n", "\n"));
+        sb.Append('\n');
+        sb.Append(@"
+# Current root rate of an HTB in whole Mbps, empty when the device has no HTB root class
+read_root_rate_mbps() {
+    local device=$1
+    local rate_str=$(tc class show dev $device 2>/dev/null | grep ""class htb 1:1 root"" | grep -o ""rate [0-9]*[a-zA-Z]*"" | awk '{print $2}')
+    [ -z ""$rate_str"" ] && return
+    case ""$rate_str"" in
+        *Gbit)  echo $(( $(echo ""$rate_str"" | sed 's/Gbit//') * 1000 )) ;;
+        *Mbit)  echo ""$rate_str"" | sed 's/Mbit//' ;;
+        *Kbit)  echo $(( ($(echo ""$rate_str"" | sed 's/Kbit//') + 500) / 1000 )) ;;
+        *bit)   echo $(( ($(echo ""$rate_str"" | sed 's/bit//') + 500000) / 1000000 )) ;;
+    esac
+}
+
+saved_down=""""
+saved_up=""""
+if ip link show ""$IFB_DEVICE"" >/dev/null 2>&1; then
+    saved_down=$(read_root_rate_mbps ""$IFB_DEVICE"")
+fi
+saved_up=$(read_root_rate_mbps ""$INTERFACE"")
+
+restore_rates() {
+    if [ -n ""$saved_down"" ] && [ ""$saved_down"" -gt 0 ] 2>/dev/null; then
+        update_all_tc_classes ""$IFB_DEVICE"" ""$saved_down"" ""$BURST_MODE"" >/dev/null 2>&1
+    fi
+    if [ -n ""$saved_up"" ] && [ ""$saved_up"" -gt 0 ] 2>/dev/null; then
+        update_all_tc_classes ""$INTERFACE"" ""$saved_up"" >/dev/null 2>&1
+    fi
+}
+trap restore_rates EXIT
+
+if [ -n ""$saved_down"" ] && [ ""$saved_down"" -gt 0 ] 2>/dev/null; then
+    update_all_tc_classes ""$IFB_DEVICE"" ""$DOWN_PROBE"" ""$BURST_MODE"" >/dev/null 2>&1
+fi
+if [ -n ""$saved_up"" ] && [ ""$saved_up"" -gt 0 ] 2>/dev/null; then
+    update_all_tc_classes ""$INTERFACE"" ""$UP_PROBE"" >/dev/null 2>&1
+fi
+
+".Replace("\r\n", "\n"));
+        sb.Append(testCommand);
+        sb.Append('\n');
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// A one-line shell command that carries the wrapper to the gateway and runs it, returning the
+    /// wrapped command's exit code. The temp file name is per-interface so two WANs never collide.
+    /// </summary>
+    public static string ToRemoteCommand(string script, string interfaceName)
+    {
+        var validation = InputSanitizer.ValidateInterface(interfaceName);
+        if (!validation.isValid)
+            throw new ArgumentException(validation.error, nameof(interfaceName));
+        var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script.Replace("\r\n", "\n")));
+        var path = $"/tmp/netopt-sqm-probe-{interfaceName}.sh";
+        return $"echo '{b64}' | base64 -d > {path} && bash {path}; rc=$?; rm -f {path}; exit $rc";
+    }
+}

--- a/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
+++ b/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
@@ -85,6 +85,8 @@ fi
     /// <summary>
     /// A one-line shell command that carries the wrapper to the gateway and runs it, returning the
     /// wrapped command's exit code. The temp file name is per-interface so two WANs never collide.
+    /// The script's stderr is dropped right here: the SSH runner merges stderr into the output it
+    /// returns, and the binary's progress lines would land in what the caller parses as JSON.
     /// </summary>
     public static string ToRemoteCommand(string script, string interfaceName)
     {
@@ -93,6 +95,6 @@ fi
             throw new ArgumentException(validation.error, nameof(interfaceName));
         var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script.Replace("\r\n", "\n")));
         var path = $"/tmp/netopt-sqm-probe-{interfaceName}.sh";
-        return $"echo '{b64}' | base64 -d > {path} && bash {path}; rc=$?; rm -f {path}; exit $rc";
+        return $"echo '{b64}' | base64 -d > {path} && bash {path} 2>/dev/null; rc=$?; rm -f {path}; exit $rc";
     }
 }

--- a/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
+++ b/src/NetworkOptimizer.Sqm/SqmShaperLiftScript.cs
@@ -35,6 +35,7 @@ public static class SqmShaperLiftScript
         sb.Append($"DOWN_PROBE=\"{downloadProbeMbps}\"\n");
         sb.Append($"UP_PROBE=\"{uploadProbeMbps}\"\n");
         sb.Append($"BURST_MODE={(rateProportionalDownloadBurst ? "1" : "0")}\n");
+        sb.Append($"PROBE_LOCK=\"{ScriptGenerator.ProbeLockPath(interfaceName)}\"\n");
         sb.Append('\n');
         sb.Append(ScriptGenerator.TcFunctionsText.Replace("\r\n", "\n"));
         sb.Append('\n');
@@ -52,6 +53,15 @@ read_root_rate_mbps() {
     esac
 }
 
+# Let a ping adjustment that is mid-run finish before the rates are read, then hold the lock the
+# ping script stands down for, so nothing rewrites the shaper while the lift is up.
+for _ in $(seq 1 20); do
+    pgrep -f -- '[-]ping\.sh' >/dev/null 2>&1 || break
+    sleep 1
+done
+mkdir -p ""$(dirname ""$PROBE_LOCK"")"" 2>/dev/null
+touch ""$PROBE_LOCK"" 2>/dev/null
+
 saved_down=""""
 saved_up=""""
 if ip link show ""$IFB_DEVICE"" >/dev/null 2>&1; then
@@ -66,6 +76,7 @@ restore_rates() {
     if [ -n ""$saved_up"" ] && [ ""$saved_up"" -gt 0 ] 2>/dev/null; then
         update_all_tc_classes ""$INTERFACE"" ""$saved_up"" >/dev/null 2>&1
     fi
+    rm -f ""$PROBE_LOCK"" 2>/dev/null
 }
 trap restore_rates EXIT
 

--- a/src/NetworkOptimizer.Storage/Interfaces/ISqmLearningRepository.cs
+++ b/src/NetworkOptimizer.Storage/Interfaces/ISqmLearningRepository.cs
@@ -1,0 +1,26 @@
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Interfaces;
+
+/// <summary>
+/// Adaptive SQM congestion profile learning: the per-WAN profile row and its raw samples.
+/// </summary>
+public interface ISqmLearningRepository
+{
+    Task<SqmCongestionProfile?> GetProfileAsync(int wanNumber, CancellationToken cancellationToken = default);
+    Task<List<SqmCongestionProfile>> GetAllProfilesAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Inserts or updates the row for the profile's WAN number.</summary>
+    Task SaveProfileAsync(SqmCongestionProfile profile, CancellationToken cancellationToken = default);
+
+    /// <summary>Deletes the profile row and every sample for the WAN.</summary>
+    Task DeleteProfileAsync(int wanNumber, CancellationToken cancellationToken = default);
+
+    Task<int> AddSampleAsync(SqmLearningSample sample, CancellationToken cancellationToken = default);
+    Task<List<SqmLearningSample>> GetSamplesAsync(int wanNumber, DateTime? sinceUtc = null, CancellationToken cancellationToken = default);
+
+    /// <summary>Applies the learner's exclusions: ids in the map are excluded with their reason, every other sample of the WAN is cleared.</summary>
+    Task SetSampleExclusionsAsync(int wanNumber, IReadOnlyDictionary<int, string> exclusions, CancellationToken cancellationToken = default);
+
+    Task DeleteSamplesAsync(int wanNumber, CancellationToken cancellationToken = default);
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260907120000_AddSqmLearningMode.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260907120000_AddSqmLearningMode.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260907120000_AddSqmLearningMode")]
+    partial class AddSqmLearningMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260907120000_AddSqmLearningMode.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260907120000_AddSqmLearningMode.cs
@@ -1,0 +1,112 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <inheritdoc />
+public partial class AddSqmLearningMode : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<double>(
+            name: "UploadCongestionSeverity",
+            table: "SqmWanConfigurations",
+            type: "REAL",
+            nullable: false,
+            defaultValue: 0.0);
+
+        migrationBuilder.AddColumn<bool>(
+            name: "UseLearnedProfile",
+            table: "SqmWanConfigurations",
+            type: "INTEGER",
+            nullable: false,
+            defaultValue: false);
+
+        migrationBuilder.CreateTable(
+            name: "SqmCongestionProfiles",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                WanNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                Interface = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                ConnectionType = table.Column<int>(type: "INTEGER", nullable: false),
+                ScheduledTaskId = table.Column<int>(type: "INTEGER", nullable: true),
+                LearningStartedAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                LearningEndsAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                LearningCompletedAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                SampleDurationSeconds = table.Column<int>(type: "INTEGER", nullable: false),
+                LastSampleAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                LastError = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
+                ConsecutiveFailures = table.Column<int>(type: "INTEGER", nullable: false),
+                DownloadMultipliersJson = table.Column<string>(type: "TEXT", nullable: true),
+                UploadMultipliersJson = table.Column<string>(type: "TEXT", nullable: true),
+                SampleCountsJson = table.Column<string>(type: "TEXT", nullable: true),
+                PeakDownloadMbps = table.Column<double>(type: "REAL", nullable: false),
+                PeakUploadMbps = table.Column<double>(type: "REAL", nullable: false),
+                ValidSampleCount = table.Column<int>(type: "INTEGER", nullable: false),
+                CoveragePercent = table.Column<double>(type: "REAL", nullable: false),
+                DaysSpanned = table.Column<int>(type: "INTEGER", nullable: false),
+                IsReliable = table.Column<bool>(type: "INTEGER", nullable: false),
+                ProfileUpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: true),
+                CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SqmCongestionProfiles", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SqmCongestionProfiles_WanNumber",
+            table: "SqmCongestionProfiles",
+            column: "WanNumber",
+            unique: true);
+
+        migrationBuilder.CreateTable(
+            name: "SqmLearningSamples",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                WanNumber = table.Column<int>(type: "INTEGER", nullable: false),
+                SampledAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                LocalDayOfWeek = table.Column<int>(type: "INTEGER", nullable: false),
+                LocalHour = table.Column<int>(type: "INTEGER", nullable: false),
+                DownloadMbps = table.Column<double>(type: "REAL", nullable: false),
+                UploadMbps = table.Column<double>(type: "REAL", nullable: false),
+                LatencyMs = table.Column<double>(type: "REAL", nullable: true),
+                DownloadLoadedLatencyMs = table.Column<double>(type: "REAL", nullable: true),
+                UploadLoadedLatencyMs = table.Column<double>(type: "REAL", nullable: true),
+                IdleDownloadMbps = table.Column<double>(type: "REAL", nullable: false),
+                IdleUploadMbps = table.Column<double>(type: "REAL", nullable: false),
+                IdleSource = table.Column<string>(type: "TEXT", maxLength: 20, nullable: false),
+                Success = table.Column<bool>(type: "INTEGER", nullable: false),
+                Error = table.Column<string>(type: "TEXT", maxLength: 500, nullable: true),
+                Excluded = table.Column<bool>(type: "INTEGER", nullable: false),
+                ExclusionReason = table.Column<string>(type: "TEXT", maxLength: 200, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SqmLearningSamples", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SqmLearningSamples_WanNumber_SampledAt",
+            table: "SqmLearningSamples",
+            columns: new[] { "WanNumber", "SampledAt" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(name: "SqmLearningSamples");
+        migrationBuilder.DropTable(name: "SqmCongestionProfiles");
+        migrationBuilder.DropColumn(name: "UseLearnedProfile", table: "SqmWanConfigurations");
+        migrationBuilder.DropColumn(name: "UploadCongestionSeverity", table: "SqmWanConfigurations");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Migrations/20260908090000_AddSqmLearningProbeLimits.Designer.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260908090000_AddSqmLearningProbeLimits.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetworkOptimizer.Storage.Models;
 
@@ -10,9 +11,11 @@ using NetworkOptimizer.Storage.Models;
 namespace NetworkOptimizer.Storage.Migrations
 {
     [DbContext(typeof(NetworkOptimizerDbContext))]
-    partial class NetworkOptimizerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908090000_AddSqmLearningProbeLimits")]
+    partial class AddSqmLearningProbeLimits
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/src/NetworkOptimizer.Storage/Migrations/20260908090000_AddSqmLearningProbeLimits.cs
+++ b/src/NetworkOptimizer.Storage/Migrations/20260908090000_AddSqmLearningProbeLimits.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace NetworkOptimizer.Storage.Migrations;
+
+/// <inheritdoc />
+public partial class AddSqmLearningProbeLimits : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<int>(name: "LiftDownloadMbps", table: "SqmLearningSamples", type: "INTEGER", nullable: true);
+        migrationBuilder.AddColumn<int>(name: "LiftUploadMbps", table: "SqmLearningSamples", type: "INTEGER", nullable: true);
+        migrationBuilder.AddColumn<bool>(name: "ProbeLimited", table: "SqmLearningSamples", type: "INTEGER", nullable: false, defaultValue: false);
+
+        migrationBuilder.AddColumn<bool>(name: "PeakIsLowerBound", table: "SqmCongestionProfiles", type: "INTEGER", nullable: false, defaultValue: false);
+        migrationBuilder.AddColumn<int>(name: "LiftDownloadMbps", table: "SqmCongestionProfiles", type: "INTEGER", nullable: true);
+        migrationBuilder.AddColumn<int>(name: "LiftUploadMbps", table: "SqmCongestionProfiles", type: "INTEGER", nullable: true);
+        migrationBuilder.AddColumn<int>(name: "LiftCeilingMbps", table: "SqmCongestionProfiles", type: "INTEGER", nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(name: "LiftCeilingMbps", table: "SqmCongestionProfiles");
+        migrationBuilder.DropColumn(name: "LiftUploadMbps", table: "SqmCongestionProfiles");
+        migrationBuilder.DropColumn(name: "LiftDownloadMbps", table: "SqmCongestionProfiles");
+        migrationBuilder.DropColumn(name: "PeakIsLowerBound", table: "SqmCongestionProfiles");
+        migrationBuilder.DropColumn(name: "ProbeLimited", table: "SqmLearningSamples");
+        migrationBuilder.DropColumn(name: "LiftUploadMbps", table: "SqmLearningSamples");
+        migrationBuilder.DropColumn(name: "LiftDownloadMbps", table: "SqmLearningSamples");
+    }
+}

--- a/src/NetworkOptimizer.Storage/Models/Identity/AuditEvent.cs
+++ b/src/NetworkOptimizer.Storage/Models/Identity/AuditEvent.cs
@@ -126,6 +126,9 @@ public static class AuditActions
     public const string SettingsChanged = "settings.changed";
     public const string SqmApplied = "sqm.applied";
     public const string SqmReverted = "sqm.reverted";
+    public const string SqmLearningStarted = "sqm.learning.started";
+    public const string SqmLearningStopped = "sqm.learning.stopped";
+    public const string SqmLearningCleared = "sqm.learning.cleared";
     public const string OptimizerApplied = "optimizer.applied";
     public const string PerfTweakApplied = "perftweak.applied";
     public const string AuditScanRun = "audit_scan.run";

--- a/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
+++ b/src/NetworkOptimizer.Storage/Models/NetworkOptimizerDbContext.cs
@@ -31,6 +31,8 @@ public class NetworkOptimizerDbContext : DbContext
     public DbSet<WiFiRadioPreference> WiFiRadioPreferences { get; set; }
     public DbSet<UniFiConnectionSettings> UniFiConnectionSettings { get; set; }
     public DbSet<SqmWanConfiguration> SqmWanConfigurations { get; set; }
+    public DbSet<SqmCongestionProfile> SqmCongestionProfiles { get; set; }
+    public DbSet<SqmLearningSample> SqmLearningSamples { get; set; }
     public DbSet<AdminSettings> AdminSettings { get; set; }
     public DbSet<UpnpNote> UpnpNotes { get; set; }
     public DbSet<ApLocation> ApLocations { get; set; }
@@ -353,6 +355,19 @@ public class NetworkOptimizerDbContext : DbContext
         {
             entity.ToTable("SqmWanConfigurations");
             entity.HasIndex(e => e.WanNumber).IsUnique();
+        });
+
+        // Adaptive SQM learned congestion profile (one row per WAN) and its raw samples
+        modelBuilder.Entity<SqmCongestionProfile>(entity =>
+        {
+            entity.ToTable("SqmCongestionProfiles");
+            entity.HasIndex(e => e.WanNumber).IsUnique();
+        });
+
+        modelBuilder.Entity<SqmLearningSample>(entity =>
+        {
+            entity.ToTable("SqmLearningSamples");
+            entity.HasIndex(e => new { e.WanNumber, e.SampledAt });
         });
 
         // AdminSettings configuration (singleton - only one row)

--- a/src/NetworkOptimizer.Storage/Models/SqmCongestionProfile.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmCongestionProfile.cs
@@ -1,0 +1,91 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// Per-WAN congestion profile learned by Adaptive SQM, plus the state of the learning run that
+/// produced it. One row per WAN number. Kept apart from <see cref="SqmWanConfiguration"/> on
+/// purpose: that row is rewritten from the page model on every deploy, and learning state stored
+/// there would be reset with it.
+/// </summary>
+public class SqmCongestionProfile
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>WAN identifier (1 or 2), matching <see cref="SqmWanConfiguration.WanNumber"/>.</summary>
+    public int WanNumber { get; set; }
+
+    /// <summary>Data-path WAN interface the samples were taken on (e.g. "eth4", "ppp0").</summary>
+    [MaxLength(50)]
+    public string Interface { get; set; } = "";
+
+    /// <summary>Friendly WAN name at the time learning started.</summary>
+    [MaxLength(100)]
+    public string Name { get; set; } = "";
+
+    /// <summary>Connection type (NetworkOptimizer.Sqm.Models.ConnectionType) at the time learning started.</summary>
+    public int ConnectionType { get; set; }
+
+    /// <summary>The scheduled task that drives the hourly samples; null once deleted.</summary>
+    public int? ScheduledTaskId { get; set; }
+
+    /// <summary>When the current learning run started (UTC).</summary>
+    public DateTime? LearningStartedAt { get; set; }
+
+    /// <summary>When the current learning run is due to end (UTC).</summary>
+    public DateTime? LearningEndsAt { get; set; }
+
+    /// <summary>When the run completed or was stopped (UTC); null while learning.</summary>
+    public DateTime? LearningCompletedAt { get; set; }
+
+    /// <summary>Seconds per direction handed to the speed test binary for each sample.</summary>
+    public int SampleDurationSeconds { get; set; } = 4;
+
+    /// <summary>When the last successful sample was taken (UTC).</summary>
+    public DateTime? LastSampleAt { get; set; }
+
+    /// <summary>Most recent sample failure, cleared by the next success.</summary>
+    [MaxLength(500)]
+    public string? LastError { get; set; }
+
+    /// <summary>Failed attempts since the last success; drives how often failures alert.</summary>
+    public int ConsecutiveFailures { get; set; }
+
+    /// <summary>168 download multipliers as a JSON array, slot = day * 24 + hour, day 0 = Monday.</summary>
+    public string? DownloadMultipliersJson { get; set; }
+
+    /// <summary>168 upload multipliers as a JSON array.</summary>
+    public string? UploadMultipliersJson { get; set; }
+
+    /// <summary>168 per-slot valid sample counts as a JSON array.</summary>
+    public string? SampleCountsJson { get; set; }
+
+    /// <summary>Best-hour download throughput the multipliers are relative to.</summary>
+    public double PeakDownloadMbps { get; set; }
+
+    /// <summary>Best-hour upload throughput the multipliers are relative to.</summary>
+    public double PeakUploadMbps { get; set; }
+
+    /// <summary>Samples that survived validation and outlier rejection.</summary>
+    public int ValidSampleCount { get; set; }
+
+    /// <summary>Percentage of the 168 hour-of-week slots holding a sample of their own.</summary>
+    public double CoveragePercent { get; set; }
+
+    /// <summary>Distinct calendar days with a valid sample.</summary>
+    public int DaysSpanned { get; set; }
+
+    /// <summary>True once the learner judges the profile fit to shape from.</summary>
+    public bool IsReliable { get; set; }
+
+    /// <summary>When the multipliers were last recomputed (UTC).</summary>
+    public DateTime? ProfileUpdatedAt { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>True when a learned curve exists, reliable or not.</summary>
+    public bool HasProfile => !string.IsNullOrEmpty(DownloadMultipliersJson) && ValidSampleCount > 0;
+}

--- a/src/NetworkOptimizer.Storage/Models/SqmCongestionProfile.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmCongestionProfile.cs
@@ -79,6 +79,18 @@ public class SqmCongestionProfile
     /// <summary>True once the learner judges the profile fit to shape from.</summary>
     public bool IsReliable { get; set; }
 
+    /// <summary>True when every valid sample hit the measurement ceiling, so the peaks are lower bounds.</summary>
+    public bool PeakIsLowerBound { get; set; }
+
+    /// <summary>Download lift the next sample uses, raised after a probe-limited sample; null = the default lift.</summary>
+    public int? LiftDownloadMbps { get; set; }
+
+    /// <summary>Upload lift the next sample uses, raised after a probe-limited sample; null = the default lift.</summary>
+    public int? LiftUploadMbps { get; set; }
+
+    /// <summary>Highest lift the WAN allows (its link speed with HTB headroom); null when the link speed is unknown.</summary>
+    public int? LiftCeilingMbps { get; set; }
+
     /// <summary>When the multipliers were last recomputed (UTC).</summary>
     public DateTime? ProfileUpdatedAt { get; set; }
 

--- a/src/NetworkOptimizer.Storage/Models/SqmLearningSample.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmLearningSample.cs
@@ -45,6 +45,15 @@ public class SqmLearningSample
     [MaxLength(20)]
     public string IdleSource { get; set; } = "gateway";
 
+    /// <summary>Rate the shaper was lifted to on the download side for this sample; null when it was not lifted.</summary>
+    public int? LiftDownloadMbps { get; set; }
+
+    /// <summary>Rate the shaper was lifted to on the upload side for this sample; null when it was not lifted.</summary>
+    public int? LiftUploadMbps { get; set; }
+
+    /// <summary>True when either direction landed within a few percent of its lift: the sample measured the lift, not the line.</summary>
+    public bool ProbeLimited { get; set; }
+
     /// <summary>False when the test itself failed; such rows carry <see cref="Error"/> and no throughput.</summary>
     public bool Success { get; set; }
 

--- a/src/NetworkOptimizer.Storage/Models/SqmLearningSample.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmLearningSample.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace NetworkOptimizer.Storage.Models;
+
+/// <summary>
+/// One Adaptive SQM learning sample: a brief gateway speed test on a WAN taken while the link was
+/// idle. Raw material for <see cref="SqmCongestionProfile"/>; kept so the profile can be
+/// recomputed and so the page can show what was measured and what was thrown out.
+/// </summary>
+public class SqmLearningSample
+{
+    [Key]
+    public int Id { get; set; }
+
+    /// <summary>WAN identifier (1 or 2).</summary>
+    public int WanNumber { get; set; }
+
+    /// <summary>When the sample was taken (UTC).</summary>
+    public DateTime SampledAt { get; set; } = DateTime.UtcNow;
+
+    /// <summary>Gateway-local day of week at sample time, 0 = Monday, the slot the schedule reads.</summary>
+    public int LocalDayOfWeek { get; set; }
+
+    /// <summary>Gateway-local hour at sample time (0-23).</summary>
+    public int LocalHour { get; set; }
+
+    public double DownloadMbps { get; set; }
+
+    public double UploadMbps { get; set; }
+
+    /// <summary>Unloaded latency reported by the test, when available.</summary>
+    public double? LatencyMs { get; set; }
+
+    public double? DownloadLoadedLatencyMs { get; set; }
+
+    public double? UploadLoadedLatencyMs { get; set; }
+
+    /// <summary>WAN download traffic observed just before the test (the idle check).</summary>
+    public double IdleDownloadMbps { get; set; }
+
+    /// <summary>WAN upload traffic observed just before the test (the idle check).</summary>
+    public double IdleUploadMbps { get; set; }
+
+    /// <summary>Where the idle reading came from: "snmp" (monitored counter interface) or "gateway" (data-path counters over SSH).</summary>
+    [MaxLength(20)]
+    public string IdleSource { get; set; } = "gateway";
+
+    /// <summary>False when the test itself failed; such rows carry <see cref="Error"/> and no throughput.</summary>
+    public bool Success { get; set; }
+
+    [MaxLength(500)]
+    public string? Error { get; set; }
+
+    /// <summary>Set by the learner when the sample was left out of the profile.</summary>
+    public bool Excluded { get; set; }
+
+    [MaxLength(200)]
+    public string? ExclusionReason { get; set; }
+}

--- a/src/NetworkOptimizer.Storage/Models/SqmWanConfiguration.cs
+++ b/src/NetworkOptimizer.Storage/Models/SqmWanConfiguration.cs
@@ -73,6 +73,12 @@ public class SqmWanConfiguration
     /// <summary>Opt-in rate-proportional download burst (~1 ms of line time) instead of the conservative 5 KB clamp. False = conservative (default).</summary>
     public bool RateProportionalDownloadBurst { get; set; } = false;
 
+    /// <summary>Upload shaping strength (0-1). 0 = static nominal upload, the behavior before this setting existed.</summary>
+    public double UploadCongestionSeverity { get; set; } = 0.0;
+
+    /// <summary>Deploy with this WAN's learned congestion profile instead of the connection type's default curve.</summary>
+    public bool UseLearnedProfile { get; set; } = false;
+
     /// <summary>When this configuration was created</summary>
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 

--- a/src/NetworkOptimizer.Storage/Repositories/SpeedTestRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/SpeedTestRepository.cs
@@ -448,6 +448,8 @@ public class SpeedTestRepository : ISpeedTestRepository
                 existing.LinkSpeedOverrideMbps = config.LinkSpeedOverrideMbps;
                 existing.BootDelaySeconds = config.BootDelaySeconds;
                 existing.RateProportionalDownloadBurst = config.RateProportionalDownloadBurst;
+                existing.UploadCongestionSeverity = config.UploadCongestionSeverity;
+                existing.UseLearnedProfile = config.UseLearnedProfile;
                 existing.UpdatedAt = DateTime.UtcNow;
             }
             else

--- a/src/NetworkOptimizer.Storage/Repositories/SqmLearningRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/SqmLearningRepository.cs
@@ -60,6 +60,10 @@ public class SqmLearningRepository : ISqmLearningRepository
                 existing.CoveragePercent = profile.CoveragePercent;
                 existing.DaysSpanned = profile.DaysSpanned;
                 existing.IsReliable = profile.IsReliable;
+                existing.PeakIsLowerBound = profile.PeakIsLowerBound;
+                existing.LiftDownloadMbps = profile.LiftDownloadMbps;
+                existing.LiftUploadMbps = profile.LiftUploadMbps;
+                existing.LiftCeilingMbps = profile.LiftCeilingMbps;
                 existing.ProfileUpdatedAt = profile.ProfileUpdatedAt;
                 existing.UpdatedAt = DateTime.UtcNow;
                 profile.Id = existing.Id;

--- a/src/NetworkOptimizer.Storage/Repositories/SqmLearningRepository.cs
+++ b/src/NetworkOptimizer.Storage/Repositories/SqmLearningRepository.cs
@@ -1,0 +1,142 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Storage.Repositories;
+
+/// <summary>
+/// Repository for Adaptive SQM congestion profile learning (profile rows and raw samples).
+/// </summary>
+public class SqmLearningRepository : ISqmLearningRepository
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly ILogger<SqmLearningRepository> _logger;
+
+    public SqmLearningRepository(NetworkOptimizerDbContext context, ILogger<SqmLearningRepository> logger)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public Task<SqmCongestionProfile?> GetProfileAsync(int wanNumber, CancellationToken cancellationToken = default) =>
+        _context.SqmCongestionProfiles.AsNoTracking().FirstOrDefaultAsync(p => p.WanNumber == wanNumber, cancellationToken);
+
+    public Task<List<SqmCongestionProfile>> GetAllProfilesAsync(CancellationToken cancellationToken = default) =>
+        _context.SqmCongestionProfiles.AsNoTracking().OrderBy(p => p.WanNumber).ToListAsync(cancellationToken);
+
+    public async Task SaveProfileAsync(SqmCongestionProfile profile, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var existing = await _context.SqmCongestionProfiles
+                .FirstOrDefaultAsync(p => p.WanNumber == profile.WanNumber, cancellationToken);
+
+            if (existing == null)
+            {
+                profile.CreatedAt = DateTime.UtcNow;
+                profile.UpdatedAt = DateTime.UtcNow;
+                _context.SqmCongestionProfiles.Add(profile);
+            }
+            else
+            {
+                existing.Interface = profile.Interface;
+                existing.Name = profile.Name;
+                existing.ConnectionType = profile.ConnectionType;
+                existing.ScheduledTaskId = profile.ScheduledTaskId;
+                existing.LearningStartedAt = profile.LearningStartedAt;
+                existing.LearningEndsAt = profile.LearningEndsAt;
+                existing.LearningCompletedAt = profile.LearningCompletedAt;
+                existing.SampleDurationSeconds = profile.SampleDurationSeconds;
+                existing.LastSampleAt = profile.LastSampleAt;
+                existing.LastError = profile.LastError;
+                existing.ConsecutiveFailures = profile.ConsecutiveFailures;
+                existing.DownloadMultipliersJson = profile.DownloadMultipliersJson;
+                existing.UploadMultipliersJson = profile.UploadMultipliersJson;
+                existing.SampleCountsJson = profile.SampleCountsJson;
+                existing.PeakDownloadMbps = profile.PeakDownloadMbps;
+                existing.PeakUploadMbps = profile.PeakUploadMbps;
+                existing.ValidSampleCount = profile.ValidSampleCount;
+                existing.CoveragePercent = profile.CoveragePercent;
+                existing.DaysSpanned = profile.DaysSpanned;
+                existing.IsReliable = profile.IsReliable;
+                existing.ProfileUpdatedAt = profile.ProfileUpdatedAt;
+                existing.UpdatedAt = DateTime.UtcNow;
+                profile.Id = existing.Id;
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save SQM congestion profile for WAN {WanNumber}", profile.WanNumber);
+            throw;
+        }
+    }
+
+    public async Task DeleteProfileAsync(int wanNumber, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await DeleteSamplesAsync(wanNumber, cancellationToken);
+            var existing = await _context.SqmCongestionProfiles
+                .FirstOrDefaultAsync(p => p.WanNumber == wanNumber, cancellationToken);
+            if (existing != null)
+            {
+                _context.SqmCongestionProfiles.Remove(existing);
+                await _context.SaveChangesAsync(cancellationToken);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to delete SQM congestion profile for WAN {WanNumber}", wanNumber);
+            throw;
+        }
+    }
+
+    public async Task<int> AddSampleAsync(SqmLearningSample sample, CancellationToken cancellationToken = default)
+    {
+        _context.SqmLearningSamples.Add(sample);
+        await _context.SaveChangesAsync(cancellationToken);
+        return sample.Id;
+    }
+
+    public Task<List<SqmLearningSample>> GetSamplesAsync(int wanNumber, DateTime? sinceUtc = null, CancellationToken cancellationToken = default)
+    {
+        var query = _context.SqmLearningSamples.AsNoTracking().Where(s => s.WanNumber == wanNumber);
+        if (sinceUtc.HasValue)
+            query = query.Where(s => s.SampledAt >= sinceUtc.Value);
+        return query.OrderBy(s => s.SampledAt).ToListAsync(cancellationToken);
+    }
+
+    public async Task SetSampleExclusionsAsync(int wanNumber, IReadOnlyDictionary<int, string> exclusions, CancellationToken cancellationToken = default)
+    {
+        var samples = await _context.SqmLearningSamples
+            .Where(s => s.WanNumber == wanNumber)
+            .ToListAsync(cancellationToken);
+        foreach (var sample in samples)
+        {
+            if (exclusions.TryGetValue(sample.Id, out var reason))
+            {
+                sample.Excluded = true;
+                sample.ExclusionReason = reason.Length > 200 ? reason[..200] : reason;
+            }
+            else
+            {
+                sample.Excluded = false;
+                sample.ExclusionReason = null;
+            }
+        }
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteSamplesAsync(int wanNumber, CancellationToken cancellationToken = default)
+    {
+        var samples = await _context.SqmLearningSamples
+            .Where(s => s.WanNumber == wanNumber)
+            .ToListAsync(cancellationToken);
+        if (samples.Count == 0) return;
+        _context.SqmLearningSamples.RemoveRange(samples);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
+++ b/src/NetworkOptimizer.UniFi/GatewayWanHelper.cs
@@ -69,6 +69,25 @@ public static class GatewayWanHelper
     }
 
     /// <summary>
+    /// The inverse of <see cref="FormatWanLabelInProse"/>: splits "Acme Fiber (WAN2)" into
+    /// ("Acme Fiber", "WAN2"). A label without a trailing parenthesised WAN token comes back whole
+    /// as the name with a null token, so nothing is silently trimmed.
+    /// </summary>
+    public static (string? Name, string? WanToken) SplitWanLabelInProse(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return (null, null);
+        var trimmed = label.Trim();
+        var open = trimmed.LastIndexOf('(');
+        if (open < 0 || !trimmed.EndsWith(')'))
+            return (trimmed, null);
+        var token = trimmed[(open + 1)..^1].Trim();
+        if (!token.StartsWith("WAN", StringComparison.OrdinalIgnoreCase) || !token[3..].All(char.IsDigit))
+            return (trimmed, null);
+        var name = trimmed[..open].Trim();
+        return (string.IsNullOrEmpty(name) ? null : name, token.ToUpperInvariant());
+    }
+
+    /// <summary>
     /// UniFi network-group convention for a 1-based WAN index: wan1 → "WAN",
     /// wanN → "WANn".
     /// </summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -108,7 +108,18 @@
                         var endsAt = GetLearningEndsAt(learnCfg);
                         var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
                         // The WAN group suffix ("(WAN4)") is dropped from the detail, as on the speed test cards.
-                        var learnWanName = System.Text.RegularExpressions.Regex.Replace(GetConfigValue(learnCfg, "wanName") ?? "", @"\s*\(WAN\d*\)\s*$", "");
+                        var learnRawName = GetConfigValue(learnCfg, "wanName") ?? "";
+                        var learnWanName = System.Text.RegularExpressions.Regex.Replace(learnRawName, @"\s*\(WAN\d*\)\s*$", "");
+                        // The WAN group tag: from the stored config, else the name's suffix, else the interface.
+                        var learnWanGroup = GetConfigValue(learnCfg, "wanGroup");
+                        if (string.IsNullOrEmpty(learnWanGroup))
+                        {
+                            var m = System.Text.RegularExpressions.Regex.Match(learnRawName, @"\((WAN\d*)\)\s*$");
+                            learnWanGroup = m.Success ? m.Groups[1].Value : task.TargetId;
+                        }
+                        // UniFi calls the first WAN's group "WAN"; to a reader that is WAN1.
+                        if (string.Equals(learnWanGroup, "WAN", StringComparison.OrdinalIgnoreCase))
+                            learnWanGroup = "WAN1";
                         <div class="schedule-card">
                             <div class="schedule-card-header">
                                 <div class="schedule-card-title">
@@ -151,9 +162,9 @@
                             </div>
                             <div class="schedule-card-body">
                                 <div class="schedule-detail-row">
-                                    @if (!string.IsNullOrEmpty(task.TargetId))
+                                    @if (!string.IsNullOrEmpty(learnWanGroup))
                                     {
-                                        <span class="schedule-detail-tag tag-muted">@task.TargetId</span>
+                                        <span class="schedule-detail-tag">@learnWanGroup</span>
                                     }
                                     <span class="schedule-detail-tag tag-muted">Hourly when idle</span>
                                     @if (endsAt.HasValue)

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1504,7 +1504,7 @@
     }
     @@media (max-width: 768px) {
         .schedule-section {
-            margin-bottom: 0.75rem;
+            margin-bottom: 0.5rem;
         }
     }
     .schedule-section-title {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -436,6 +436,109 @@
                     </div>
                 }
             </div>
+
+            @if (_scheduledTasks.Any(t => t.TaskType == ScheduleService.SqmLearningTaskType))
+            {
+                <div class="schedule-section">
+                    <div class="schedule-section-header">
+                        <h2 class="schedule-section-title">Adaptive SQM Learning</h2>
+                    </div>
+                    <p class="schedule-section-desc">One-time, hourly for 7 days: a brief gateway speed test on the WAN whenever it is idle, building that connection's own congestion profile. Started and applied from Adaptive SQM.</p>
+                    @foreach (var task in _scheduledTasks.Where(t => t.TaskType == ScheduleService.SqmLearningTaskType))
+                    {
+                        var learnCfg = ParseTargetConfig(task.TargetConfig);
+                        var endsAt = GetLearningEndsAt(learnCfg);
+                        var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
+                        <div class="schedule-card">
+                            <div class="schedule-card-header">
+                                <div class="schedule-card-title">
+                                    @if (_canConfigure)
+                                    {
+                                    <label class="toggle-switch">
+                                        <input type="checkbox" checked="@task.Enabled" @onchange="() => ToggleSchedule(task)" disabled="@ended" />
+                                        <span class="toggle-slider"></span>
+                                    </label>
+                                    }
+                                    <span>@task.Name</span>
+                                </div>
+                                <div class="schedule-card-actions">
+                                    @if (_canOperate && task.Enabled && !ended)
+                                    {
+                                    <button class="btn btn-sm btn-secondary"
+                                            @onclick="() => RunScheduleNow(task)"
+                                            disabled="@(ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))">
+                                        @if (ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))
+                                        {
+                                            <span class="spinner spinner-sm"></span>
+                                            <text>Sampling...</text>
+                                        }
+                                        else
+                                        {
+                                            <text>Run Now</text>
+                                        }
+                                    </button>
+                                    }
+                                    <a class="btn btn-sm btn-secondary" href="/sqm">Open Adaptive SQM</a>
+                                    @if (_canConfigure)
+                                    {
+                                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteSchedule(task)">Delete</button>
+                                    }
+                                </div>
+                            </div>
+                            <div class="schedule-card-body">
+                                <div class="schedule-detail-row">
+                                    @if (GetConfigValue(learnCfg, "wanName") is string learnWan && !string.IsNullOrEmpty(learnWan))
+                                    {
+                                        <span class="schedule-detail-tag">@learnWan</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(task.TargetId))
+                                    {
+                                        <span class="schedule-detail-tag tag-muted">@task.TargetId</span>
+                                    }
+                                    <span class="schedule-detail-tag tag-muted">Hourly when idle</span>
+                                    @if (endsAt.HasValue)
+                                    {
+                                        <span class="schedule-detail-tag @(ended ? "tag-accent" : "tag-muted")">@(ended ? "Ended" : "Ends") @endsAt.Value.ToLocalTime().ToString("MMM d, HH:mm")</span>
+                                    }
+                                </div>
+                                @if (task.LastRunAt.HasValue || (task.NextRunAt.HasValue && task.Enabled))
+                                {
+                                    <div class="schedule-status">
+                                        @if (task.LastRunAt.HasValue)
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Last check:</span>
+                                                <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
+                                                @if (!string.IsNullOrEmpty(task.LastStatus))
+                                                {
+                                                    <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
+                                                }
+                                            </span>
+                                        }
+                                        @if (!string.IsNullOrEmpty(task.LastResultSummary))
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-value">@task.LastResultSummary</span>
+                                            </span>
+                                        }
+                                        @if (task.NextRunAt.HasValue && task.Enabled && !ended)
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Next check:</span>
+                                                <span class="detail-value">@FormatTime(task.NextRunAt.Value)</span>
+                                            </span>
+                                        }
+                                    </div>
+                                }
+                                @if (!string.IsNullOrEmpty(task.LastErrorMessage))
+                                {
+                                    <div class="alert alert-danger schedule-error">@task.LastErrorMessage</div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
         }
 
         @* ========== Data Usage Tab ========== *@
@@ -3693,6 +3796,14 @@
             : detail == "Server" ? "Agent"
             : detail.StartsWith("Server, ", StringComparison.Ordinal) ? $"Agent, {detail["Server, ".Length..]}"
             : detail;
+
+    /// <summary>End of an Adaptive SQM learning run, from its stored config; null when unreadable.</summary>
+    private static DateTime? GetLearningEndsAt(Dictionary<string, JsonElement>? config)
+    {
+        if (config == null || !config.TryGetValue("endsAt", out var el)) return null;
+        if (el.ValueKind != JsonValueKind.String || !el.TryGetDateTime(out var endsAt)) return null;
+        return endsAt.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(endsAt, DateTimeKind.Utc) : endsAt.ToUniversalTime();
+    }
 
     private static (string BaseName, string? Detail) SplitTaskName(string name)
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -108,18 +108,12 @@
                         var endsAt = GetLearningEndsAt(learnCfg);
                         var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
                         // The WAN group suffix ("(WAN4)") is dropped from the detail, as on the speed test cards.
-                        var learnRawName = GetConfigValue(learnCfg, "wanName") ?? "";
-                        var learnWanName = System.Text.RegularExpressions.Regex.Replace(learnRawName, @"\s*\(WAN\d*\)\s*$", "");
-                        // The WAN group tag: from the stored config, else the name's suffix, else the interface.
-                        var learnWanGroup = GetConfigValue(learnCfg, "wanGroup");
-                        if (string.IsNullOrEmpty(learnWanGroup))
-                        {
-                            var m = System.Text.RegularExpressions.Regex.Match(learnRawName, @"\((WAN\d*)\)\s*$");
-                            learnWanGroup = m.Success ? m.Groups[1].Value : task.TargetId;
-                        }
-                        // UniFi calls the first WAN's group "WAN"; to a reader that is WAN1.
-                        if (string.Equals(learnWanGroup, "WAN", StringComparison.OrdinalIgnoreCase))
-                            learnWanGroup = "WAN1";
+                        // The Adaptive SQM connection name carries its WAN token in prose form ("Name (WAN4)");
+                        // the tag shows the group, so the detail shows the name alone.
+                        var (learnWanName, learnNameToken) = NetworkOptimizer.UniFi.GatewayWanHelper.SplitWanLabelInProse(GetConfigValue(learnCfg, "wanName"));
+                        var learnWanGroup = GetConfigValue(learnCfg, "wanGroup") ?? learnNameToken ?? task.TargetId;
+                        if (!string.IsNullOrEmpty(learnWanGroup))
+                            learnWanGroup = DisplayFormatters.NormalizeWanDisplay(learnWanGroup);
                         <div class="schedule-card">
                             <div class="schedule-card-header">
                                 <div class="schedule-card-title">

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -107,6 +107,7 @@
                         var learnCfg = ParseTargetConfig(task.TargetConfig);
                         var endsAt = GetLearningEndsAt(learnCfg);
                         var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
+                        var learnWanName = GetConfigValue(learnCfg, "wanName");
                         <div class="schedule-card">
                             <div class="schedule-card-header">
                                 <div class="schedule-card-title">
@@ -117,7 +118,11 @@
                                         <span class="toggle-slider"></span>
                                     </label>
                                     }
-                                    <span>@task.Name</span>
+                                    <span>Adaptive SQM Learning</span>
+                                    @if (!string.IsNullOrEmpty(learnWanName))
+                                    {
+                                        <span class="schedule-name-detail">@learnWanName</span>
+                                    }
                                 </div>
                                 <div class="schedule-card-actions">
                                     @if (_canOperate && task.Enabled && !ended)
@@ -145,10 +150,6 @@
                             </div>
                             <div class="schedule-card-body">
                                 <div class="schedule-detail-row">
-                                    @if (GetConfigValue(learnCfg, "wanName") is string learnWan && !string.IsNullOrEmpty(learnWan))
-                                    {
-                                        <span class="schedule-detail-tag">@learnWan</span>
-                                    }
                                     @if (!string.IsNullOrEmpty(task.TargetId))
                                     {
                                         <span class="schedule-detail-tag tag-muted">@task.TargetId</span>

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -95,6 +95,109 @@
                     <button class="btn btn-sm btn-secondary" @onclick="() => _scheduleMessage = null">Dismiss</button>
                 </div>
             }
+            @if (_scheduledTasks.Any(t => t.TaskType == ScheduleService.SqmLearningTaskType))
+            {
+                <div class="schedule-section">
+                    <div class="schedule-section-header">
+                        <h2 class="schedule-section-title">Adaptive SQM Learning</h2>
+                    </div>
+                    <p class="schedule-section-desc">One-time, hourly for 7 days: a brief gateway speed test on the WAN whenever it is idle, building that connection's own congestion profile. Started and applied from Adaptive SQM.</p>
+                    @foreach (var task in _scheduledTasks.Where(t => t.TaskType == ScheduleService.SqmLearningTaskType))
+                    {
+                        var learnCfg = ParseTargetConfig(task.TargetConfig);
+                        var endsAt = GetLearningEndsAt(learnCfg);
+                        var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
+                        <div class="schedule-card">
+                            <div class="schedule-card-header">
+                                <div class="schedule-card-title">
+                                    @if (_canConfigure)
+                                    {
+                                    <label class="toggle-switch">
+                                        <input type="checkbox" checked="@task.Enabled" @onchange="() => ToggleSchedule(task)" disabled="@ended" />
+                                        <span class="toggle-slider"></span>
+                                    </label>
+                                    }
+                                    <span>@task.Name</span>
+                                </div>
+                                <div class="schedule-card-actions">
+                                    @if (_canOperate && task.Enabled && !ended)
+                                    {
+                                    <button class="btn btn-sm btn-secondary"
+                                            @onclick="() => RunScheduleNow(task)"
+                                            disabled="@(ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))">
+                                        @if (ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))
+                                        {
+                                            <span class="spinner spinner-sm"></span>
+                                            <text>Sampling...</text>
+                                        }
+                                        else
+                                        {
+                                            <text>Run Now</text>
+                                        }
+                                    </button>
+                                    }
+                                    <a class="btn btn-sm btn-secondary" href="/sqm">Open Adaptive SQM</a>
+                                    @if (_canConfigure)
+                                    {
+                                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteSchedule(task)">Delete</button>
+                                    }
+                                </div>
+                            </div>
+                            <div class="schedule-card-body">
+                                <div class="schedule-detail-row">
+                                    @if (GetConfigValue(learnCfg, "wanName") is string learnWan && !string.IsNullOrEmpty(learnWan))
+                                    {
+                                        <span class="schedule-detail-tag">@learnWan</span>
+                                    }
+                                    @if (!string.IsNullOrEmpty(task.TargetId))
+                                    {
+                                        <span class="schedule-detail-tag tag-muted">@task.TargetId</span>
+                                    }
+                                    <span class="schedule-detail-tag tag-muted">Hourly when idle</span>
+                                    @if (endsAt.HasValue)
+                                    {
+                                        <span class="schedule-detail-tag @(ended ? "tag-accent" : "tag-muted")">@(ended ? "Ended" : "Ends") @endsAt.Value.ToLocalTime().ToString("MMM d, HH:mm")</span>
+                                    }
+                                </div>
+                                @if (task.LastRunAt.HasValue || (task.NextRunAt.HasValue && task.Enabled))
+                                {
+                                    <div class="schedule-status">
+                                        @if (task.LastRunAt.HasValue)
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Last check:</span>
+                                                <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
+                                                @if (!string.IsNullOrEmpty(task.LastStatus))
+                                                {
+                                                    <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
+                                                }
+                                            </span>
+                                        }
+                                        @if (!string.IsNullOrEmpty(task.LastResultSummary))
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-value">@task.LastResultSummary</span>
+                                            </span>
+                                        }
+                                        @if (task.NextRunAt.HasValue && task.Enabled && !ended)
+                                        {
+                                            <span class="schedule-status-item">
+                                                <span class="detail-label">Next check:</span>
+                                                <span class="detail-value">@FormatTime(task.NextRunAt.Value)</span>
+                                            </span>
+                                        }
+                                    </div>
+                                }
+                                @if (!string.IsNullOrEmpty(task.LastErrorMessage))
+                                {
+                                    <div class="alert alert-danger schedule-error">@task.LastErrorMessage</div>
+                                }
+                            </div>
+                        </div>
+                    }
+                </div>
+            }
+
             <div class="schedule-section">
                 <h2 class="schedule-section-title">Security Audit</h2>
                 @{ var auditTask = _scheduledTasks.FirstOrDefault(t => t.TaskType == "audit"); }
@@ -437,108 +540,6 @@
                 }
             </div>
 
-            @if (_scheduledTasks.Any(t => t.TaskType == ScheduleService.SqmLearningTaskType))
-            {
-                <div class="schedule-section">
-                    <div class="schedule-section-header">
-                        <h2 class="schedule-section-title">Adaptive SQM Learning</h2>
-                    </div>
-                    <p class="schedule-section-desc">One-time, hourly for 7 days: a brief gateway speed test on the WAN whenever it is idle, building that connection's own congestion profile. Started and applied from Adaptive SQM.</p>
-                    @foreach (var task in _scheduledTasks.Where(t => t.TaskType == ScheduleService.SqmLearningTaskType))
-                    {
-                        var learnCfg = ParseTargetConfig(task.TargetConfig);
-                        var endsAt = GetLearningEndsAt(learnCfg);
-                        var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
-                        <div class="schedule-card">
-                            <div class="schedule-card-header">
-                                <div class="schedule-card-title">
-                                    @if (_canConfigure)
-                                    {
-                                    <label class="toggle-switch">
-                                        <input type="checkbox" checked="@task.Enabled" @onchange="() => ToggleSchedule(task)" disabled="@ended" />
-                                        <span class="toggle-slider"></span>
-                                    </label>
-                                    }
-                                    <span>@task.Name</span>
-                                </div>
-                                <div class="schedule-card-actions">
-                                    @if (_canOperate && task.Enabled && !ended)
-                                    {
-                                    <button class="btn btn-sm btn-secondary"
-                                            @onclick="() => RunScheduleNow(task)"
-                                            disabled="@(ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))">
-                                        @if (ScheduleService.IsTaskRunning(task.Id, SiteContext.Slug))
-                                        {
-                                            <span class="spinner spinner-sm"></span>
-                                            <text>Sampling...</text>
-                                        }
-                                        else
-                                        {
-                                            <text>Run Now</text>
-                                        }
-                                    </button>
-                                    }
-                                    <a class="btn btn-sm btn-secondary" href="/sqm">Open Adaptive SQM</a>
-                                    @if (_canConfigure)
-                                    {
-                                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteSchedule(task)">Delete</button>
-                                    }
-                                </div>
-                            </div>
-                            <div class="schedule-card-body">
-                                <div class="schedule-detail-row">
-                                    @if (GetConfigValue(learnCfg, "wanName") is string learnWan && !string.IsNullOrEmpty(learnWan))
-                                    {
-                                        <span class="schedule-detail-tag">@learnWan</span>
-                                    }
-                                    @if (!string.IsNullOrEmpty(task.TargetId))
-                                    {
-                                        <span class="schedule-detail-tag tag-muted">@task.TargetId</span>
-                                    }
-                                    <span class="schedule-detail-tag tag-muted">Hourly when idle</span>
-                                    @if (endsAt.HasValue)
-                                    {
-                                        <span class="schedule-detail-tag @(ended ? "tag-accent" : "tag-muted")">@(ended ? "Ended" : "Ends") @endsAt.Value.ToLocalTime().ToString("MMM d, HH:mm")</span>
-                                    }
-                                </div>
-                                @if (task.LastRunAt.HasValue || (task.NextRunAt.HasValue && task.Enabled))
-                                {
-                                    <div class="schedule-status">
-                                        @if (task.LastRunAt.HasValue)
-                                        {
-                                            <span class="schedule-status-item">
-                                                <span class="detail-label">Last check:</span>
-                                                <span class="detail-value">@FormatTime(task.LastRunAt.Value)</span>
-                                                @if (!string.IsNullOrEmpty(task.LastStatus))
-                                                {
-                                                    <span class="status-badge @GetScheduleStatusClass(task.LastStatus)">@task.LastStatus</span>
-                                                }
-                                            </span>
-                                        }
-                                        @if (!string.IsNullOrEmpty(task.LastResultSummary))
-                                        {
-                                            <span class="schedule-status-item">
-                                                <span class="detail-value">@task.LastResultSummary</span>
-                                            </span>
-                                        }
-                                        @if (task.NextRunAt.HasValue && task.Enabled && !ended)
-                                        {
-                                            <span class="schedule-status-item">
-                                                <span class="detail-label">Next check:</span>
-                                                <span class="detail-value">@FormatTime(task.NextRunAt.Value)</span>
-                                            </span>
-                                        }
-                                    </div>
-                                }
-                                @if (!string.IsNullOrEmpty(task.LastErrorMessage))
-                                {
-                                    <div class="alert alert-danger schedule-error">@task.LastErrorMessage</div>
-                                }
-                            </div>
-                        </div>
-                    }
-                </div>
-            }
         }
 
         @* ========== Data Usage Tab ========== *@
@@ -1500,6 +1501,11 @@
     /* Schedule tab */
     .schedule-section {
         margin-bottom: 1.5rem;
+    }
+    @@media (max-width: 768px) {
+        .schedule-section {
+            margin-bottom: 0.75rem;
+        }
     }
     .schedule-section-title {
         font-size: 1rem;

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -22,6 +22,7 @@
 @inject ILogger<Alerts> Logger
 @inject NavigationManager NavigationManager
 @inject ISqmService SqmService
+@inject NetworkOptimizer.Web.Services.SqmLearning.ISqmLearningService LearningService
 @inject IIperf3SpeedTestService SpeedTestService
 @inject UniFiConnectionService ConnectionService
 @inject IGatewaySshService GatewaySshService
@@ -150,7 +151,7 @@
                                     <a class="btn btn-sm btn-secondary" href="/sqm">Open Adaptive SQM</a>
                                     @if (_canConfigure)
                                     {
-                                    <button class="btn btn-sm btn-danger" @onclick="() => DeleteSchedule(task)">Delete</button>
+                                    <button class="btn btn-sm btn-danger" @onclick="() => RemoveLearningSchedule(task)">Remove</button>
                                     }
                                 </div>
                             </div>
@@ -3744,6 +3745,26 @@
         catch (Exception ex)
         {
             Logger.LogError(ex, "Error deleting schedule {Id}", task.Id);
+        }
+    }
+
+    // Through the learning service so the profile is stamped stopped, as Stop Learning on Adaptive SQM does.
+    private async Task RemoveLearningSchedule(ScheduledTask task)
+    {
+        var wan = NetworkOptimizer.Web.Services.SqmLearning.SqmLearningTaskConfig.Parse(task.TargetConfig)?.WanNumber;
+        if (wan is null)
+        {
+            await DeleteSchedule(task);
+            return;
+        }
+        try
+        {
+            await LearningService.RemoveScheduleAsync(wan.Value);
+            await LoadSchedules();
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error removing learning schedule {Id}", task.Id);
         }
     }
 

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1607,6 +1607,9 @@
         border-top: 1px solid var(--border-color);
         font-size: 0.8125rem;
     }
+    .schedule-status .status-badge {
+        text-transform: capitalize;
+    }
     .schedule-status-item {
         display: flex;
         align-items: center;

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -1500,7 +1500,7 @@
 
     /* Schedule tab */
     .schedule-section {
-        margin-bottom: 1.5rem;
+        margin-bottom: 1rem;
     }
     @@media (max-width: 768px) {
         .schedule-section {

--- a/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Alerts.razor
@@ -107,7 +107,8 @@
                         var learnCfg = ParseTargetConfig(task.TargetConfig);
                         var endsAt = GetLearningEndsAt(learnCfg);
                         var ended = endsAt.HasValue && endsAt.Value <= DateTime.UtcNow;
-                        var learnWanName = GetConfigValue(learnCfg, "wanName");
+                        // The WAN group suffix ("(WAN4)") is dropped from the detail, as on the speed test cards.
+                        var learnWanName = System.Text.RegularExpressions.Regex.Replace(GetConfigValue(learnCfg, "wanName") ?? "", @"\s*\(WAN\d*\)\s*$", "");
                         <div class="schedule-card">
                             <div class="schedule-card-header">
                                 <div class="schedule-card-title">

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1856,7 +1856,9 @@
                 }
                 @if (status.ObservedMinDownloadMbps.HasValue)
                 {
-                    var insight = learned != null && status.DaysSpanned >= 2 ? NetworkOptimizer.Sqm.CongestionProfileInsights.Describe(learned, model.ConnectionType) : null;
+                    // Only once a whole day's shape is known: every hour sampled and two days of running.
+                    var insightReady = learned is { HasFullDayCycle: true } && status.StartedAt is { } startedAt && DateTime.UtcNow - startedAt >= TimeSpan.FromHours(48);
+                    var insight = insightReady ? NetworkOptimizer.Sqm.CongestionProfileInsights.Describe(learned!, model.ConnectionType) : null;
                     <div class="learning-insights">
                         <span class="insight-label">So far</span>
                         <span>@status.ObservedMinDownloadMbps.Value.ToString("F0") to @status.ObservedMaxDownloadMbps!.Value.ToString("F0") Mbps down, @status.ObservedMinUploadMbps!.Value.ToString("F0") to @status.ObservedMaxUploadMbps!.Value.ToString("F0") up.</span>
@@ -1869,7 +1871,7 @@
                         }
                         else if (status.IsActive)
                         {
-                            <span class="form-hint insight-pending">Slowest hours, and how they compare with the default curve, appear after two days of samples.</span>
+                            <span class="form-hint insight-pending">Slowest hours, and how they compare with the default curve, appear once every hour of the day has been sampled, after two days.</span>
                         }
                     </div>
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1800,14 +1800,16 @@
             @if (status == null || (!status.IsActive && !status.HasProfile && !status.IsCompleted))
             {
                 <p class="learning-text">
-                    Learn this connection's real weekly congestion pattern instead of relying on the @ConnectionProfile.GetConnectionTypeName(model.ConnectionType) default.
-                    One brief gateway speed test per idle hour for 7 days (@SqmLearningTaskConfig.DefaultDurationSeconds s per direction),
-                    about @EstimateSampleMb(model).ToString("F0") MB per sample and up to @EstimateWeekGb(model).ToString("F1") GB over the week at your nominal speeds.
-                    @if (!ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
-                    {
-                        <text> Most useful on cellular, satellite, and fixed wireless: shared, limited-capacity access where the hour-by-hour speed follows how congested the tower, cell, or beam is.</text>
-                    }
+                    Learn this connection's real weekly congestion pattern instead of the @ConnectionProfile.GetConnectionTypeName(model.ConnectionType) default.
+                    One brief gateway speed test each idle hour for 7 days.
                 </p>
+                <p class="learning-text">
+                    Data use: about <strong>@EstimateSampleMb(model).ToString("F0") MB per sample</strong>, up to <strong>@EstimateWeekGb(model).ToString("F0") GB over the week</strong>.
+                </p>
+                @if (!ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
+                {
+                    <p class="learning-text">Most useful on cellular, satellite, and fixed wireless: shared, limited-capacity access where the hour-by-hour speed follows how congested the tower, cell, or beam is.</p>
+                }
                 <div class="learning-actions">
                     <button type="button" class="btn btn-sm btn-primary" @onclick="() => StartLearning(model)"
                             disabled="@(!_canOperate || _learningBusy || string.IsNullOrEmpty(model.Interface) || model.NominalDownload <= 0 || model.NominalUpload <= 0)">

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1796,7 +1796,7 @@
             var status = model.LearningStatus;
             var learned = status?.Profile;
         }
-            <h4>Congestion Profile Learning <span class="tooltip-icon tooltip-icon-sm" data-tooltip="A one-time, hourly schedule for 7 days. Each hour, once the WAN has been idle (under 1 Mbps each way), the gateway runs a brief speed test on this interface with Adaptive SQM lifted out of the way, so the result is the line, not the current shaping rate. Errant samples are discarded and the curve is smoothed across neighboring hours and days. It also appears on Alerts & Schedule - Schedule.">?</span></h4>
+            <h4>Congestion Profile Learning <span class="tooltip-icon tooltip-icon-sm" data-tooltip="A week of brief hourly speed tests, taken only while the WAN is quiet, builds this connection's own congestion curve.">?</span></h4>
             @if (status == null || (!status.IsActive && !status.HasProfile && !status.IsCompleted))
             {
                 <p class="learning-text">

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1619,21 +1619,33 @@
     }
 
     .learning-insights {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
+        display: grid;
+        grid-template-columns: max-content 1fr;
+        column-gap: 0.75rem;
+        row-gap: 0.3rem;
+        align-items: baseline;
         margin-bottom: 0.75rem;
         font-size: 0.85rem;
         color: var(--text-primary);
     }
 
     .insight-label {
-        display: inline-block;
-        min-width: 8.5rem;
         color: var(--text-secondary);
         font-size: 0.75rem;
         text-transform: uppercase;
         letter-spacing: 0.05em;
+        white-space: nowrap;
+    }
+
+    @@media (max-width: 768px) {
+        .learning-insights {
+            grid-template-columns: 1fr;
+            row-gap: 0.15rem;
+        }
+
+        .learning-insights > span:not(.insight-label) {
+            margin-bottom: 0.4rem;
+        }
     }
 
     .learning-actions {
@@ -1831,15 +1843,19 @@
                 {
                     var insight = learned != null && status.DaysSpanned >= 2 ? NetworkOptimizer.Sqm.CongestionProfileInsights.Describe(learned, model.ConnectionType) : null;
                     <div class="learning-insights">
-                        <div><span class="insight-label">So far</span>@status.ObservedMinDownloadMbps.Value.ToString("F0") to @status.ObservedMaxDownloadMbps!.Value.ToString("F0") Mbps down, @status.ObservedMinUploadMbps!.Value.ToString("F0") to @status.ObservedMaxUploadMbps!.Value.ToString("F0") up.</div>
+                        <span class="insight-label">So far</span>
+                        <span>@status.ObservedMinDownloadMbps.Value.ToString("F0") to @status.ObservedMaxDownloadMbps!.Value.ToString("F0") Mbps down, @status.ObservedMinUploadMbps!.Value.ToString("F0") to @status.ObservedMaxUploadMbps!.Value.ToString("F0") up.</span>
                         @if (insight != null)
                         {
-                            <div><span class="insight-label">Slowest</span>@insight.SlowestSentence.</div>
-                            <div><span class="insight-label">Versus the default</span>@insight.ComparisonSentence(ConnectionProfile.GetConnectionTypeName(model.ConnectionType)).</div>
+                            <span class="insight-label">Slowest</span>
+                            <span>@insight.SlowestSentence.</span>
+                            <span class="insight-label">vs default</span>
+                            <span>@insight.ComparisonSentence(ConnectionProfile.GetConnectionTypeName(model.ConnectionType)).</span>
                         }
                         else if (status.IsActive)
                         {
-                            <div><span class="insight-label">Slowest</span>after a couple of days of samples.</div>
+                            <span class="insight-label">Slowest</span>
+                            <span>after a couple of days of samples.</span>
                         }
                     </div>
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1813,27 +1813,6 @@
                 {
                     <p class="learning-text">Not enough of the week was sampled to rely on this profile yet. You can still select it, or relearn for a fuller picture.</p>
                 }
-                @if (status.ProbeLimitedSampleCount > 0)
-                {
-                    <p class="learning-text">
-                        @if (status.PeakIsLowerBound)
-                        {
-                            <text>Every sample so far hit the measurement ceiling, so the peak is a lower bound: the line is at least that fast. </text>
-                        }
-                        else
-                        {
-                            <text>@status.ProbeLimitedSampleCount of @status.ValidSampleCount samples hit the measurement ceiling and were kept out of the peak. </text>
-                        }
-                        @if (status.LiftAtCeiling)
-                        {
-                            <text>The ceiling is now the WAN link speed with headroom (@(status.LiftCeilingMbps) Mbps), so it cannot be raised further; at those hours the line is at least that fast.</text>
-                        }
-                        else if (status.LiftDownloadMbps.HasValue || status.LiftUploadMbps.HasValue)
-                        {
-                            <text>The lift has been raised to @(status.LiftDownloadMbps?.ToString() ?? "default") / @(status.LiftUploadMbps?.ToString() ?? "default") Mbps for the next samples. If this keeps happening, the nominal speeds are set well below what the line delivers.</text>
-                        }
-                    </p>
-                }
                 @if (learned != null)
                 {
                     var down = LearnedCongestionProfile.HourOfDayAverages(learned.DownloadMultipliers);

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1608,18 +1608,20 @@
     .learning-status {
         display: flex;
         flex-wrap: wrap;
+        align-items: center;
         gap: 0.5rem 1.25rem;
         margin-bottom: 0.75rem;
         font-size: 0.85rem;
     }
 
-    .learning-status .detail-label {
-        color: var(--text-secondary);
-        margin-right: 0.25rem;
+    .learning-status > span {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
     }
 
-    .learning-status .status-badge {
-        margin-right: 0.4rem;
+    .learning-status .detail-label {
+        color: var(--text-secondary);
     }
 
     .learning-insights {

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -601,9 +601,12 @@
                 </div>
             </div>
 
-            @* Tour anchor sits on WAN 1 only, like the burst toggle below. *@
+            @* Tour anchors sit on WAN 1 only, like the burst toggle below. *@
             <div data-tour="sqm-congestion-profile">
                 @CongestionProfilePanel(wan1Config)
+            </div>
+            <div data-tour="sqm-learning">
+                @LearningPanel(wan1Config)
             </div>
 
             <div class="form-group">
@@ -658,16 +661,13 @@
                 </div>
                 @* Tour anchor sits on WAN 1 only; a duplicate selector would just resolve to this one. *@
                 <div class="form-group" data-tour="sqm-download-burst">
-                    <label class="toggle-label">
+                    <label class="checkbox-label">
                         <input type="checkbox" @bind="wan1Config.RateProportionalDownloadBurst" />
                         <span>Larger download burst</span>
                     </label>
                     <small class="form-hint">@BurstOptInHint</small>
                 </div>
             </div>
-                </div>
-                <div class="learning-section" data-tour="sqm-learning">
-                    @LearningPanel(wan1Config)
                 </div>
             </div>
         </div>
@@ -781,6 +781,7 @@
             </div>
 
             @CongestionProfilePanel(wan2Config)
+            @LearningPanel(wan2Config)
 
             <div class="form-group">
                 <label class="form-label">Ping Target Host</label>
@@ -833,16 +834,13 @@
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="toggle-label">
+                    <label class="checkbox-label">
                         <input type="checkbox" @bind="wan2Config.RateProportionalDownloadBurst" />
                         <span>Larger download burst</span>
                     </label>
                     <small class="form-hint">@BurstOptInHint</small>
                 </div>
             </div>
-                </div>
-                <div class="learning-section">
-                    @LearningPanel(wan2Config)
                 </div>
             </div>
         </div>
@@ -1601,14 +1599,6 @@
         color: var(--text-muted);
     }
 
-    .learning-section {
-        padding: 0 16px 16px;
-    }
-
-    .learning-section .calculated-params {
-        margin-top: 0;
-    }
-
     .learning-text {
         margin: 0 0 0.75rem 0;
         font-size: 0.85rem;
@@ -1754,8 +1744,7 @@
         </div>
     </div>;
 
-    // Rendered below the WAN's card body rather than inside it: the body is dimmed and
-    // click-blocked until Adaptive SQM is enabled for the WAN, and learning is meant to run first.
+    // Sits directly under Congestion Schedule as its peer, so it shares the card body's enable gate.
     private RenderFragment<WanConfigModel> LearningPanel => model =>
     @<div class="calculated-params" style="margin-top: 0.75rem;">
         @{
@@ -1771,7 +1760,7 @@
                     about @EstimateSampleMb(model).ToString("F0") MB per sample and up to @EstimateWeekGb(model).ToString("F1") GB over the week at your nominal speeds.
                     @if (!ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
                     {
-                        <text> Most useful on cellular, satellite, and fixed wireless, where the tower or cell decides the hour-by-hour speed.</text>
+                        <text> Most useful on cellular, satellite, and fixed wireless: shared, limited-capacity access where the hour-by-hour speed follows how congested the tower, cell, or beam is.</text>
                     }
                 </p>
                 <div class="learning-actions">

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1643,6 +1643,11 @@
         white-space: nowrap;
     }
 
+    .insight-pending {
+        grid-column: 1 / -1;
+        margin: 0;
+    }
+
     @@media (max-width: 768px) {
         .learning-insights {
             grid-template-columns: 1fr;
@@ -1860,8 +1865,7 @@
                         }
                         else if (status.IsActive)
                         {
-                            <span class="insight-label">Slowest</span>
-                            <span>after a couple of days of samples.</span>
+                            <span class="form-hint insight-pending">Slowest hours, and how they compare with the default curve, appear after two days of samples.</span>
                         }
                     </div>
                 }

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1648,6 +1648,10 @@
         margin: 0;
     }
 
+    .learn-tip-pct {
+        color: var(--text-muted);
+    }
+
     @@media (max-width: 768px) {
         .learning-insights {
             grid-template-columns: 1fr;
@@ -1879,7 +1883,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(down[hour] * 100):F0}%</span>")"></div>
+                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps <span class=\"learn-tip-pct\">{Math.Round(down[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>
@@ -1889,7 +1893,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(up[hour] * 100):F0}%</span>")"></div>
+                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps <span class=\"learn-tip-pct\">{Math.Round(up[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -9,6 +9,7 @@
 @inject SiteContextService SiteContext
 @inject NetworkOptimizer.Web.Services.Licensing.LicenseStateService LicenseState
 @inject IGatewaySshService GatewaySshService
+@inject NetworkOptimizer.Web.Services.SqmLearning.ISqmLearningService LearningService
 @inject IJSRuntime JS
 @inject ILogger<Sqm> Logger
 @inject PullToRefreshState PtrState
@@ -19,6 +20,7 @@
 @using NetworkOptimizer.Sqm.Models
 @using NetworkOptimizer.Storage.Models
 @using NetworkOptimizer.Web.Services.Ssh
+@using NetworkOptimizer.Web.Services.SqmLearning
 
 <PageTitle>Adaptive SQM - Network Optimizer</PageTitle>
 
@@ -599,23 +601,9 @@
                 </div>
             </div>
 
-            @{ var wan1CongestionRange = wan1Config.GetCongestionRange(); }
-            <div class="calculated-params" style="margin-top: 0.75rem;">
-                <h4>Congestion Schedule <span class="tooltip-icon tooltip-icon-sm" data-tooltip="How much the shaping rate drops during peak hours. The schedule varies by time of day based on your connection type's congestion profile.">?</span></h4>
-                <div class="params-grid">
-                    <div class="param">
-                        <span class="param-label">Congestion Range</span>
-                        <span class="param-value">@wan1CongestionRange.Min–@wan1CongestionRange.Max</span>
-                        <span class="param-unit">Mbps</span>
-                    </div>
-                    <div class="param">
-                        <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
-                        <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan1Config.CongestionSeverity" @bind:event="oninput" />
-                            <span class="param-value">@wan1Config.CongestionSeverity.ToString("F2")</span>
-                        </div>
-                    </div>
-                </div>
+            @* Tour anchor sits on WAN 1 only, like the burst toggle below. *@
+            <div data-tour="sqm-congestion-profile">
+                @CongestionProfilePanel(wan1Config)
             </div>
 
             <div class="form-group">
@@ -677,6 +665,9 @@
                     <small class="form-hint">@BurstOptInHint</small>
                 </div>
             </div>
+                </div>
+                <div class="learning-section" data-tour="sqm-learning">
+                    @LearningPanel(wan1Config)
                 </div>
             </div>
         </div>
@@ -789,24 +780,7 @@
                 </div>
             </div>
 
-            @{ var wan2CongestionRange = wan2Config.GetCongestionRange(); }
-            <div class="calculated-params" style="margin-top: 0.75rem;">
-                <h4>Congestion Schedule <span class="tooltip-icon tooltip-icon-sm" data-tooltip="How much the shaping rate drops during peak hours. The schedule varies by time of day based on your connection type's congestion profile.">?</span></h4>
-                <div class="params-grid">
-                    <div class="param">
-                        <span class="param-label">Congestion Range</span>
-                        <span class="param-value">@wan2CongestionRange.Min–@wan2CongestionRange.Max</span>
-                        <span class="param-unit">Mbps</span>
-                    </div>
-                    <div class="param">
-                        <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = default profile. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
-                        <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
-                            <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="wan2Config.CongestionSeverity" @bind:event="oninput" />
-                            <span class="param-value">@wan2Config.CongestionSeverity.ToString("F2")</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            @CongestionProfilePanel(wan2Config)
 
             <div class="form-group">
                 <label class="form-label">Ping Target Host</label>
@@ -866,6 +840,9 @@
                     <small class="form-hint">@BurstOptInHint</small>
                 </div>
             </div>
+                </div>
+                <div class="learning-section">
+                    @LearningPanel(wan2Config)
                 </div>
             </div>
         </div>
@@ -1603,10 +1580,468 @@
         font-weight: 600;
         color: var(--text-secondary);
     }
+
+    .param-select {
+        font-weight: 600;
+        font-size: 0.9rem;
+        color: var(--text-primary);
+        background: var(--bg-tertiary);
+        border: 1px solid transparent;
+        border-radius: 4px;
+        padding: 2px 4px;
+        max-width: 100%;
+    }
+
+    .param-select:hover, .param-select:focus {
+        border-color: var(--primary-color);
+        outline: none;
+    }
+
+    .param-value.is-off {
+        color: var(--text-muted);
+    }
+
+    .learning-section {
+        padding: 0 16px 16px;
+    }
+
+    .learning-section .calculated-params {
+        margin-top: 0;
+    }
+
+    .learning-text {
+        margin: 0 0 0.75rem 0;
+        font-size: 0.85rem;
+        color: var(--text-secondary);
+    }
+
+    .learning-status {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1.25rem;
+        margin-bottom: 0.75rem;
+        font-size: 0.85rem;
+    }
+
+    .learning-status .detail-label {
+        color: var(--text-secondary);
+        margin-right: 0.25rem;
+    }
+
+    .learning-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+    }
+
+    .learn-strip {
+        display: flex;
+        align-items: flex-end;
+        gap: 0.5rem;
+        margin-bottom: 0.35rem;
+    }
+
+    .learn-strip-label {
+        width: 2.5rem;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--text-secondary);
+        padding-bottom: 2px;
+    }
+
+    .learn-strip-bars {
+        display: flex;
+        align-items: flex-end;
+        gap: 2px;
+        height: 44px;
+        flex: 1;
+    }
+
+    .learn-bar {
+        flex: 1;
+        min-height: 2px;
+        border-radius: 2px 2px 0 0;
+        background: var(--speed-download-color);
+        opacity: 0.85;
+    }
+
+    .learn-bar.up {
+        background: var(--speed-upload-color);
+    }
+
+    .learn-strip-axis {
+        display: flex;
+        justify-content: space-between;
+        margin-left: 3rem;
+        margin-bottom: 0.75rem;
+        font-size: 0.7rem;
+        color: var(--text-muted);
+    }
 </style>
 
 @code {
     private bool IsLicenseRestricted => !LicenseState.IsSiteOperational(SiteContext.Slug);
+
+    // ========== Congestion profile: schedule tuning, upload strength, learning ==========
+
+    private bool _learningBusy;
+
+    private RenderFragment<WanConfigModel> CongestionProfilePanel => model =>
+    @<div class="congestion-profile">
+        @{
+            var range = model.GetCongestionRange();
+            var uploadRange = model.GetUploadRange();
+            var supportsUpload = ConnectionProfile.SupportsDynamicUpload(model.ConnectionType);
+            var status = model.LearningStatus;
+            var learned = status?.Profile;
+            var learnedAvailable = learned != null;
+            var useLearned = model.UseLearnedProfile && learnedAvailable;
+        }
+        <div class="calculated-params" style="margin-top: 0.75rem;">
+            <h4>Congestion Schedule <span class="tooltip-icon tooltip-icon-sm" data-tooltip="How much the shaping rate drops during peak hours. The schedule varies by time of day based on the congestion profile: your connection type's default, or one learned on this line.">?</span></h4>
+            <div class="params-grid">
+                <div class="param">
+                    <span class="param-label">Profile <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Default follows the built-in weekly curve for your connection type. Learned follows the curve measured on this WAN by Congestion Profile Learning below.">?</span></span>
+                    <select class="param-select" value="@(useLearned ? "learned" : "default")" disabled="@(!_canOperate)"
+                            @onchange="e => OnProfileSourceChanged(model, e.Value?.ToString())">
+                        <option value="default">Default</option>
+                        <option value="learned" disabled="@(!learnedAvailable)">@(learnedAvailable ? "Learned" : "Learned (none yet)")</option>
+                    </select>
+                </div>
+                <div class="param">
+                    <span class="param-label">Congestion Range</span>
+                    <span class="param-value">@range.Min–@range.Max</span>
+                    <span class="param-unit">Mbps</span>
+                </div>
+                <div class="param">
+                    <span class="param-label">Severity <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Scales how deep the congestion dips go. 1.0 = the profile as is. Higher = more aggressive shaping at peak. Lower = flatter curve.">?</span></span>
+                    <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
+                        <input type="range" min="0" max="2" step="0.01" style="width: 100px;" @bind="model.CongestionSeverity" @bind:event="oninput" />
+                        <span class="param-value">@model.CongestionSeverity.ToString("F2")</span>
+                    </div>
+                </div>
+                @if (supportsUpload)
+                {
+                    <div class="param">
+                        <span class="param-label">Upload Range <span class="tooltip-icon tooltip-icon-sm" data-tooltip="Where the upload rate sits over the week when upload shaping strength is above 0. It never drops below half of nominal upload.">?</span></span>
+                        <span class="param-value @(model.UploadCongestionSeverity <= 0 ? "is-off" : "")">@uploadRange.Min–@uploadRange.Max</span>
+                        <span class="param-unit">Mbps</span>
+                    </div>
+                    <div class="param">
+                        <span class="param-label">Upload Strength <span class="tooltip-icon tooltip-icon-sm" data-tooltip="How much of the congestion profile applies to upload. 0 = upload stays at nominal (the old behavior). 0.5 = half the dip. 1.0 = the full dip. Shared media (cellular, satellite, fixed wireless) lose upstream at peak too, so this defaults to 0.5 for them.">?</span></span>
+                        <div class="wan-time-slider" style="padding: 0; gap: 0.5rem; justify-content: center;">
+                            <input type="range" min="0" max="1" step="0.05" style="width: 100px;" @bind="model.UploadCongestionSeverity" @bind:event="oninput" />
+                            <span class="param-value @(model.UploadCongestionSeverity <= 0 ? "is-off" : "")">@(model.UploadCongestionSeverity <= 0 ? "Off" : model.UploadCongestionSeverity.ToString("F2"))</span>
+                        </div>
+                    </div>
+                }
+            </div>
+            @if (useLearned && learned != null)
+            {
+                var peaksMatch = model.NominalDownload == (int)Math.Round(learned.PeakDownloadMbps)
+                                 && model.NominalUpload == (int)Math.Round(learned.PeakUploadMbps);
+                <small class="form-hint" style="display: block; margin-top: 0.5rem;">
+                    The learned curve is relative to its best hour: @learned.PeakDownloadMbps.ToString("F0") / @learned.PeakUploadMbps.ToString("F0") Mbps.
+                    @if (!peaksMatch)
+                    {
+                        <text>Your nominal speeds differ, so hours above nominal are capped at it. </text>
+                        <button type="button" class="btn btn-sm btn-secondary" style="margin-left: 0.25rem;" @onclick="() => ApplyLearnedPeaks(model)" disabled="@(!_canOperate)">Use learned peaks as nominal</button>
+                    }
+                </small>
+            }
+        </div>
+    </div>;
+
+    // Rendered below the WAN's card body rather than inside it: the body is dimmed and
+    // click-blocked until Adaptive SQM is enabled for the WAN, and learning is meant to run first.
+    private RenderFragment<WanConfigModel> LearningPanel => model =>
+    @<div class="calculated-params" style="margin-top: 0.75rem;">
+        @{
+            var status = model.LearningStatus;
+            var learned = status?.Profile;
+        }
+            <h4>Congestion Profile Learning <span class="tooltip-icon tooltip-icon-sm" data-tooltip="A one-time, hourly schedule for 7 days. Each hour, once the WAN has been idle (under 1 Mbps each way), the gateway runs a brief speed test on this interface with Adaptive SQM lifted out of the way, so the result is the line, not the current shaping rate. Errant samples are discarded and the curve is smoothed across neighboring hours and days. It also appears on Alerts & Schedule - Schedule.">?</span></h4>
+            @if (status == null || (!status.IsActive && !status.HasProfile && !status.IsCompleted))
+            {
+                <p class="learning-text">
+                    Learn this connection's real weekly congestion pattern instead of relying on the @ConnectionProfile.GetConnectionTypeName(model.ConnectionType) default.
+                    One brief gateway speed test per idle hour for 7 days (@SqmLearningTaskConfig.DefaultDurationSeconds s per direction),
+                    about @EstimateSampleMb(model).ToString("F0") MB per sample and up to @EstimateWeekGb(model).ToString("F1") GB over the week at your nominal speeds.
+                    @if (!ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
+                    {
+                        <text> Most useful on cellular, satellite, and fixed wireless, where the tower or cell decides the hour-by-hour speed.</text>
+                    }
+                </p>
+                <div class="learning-actions">
+                    <button type="button" class="btn btn-sm btn-primary" @onclick="() => StartLearning(model)"
+                            disabled="@(!_canOperate || _learningBusy || string.IsNullOrEmpty(model.Interface) || model.NominalDownload <= 0 || model.NominalUpload <= 0)">
+                        Start Learning
+                    </button>
+                    @if (string.IsNullOrEmpty(model.Interface) || model.NominalDownload <= 0 || model.NominalUpload <= 0)
+                    {
+                        <small class="form-hint" style="margin: 0;">Select the interface and enter nominal speeds first.</small>
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="learning-status">
+                    @if (status.IsActive)
+                    {
+                        var day = status.StartedAt.HasValue ? Math.Clamp((int)Math.Floor((DateTime.UtcNow - status.StartedAt.Value).TotalDays) + 1, 1, 7) : 1;
+                        <span><span class="detail-label">Status:</span><span class="status-badge status-active">Learning</span> day @day of 7</span>
+                    }
+                    else if (status.IsCompleted)
+                    {
+                        <span><span class="detail-label">Status:</span>@(status.IsReliable ? "Complete" : "Ended") @(status.CompletedAt.HasValue ? status.CompletedAt.Value.ToLocalTime().ToString("MMM d, HH:mm") : "")</span>
+                    }
+                    <span><span class="detail-label">Samples:</span>@status.ValidSampleCount valid of @status.TotalSampleCount</span>
+                    <span><span class="detail-label">Week covered:</span>@status.CoveragePercent.ToString("F0")%</span>
+                    @if (status.HasProfile)
+                    {
+                        <span><span class="detail-label">Peak:</span>@status.PeakDownloadMbps.ToString("F0") / @status.PeakUploadMbps.ToString("F0") Mbps</span>
+                    }
+                    @if (status.LastSampleAt.HasValue)
+                    {
+                        <span><span class="detail-label">Last sample:</span>@status.LastSampleAt.Value.ToLocalTime().ToString("MMM d, HH:mm")</span>
+                    }
+                    @if (status.IsRunning)
+                    {
+                        <span><span class="spinner-sm"></span> sampling now</span>
+                    }
+                    else if (status.IsActive && status.NextRunAt.HasValue)
+                    {
+                        <span><span class="detail-label">Next check:</span>@status.NextRunAt.Value.ToLocalTime().ToString("HH:mm")</span>
+                    }
+                    @if (!string.IsNullOrEmpty(status.LastSummary) && status.IsActive)
+                    {
+                        <span class="form-hint" style="margin: 0;">@status.LastSummary</span>
+                    }
+                </div>
+                @if (status.HasProfile && !status.IsReliable && status.IsCompleted)
+                {
+                    <p class="learning-text">Not enough of the week was sampled to rely on this profile yet. You can still select it, or relearn for a fuller picture.</p>
+                }
+                @if (learned != null)
+                {
+                    var down = LearnedCongestionProfile.HourOfDayAverages(learned.DownloadMultipliers);
+                    var up = LearnedCongestionProfile.HourOfDayAverages(learned.UploadMultipliers);
+                    <div class="learn-strip">
+                        <div class="learn-strip-label">Down</div>
+                        <div class="learn-strip-bars">
+                            @for (var h = 0; h < 24; h++)
+                            {
+                                var hour = h;
+                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps ({down[hour]:P0}), averaged over the week")"></div>
+                            }
+                        </div>
+                    </div>
+                    <div class="learn-strip">
+                        <div class="learn-strip-label">Up</div>
+                        <div class="learn-strip-bars">
+                            @for (var h = 0; h < 24; h++)
+                            {
+                                var hour = h;
+                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps ({up[hour]:P0}), averaged over the week")"></div>
+                            }
+                        </div>
+                    </div>
+                    <div class="learn-strip-axis"><span>0h</span><span>6h</span><span>12h</span><span>18h</span><span>23h</span></div>
+                }
+                @if (!string.IsNullOrEmpty(status.LastError))
+                {
+                    <div class="alert alert-warning" style="margin-bottom: 0.75rem;">Last sample problem: @status.LastError</div>
+                }
+                <div class="learning-actions">
+                    @if (status.IsActive)
+                    {
+                        <button type="button" class="btn btn-sm btn-secondary" @onclick="() => RunLearningSampleNow(model)" disabled="@(!_canOperate || _learningBusy || status.IsRunning)">
+                            @(status.IsRunning ? "Sampling..." : "Run Sample Now")
+                        </button>
+                        <button type="button" class="btn btn-sm btn-secondary" @onclick="() => StopLearning(model)" disabled="@(!_canOperate || _learningBusy)">Stop Learning</button>
+                    }
+                    else
+                    {
+                        <button type="button" class="btn btn-sm btn-primary" @onclick="() => StartLearning(model)"
+                                disabled="@(!_canOperate || _learningBusy || string.IsNullOrEmpty(model.Interface) || model.NominalDownload <= 0 || model.NominalUpload <= 0)">
+                            @(status.HasProfile ? "Relearn" : "Start Learning")
+                        </button>
+                    }
+                    @if (status.HasProfile)
+                    {
+                        <button type="button" class="btn btn-sm btn-secondary" @onclick="() => ExportLearnedProfile(model)" disabled="@_learningBusy">Export JSON</button>
+                    }
+                    @if (!status.IsActive)
+                    {
+                        <button type="button" class="btn btn-sm btn-danger" @onclick="() => ClearLearning(model)" disabled="@(!_canOperate || _learningBusy)">Clear</button>
+                    }
+                    <a href="/alerts?tab=schedule" class="form-hint" style="margin: 0;">View on Schedule</a>
+                </div>
+            }
+    </div>;
+
+    private static double EstimateSampleMb(WanConfigModel model)
+    {
+        // Both directions for the sample duration, plus ramp-up and control traffic.
+        var seconds = SqmLearningTaskConfig.DefaultDurationSeconds;
+        return (model.NominalDownload + model.NominalUpload) * seconds / 8.0 * 1.15;
+    }
+
+    private static double EstimateWeekGb(WanConfigModel model) =>
+        EstimateSampleMb(model) * 24 * SqmLearningTaskConfig.DefaultDays / 1024.0;
+
+    private async Task LoadLearningStatusAsync()
+    {
+        foreach (var config in new[] { wan1Config, wan2Config })
+        {
+            try
+            {
+                config.LearningStatus = await LearningService.GetStatusAsync(config.WanNumber);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogDebug(ex, "Could not load learning status for WAN {Wan}", config.WanNumber);
+            }
+        }
+    }
+
+    private void OnProfileSourceChanged(WanConfigModel model, string? value)
+    {
+        model.UseLearnedProfile = value == "learned" && model.LearningStatus?.Profile != null;
+    }
+
+    private void ApplyLearnedPeaks(WanConfigModel model)
+    {
+        if (model.LearningStatus?.Profile is not { } learned) return;
+        model.NominalDownload = Math.Max(10, (int)Math.Round(learned.PeakDownloadMbps));
+        model.NominalUpload = Math.Max(1, (int)Math.Round(learned.PeakUploadMbps));
+        UpdateCalculatedSpeeds(model, resetLatency: false);
+    }
+
+    private async Task StartLearning(WanConfigModel model)
+    {
+        if (!_canOperate || _learningBusy) return;
+        _learningBusy = true;
+        try
+        {
+            // The schedule carries the sizing facts itself, so learning can start before the WAN
+            // is saved or deployed and never writes the SQM configuration row.
+            var wan = wanInterfaces.FirstOrDefault(w => w.Interface.Equals(model.Interface, StringComparison.OrdinalIgnoreCase));
+            model.LearningStatus = await LearningService.StartAsync(new SqmLearningStartRequest
+            {
+                WanNumber = model.WanNumber,
+                Interface = model.Interface,
+                Name = model.Name,
+                ConnectionType = model.ConnectionType,
+                WanGroup = wan?.NetworkGroup,
+                NominalDownloadMbps = model.NominalDownload,
+                NominalUploadMbps = model.NominalUpload,
+                LinkSpeedOverrideMbps = model.EffectiveLinkSpeedMbps,
+                RateProportionalDownloadBurst = model.RateProportionalDownloadBurst,
+            });
+            StatusMessage($"Learning started for {model.Name}. The first sample runs within a minute once the WAN is idle; it also shows on Alerts & Schedule - Schedule.", true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to start congestion profile learning for WAN {Wan}", model.WanNumber);
+            StatusMessage($"Could not start learning: {ex.Message}", false);
+        }
+        finally
+        {
+            _learningBusy = false;
+        }
+    }
+
+    private async Task StopLearning(WanConfigModel model)
+    {
+        if (!_canOperate || _learningBusy) return;
+        _learningBusy = true;
+        try
+        {
+            await LearningService.StopAsync(model.WanNumber);
+            model.LearningStatus = await LearningService.GetStatusAsync(model.WanNumber);
+            StatusMessage($"Learning stopped for {model.Name}. What was learned so far is kept.", true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to stop congestion profile learning for WAN {Wan}", model.WanNumber);
+            StatusMessage($"Could not stop learning: {ex.Message}", false);
+        }
+        finally
+        {
+            _learningBusy = false;
+        }
+    }
+
+    private async Task RunLearningSampleNow(WanConfigModel model)
+    {
+        if (!_canOperate || _learningBusy) return;
+        _learningBusy = true;
+        try
+        {
+            var started = await LearningService.RunSampleNowAsync(model.WanNumber);
+            StatusMessage(started
+                ? $"Taking a sample on {model.Name} now (it waits for the WAN to be idle)."
+                : "A sample is already running.", started);
+            // Give the schedule loop a moment to mark the task running, then show it.
+            await Task.Delay(1500);
+            model.LearningStatus = await LearningService.GetStatusAsync(model.WanNumber);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to run a learning sample for WAN {Wan}", model.WanNumber);
+            StatusMessage($"Could not run a sample: {ex.Message}", false);
+        }
+        finally
+        {
+            _learningBusy = false;
+        }
+    }
+
+    private async Task ClearLearning(WanConfigModel model)
+    {
+        if (!_canOperate || _learningBusy) return;
+        _learningBusy = true;
+        try
+        {
+            await LearningService.ClearAsync(model.WanNumber);
+            model.LearningStatus = null;
+            model.UseLearnedProfile = false;
+            StatusMessage($"Learned profile and samples cleared for {model.Name}.", true);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to clear the learned profile for WAN {Wan}", model.WanNumber);
+            StatusMessage($"Could not clear the learned profile: {ex.Message}", false);
+        }
+        finally
+        {
+            _learningBusy = false;
+        }
+    }
+
+    private async Task ExportLearnedProfile(WanConfigModel model)
+    {
+        try
+        {
+            var json = await LearningService.ExportProfileJsonAsync(model.WanNumber);
+            if (string.IsNullOrEmpty(json))
+            {
+                StatusMessage("There is no learned profile to export yet.", false);
+                return;
+            }
+            var fileName = $"congestion-profile-{SanitizeWanName(model.Name).ToLowerInvariant().Replace(' ', '-')}.json";
+            var base64 = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(json));
+            await JS.InvokeVoidAsync("downloadFile", fileName, "application/json", base64);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to export the learned profile for WAN {Wan}", model.WanNumber);
+            StatusMessage($"Could not export the profile: {ex.Message}", false);
+        }
+    }
 
     private const string BurstOptInHint =
         "Helps downloads that fall short of full speed, especially to Wi-Fi clients. " +
@@ -1695,6 +2130,7 @@
     // WAN configurations (defaults overwritten by ApplyDetectedWanInterfaces)
     private WanConfigModel wan1Config = new()
     {
+        WanNumber = 1,
         Enabled = false,  // Start disabled - user must select interface and enable
         Name = "WAN1",
         Interface = "",
@@ -1707,6 +2143,7 @@
 
     private WanConfigModel wan2Config = new()
     {
+        WanNumber = 2,
         Enabled = false,
         Name = "WAN2",
         Interface = "",
@@ -1832,6 +2269,7 @@
                     if (!isRefreshingDashboard)
                     {
                         await LoadSqmMonitorDataAsync(); // Also adjusts polling interval
+                        await LoadLearningStatusAsync();
                         StateHasChanged();
                     }
                 }),
@@ -1998,12 +2436,16 @@
                         config.LatencyThreshold = saved.LatencyThresholdMs.Value;
 
                     config.CongestionSeverity = saved.CongestionSeverity;
+                    config.UploadCongestionSeverity = saved.UploadCongestionSeverity;
+                    config.UseLearnedProfile = saved.UseLearnedProfile;
 
                     // Track this interface as loaded
                     if (!string.IsNullOrEmpty(saved.Interface))
                         loadedInterfaces.Add(saved.Interface);
                 }
             }
+
+            await LoadLearningStatusAsync();
 
             // Set initial collapsed state: collapsed if config exists, expanded if needs setup
             _wan1Collapsed = wan1HasSavedConfig;
@@ -2043,6 +2485,8 @@
                     LatencyThresholdMs = Math.Abs(wan1Config.LatencyThreshold - wan1Config.DefaultLatencyThreshold) > 0.01
                         ? wan1Config.LatencyThreshold : null,
                     CongestionSeverity = wan1Config.CongestionSeverity,
+                    UploadCongestionSeverity = wan1Config.UploadCongestionSeverity,
+                    UseLearnedProfile = wan1Config.UseLearnedProfile,
                     LinkSpeedOverrideMbps = wan1Config.LinkSpeedOverrideMbps,
                     BootDelaySeconds = wan1Config.BootDelaySeconds,
                     RateProportionalDownloadBurst = wan1Config.RateProportionalDownloadBurst,
@@ -2073,6 +2517,8 @@
                     LatencyThresholdMs = Math.Abs(wan2Config.LatencyThreshold - wan2Config.DefaultLatencyThreshold) > 0.01
                         ? wan2Config.LatencyThreshold : null,
                     CongestionSeverity = wan2Config.CongestionSeverity,
+                    UploadCongestionSeverity = wan2Config.UploadCongestionSeverity,
+                    UseLearnedProfile = wan2Config.UseLearnedProfile,
                     LinkSpeedOverrideMbps = wan2Config.LinkSpeedOverrideMbps,
                     BootDelaySeconds = wan2Config.BootDelaySeconds,
                     RateProportionalDownloadBurst = wan2Config.RateProportionalDownloadBurst,
@@ -2232,6 +2678,7 @@
         {
             config.BaselineLatency = profile.BaselineLatency;
             config.LatencyThreshold = profile.LatencyThreshold;
+            config.UploadCongestionSeverity = ConnectionProfile.DefaultUploadCongestionSeverity(config.ConnectionType);
         }
         config.DefaultLatencyThreshold = profile.LatencyThreshold;
 
@@ -2291,6 +2738,7 @@
         wan1Config.EveningMinute = 0;
         wan1Config.BootDelaySeconds = null;
         wan1Config.RateProportionalDownloadBurst = true;
+        wan1Config.UseLearnedProfile = false;
         UpdateCalculatedSpeeds(wan1Config);
 
         // Reset WAN2 to defaults
@@ -2308,6 +2756,7 @@
         wan2Config.EveningMinute = 0;
         wan2Config.BootDelaySeconds = null;
         wan2Config.RateProportionalDownloadBurst = true;
+        wan2Config.UseLearnedProfile = false;
         UpdateCalculatedSpeeds(wan2Config);
     }
 
@@ -3212,6 +3661,18 @@
         config.LatencyThreshold = model.LatencyThreshold;
         config.CongestionSeverity = model.CongestionSeverity;
 
+        // Upload strength only where the medium supports it; a learned profile replaces the
+        // built-in curve, scaled so the deployed schedule reproduces the learned throughput under
+        // the user's nominal speeds.
+        config.UploadCongestionSeverity = ConnectionProfile.SupportsDynamicUpload(model.ConnectionType)
+            ? Math.Clamp(model.UploadCongestionSeverity, 0, 1)
+            : 0;
+        if (model.UseLearnedProfile && model.LearningStatus?.Profile is { } learned)
+        {
+            config.LearnedDownloadPattern = LearnedCongestionProfile.ScaledPattern(learned.DownloadMultipliers, learned.PeakDownloadMbps, model.NominalDownload);
+            config.LearnedUploadPattern = LearnedCongestionProfile.ScaledPattern(learned.UploadMultipliers, learned.PeakUploadMbps, model.NominalUpload);
+        }
+
         return config;
     }
 
@@ -3318,6 +3779,18 @@
         // Congestion severity (0.9-1.1, scales dip magnitude)
         public double CongestionSeverity { get; set; } = 1.0;
 
+        // WAN slot this model is bound to (1 or 2); the learning state and profile are keyed on it
+        public int WanNumber { get; init; }
+
+        // Upload shaping strength (0 = static nominal upload, the pre-existing behavior)
+        public double UploadCongestionSeverity { get; set; }
+
+        // Deploy with the learned profile instead of the connection type's default curve
+        public bool UseLearnedProfile { get; set; }
+
+        // Learning state and learned curves for this WAN, refreshed with the page
+        public SqmLearningStatus? LearningStatus { get; set; }
+
         // Speedtest schedule
         public int MorningHour { get; set; } = 6;
         public int MorningMinute { get; set; } = 0;
@@ -3351,13 +3824,45 @@
 
         // Congestion schedule range (effective shaping rates from baseline-proportional safety cap)
         // Keep this formula in sync with the bash clamp in ScriptGenerator.cs.
-        public (int Min, int Max) GetCongestionRange()
+        // The profile the schedule previews and deploys from: the connection type's curve, or the
+        // learned one scaled to the nominal speeds (same scaling as CreateSqmConfiguration).
+        public ConnectionProfile BuildProfile()
         {
             var profile = new ConnectionProfile
             {
                 Type = ConnectionType,
-                NominalDownloadMbps = NominalDownload
+                NominalDownloadMbps = NominalDownload,
+                NominalUploadMbps = NominalUpload
             };
+            if (UseLearnedProfile && LearningStatus?.Profile is { } learned)
+            {
+                profile.CustomDownloadPattern = LearnedCongestionProfile.ScaledPattern(learned.DownloadMultipliers, learned.PeakDownloadMbps, NominalDownload);
+                profile.CustomUploadPattern = LearnedCongestionProfile.ScaledPattern(learned.UploadMultipliers, learned.PeakUploadMbps, NominalUpload);
+            }
+            return profile;
+        }
+
+        // Upload range over the week at the current strength (nominal when strength is 0).
+        public (int Min, int Max) GetUploadRange()
+        {
+            if (NominalUpload <= 0) return (0, 0);
+            var pattern = BuildProfile().GetUploadPatternPublic();
+            double minRate = double.MaxValue, maxRate = double.MinValue;
+            for (int day = 0; day < 7; day++)
+            {
+                for (int hour = 0; hour < 24; hour++)
+                {
+                    var rate = ConnectionProfile.EffectiveUploadMultiplier(pattern[day, hour], UploadCongestionSeverity) * NominalUpload;
+                    if (rate < minRate) minRate = rate;
+                    if (rate > maxRate) maxRate = rate;
+                }
+            }
+            return (Math.Max(1, (int)minRate), Math.Max(1, (int)maxRate));
+        }
+
+        public (int Min, int Max) GetCongestionRange()
+        {
+            var profile = BuildProfile();
             var pattern = profile.GetBaselinePatternPublic();
             double absoluteMax = profile.AbsoluteMaxDownloadMbps;
             double safetyCap = profile.SafetyCapPercent;
@@ -3418,7 +3923,7 @@
             Enabled, Name, Interface, ConnectionType, NominalDownload, NominalUpload,
             PingHost, SpeedtestServerId, MorningHour, MorningMinute, EveningHour, EveningMinute,
             BaselineLatency, LatencyThreshold, CongestionSeverity, LinkSpeedOverrideMbps,
-            BootDelaySeconds, RateProportionalDownloadBurst);
+            BootDelaySeconds, RateProportionalDownloadBurst, UploadCongestionSeverity, UseLearnedProfile);
 
         // Check if current config differs from a snapshot
         public bool DiffersFrom(WanConfigSnapshot? snapshot)
@@ -3441,7 +3946,9 @@
                    Math.Abs(CongestionSeverity - snapshot.CongestionSeverity) > 0.001 ||
                    LinkSpeedOverrideMbps != snapshot.LinkSpeedOverrideMbps ||
                    BootDelaySeconds != snapshot.BootDelaySeconds ||
-                   RateProportionalDownloadBurst != snapshot.RateProportionalDownloadBurst;
+                   RateProportionalDownloadBurst != snapshot.RateProportionalDownloadBurst ||
+                   Math.Abs(UploadCongestionSeverity - snapshot.UploadCongestionSeverity) > 0.001 ||
+                   UseLearnedProfile != snapshot.UseLearnedProfile;
         }
     }
 
@@ -3451,7 +3958,8 @@
         int NominalDownload, int NominalUpload, string PingHost, string? SpeedtestServerId,
         int MorningHour, int MorningMinute, int EveningHour, int EveningMinute,
         double BaselineLatency, double LatencyThreshold, double CongestionSeverity,
-        int? LinkSpeedOverrideMbps, int? BootDelaySeconds, bool RateProportionalDownloadBurst);
+        int? LinkSpeedOverrideMbps, int? BootDelaySeconds, bool RateProportionalDownloadBurst,
+        double UploadCongestionSeverity, bool UseLearnedProfile);
 
     public void Dispose()
     {

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1806,9 +1806,13 @@
                 <p class="learning-text">
                     Data use: about <strong>@EstimateSampleMb(model).ToString("F0") MB per sample</strong>, up to <strong>@EstimateWeekGb(model).ToString("F0") GB over the week</strong>.
                 </p>
-                @if (!ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
+                @if (ConnectionProfile.SupportsDynamicUpload(model.ConnectionType))
                 {
-                    <p class="learning-text">Most useful on cellular, satellite, and fixed wireless: shared, limited-capacity access where the hour-by-hour speed follows how congested the tower, cell, or beam is.</p>
+                    <p class="learning-text">Especially useful here. These are shared, limited-capacity links where the hour-by-hour speed follows how busy the tower, cell, or beam is.</p>
+                }
+                else
+                {
+                    <p class="learning-text">Useful here if speeds sag at prime time. Cable nodes and PON splits are shared with the neighborhood, and the learned curve follows what your line actually delivers hour by hour instead of a generic one.</p>
                 }
                 <div class="learning-actions">
                     <button type="button" class="btn btn-sm btn-primary" @onclick="() => StartLearning(model)"

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1813,6 +1813,27 @@
                 {
                     <p class="learning-text">Not enough of the week was sampled to rely on this profile yet. You can still select it, or relearn for a fuller picture.</p>
                 }
+                @if (status.ProbeLimitedSampleCount > 0)
+                {
+                    <p class="learning-text">
+                        @if (status.PeakIsLowerBound)
+                        {
+                            <text>Every sample so far hit the measurement ceiling, so the peak is a lower bound: the line is at least that fast. </text>
+                        }
+                        else
+                        {
+                            <text>@status.ProbeLimitedSampleCount of @status.ValidSampleCount samples hit the measurement ceiling and were kept out of the peak. </text>
+                        }
+                        @if (status.LiftAtCeiling)
+                        {
+                            <text>The ceiling is now the WAN link speed with headroom (@(status.LiftCeilingMbps) Mbps), so it cannot be raised further; at those hours the line is at least that fast.</text>
+                        }
+                        else if (status.LiftDownloadMbps.HasValue || status.LiftUploadMbps.HasValue)
+                        {
+                            <text>The lift has been raised to @(status.LiftDownloadMbps?.ToString() ?? "default") / @(status.LiftUploadMbps?.ToString() ?? "default") Mbps for the next samples. If this keeps happening, the nominal speeds are set well below what the line delivers.</text>
+                        }
+                    </p>
+                }
                 @if (learned != null)
                 {
                     var down = LearnedCongestionProfile.HourOfDayAverages(learned.DownloadMultipliers);

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1618,6 +1618,10 @@
         margin-right: 0.25rem;
     }
 
+    .learning-status .status-badge {
+        margin-right: 0.4rem;
+    }
+
     .learning-insights {
         display: grid;
         grid-template-columns: max-content 1fr;

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1879,7 +1879,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps ({down[hour]:P0}), averaged over the week")"></div>
+                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(down[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>
@@ -1889,7 +1889,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps ({up[hour]:P0}), averaged over the week")"></div>
+                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(up[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1860,6 +1860,10 @@
                     </div>
                     <div class="learn-strip-axis"><span>0h</span><span>6h</span><span>12h</span><span>18h</span><span>23h</span></div>
                 }
+                @if (deploymentStatus?.IsDeployed == true && deploymentStatus.PingScriptsWithoutProbeGuard > 0)
+                {
+                    <div class="alert alert-warning" style="margin-bottom: 0.75rem;">Redeploy Adaptive SQM so it doesn't interfere with congestion learning.</div>
+                }
                 @if (!string.IsNullOrEmpty(status.LastError))
                 {
                     <div class="alert alert-warning" style="margin-bottom: 0.75rem;">Last sample problem: @status.LastError</div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1879,7 +1879,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(down[hour] * 100):F0}%</span>")"></div>
+                                <div class="learn-bar" style="height: @((down[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {down[hour] * learned.PeakDownloadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(down[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>
@@ -1889,7 +1889,7 @@
                             @for (var h = 0; h < 24; h++)
                             {
                                 var hour = h;
-                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(up[hour] * 100):F0}%</span>")"></div>
+                                <div class="learn-bar up" style="height: @((up[hour] * 100).ToString("F0"))%" data-tooltip-html data-tooltip="@($"{hour:00}:00 · {up[hour] * learned.PeakUploadMbps:F0} Mbps <span class=\"text-muted\">{Math.Round(up[hour] * 100):F0}%</span>")"></div>
                             }
                         </div>
                     </div>

--- a/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/Sqm.razor
@@ -1618,6 +1618,24 @@
         margin-right: 0.25rem;
     }
 
+    .learning-insights {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-bottom: 0.75rem;
+        font-size: 0.85rem;
+        color: var(--text-primary);
+    }
+
+    .insight-label {
+        display: inline-block;
+        min-width: 8.5rem;
+        color: var(--text-secondary);
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
     .learning-actions {
         display: flex;
         flex-wrap: wrap;
@@ -1788,10 +1806,6 @@
                     }
                     <span><span class="detail-label">Samples:</span>@status.ValidSampleCount valid of @status.TotalSampleCount</span>
                     <span><span class="detail-label">Week covered:</span>@status.CoveragePercent.ToString("F0")%</span>
-                    @if (status.HasProfile)
-                    {
-                        <span><span class="detail-label">Peak:</span>@status.PeakDownloadMbps.ToString("F0") / @status.PeakUploadMbps.ToString("F0") Mbps</span>
-                    }
                     @if (status.LastSampleAt.HasValue)
                     {
                         <span><span class="detail-label">Last sample:</span>@status.LastSampleAt.Value.ToLocalTime().ToString("MMM d, HH:mm")</span>
@@ -1804,7 +1818,7 @@
                     {
                         <span><span class="detail-label">Next check:</span>@status.NextRunAt.Value.ToLocalTime().ToString("HH:mm")</span>
                     }
-                    @if (!string.IsNullOrEmpty(status.LastSummary) && status.IsActive)
+                    @if (status.IsActive && status.LastSummary?.StartsWith("Waiting", StringComparison.Ordinal) == true)
                     {
                         <span class="form-hint" style="margin: 0;">@status.LastSummary</span>
                     }
@@ -1812,6 +1826,22 @@
                 @if (status.HasProfile && !status.IsReliable && status.IsCompleted)
                 {
                     <p class="learning-text">Not enough of the week was sampled to rely on this profile yet. You can still select it, or relearn for a fuller picture.</p>
+                }
+                @if (status.ObservedMinDownloadMbps.HasValue)
+                {
+                    var insight = learned != null && status.DaysSpanned >= 2 ? NetworkOptimizer.Sqm.CongestionProfileInsights.Describe(learned, model.ConnectionType) : null;
+                    <div class="learning-insights">
+                        <div><span class="insight-label">So far</span>@status.ObservedMinDownloadMbps.Value.ToString("F0") to @status.ObservedMaxDownloadMbps!.Value.ToString("F0") Mbps down, @status.ObservedMinUploadMbps!.Value.ToString("F0") to @status.ObservedMaxUploadMbps!.Value.ToString("F0") up.</div>
+                        @if (insight != null)
+                        {
+                            <div><span class="insight-label">Slowest</span>@insight.SlowestSentence.</div>
+                            <div><span class="insight-label">Versus the default</span>@insight.ComparisonSentence(ConnectionProfile.GetConnectionTypeName(model.ConnectionType)).</div>
+                        }
+                        else if (status.IsActive)
+                        {
+                            <div><span class="insight-label">Slowest</span>after a couple of days of samples.</div>
+                        }
+                    </div>
                 }
                 @if (learned != null)
                 {

--- a/src/NetworkOptimizer.Web/Program.cs
+++ b/src/NetworkOptimizer.Web/Program.cs
@@ -20,6 +20,7 @@ using NetworkOptimizer.Web.Services.Gates;
 using NetworkOptimizer.Web.Services.Identity;
 using NetworkOptimizer.Web.Services.Licensing;
 using NetworkOptimizer.Web.Services.OntProviders;
+using NetworkOptimizer.Web.Services.SqmLearning;
 using NetworkOptimizer.Web.Services.Ssh;
 using Serilog;
 using Serilog.Events;
@@ -247,6 +248,7 @@ builder.Services.AddSingleton<NetworkOptimizer.Storage.Interfaces.ISharedFirmwar
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.IMonitoringInterfaceRepository, NetworkOptimizer.Storage.Repositories.MonitoringInterfaceRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISpeedTestRepository, NetworkOptimizer.Storage.Repositories.SpeedTestRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmRepository, NetworkOptimizer.Storage.Repositories.SqmRepository>();
+builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISqmLearningRepository, NetworkOptimizer.Storage.Repositories.SqmLearningRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Alerts.Interfaces.IAlertRepository, NetworkOptimizer.Storage.Repositories.AlertRepository>();
 builder.Services.AddScoped<NetworkOptimizer.Storage.Interfaces.ISiteRepository, NetworkOptimizer.Storage.Repositories.SiteRepository>();
 builder.Services.AddSingleton<SiteRegistryChangeNotifier>();
@@ -786,6 +788,11 @@ builder.Services.AddScoped<NetworkOptimizer.Web.Services.Ssh.GatewayShaperProbeS
 // the method's [RequireRole] and writes its [AuditAction] envelope.
 builder.Services.AddMutatingService<ISqmService, SqmService>();
 builder.Services.AddMutatingService<ISqmDeploymentService, SqmDeploymentService>();
+// Congestion profile learning: the gated surface the page uses, plus the scoped pieces the
+// schedule executor resolves from a site-pinned scope.
+builder.Services.AddMutatingService<ISqmLearningService, SqmLearningService>();
+builder.Services.AddScoped<SqmLearningExecutor>();
+builder.Services.AddScoped<WanIdleGate>();
 builder.Services.AddMutatingService<IWanSteerDeploymentService, WanSteerDeploymentService>();
 builder.Services.AddMutatingService<IWanSteerRuleService, WanSteerRuleService>();
 builder.Services.AddMutatingService<ISiteConfigurationService, SiteConfigurationService>();

--- a/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
@@ -332,6 +332,8 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         }
 
         var (servers, streams) = maxMode ? (6, 24) : (4, 20);
+        if (options.Streams is > 0)
+            streams = Math.Clamp(options.Streams.Value, 1, 48);
         var duration = Math.Clamp(options.DurationSeconds, 2, 60);
         var binaryCommand = $"{RemoteBinaryPath}{ifaceArg} -streams {streams} -servers {servers} -duration {duration}";
 

--- a/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
@@ -344,7 +344,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         {
             var wrapper = NetworkOptimizer.Sqm.SqmShaperLiftScript.Wrap(
                 binaryCommand, interfaceName, lift.DownloadProbeMbps, lift.UploadProbeMbps, lift.RateProportionalDownloadBurst);
-            command = NetworkOptimizer.Sqm.SqmShaperLiftScript.ToRemoteCommand(wrapper, interfaceName) + " 2>/dev/null";
+            command = NetworkOptimizer.Sqm.SqmShaperLiftScript.ToRemoteCommand(wrapper, interfaceName);
         }
         else
         {

--- a/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
+++ b/src/NetworkOptimizer.Web/Services/GatewayWanSpeedTestService.cs
@@ -232,8 +232,10 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         Action<(string Phase, int Percent, string? Status)>? onProgress = null,
         IReadOnlyList<WanInterfaceInfo>? allInterfaces = null,
         bool maxMode = false,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        GatewayWanTestOptions? options = null)
     {
+        options ??= new GatewayWanTestOptions();
         if (_licenseState != null && !_licenseState.IsSiteOperational(_siteSlug))
         {
             _logger.LogWarning("Gateway WAN speed test refused: site {Site} is license-restricted", _siteSlug);
@@ -250,7 +252,10 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
                 return null;
             }
             _isRunning = true;
-            _lastCompletedResult = null;
+            // An ephemeral run (a learning sample) is not the page's run, so it leaves the last
+            // shown result alone.
+            if (!options.Ephemeral)
+                _lastCompletedResult = null;
         }
 
         try
@@ -277,7 +282,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
                 if (!deploySuccess)
                 {
                     Report("Error", 0, deployError);
-                    return SaveFailedResult(deployError, wanNetworkGroup, wanName);
+                    return FailResult(deployError, wanNetworkGroup, wanName, options);
                 }
             }
             Report("Preparing", 8, "Binary ready");
@@ -288,7 +293,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
                 return await RunParallelWanTests(allInterfaces!, maxMode, Report, cancellationToken);
             }
 
-            return await RunSingleWanTest(interfaceName, wanNetworkGroup, wanName, maxMode, Report, cancellationToken);
+            return await RunSingleWanTest(interfaceName, wanNetworkGroup, wanName, maxMode, options, Report, cancellationToken);
         }
         catch (OperationCanceledException)
         {
@@ -302,7 +307,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
             _logger.LogError(ex, "Gateway WAN speed test failed");
             lock (_lock) { _currentPhase = "Error"; _currentPercent = 0; _currentStatus = ex.Message; }
             onProgress?.Invoke(("Error", 0, ex.Message));
-            return SaveFailedResult(ex.Message, wanNetworkGroup, wanName);
+            return FailResult(ex.Message, wanNetworkGroup, wanName, options);
         }
         finally
         {
@@ -315,6 +320,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         string? wanNetworkGroup,
         string? wanName,
         bool maxMode,
+        GatewayWanTestOptions options,
         Action<string, int, string?> report,
         CancellationToken cancellationToken)
     {
@@ -326,7 +332,23 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         }
 
         var (servers, streams) = maxMode ? (6, 24) : (4, 20);
-        var command = $"{RemoteBinaryPath}{ifaceArg} -streams {streams} -servers {servers} -duration 8 2>/dev/null";
+        var duration = Math.Clamp(options.DurationSeconds, 2, 60);
+        var binaryCommand = $"{RemoteBinaryPath}{ifaceArg} -streams {streams} -servers {servers} -duration {duration}";
+
+        // With a shaper lift the binary runs inside a wrapper that raises the WAN's HTB roots to
+        // the probe rates first and restores them from an EXIT trap, all in the one SSH session.
+        string command;
+        if (options.ShaperLift is { } lift && !string.IsNullOrEmpty(interfaceName))
+        {
+            var wrapper = NetworkOptimizer.Sqm.SqmShaperLiftScript.Wrap(
+                binaryCommand, interfaceName, lift.DownloadProbeMbps, lift.UploadProbeMbps, lift.RateProportionalDownloadBurst);
+            command = NetworkOptimizer.Sqm.SqmShaperLiftScript.ToRemoteCommand(wrapper, interfaceName) + " 2>/dev/null";
+        }
+        else
+        {
+            command = binaryCommand + " 2>/dev/null";
+        }
+
         var sshTask = _gatewaySsh.RunCommandAsync(
             command, TimeSpan.FromSeconds(120), cancellationToken);
 
@@ -339,7 +361,7 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
             var error = $"Gateway speed test failed: {result.output}";
             _logger.LogWarning(error);
             report("Error", 0, error);
-            return SaveFailedResult(error, wanNetworkGroup, wanName);
+            return FailResult(error, wanNetworkGroup, wanName, options);
         }
 
         report("Parsing", 95, "Processing results...");
@@ -349,11 +371,25 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         {
             var error = "Failed to parse speed test output";
             report("Error", 0, error);
-            return SaveFailedResult(error, wanNetworkGroup, wanName);
+            return FailResult(error, wanNetworkGroup, wanName, options);
+        }
+
+        if (options.Ephemeral)
+        {
+            // The caller keeps its own record. Nothing is stored, alerted, or analyzed, and the
+            // page's "last result" is left alone so a learning sample never shows up as a run.
+            report("Complete", 100, $"Down: {testResult.DownloadMbps:F1} / Up: {testResult.UploadMbps:F1} Mbps");
+            return testResult;
         }
 
         return await SaveAndCompleteResult(testResult, interfaceName, report, cancellationToken);
     }
+
+    /// <summary>A failed result: stored for a normal run, returned unstored for an ephemeral one.</summary>
+    private Iperf3Result? FailResult(string? errorMessage, string? wanNetworkGroup, string? wanName, GatewayWanTestOptions options) =>
+        options.Ephemeral
+            ? BuildFailedResult(errorMessage, wanNetworkGroup, wanName)
+            : SaveFailedResult(errorMessage, wanNetworkGroup, wanName);
 
     private async Task<Iperf3Result?> RunParallelWanTests(
         IReadOnlyList<WanInterfaceInfo> interfaces,
@@ -731,22 +767,24 @@ public class GatewayWanSpeedTestService : IGatewayWanSpeedTestService
         }
     }
 
+    private static Iperf3Result BuildFailedResult(string? errorMessage, string? wanNetworkGroup, string? wanName) => new()
+    {
+        Direction = SpeedTestDirection.UwnWanGateway,
+        DeviceHost = "UWN Test",
+        DeviceName = "Gateway",
+        DeviceType = "WAN",
+        WanNetworkGroup = wanNetworkGroup,
+        WanName = wanName,
+        TestTime = DateTime.UtcNow,
+        Success = false,
+        ErrorMessage = errorMessage,
+    };
+
     private Iperf3Result? SaveFailedResult(string? errorMessage, string? wanNetworkGroup, string? wanName)
     {
         try
         {
-            var failedResult = new Iperf3Result
-            {
-                Direction = SpeedTestDirection.UwnWanGateway,
-                DeviceHost = "UWN Test",
-                DeviceName = "Gateway",
-                DeviceType = "WAN",
-                WanNetworkGroup = wanNetworkGroup,
-                WanName = wanName,
-                TestTime = DateTime.UtcNow,
-                Success = false,
-                ErrorMessage = errorMessage,
-            };
+            var failedResult = BuildFailedResult(errorMessage, wanNetworkGroup, wanName);
             using var context = CreateSiteDb();
             context.Iperf3Results.Add(failedResult);
             context.SaveChanges();

--- a/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
+++ b/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
@@ -6,6 +6,29 @@ using NetworkOptimizer.Web.Services.Gates;
 namespace NetworkOptimizer.Web.Services;
 
 /// <summary>
+/// Per-run tuning for the gateway WAN speed test. The defaults reproduce the standard test exactly;
+/// Adaptive SQM learning passes a short duration, keeps its own record, and lifts the shaper.
+/// </summary>
+public sealed record GatewayWanTestOptions
+{
+    /// <summary>Seconds per direction handed to the binary. The standard test uses 8.</summary>
+    public int DurationSeconds { get; init; } = 8;
+
+    /// <summary>
+    /// Return the parsed result without storing it, alerting on it, or analyzing its path. For a
+    /// caller that records the measurement itself, so hourly samples never land in the WAN Speed
+    /// Test history or trip a speed-degradation alert.
+    /// </summary>
+    public bool Ephemeral { get; init; }
+
+    /// <summary>Lift the WAN's shaper around the test so it measures the line, not the current SQM rate.</summary>
+    public SqmShaperLift? ShaperLift { get; init; }
+}
+
+/// <summary>Rates to hold on the WAN's HTB roots while a measurement runs; restored when the binary exits.</summary>
+public sealed record SqmShaperLift(int DownloadProbeMbps, int UploadProbeMbps, bool RateProportionalDownloadBurst);
+
+/// <summary>
 /// The WAN speed test surface shared by the server-side (uwnspeedtest) runner. Running a speed test
 /// is the one mutating action an Operator may take (design doc 08); editing or deleting stored
 /// results is an Admin change to recorded data.
@@ -118,7 +141,8 @@ public interface IGatewayWanSpeedTestService
         Action<(string Phase, int Percent, string? Status)>? onProgress = null,
         IReadOnlyList<WanInterfaceInfo>? allInterfaces = null,
         bool maxMode = false,
-        CancellationToken cancellationToken = default);
+        CancellationToken cancellationToken = default,
+        GatewayWanTestOptions? options = null);
 
     /// <summary>Stored gateway WAN results for this site.</summary>
     [RequireRole(Roles.Viewer)]

--- a/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
+++ b/src/NetworkOptimizer.Web/Services/ISpeedTestServices.cs
@@ -14,6 +14,9 @@ public sealed record GatewayWanTestOptions
     /// <summary>Seconds per direction handed to the binary. The standard test uses 8.</summary>
     public int DurationSeconds { get; init; } = 8;
 
+    /// <summary>Concurrent connections; null keeps the standard test's count (20, or 24 at max load).</summary>
+    public int? Streams { get; init; }
+
     /// <summary>
     /// Return the parsed result without storing it, alerting on it, or analyzing its path. For a
     /// caller that records the measurement itself, so hourly samples never land in the WAN Speed

--- a/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
+++ b/src/NetworkOptimizer.Web/Services/ScheduleExecutorRegistration.cs
@@ -24,6 +24,30 @@ public static class ScheduleExecutorRegistration
             ExecuteWanSpeedTestAsync(app.Services, siteKey, taskId, targetId, targetConfig, ct);
         scheduleService.LanSpeedTestExecutor = (siteKey, targetId, _, ct) =>
             ExecuteLanSpeedTestAsync(app.Services, siteKey, targetId, ct);
+        scheduleService.SqmLearningExecutor = (siteKey, taskId, targetId, targetConfig, ct) =>
+            ExecuteSqmLearningAsync(app.Services, siteKey, taskId, targetId, targetConfig, ct);
+    }
+
+    /// <summary>
+    /// One Adaptive SQM learning sample. Quiet on a restricted site: an hourly failure alert for a
+    /// week would be the wrong way to say the site is not operational.
+    /// </summary>
+    private static async Task<NetworkOptimizer.Alerts.ScheduleRunOutcome> ExecuteSqmLearningAsync(
+        IServiceProvider services, string siteKey, int taskId, string? targetId, string? targetConfig, CancellationToken ct)
+    {
+        if (IsLicenseRestricted(services, siteKey))
+            return new NetworkOptimizer.Alerts.ScheduleRunOutcome(false, null, LicenseRestrictedError, Notify: false);
+
+        using var scope = CreatePinnedScope(services, siteKey);
+        try
+        {
+            var executor = scope.ServiceProvider.GetRequiredService<SqmLearning.SqmLearningExecutor>();
+            return await executor.RunAsync(taskId, targetId, targetConfig, ct);
+        }
+        catch (Exception ex)
+        {
+            return new NetworkOptimizer.Alerts.ScheduleRunOutcome(false, null, ex.Message, Notify: false);
+        }
     }
 
     /// <summary>Scheduled operations record a clean failure for license-restricted sites.</summary>

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -145,7 +145,10 @@ public class SqmDeploymentService : ISqmDeploymentService
                 "echo '---WATCHDOG_RUNNING---'; crontab -l 2>/dev/null | grep -q sqm-watchdog && echo 'active' || echo 'inactive'; " +
                 "echo '---CRON_CHECK---'; crontab -l 2>/dev/null | grep -c sqm || echo '0'; " +
                 "echo '---SPEEDTEST_CLI---'; which speedtest >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
-                "echo '---BC_CHECK---'; which bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'";
+                "echo '---BC_CHECK---'; which bc >/dev/null 2>&1 && echo 'installed' || echo 'missing'; " +
+                // Ping scripts from before the probe lock existed keep adjusting during a congestion
+                // learning sample; a redeploy installs the guard.
+                $"echo '---PING_GUARD_MISSING---'; for f in {SqmDir}/*-ping.sh; do [ -f \"$f\" ] && ! grep -q PROBE_LOCK \"$f\" && echo \"$f\"; done | wc -l";
 
             var result = await RunCommandAsync(combinedCommand);
             var sections = ParseDelimitedOutput(result.output);
@@ -180,6 +183,11 @@ public class SqmDeploymentService : ISqmDeploymentService
             status.SpeedtestCliInstalled = result.success && GetSection(sections, "SPEEDTEST_CLI").Contains("installed");
 
             status.BcInstalled = result.success && GetSection(sections, "BC_CHECK").Contains("installed");
+
+            if (int.TryParse(GetSection(sections, "PING_GUARD_MISSING").Trim(), out int unguarded))
+            {
+                status.PingScriptsWithoutProbeGuard = unguarded;
+            }
 
             status.IsDeployed = status.SpeedtestScriptDeployed && status.PingScriptDeployed;
         }
@@ -1381,6 +1389,12 @@ public class SqmDeploymentStatus
     public bool SpeedtestCliInstalled { get; set; }
     public bool BcInstalled { get; set; }
     public string? Error { get; set; }
+
+    /// <summary>
+    /// Deployed ping scripts that predate the probe lock and so keep adjusting during a congestion
+    /// learning sample. Zero once Adaptive SQM has been redeployed from a build that has the guard.
+    /// </summary>
+    public int PingScriptsWithoutProbeGuard { get; set; }
 
     /// <summary>
     /// True when the gateway is unreachable only because this site's on-site agent

--- a/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmDeploymentService.cs
@@ -405,7 +405,7 @@ public class SqmDeploymentService : ISqmDeploymentService
             steps.Add("Generating SQM boot script...");
             var generator = new ScriptGenerator(config, initialDelaySeconds);
             baseline ??= GenerateDefaultBaseline(config);
-            var scripts = generator.GenerateAllScripts(baseline);
+            var scripts = generator.GenerateAllScripts(baseline, GenerateUploadBaseline(config));
             var bootScriptName = generator.GetBootScriptName();
 
             // Step 3: Deploy the boot script
@@ -871,19 +871,17 @@ public class SqmDeploymentService : ISqmDeploymentService
     /// </summary>
     private Dictionary<string, string> GenerateDefaultBaseline(SqmConfig config)
     {
-        // Create a ConnectionProfile to get the hourly baseline pattern
-        var profile = new ConnectionProfile
-        {
-            Type = config.ConnectionType,
-            Name = config.ConnectionName ?? "",
-            Interface = config.Interface,
-            NominalDownloadMbps = config.NominalDownloadSpeed,
-            NominalUploadMbps = config.NominalUploadSpeed
-        };
-
-        // Get the 168-hour baseline scaled to nominal speed, with congestion severity applied
-        return profile.GetHourlyBaseline(config.CongestionSeverity);
+        // The configuration's profile carries the learned curves when a learned profile is in use;
+        // otherwise this is the connection type's built-in pattern, as before.
+        return config.GetProfile().GetHourlyBaseline(config.CongestionSeverity);
     }
+
+    /// <summary>
+    /// The 168-hour upload schedule, or null when upload stays static (strength 0, the default),
+    /// in which case the generated scripts are identical to those before dynamic upload existed.
+    /// </summary>
+    private static Dictionary<string, string>? GenerateUploadBaseline(SqmConfig config) =>
+        config.DynamicUpload ? config.GetProfile().GetHourlyUploadBaseline(config.UploadCongestionSeverity) : null;
 
     /// <summary>
     /// Get SQM status for all WANs by parsing gateway logs

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/GatewayInterfaceRateProbe.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/GatewayInterfaceRateProbe.cs
@@ -21,13 +21,15 @@ public static class GatewayInterfaceRateProbe
     /// <param name="Hour">Gateway-local hour.</param>
     /// <param name="SqmSpeedtestRunning">True while a deployed *-speedtest.sh is executing.</param>
     /// <param name="InterfacePresent">False when the interface has no counters on the gateway.</param>
+    /// <param name="Minute">Gateway-local minute (0-59).</param>
     public sealed record Reading(
         double DownloadMbps,
         double UploadMbps,
         int DayOfWeek,
         int Hour,
         bool SqmSpeedtestRunning,
-        bool InterfacePresent);
+        bool InterfacePresent,
+        int Minute = 0);
 
     /// <summary>The shell command for one probe of the given interface.</summary>
     public static string BuildCommand(string interfaceName)
@@ -43,7 +45,7 @@ public static class GatewayInterfaceRateProbe
                $"sleep {WindowSeconds}; " +
                $"r2=$(cat {stats}/rx_bytes 2>/dev/null || echo 0); t2=$(cat {stats}/tx_bytes 2>/dev/null || echo 0); " +
                "echo \"rx_bytes=$((r2 - r1))\"; echo \"tx_bytes=$((t2 - t1))\"; " +
-               "echo \"day=$(( $(date +%u) - 1 ))\"; echo \"hour=$(date +%-H)\"; " +
+               "echo \"day=$(( $(date +%u) - 1 ))\"; echo \"hour=$(date +%-H)\"; echo \"minute=$(date +%-M)\"; " +
                "echo \"present=$present\"; " +
                "echo \"sqm_speedtest=$(pgrep -f -- '[-]speedtest\\.sh' >/dev/null 2>&1 && echo 1 || echo 0)\"";
     }
@@ -71,13 +73,14 @@ public static class GatewayInterfaceRateProbe
 
         var present = !values.TryGetValue("present", out var p) || p != "0";
         var running = values.TryGetValue("sqm_speedtest", out var s) && s == "1";
+        var minute = TryInt(values, "minute", out var mi) && mi is >= 0 and <= 59 ? mi : 0;
 
         // A counter that wrapped or reset reads negative; treat that window as unknown-busy
         // rather than idle, since the honest answer is "could not tell".
         var downMbps = rx < 0 ? double.MaxValue : rx * 8.0 / WindowSeconds / 1_000_000.0;
         var upMbps = tx < 0 ? double.MaxValue : tx * 8.0 / WindowSeconds / 1_000_000.0;
 
-        return new Reading(downMbps, upMbps, day, hour, running, present);
+        return new Reading(downMbps, upMbps, day, hour, running, present, minute);
     }
 
     private static bool TryLong(Dictionary<string, string> values, string key, out long value)

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/GatewayInterfaceRateProbe.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/GatewayInterfaceRateProbe.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using NetworkOptimizer.Sqm;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// One SSH round trip that reads what a learning sample needs from the gateway itself: the WAN
+/// data-path interface's traffic over a short window (the idle fallback when SNMP monitoring is
+/// not delivering), the gateway's local day and hour (the slot the deployed schedule reads), and
+/// whether the Adaptive SQM speed test script is mid-run.
+/// </summary>
+public static class GatewayInterfaceRateProbe
+{
+    /// <summary>Seconds the counters are sampled over.</summary>
+    public const int WindowSeconds = 3;
+
+    /// <summary>The reading the probe produced.</summary>
+    /// <param name="DownloadMbps">Traffic received on the WAN interface over the window.</param>
+    /// <param name="UploadMbps">Traffic sent on the WAN interface over the window.</param>
+    /// <param name="DayOfWeek">Gateway-local day, 0 = Monday.</param>
+    /// <param name="Hour">Gateway-local hour.</param>
+    /// <param name="SqmSpeedtestRunning">True while a deployed *-speedtest.sh is executing.</param>
+    /// <param name="InterfacePresent">False when the interface has no counters on the gateway.</param>
+    public sealed record Reading(
+        double DownloadMbps,
+        double UploadMbps,
+        int DayOfWeek,
+        int Hour,
+        bool SqmSpeedtestRunning,
+        bool InterfacePresent);
+
+    /// <summary>The shell command for one probe of the given interface.</summary>
+    public static string BuildCommand(string interfaceName)
+    {
+        var validation = InputSanitizer.ValidateInterface(interfaceName);
+        if (!validation.isValid)
+            throw new ArgumentException(validation.error, nameof(interfaceName));
+
+        var stats = $"/sys/class/net/{interfaceName}/statistics";
+        // The pgrep pattern is bracketed so the probe's own command line never matches itself.
+        return $"present=$(test -d /sys/class/net/{interfaceName} && echo 1 || echo 0); " +
+               $"r1=$(cat {stats}/rx_bytes 2>/dev/null || echo 0); t1=$(cat {stats}/tx_bytes 2>/dev/null || echo 0); " +
+               $"sleep {WindowSeconds}; " +
+               $"r2=$(cat {stats}/rx_bytes 2>/dev/null || echo 0); t2=$(cat {stats}/tx_bytes 2>/dev/null || echo 0); " +
+               "echo \"rx_bytes=$((r2 - r1))\"; echo \"tx_bytes=$((t2 - t1))\"; " +
+               "echo \"day=$(( $(date +%u) - 1 ))\"; echo \"hour=$(date +%-H)\"; " +
+               "echo \"present=$present\"; " +
+               "echo \"sqm_speedtest=$(pgrep -f -- '[-]speedtest\\.sh' >/dev/null 2>&1 && echo 1 || echo 0)\"";
+    }
+
+    /// <summary>Parses the probe's key=value output; null when it is not the probe's output.</summary>
+    public static Reading? Parse(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output)) return null;
+
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var raw in output.Split('\n'))
+        {
+            var line = raw.Trim();
+            var eq = line.IndexOf('=');
+            if (eq <= 0) continue;
+            values[line[..eq]] = line[(eq + 1)..].Trim();
+        }
+
+        if (!TryLong(values, "rx_bytes", out var rx) || !TryLong(values, "tx_bytes", out var tx))
+            return null;
+        if (!TryInt(values, "day", out var day) || !TryInt(values, "hour", out var hour))
+            return null;
+        if (day is < 0 or > 6 || hour is < 0 or > 23)
+            return null;
+
+        var present = !values.TryGetValue("present", out var p) || p != "0";
+        var running = values.TryGetValue("sqm_speedtest", out var s) && s == "1";
+
+        // A counter that wrapped or reset reads negative; treat that window as unknown-busy
+        // rather than idle, since the honest answer is "could not tell".
+        var downMbps = rx < 0 ? double.MaxValue : rx * 8.0 / WindowSeconds / 1_000_000.0;
+        var upMbps = tx < 0 ? double.MaxValue : tx * 8.0 / WindowSeconds / 1_000_000.0;
+
+        return new Reading(downMbps, upMbps, day, hour, running, present);
+    }
+
+    private static bool TryLong(Dictionary<string, string> values, string key, out long value)
+    {
+        value = 0;
+        return values.TryGetValue(key, out var s) && long.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryInt(Dictionary<string, string> values, string key, out int value)
+    {
+        value = 0;
+        return values.TryGetValue(key, out var s) && int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
@@ -109,6 +109,12 @@ public sealed class SqmLearningStatus
     public double PeakUploadMbps { get; set; }
     public int DurationSeconds { get; set; }
 
+    /// <summary>Range the line has delivered across the valid samples so far; null until there is one.</summary>
+    public double? ObservedMinDownloadMbps { get; set; }
+    public double? ObservedMaxDownloadMbps { get; set; }
+    public double? ObservedMinUploadMbps { get; set; }
+    public double? ObservedMaxUploadMbps { get; set; }
+
     /// <summary>Valid samples that ran into the lifted shaper rate instead of measuring the line.</summary>
     public int ProbeLimitedSampleCount { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
@@ -32,6 +32,11 @@ public interface ISqmLearningService
     [AuditAction(AuditActions.SqmLearningStopped, TargetType = "wan")]
     Task StopAsync(int wanNumber);
 
+    /// <summary>Stops the run and takes its schedule off the Schedule tab, keeping the samples and profile.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.SqmLearningStopped, TargetType = "wan")]
+    Task RemoveScheduleAsync(int wanNumber);
+
     /// <summary>Removes the schedule, the samples, and the learned profile for the WAN.</summary>
     [RequireRole(Roles.Operator)]
     [AuditAction(AuditActions.SqmLearningCleared, TargetType = "wan")]

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
@@ -109,6 +109,23 @@ public sealed class SqmLearningStatus
     public double PeakUploadMbps { get; set; }
     public int DurationSeconds { get; set; }
 
+    /// <summary>Valid samples that ran into the lifted shaper rate instead of measuring the line.</summary>
+    public int ProbeLimitedSampleCount { get; set; }
+
+    /// <summary>True when every valid sample was probe-limited, so the peaks are lower bounds.</summary>
+    public bool PeakIsLowerBound { get; set; }
+
+    /// <summary>Lift the next sample uses, when raised above the default.</summary>
+    public int? LiftDownloadMbps { get; set; }
+    public int? LiftUploadMbps { get; set; }
+
+    /// <summary>Highest lift the WAN allows (link speed with headroom); null when unknown.</summary>
+    public int? LiftCeilingMbps { get; set; }
+
+    /// <summary>True when a raised lift has reached the link ceiling and cannot go higher.</summary>
+    public bool LiftAtCeiling =>
+        LiftCeilingMbps is > 0 && ((LiftDownloadMbps ?? 0) >= LiftCeilingMbps || (LiftUploadMbps ?? 0) >= LiftCeilingMbps);
+
     /// <summary>The learned curves, when <see cref="HasProfile"/>.</summary>
     public LearnedCongestionProfile? Profile { get; set; }
 }

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/ISqmLearningService.cs
@@ -1,0 +1,114 @@
+using NetworkOptimizer.Sqm.Models;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Models.Identity;
+using NetworkOptimizer.Web.Services.Gates;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// Adaptive SQM congestion profile learning for the site in context: starting and stopping the
+/// one-time learning schedule, reading its progress, and the learned profile. Starting, stopping,
+/// and running a sample operate the deployed system within its envelope, so they are Operator;
+/// reads are Viewer.
+/// </summary>
+[MutatingService(SiteScoped = true)]
+public interface ISqmLearningService
+{
+    /// <summary>Learning state and profile for a WAN; null when nothing has ever been learned or started.</summary>
+    [RequireRole(Roles.Viewer)]
+    Task<SqmLearningStatus?> GetStatusAsync(int wanNumber);
+
+    /// <summary>Raw samples of the current run, newest first.</summary>
+    [RequireRole(Roles.Viewer)]
+    Task<List<SqmLearningSample>> GetSamplesAsync(int wanNumber, int count = 200);
+
+    /// <summary>Starts a 7-day learning run for the WAN, creating its hourly schedule. Idempotent while one is active.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.SqmLearningStarted, TargetType = "wan")]
+    Task<SqmLearningStatus> StartAsync(SqmLearningStartRequest request);
+
+    /// <summary>Stops the run early, keeping whatever was learned.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.SqmLearningStopped, TargetType = "wan")]
+    Task StopAsync(int wanNumber);
+
+    /// <summary>Removes the schedule, the samples, and the learned profile for the WAN.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.SqmLearningCleared, TargetType = "wan")]
+    Task ClearAsync(int wanNumber);
+
+    /// <summary>Runs the learning schedule now. False when it is already running or there is none.</summary>
+    [RequireRole(Roles.Operator)]
+    [AuditAction(AuditActions.ScheduleChanged, TargetType = "schedule")]
+    Task<bool> RunSampleNowAsync(int wanNumber);
+
+    /// <summary>The learned profile as shareable JSON; null when there is none.</summary>
+    [RequireRole(Roles.Viewer)]
+    Task<string?> ExportProfileJsonAsync(int wanNumber);
+}
+
+/// <summary>What the page needs to start learning on a WAN.</summary>
+public sealed class SqmLearningStartRequest
+{
+    public int WanNumber { get; set; }
+    public string Interface { get; set; } = "";
+    public string Name { get; set; } = "";
+    public ConnectionType ConnectionType { get; set; }
+
+    /// <summary>UniFi WAN network group ("WAN", "WAN2"), when the page knows it.</summary>
+    public string? WanGroup { get; set; }
+
+    /// <summary>Nominal speeds and shaping facts from the form, used to size the shaper lift.</summary>
+    public int NominalDownloadMbps { get; set; }
+    public int NominalUploadMbps { get; set; }
+    public int? LinkSpeedOverrideMbps { get; set; }
+    public bool RateProportionalDownloadBurst { get; set; }
+
+    public int Days { get; set; } = SqmLearningTaskConfig.DefaultDays;
+    public int DurationSeconds { get; set; } = SqmLearningTaskConfig.DefaultDurationSeconds;
+}
+
+/// <summary>Learning state of one WAN, combining the profile row with its schedule task.</summary>
+public sealed class SqmLearningStatus
+{
+    public int WanNumber { get; set; }
+    public string Interface { get; set; } = "";
+    public string Name { get; set; } = "";
+
+    /// <summary>A learned curve exists (reliable or not).</summary>
+    public bool HasProfile { get; set; }
+
+    /// <summary>The schedule exists, is enabled, and the window has not ended.</summary>
+    public bool IsActive { get; set; }
+
+    /// <summary>The run finished or was stopped.</summary>
+    public bool IsCompleted { get; set; }
+
+    public int? TaskId { get; set; }
+    public bool TaskEnabled { get; set; }
+
+    /// <summary>A sample is being taken right now.</summary>
+    public bool IsRunning { get; set; }
+
+    public DateTime? StartedAt { get; set; }
+    public DateTime? EndsAt { get; set; }
+    public DateTime? CompletedAt { get; set; }
+    public DateTime? LastRunAt { get; set; }
+    public DateTime? NextRunAt { get; set; }
+    public DateTime? LastSampleAt { get; set; }
+    public string? LastStatus { get; set; }
+    public string? LastSummary { get; set; }
+    public string? LastError { get; set; }
+
+    public int ValidSampleCount { get; set; }
+    public int TotalSampleCount { get; set; }
+    public double CoveragePercent { get; set; }
+    public int DaysSpanned { get; set; }
+    public bool IsReliable { get; set; }
+    public double PeakDownloadMbps { get; set; }
+    public double PeakUploadMbps { get; set; }
+    public int DurationSeconds { get; set; }
+
+    /// <summary>The learned curves, when <see cref="HasProfile"/>.</summary>
+    public LearnedCongestionProfile? Profile { get; set; }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -207,9 +207,8 @@ public class SqmLearningExecutor
         profile.Interface = iface;
         await RecomputeAsync(profile, ct);
 
-        var summary = $"Sample {sample.DownloadMbps:F0} / {sample.UploadMbps:F0} Mbps" +
-                      (sample.ProbeLimited ? " (hit the measurement ceiling, lift raised)" : "") +
-                      $" · {profile.ValidSampleCount} samples, {profile.CoveragePercent:F0}% of the week covered";
+        var summary = $"Sample {sample.DownloadMbps:F0} / {sample.UploadMbps:F0} Mbps · " +
+                      $"{profile.ValidSampleCount} samples, {profile.CoveragePercent:F0}% of the week covered";
         _logger.LogInformation("Adaptive SQM learning sample for WAN {Wan} ({Iface}): {Summary}", cfg.WanNumber, iface, summary);
         return new ScheduleRunOutcome(true, summary, null, Notify: false);
 

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -24,6 +24,15 @@ public class SqmLearningExecutor
     /// <summary>Connections per sample: half the standard test's, plenty to saturate a shared-medium WAN for 4 s.</summary>
     public const int SampleStreams = 10;
 
+    /// <summary>A direction that lands at or above this fraction of its lift measured the lift, not the line.</summary>
+    public const double ProbeLimitedFraction = 0.95;
+
+    /// <summary>How far the lift is raised after a probe-limited sample.</summary>
+    public const double LiftRaiseFactor = 1.5;
+
+    /// <summary>Sanity ceiling for a raised lift when the link speed is unknown.</summary>
+    public const int MaxLiftMbps = 100_000;
+
     /// <summary>Failures alert on the third in a row and then once a day, not every hour.</summary>
     public const int FailureAlertThreshold = 3;
     public const int FailureAlertRepeatEvery = 24;
@@ -115,12 +124,17 @@ public class SqmLearningExecutor
         if (!idle.IsIdle)
             return Wait($"Waiting for an idle stretch: {profile.Name} at {FormatMbps(idle.DownloadMbps)} down / {FormatMbps(idle.UploadMbps)} up");
 
+        // The lift starts from the configuration and rises after any sample that ran into it, so a
+        // conservative nominal cannot cap what learning sees.
+        var ceiling = LinkCeiling(wanConfig);
+        var lift = RaiseLift(BuildLift(wanConfig), profile.LiftDownloadMbps, profile.LiftUploadMbps, ceiling);
+        profile.LiftCeilingMbps = ceiling;
         var options = new GatewayWanTestOptions
         {
             DurationSeconds = cfg.DurationSeconds,
             Streams = SampleStreams,
             Ephemeral = true,
-            ShaperLift = BuildLift(wanConfig),
+            ShaperLift = lift,
         };
 
         Iperf3Result? result;
@@ -151,13 +165,24 @@ public class SqmLearningExecutor
             IdleDownloadMbps = Math.Round(idle.DownloadMbps, 3),
             IdleUploadMbps = Math.Round(idle.UploadMbps, 3),
             IdleSource = idle.Source,
+            LiftDownloadMbps = lift?.DownloadProbeMbps,
+            LiftUploadMbps = lift?.UploadProbeMbps,
             Success = result.Success,
             Error = result.Success ? null : Trim(result.ErrorMessage),
         };
+        var limitedDown = result.Success && lift != null && IsProbeLimited(result.DownloadMbps, lift.DownloadProbeMbps);
+        var limitedUp = result.Success && lift != null && IsProbeLimited(result.UploadMbps, lift.UploadProbeMbps);
+        sample.ProbeLimited = limitedDown || limitedUp;
         await _repo.AddSampleAsync(sample, ct);
 
         if (!result.Success)
             return await FailAsync(profile, result.ErrorMessage ?? "The gateway speed test reported a failure.", ct);
+
+        // A direction that hit its lift gets a higher lift next time, up to the link ceiling.
+        if (limitedDown)
+            profile.LiftDownloadMbps = Math.Max(profile.LiftDownloadMbps ?? 0, NextLift(result.DownloadMbps, ceiling));
+        if (limitedUp)
+            profile.LiftUploadMbps = Math.Max(profile.LiftUploadMbps ?? 0, NextLift(result.UploadMbps, ceiling));
 
         profile.LastSampleAt = sample.SampledAt;
         profile.LastError = null;
@@ -165,8 +190,9 @@ public class SqmLearningExecutor
         profile.Interface = iface;
         await RecomputeAsync(profile, ct);
 
-        var summary = $"Sample {sample.DownloadMbps:F0} / {sample.UploadMbps:F0} Mbps · " +
-                      $"{profile.ValidSampleCount} samples, {profile.CoveragePercent:F0}% of the week covered";
+        var summary = $"Sample {sample.DownloadMbps:F0} / {sample.UploadMbps:F0} Mbps" +
+                      (sample.ProbeLimited ? " (hit the measurement ceiling, lift raised)" : "") +
+                      $" · {profile.ValidSampleCount} samples, {profile.CoveragePercent:F0}% of the week covered";
         _logger.LogInformation("Adaptive SQM learning sample for WAN {Wan} ({Iface}): {Summary}", cfg.WanNumber, iface, summary);
         return new ScheduleRunOutcome(true, summary, null, Notify: false);
 
@@ -179,7 +205,7 @@ public class SqmLearningExecutor
     {
         var rows = await _repo.GetSamplesAsync(profile.WanNumber, profile.LearningStartedAt, ct);
         var samples = rows.Where(r => r.Success)
-            .Select(r => new LearningSample(r.Id, r.LocalDayOfWeek, r.LocalHour, r.DownloadMbps, r.UploadMbps, r.SampledAt))
+            .Select(r => new LearningSample(r.Id, r.LocalDayOfWeek, r.LocalHour, r.DownloadMbps, r.UploadMbps, r.SampledAt, r.ProbeLimited))
             .ToList();
 
         var learned = CongestionProfileLearner.Learn(samples);
@@ -196,6 +222,7 @@ public class SqmLearningExecutor
         profile.CoveragePercent = Math.Round(p.Coverage * 100, 1);
         profile.DaysSpanned = p.DaysSpanned;
         profile.IsReliable = p.IsReliable;
+        profile.PeakIsLowerBound = p.PeakIsLowerBound;
         profile.ProfileUpdatedAt = DateTime.UtcNow;
         await _repo.SaveProfileAsync(profile, ct);
     }
@@ -234,32 +261,60 @@ public class SqmLearningExecutor
     }
 
     /// <summary>
-    /// Probe rates that stay clear of the line rate: at least twice nominal so a conservative
-    /// nominal cannot cap the measurement, at least the deploy's own probe rate, and never above
-    /// the link ceiling the deploy uses. Null when the WAN has no saved configuration to size from.
+    /// The same probe the deployed Adaptive SQM speed test uses: download 3% above the highest rate
+    /// the WAN ever shapes to, upload just above nominal. The link stays shaped during the sample,
+    /// so a learning run never turns bufferbloat loose for its test window; a sample that clips at
+    /// this probe raises it for the next one (<see cref="RaiseLift"/>). Never above the link
+    /// ceiling. Null when the WAN has no configuration to size from.
     /// </summary>
     internal static SqmShaperLift? BuildLift(SqmWanConfiguration? wanConfig)
     {
         if (wanConfig == null || wanConfig.NominalDownloadMbps <= 0)
             return null;
 
+        var nominalUp = Math.Max(1, wanConfig.NominalUploadMbps);
         var sqm = new SqmConfig
         {
             ConnectionType = (ConnectionType)wanConfig.ConnectionType,
             NominalDownloadSpeed = wanConfig.NominalDownloadMbps,
-            NominalUploadSpeed = Math.Max(1, wanConfig.NominalUploadMbps),
+            NominalUploadSpeed = nominalUp,
         };
         sqm.ApplyProfileSettings(wanConfig.LinkSpeedOverrideMbps);
 
-        var down = Math.Max(sqm.SpeedtestProbeRateMbps, wanConfig.NominalDownloadMbps * 2);
-        var up = Math.Max(10, Math.Max(1, wanConfig.NominalUploadMbps) * 2);
-        if (wanConfig.LinkSpeedOverrideMbps is > 0)
+        var down = sqm.SpeedtestProbeRateMbps;
+        var up = Math.Max(nominalUp + 1, (int)Math.Ceiling(nominalUp * 1.03));
+        if (LinkCeiling(wanConfig) is { } ceiling)
         {
-            var ceiling = (int)(wanConfig.LinkSpeedOverrideMbps.Value * 0.98);
             down = Math.Min(down, ceiling);
             up = Math.Min(up, ceiling);
         }
         return new SqmShaperLift(down, up, wanConfig.RateProportionalDownloadBurst);
+    }
+
+    /// <summary>The highest lift the WAN allows: link speed with HTB headroom, or null when unknown.</summary>
+    internal static int? LinkCeiling(SqmWanConfiguration wanConfig) =>
+        wanConfig.LinkSpeedOverrideMbps is > 0 ? (int)(wanConfig.LinkSpeedOverrideMbps.Value * 0.98) : null;
+
+    /// <summary>Whether a measured direction ran into its lift rather than the line.</summary>
+    internal static bool IsProbeLimited(double measuredMbps, int liftMbps) =>
+        liftMbps > 0 && measuredMbps >= liftMbps * ProbeLimitedFraction;
+
+    /// <summary>The lift to use after a direction clipped at <paramref name="clippedMbps"/>.</summary>
+    internal static int NextLift(double clippedMbps, int? ceiling) =>
+        Math.Min((int)Math.Ceiling(clippedMbps * LiftRaiseFactor), ceiling ?? MaxLiftMbps);
+
+    /// <summary>The configured lift raised to any remembered per-direction lift, never above the ceiling.</summary>
+    internal static SqmShaperLift? RaiseLift(SqmShaperLift? baseLift, int? liftDown, int? liftUp, int? ceiling)
+    {
+        if (baseLift == null) return null;
+        var down = Math.Max(baseLift.DownloadProbeMbps, liftDown ?? 0);
+        var up = Math.Max(baseLift.UploadProbeMbps, liftUp ?? 0);
+        if (ceiling is > 0)
+        {
+            down = Math.Min(down, ceiling.Value);
+            up = Math.Min(up, ceiling.Value);
+        }
+        return baseLift with { DownloadProbeMbps = down, UploadProbeMbps = up };
     }
 
     private async Task<string?> ResolveWanGroupAsync(string iface)

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -24,6 +24,9 @@ public class SqmLearningExecutor
     /// <summary>Connections per sample: half the standard test's, plenty to saturate a shared-medium WAN for 4 s.</summary>
     public const int SampleStreams = 10;
 
+    /// <summary>A sample stays this far clear of a scheduled Adaptive SQM speed test so the two never overlap.</summary>
+    public const int ScheduledProbeClearanceMinutes = 3;
+
     /// <summary>A direction that lands at or above this fraction of its lift measured the lift, not the line.</summary>
     public const double ProbeLimitedFraction = 0.95;
 
@@ -121,6 +124,8 @@ public class SqmLearningExecutor
 
         if (gateway.SqmSpeedtestRunning)
             return Wait($"Waiting: the Adaptive SQM speed test is running on {profile.Name}");
+        if (saved != null && ScheduledProbeImminent(gateway.Hour, gateway.Minute, saved, ScheduledProbeClearanceMinutes))
+            return Wait($"Waiting: an Adaptive SQM speed test is due within {ScheduledProbeClearanceMinutes} minutes");
         if (!idle.IsIdle)
             return Wait($"Waiting for an idle stretch: {profile.Name} at {FormatMbps(idle.DownloadMbps)} down / {FormatMbps(idle.UploadMbps)} up");
 
@@ -289,6 +294,25 @@ public class SqmLearningExecutor
             up = Math.Min(up, ceiling);
         }
         return new SqmShaperLift(down, up, wanConfig.RateProportionalDownloadBurst);
+    }
+
+    /// <summary>
+    /// True when one of the WAN's two scheduled Adaptive SQM speed tests (saved as gateway-local
+    /// times) is due within <paramref name="windowMinutes"/> of the gateway's clock.
+    /// </summary>
+    internal static bool ScheduledProbeImminent(int hour, int minute, SqmWanConfiguration wanConfig, int windowMinutes)
+    {
+        var now = hour * 60 + minute;
+        foreach (var due in new[]
+                 {
+                     wanConfig.SpeedtestMorningHour * 60 + wanConfig.SpeedtestMorningMinute,
+                     wanConfig.SpeedtestEveningHour * 60 + wanConfig.SpeedtestEveningMinute,
+                 })
+        {
+            var ahead = ((due - now) % 1440 + 1440) % 1440;
+            if (ahead <= windowMinutes) return true;
+        }
+        return false;
     }
 
     /// <summary>The highest lift the WAN allows: link speed with HTB headroom, or null when unknown.</summary>

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -21,6 +21,9 @@ public class SqmLearningExecutor
     /// <summary>How soon a busy or contended attempt is retried, so a quiet stretch within the hour is caught.</summary>
     public static readonly TimeSpan BusyRetry = TimeSpan.FromMinutes(10);
 
+    /// <summary>Connections per sample: half the standard test's, plenty to saturate a shared-medium WAN for 4 s.</summary>
+    public const int SampleStreams = 10;
+
     /// <summary>Failures alert on the third in a row and then once a day, not every hour.</summary>
     public const int FailureAlertThreshold = 3;
     public const int FailureAlertRepeatEvery = 24;
@@ -115,6 +118,7 @@ public class SqmLearningExecutor
         var options = new GatewayWanTestOptions
         {
             DurationSeconds = cfg.DurationSeconds,
+            Streams = SampleStreams,
             Ephemeral = true,
             ShaperLift = BuildLift(wanConfig),
         };

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -135,11 +135,15 @@ public class SqmLearningExecutor
         var idle = monitored ?? new WanIdleGate.IdleReading(gateway.DownloadMbps, gateway.UploadMbps, "gateway");
 
         if (gateway.SqmSpeedtestRunning)
-            return Wait($"Waiting: the Adaptive SQM speed test is running on {profile.Name}");
+            return Wait("Waiting for the Adaptive SQM speed test to finish");
         if (saved != null && ScheduledProbeImminent(gateway.Hour, gateway.Minute, saved, ScheduledProbeClearanceMinutes))
-            return Wait($"Waiting: an Adaptive SQM speed test is due within {ScheduledProbeClearanceMinutes} minutes");
-        if (!idle.IsIdle)
-            return Wait($"Waiting for an idle stretch: {profile.Name} at {FormatMbps(idle.DownloadMbps)} down / {FormatMbps(idle.UploadMbps)} up");
+            return Wait("Waiting for the scheduled Adaptive SQM speed test to pass");
+        if (!idle.IsIdleFor(wanConfig.NominalDownloadMbps, wanConfig.NominalUploadMbps))
+        {
+            _logger.LogDebug("Learning sample deferred on {Iface}: {Down} down / {Up} up ({Source})",
+                iface, FormatMbps(idle.DownloadMbps), FormatMbps(idle.UploadMbps), idle.Source);
+            return Wait("Waiting for a quiet moment on the WAN");
+        }
 
         // The lift starts from the configuration and rises after any sample that ran into it, so a
         // conservative nominal cannot cap what learning sees.
@@ -166,7 +170,7 @@ public class SqmLearningExecutor
         }
 
         if (result == null)
-            return Wait($"Waiting: another WAN speed test is running");
+            return Wait("Waiting for another WAN speed test to finish");
 
         var sample = new SqmLearningSample
         {
@@ -212,8 +216,9 @@ public class SqmLearningExecutor
         _logger.LogInformation("Adaptive SQM learning sample for WAN {Wan} ({Iface}): {Summary}", cfg.WanNumber, iface, summary);
         return new ScheduleRunOutcome(true, summary, null, Notify: false);
 
+        // A deferral is recorded as "waiting", never "success": the row must not read as a result.
         static ScheduleRunOutcome Wait(string why) =>
-            new(true, why, null, NextRunAt: DateTime.UtcNow + BusyRetry, Notify: false);
+            new(true, why, null, NextRunAt: DateTime.UtcNow + BusyRetry, Notify: false, Status: "waiting");
     }
 
     /// <summary>Re-learns the profile from every sample of the current run and stores it.</summary>

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -30,8 +30,20 @@ public class SqmLearningExecutor
     /// <summary>A direction that lands at or above this fraction of its lift measured the lift, not the line.</summary>
     public const double ProbeLimitedFraction = 0.95;
 
-    /// <summary>How far the lift is raised after a probe-limited sample.</summary>
-    public const double LiftRaiseFactor = 1.5;
+    /// <summary>How far the download lift is raised after a probe-limited sample.</summary>
+    public const double DownloadLiftRaiseFactor = 1.5;
+
+    /// <summary>
+    /// How far the upload lift is raised after a probe-limited sample. Smaller steps than download:
+    /// a lifted window costs the most upstream on cable and cellular, where bufferbloat lands first.
+    /// </summary>
+    public const double UploadLiftRaiseFactor = 1.25;
+
+    /// <summary>
+    /// The upload lift starts this far above nominal. A line that delivers its full nominal upload
+    /// (most do) would otherwise sit inside the probe-limited band on every first sample.
+    /// </summary>
+    public const double UploadLiftHeadroom = 1.10;
 
     /// <summary>Sanity ceiling for a raised lift when the link speed is unknown.</summary>
     public const int MaxLiftMbps = 100_000;
@@ -185,9 +197,9 @@ public class SqmLearningExecutor
 
         // A direction that hit its lift gets a higher lift next time, up to the link ceiling.
         if (limitedDown)
-            profile.LiftDownloadMbps = Math.Max(profile.LiftDownloadMbps ?? 0, NextLift(result.DownloadMbps, ceiling));
+            profile.LiftDownloadMbps = Math.Max(profile.LiftDownloadMbps ?? 0, NextLift(result.DownloadMbps, ceiling, DownloadLiftRaiseFactor));
         if (limitedUp)
-            profile.LiftUploadMbps = Math.Max(profile.LiftUploadMbps ?? 0, NextLift(result.UploadMbps, ceiling));
+            profile.LiftUploadMbps = Math.Max(profile.LiftUploadMbps ?? 0, NextLift(result.UploadMbps, ceiling, UploadLiftRaiseFactor));
 
         profile.LastSampleAt = sample.SampledAt;
         profile.LastError = null;
@@ -266,11 +278,11 @@ public class SqmLearningExecutor
     }
 
     /// <summary>
-    /// The same probe the deployed Adaptive SQM speed test uses: download 3% above the highest rate
-    /// the WAN ever shapes to, upload just above nominal. The link stays shaped during the sample,
-    /// so a learning run never turns bufferbloat loose for its test window; a sample that clips at
-    /// this probe raises it for the next one (<see cref="RaiseLift"/>). Never above the link
-    /// ceiling. Null when the WAN has no configuration to size from.
+    /// The same download probe the deployed Adaptive SQM speed test uses (3% above the highest rate
+    /// the WAN ever shapes to) and an upload lift 10% above nominal. The link stays shaped during
+    /// the sample, so a learning run never turns bufferbloat loose for its test window; a sample
+    /// that clips at this probe raises it for the next one (<see cref="RaiseLift"/>). Never above
+    /// the link ceiling. Null when the WAN has no configuration to size from.
     /// </summary>
     internal static SqmShaperLift? BuildLift(SqmWanConfiguration? wanConfig)
     {
@@ -287,7 +299,7 @@ public class SqmLearningExecutor
         sqm.ApplyProfileSettings(wanConfig.LinkSpeedOverrideMbps);
 
         var down = sqm.SpeedtestProbeRateMbps;
-        var up = Math.Max(nominalUp + 1, (int)Math.Ceiling(nominalUp * 1.03));
+        var up = Math.Max(nominalUp + 1, (int)Math.Ceiling(nominalUp * UploadLiftHeadroom));
         if (LinkCeiling(wanConfig) is { } ceiling)
         {
             down = Math.Min(down, ceiling);
@@ -324,8 +336,8 @@ public class SqmLearningExecutor
         liftMbps > 0 && measuredMbps >= liftMbps * ProbeLimitedFraction;
 
     /// <summary>The lift to use after a direction clipped at <paramref name="clippedMbps"/>.</summary>
-    internal static int NextLift(double clippedMbps, int? ceiling) =>
-        Math.Min((int)Math.Ceiling(clippedMbps * LiftRaiseFactor), ceiling ?? MaxLiftMbps);
+    internal static int NextLift(double clippedMbps, int? ceiling, double raiseFactor) =>
+        Math.Min((int)Math.Ceiling(clippedMbps * raiseFactor), ceiling ?? MaxLiftMbps);
 
     /// <summary>The configured lift raised to any remembered per-direction lift, never above the ceiling.</summary>
     internal static SqmShaperLift? RaiseLift(SqmShaperLift? baseLift, int? liftDown, int? liftUp, int? ceiling)

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningExecutor.cs
@@ -1,0 +1,283 @@
+using System.Text.Json;
+using NetworkOptimizer.Alerts;
+using NetworkOptimizer.Alerts.Interfaces;
+using NetworkOptimizer.Sqm;
+using NetworkOptimizer.Sqm.Models;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.Ssh;
+using SqmConfig = NetworkOptimizer.Sqm.Models.SqmConfiguration;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// Takes one Adaptive SQM learning sample when its schedule fires: waits for the WAN to be idle,
+/// runs the standard gateway WAN speed test with a short duration and the shaper lifted, records
+/// the sample, and recomputes the learned profile. Resolved from a scope pinned to the site the
+/// task belongs to, so every dependency here is that site's.
+/// </summary>
+public class SqmLearningExecutor
+{
+    /// <summary>How soon a busy or contended attempt is retried, so a quiet stretch within the hour is caught.</summary>
+    public static readonly TimeSpan BusyRetry = TimeSpan.FromMinutes(10);
+
+    /// <summary>Failures alert on the third in a row and then once a day, not every hour.</summary>
+    public const int FailureAlertThreshold = 3;
+    public const int FailureAlertRepeatEvery = 24;
+
+    private readonly ISqmLearningRepository _repo;
+    private readonly ISpeedTestRepository _speedTests;
+    private readonly IScheduleRepository _schedules;
+    private readonly IGatewaySshService _gatewaySsh;
+    private readonly IGatewayWanSpeedTestService _gatewayTest;
+    private readonly ISqmService _sqmService;
+    private readonly WanIdleGate _idleGate;
+    private readonly ILogger<SqmLearningExecutor> _logger;
+
+    public SqmLearningExecutor(
+        ISqmLearningRepository repo,
+        ISpeedTestRepository speedTests,
+        IScheduleRepository schedules,
+        IGatewaySshService gatewaySsh,
+        IGatewayWanSpeedTestService gatewayTest,
+        ISqmService sqmService,
+        WanIdleGate idleGate,
+        ILogger<SqmLearningExecutor> logger)
+    {
+        _repo = repo;
+        _speedTests = speedTests;
+        _schedules = schedules;
+        _gatewaySsh = gatewaySsh;
+        _gatewayTest = gatewayTest;
+        _sqmService = sqmService;
+        _idleGate = idleGate;
+        _logger = logger;
+    }
+
+    public async Task<ScheduleRunOutcome> RunAsync(int taskId, string? targetId, string? targetConfig, CancellationToken ct)
+    {
+        var cfg = SqmLearningTaskConfig.Parse(targetConfig);
+        if (cfg == null)
+            return new ScheduleRunOutcome(false, null, "This learning schedule has no configuration; start it again from Adaptive SQM.");
+
+        var profile = await _repo.GetProfileAsync(cfg.WanNumber, ct) ?? new SqmCongestionProfile
+        {
+            WanNumber = cfg.WanNumber,
+            Interface = targetId ?? "",
+            Name = cfg.WanName ?? $"WAN{cfg.WanNumber}",
+            ConnectionType = cfg.ConnectionType,
+            ScheduledTaskId = taskId,
+            LearningStartedAt = DateTime.UtcNow,
+            LearningEndsAt = cfg.EndsAt,
+            SampleDurationSeconds = cfg.DurationSeconds,
+        };
+
+        var now = DateTime.UtcNow;
+        if (now >= cfg.EndsAt)
+            return await CompleteAsync(taskId, profile, ct);
+
+        // Sizing for the shaper lift: the saved WAN configuration when there is one (the user may
+        // have refined the nominal speeds since), else the figures captured when learning started.
+        // Without a lift a sample would measure whatever rate the shaper holds, which is exactly
+        // what learning must not record.
+        var saved = await _speedTests.GetSqmWanConfigAsync(cfg.WanNumber, ct);
+        var wanConfig = saved is { NominalDownloadMbps: > 0 } ? saved : cfg.ToWanConfiguration(targetId);
+        if (wanConfig.NominalDownloadMbps <= 0)
+            return await FailAsync(profile, "No nominal speeds are known for this WAN; start learning again from the Adaptive SQM page.", ct);
+
+        var iface = !string.IsNullOrEmpty(targetId) ? targetId : wanConfig.Interface;
+        if (string.IsNullOrEmpty(iface))
+            return await FailAsync(profile, "The WAN has no interface configured for Adaptive SQM.", ct);
+        var ifaceCheck = InputSanitizer.ValidateInterface(iface);
+        if (!ifaceCheck.isValid)
+            return await FailAsync(profile, $"Invalid WAN interface: {ifaceCheck.error}", ct);
+
+        // The gateway probe always runs: it supplies the gateway's local day and hour (the slot the
+        // deployed schedule reads) and whether the SQM speed test script is busy. Its traffic
+        // reading is the fallback; the monitored SNMP series decides idleness when it is available.
+        var (ok, output) = await _gatewaySsh.RunCommandAsync(
+            GatewayInterfaceRateProbe.BuildCommand(iface), TimeSpan.FromSeconds(30), ct);
+        var gateway = ok ? GatewayInterfaceRateProbe.Parse(output) : null;
+        if (gateway == null)
+            return await FailAsync(profile, $"Could not read WAN traffic from the gateway: {Trim(output)}", ct);
+        if (!gateway.InterfacePresent)
+            return await FailAsync(profile, $"Interface {iface} was not found on the gateway.", ct);
+
+        var wanGroup = cfg.WanGroup ?? await ResolveWanGroupAsync(iface);
+        var monitored = wanGroup != null ? await _idleGate.ReadMonitoredAsync(wanGroup, ct) : null;
+        var idle = monitored ?? new WanIdleGate.IdleReading(gateway.DownloadMbps, gateway.UploadMbps, "gateway");
+
+        if (gateway.SqmSpeedtestRunning)
+            return Wait($"Waiting: the Adaptive SQM speed test is running on {profile.Name}");
+        if (!idle.IsIdle)
+            return Wait($"Waiting for an idle stretch: {profile.Name} at {FormatMbps(idle.DownloadMbps)} down / {FormatMbps(idle.UploadMbps)} up");
+
+        var options = new GatewayWanTestOptions
+        {
+            DurationSeconds = cfg.DurationSeconds,
+            Ephemeral = true,
+            ShaperLift = BuildLift(wanConfig),
+        };
+
+        Iperf3Result? result;
+        try
+        {
+            result = await _gatewayTest.RunTestAsync(iface, wanGroup, cfg.WanName ?? profile.Name,
+                onProgress: null, allInterfaces: null, maxMode: false, cancellationToken: ct, options: options);
+        }
+        catch (Exception ex)
+        {
+            return await FailAsync(profile, $"Gateway speed test failed: {ex.Message}", ct);
+        }
+
+        if (result == null)
+            return Wait($"Waiting: another WAN speed test is running");
+
+        var sample = new SqmLearningSample
+        {
+            WanNumber = cfg.WanNumber,
+            SampledAt = DateTime.UtcNow,
+            LocalDayOfWeek = gateway.DayOfWeek,
+            LocalHour = gateway.Hour,
+            DownloadMbps = Math.Round(result.DownloadMbps, 2),
+            UploadMbps = Math.Round(result.UploadMbps, 2),
+            LatencyMs = result.PingMs,
+            DownloadLoadedLatencyMs = result.DownloadLatencyMs,
+            UploadLoadedLatencyMs = result.UploadLatencyMs,
+            IdleDownloadMbps = Math.Round(idle.DownloadMbps, 3),
+            IdleUploadMbps = Math.Round(idle.UploadMbps, 3),
+            IdleSource = idle.Source,
+            Success = result.Success,
+            Error = result.Success ? null : Trim(result.ErrorMessage),
+        };
+        await _repo.AddSampleAsync(sample, ct);
+
+        if (!result.Success)
+            return await FailAsync(profile, result.ErrorMessage ?? "The gateway speed test reported a failure.", ct);
+
+        profile.LastSampleAt = sample.SampledAt;
+        profile.LastError = null;
+        profile.ConsecutiveFailures = 0;
+        profile.Interface = iface;
+        await RecomputeAsync(profile, ct);
+
+        var summary = $"Sample {sample.DownloadMbps:F0} / {sample.UploadMbps:F0} Mbps · " +
+                      $"{profile.ValidSampleCount} samples, {profile.CoveragePercent:F0}% of the week covered";
+        _logger.LogInformation("Adaptive SQM learning sample for WAN {Wan} ({Iface}): {Summary}", cfg.WanNumber, iface, summary);
+        return new ScheduleRunOutcome(true, summary, null, Notify: false);
+
+        static ScheduleRunOutcome Wait(string why) =>
+            new(true, why, null, NextRunAt: DateTime.UtcNow + BusyRetry, Notify: false);
+    }
+
+    /// <summary>Re-learns the profile from every sample of the current run and stores it.</summary>
+    public async Task RecomputeAsync(SqmCongestionProfile profile, CancellationToken ct)
+    {
+        var rows = await _repo.GetSamplesAsync(profile.WanNumber, profile.LearningStartedAt, ct);
+        var samples = rows.Where(r => r.Success)
+            .Select(r => new LearningSample(r.Id, r.LocalDayOfWeek, r.LocalHour, r.DownloadMbps, r.UploadMbps, r.SampledAt))
+            .ToList();
+
+        var learned = CongestionProfileLearner.Learn(samples);
+        var exclusions = learned.Exclusions.ToDictionary(e => (int)e.SampleId, e => e.Reason);
+        await _repo.SetSampleExclusionsAsync(profile.WanNumber, exclusions, ct);
+
+        var p = learned.Profile;
+        profile.DownloadMultipliersJson = JsonSerializer.Serialize(p.DownloadMultipliers);
+        profile.UploadMultipliersJson = JsonSerializer.Serialize(p.UploadMultipliers);
+        profile.SampleCountsJson = JsonSerializer.Serialize(p.SampleCounts);
+        profile.PeakDownloadMbps = p.PeakDownloadMbps;
+        profile.PeakUploadMbps = p.PeakUploadMbps;
+        profile.ValidSampleCount = p.ValidSampleCount;
+        profile.CoveragePercent = Math.Round(p.Coverage * 100, 1);
+        profile.DaysSpanned = p.DaysSpanned;
+        profile.IsReliable = p.IsReliable;
+        profile.ProfileUpdatedAt = DateTime.UtcNow;
+        await _repo.SaveProfileAsync(profile, ct);
+    }
+
+    private async Task<ScheduleRunOutcome> CompleteAsync(int taskId, SqmCongestionProfile profile, CancellationToken ct)
+    {
+        await RecomputeAsync(profile, ct);
+        profile.LearningCompletedAt = DateTime.UtcNow;
+        await _repo.SaveProfileAsync(profile, ct);
+
+        var task = await _schedules.GetByIdAsync(taskId, ct);
+        if (task != null && task.Enabled)
+        {
+            task.Enabled = false;
+            await _schedules.UpdateAsync(task, ct);
+        }
+
+        var summary = profile.IsReliable
+            ? $"Learning complete: {profile.ValidSampleCount} samples over {profile.DaysSpanned} days, peak {profile.PeakDownloadMbps:F0} / {profile.PeakUploadMbps:F0} Mbps"
+            : $"Learning ended with {profile.ValidSampleCount} samples covering {profile.CoveragePercent:F0}% of the week - not enough to rely on yet";
+        _logger.LogInformation("Adaptive SQM learning for WAN {Wan} finished: {Summary}", profile.WanNumber, summary);
+        return new ScheduleRunOutcome(true, summary, null, Notify: true);
+    }
+
+    private async Task<ScheduleRunOutcome> FailAsync(SqmCongestionProfile profile, string error, CancellationToken ct)
+    {
+        profile.ConsecutiveFailures++;
+        profile.LastError = Trim(error);
+        try { await _repo.SaveProfileAsync(profile, ct); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Could not record the learning failure for WAN {Wan}", profile.WanNumber); }
+
+        var n = profile.ConsecutiveFailures;
+        var notify = n == FailureAlertThreshold || (n > FailureAlertThreshold && n % FailureAlertRepeatEvery == 0);
+        _logger.LogWarning("Adaptive SQM learning sample failed for WAN {Wan} ({Count} in a row): {Error}", profile.WanNumber, n, error);
+        return new ScheduleRunOutcome(false, null, error, Notify: notify);
+    }
+
+    /// <summary>
+    /// Probe rates that stay clear of the line rate: at least twice nominal so a conservative
+    /// nominal cannot cap the measurement, at least the deploy's own probe rate, and never above
+    /// the link ceiling the deploy uses. Null when the WAN has no saved configuration to size from.
+    /// </summary>
+    internal static SqmShaperLift? BuildLift(SqmWanConfiguration? wanConfig)
+    {
+        if (wanConfig == null || wanConfig.NominalDownloadMbps <= 0)
+            return null;
+
+        var sqm = new SqmConfig
+        {
+            ConnectionType = (ConnectionType)wanConfig.ConnectionType,
+            NominalDownloadSpeed = wanConfig.NominalDownloadMbps,
+            NominalUploadSpeed = Math.Max(1, wanConfig.NominalUploadMbps),
+        };
+        sqm.ApplyProfileSettings(wanConfig.LinkSpeedOverrideMbps);
+
+        var down = Math.Max(sqm.SpeedtestProbeRateMbps, wanConfig.NominalDownloadMbps * 2);
+        var up = Math.Max(10, Math.Max(1, wanConfig.NominalUploadMbps) * 2);
+        if (wanConfig.LinkSpeedOverrideMbps is > 0)
+        {
+            var ceiling = (int)(wanConfig.LinkSpeedOverrideMbps.Value * 0.98);
+            down = Math.Min(down, ceiling);
+            up = Math.Min(up, ceiling);
+        }
+        return new SqmShaperLift(down, up, wanConfig.RateProportionalDownloadBurst);
+    }
+
+    private async Task<string?> ResolveWanGroupAsync(string iface)
+    {
+        try
+        {
+            var wans = await _sqmService.GetWanInterfacesFromControllerAsync();
+            return wans.FirstOrDefault(w => w.Interface.Equals(iface, StringComparison.OrdinalIgnoreCase))?.NetworkGroup;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not resolve the WAN group for {Iface}", iface);
+            return null;
+        }
+    }
+
+    private static string FormatMbps(double mbps) => mbps >= 1000 ? $"{mbps / 1000:F1} Gbps" : $"{mbps:F1} Mbps";
+
+    private static string Trim(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "(no detail)";
+        var t = text.Trim();
+        return t.Length > 480 ? t[..480] + "..." : t;
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
@@ -148,6 +148,14 @@ public class SqmLearningService : ISqmLearningService
         _logger.LogInformation("Adaptive SQM learning stopped for WAN {Wan} on site {Site}", wanNumber, _siteContext.Slug);
     }
 
+    public async Task RemoveScheduleAsync(int wanNumber)
+    {
+        await StopAsync(wanNumber);
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile != null && await FindTaskAsync(profile) is { } task)
+            await _schedules.DeleteAsync(task.Id);
+    }
+
     public async Task ClearAsync(int wanNumber)
     {
         var profile = await _repo.GetProfileAsync(wanNumber);

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
@@ -186,6 +186,7 @@ public class SqmLearningService : ISqmLearningService
             reliable = profile.IsReliable,
             peakDownloadMbps = profile.PeakDownloadMbps,
             peakUploadMbps = profile.PeakUploadMbps,
+            peakIsLowerBound = profile.PeakIsLowerBound,
             slotLayout = "index = day * 24 + hour, day 0 = Monday",
             downloadMultipliers = learned?.DownloadMultipliers,
             uploadMultipliers = learned?.UploadMultipliers,
@@ -214,6 +215,7 @@ public class SqmLearningService : ISqmLearningService
                 ValidSampleCount = profile.ValidSampleCount,
                 DaysSpanned = profile.DaysSpanned,
                 IsReliable = profile.IsReliable,
+                PeakIsLowerBound = profile.PeakIsLowerBound,
             };
         }
         catch (JsonException)
@@ -272,6 +274,11 @@ public class SqmLearningService : ISqmLearningService
             PeakDownloadMbps = profile.PeakDownloadMbps,
             PeakUploadMbps = profile.PeakUploadMbps,
             DurationSeconds = profile.SampleDurationSeconds,
+            ProbeLimitedSampleCount = samples.Count(s => s.Success && !s.Excluded && s.ProbeLimited),
+            PeakIsLowerBound = profile.PeakIsLowerBound,
+            LiftDownloadMbps = profile.LiftDownloadMbps,
+            LiftUploadMbps = profile.LiftUploadMbps,
+            LiftCeilingMbps = profile.LiftCeilingMbps,
             Profile = ToLearned(profile),
         };
     }

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
@@ -1,0 +1,278 @@
+using System.Text.Json;
+using NetworkOptimizer.Alerts;
+using NetworkOptimizer.Alerts.Interfaces;
+using NetworkOptimizer.Alerts.Models;
+using NetworkOptimizer.Sqm.Models;
+using NetworkOptimizer.Storage.Interfaces;
+using NetworkOptimizer.Storage.Models;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// Adaptive SQM congestion profile learning for the site in context. The schedule task is the
+/// single source of truth for whether learning is running; the profile row holds the data.
+/// </summary>
+public class SqmLearningService : ISqmLearningService
+{
+    private readonly ISqmLearningRepository _repo;
+    private readonly IScheduleRepository _schedules;
+    private readonly ScheduleService _scheduleService;
+    private readonly SiteContextService _siteContext;
+    private readonly ILogger<SqmLearningService> _logger;
+
+    public SqmLearningService(
+        ISqmLearningRepository repo,
+        IScheduleRepository schedules,
+        ScheduleService scheduleService,
+        SiteContextService siteContext,
+        ILogger<SqmLearningService> logger)
+    {
+        _repo = repo;
+        _schedules = schedules;
+        _scheduleService = scheduleService;
+        _siteContext = siteContext;
+        _logger = logger;
+    }
+
+    public async Task<SqmLearningStatus?> GetStatusAsync(int wanNumber)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile == null) return null;
+        return await BuildStatusAsync(profile);
+    }
+
+    public async Task<List<SqmLearningSample>> GetSamplesAsync(int wanNumber, int count = 200)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        var samples = await _repo.GetSamplesAsync(wanNumber, profile?.LearningStartedAt);
+        return samples.OrderByDescending(s => s.SampledAt).Take(Math.Max(1, count)).ToList();
+    }
+
+    public async Task<SqmLearningStatus> StartAsync(SqmLearningStartRequest request)
+    {
+        if (request.WanNumber <= 0) throw new ArgumentException("WAN number is required", nameof(request));
+        var ifaceCheck = NetworkOptimizer.Sqm.InputSanitizer.ValidateInterface(request.Interface);
+        if (!ifaceCheck.isValid) throw new ArgumentException(ifaceCheck.error, nameof(request));
+
+        var profile = await _repo.GetProfileAsync(request.WanNumber);
+        if (profile != null)
+        {
+            var existing = await FindTaskAsync(profile);
+            if (existing is { Enabled: true } && profile.LearningEndsAt > DateTime.UtcNow && profile.LearningCompletedAt == null)
+                return await BuildStatusAsync(profile);
+        }
+
+        // A new run starts clean: the previous run's samples describe a week that is over.
+        await _repo.DeleteSamplesAsync(request.WanNumber);
+        if (profile != null && await FindTaskAsync(profile) is { } stale)
+            await _schedules.DeleteAsync(stale.Id);
+
+        var now = DateTime.UtcNow;
+        var days = Math.Clamp(request.Days, 1, 28);
+        var duration = Math.Clamp(request.DurationSeconds, 2, 20);
+        if (request.NominalDownloadMbps <= 0 || request.NominalUploadMbps <= 0)
+            throw new ArgumentException("Nominal download and upload speeds are required to size the measurement", nameof(request));
+
+        var cfg = new SqmLearningTaskConfig
+        {
+            WanNumber = request.WanNumber,
+            WanName = request.Name,
+            WanGroup = request.WanGroup,
+            ConnectionType = (int)request.ConnectionType,
+            EndsAt = now.AddDays(days),
+            DurationSeconds = duration,
+            NominalDownloadMbps = request.NominalDownloadMbps,
+            NominalUploadMbps = request.NominalUploadMbps,
+            LinkSpeedOverrideMbps = request.LinkSpeedOverrideMbps,
+            RateProportionalDownloadBurst = request.RateProportionalDownloadBurst,
+        };
+
+        var task = new ScheduledTask
+        {
+            TaskType = ScheduleService.SqmLearningTaskType,
+            Name = $"Adaptive SQM Learning ({request.Name})",
+            Enabled = true,
+            FrequencyMinutes = 60,
+            TargetId = request.Interface,
+            TargetConfig = cfg.ToJson(),
+            // The first sample follows promptly so the user sees the run is alive.
+            NextRunAt = now.AddMinutes(1),
+        };
+        var taskId = await _schedules.SaveAsync(task);
+
+        profile ??= new SqmCongestionProfile { WanNumber = request.WanNumber };
+        profile.Interface = request.Interface;
+        profile.Name = request.Name;
+        profile.ConnectionType = (int)request.ConnectionType;
+        profile.ScheduledTaskId = taskId;
+        profile.LearningStartedAt = now;
+        profile.LearningEndsAt = cfg.EndsAt;
+        profile.LearningCompletedAt = null;
+        profile.SampleDurationSeconds = duration;
+        profile.LastSampleAt = null;
+        profile.LastError = null;
+        profile.ConsecutiveFailures = 0;
+        profile.DownloadMultipliersJson = null;
+        profile.UploadMultipliersJson = null;
+        profile.SampleCountsJson = null;
+        profile.PeakDownloadMbps = 0;
+        profile.PeakUploadMbps = 0;
+        profile.ValidSampleCount = 0;
+        profile.CoveragePercent = 0;
+        profile.DaysSpanned = 0;
+        profile.IsReliable = false;
+        profile.ProfileUpdatedAt = null;
+        await _repo.SaveProfileAsync(profile);
+
+        _logger.LogInformation("Adaptive SQM learning started for WAN {Wan} ({Iface}) on site {Site}, ends {Ends:u}",
+            request.WanNumber, request.Interface, _siteContext.Slug, cfg.EndsAt);
+        return await BuildStatusAsync(profile);
+    }
+
+    public async Task StopAsync(int wanNumber)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile == null) return;
+
+        var task = await FindTaskAsync(profile);
+        if (task is { Enabled: true })
+        {
+            task.Enabled = false;
+            await _schedules.UpdateAsync(task);
+        }
+        if (profile.LearningCompletedAt == null && profile.LearningStartedAt != null)
+        {
+            profile.LearningCompletedAt = DateTime.UtcNow;
+            await _repo.SaveProfileAsync(profile);
+        }
+        _logger.LogInformation("Adaptive SQM learning stopped for WAN {Wan} on site {Site}", wanNumber, _siteContext.Slug);
+    }
+
+    public async Task ClearAsync(int wanNumber)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile != null && await FindTaskAsync(profile) is { } task)
+            await _schedules.DeleteAsync(task.Id);
+        await _repo.DeleteProfileAsync(wanNumber);
+        _logger.LogInformation("Adaptive SQM learned profile cleared for WAN {Wan} on site {Site}", wanNumber, _siteContext.Slug);
+    }
+
+    public async Task<bool> RunSampleNowAsync(int wanNumber)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile == null) return false;
+        var task = await FindTaskAsync(profile);
+        if (task == null) return false;
+        return await _scheduleService.RunNowAsync(task.Id, _siteContext.Slug);
+    }
+
+    public async Task<string?> ExportProfileJsonAsync(int wanNumber)
+    {
+        var profile = await _repo.GetProfileAsync(wanNumber);
+        if (profile == null || !profile.HasProfile) return null;
+        var learned = ToLearned(profile);
+        var export = new
+        {
+            format = "network-optimizer-congestion-profile",
+            version = 1,
+            generatedAt = DateTime.UtcNow,
+            connectionType = ((ConnectionType)profile.ConnectionType).ToString(),
+            name = profile.Name,
+            learnedFrom = profile.LearningStartedAt,
+            learnedTo = profile.LearningCompletedAt ?? profile.ProfileUpdatedAt,
+            validSamples = profile.ValidSampleCount,
+            coveragePercent = profile.CoveragePercent,
+            daysSpanned = profile.DaysSpanned,
+            reliable = profile.IsReliable,
+            peakDownloadMbps = profile.PeakDownloadMbps,
+            peakUploadMbps = profile.PeakUploadMbps,
+            slotLayout = "index = day * 24 + hour, day 0 = Monday",
+            downloadMultipliers = learned?.DownloadMultipliers,
+            uploadMultipliers = learned?.UploadMultipliers,
+            sampleCounts = learned?.SampleCounts,
+        };
+        return JsonSerializer.Serialize(export, new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    /// <summary>The learned curves stored on a profile row, or null when it has none yet.</summary>
+    public static LearnedCongestionProfile? ToLearned(SqmCongestionProfile profile)
+    {
+        if (!profile.HasProfile) return null;
+        try
+        {
+            var down = JsonSerializer.Deserialize<double[]>(profile.DownloadMultipliersJson!);
+            var up = string.IsNullOrEmpty(profile.UploadMultipliersJson) ? null : JsonSerializer.Deserialize<double[]>(profile.UploadMultipliersJson);
+            var counts = string.IsNullOrEmpty(profile.SampleCountsJson) ? null : JsonSerializer.Deserialize<int[]>(profile.SampleCountsJson);
+            if (down == null || down.Length != LearnedCongestionProfile.Slots) return null;
+            return new LearnedCongestionProfile
+            {
+                DownloadMultipliers = down,
+                UploadMultipliers = up is { Length: LearnedCongestionProfile.Slots } ? up : down,
+                SampleCounts = counts is { Length: LearnedCongestionProfile.Slots } ? counts : new int[LearnedCongestionProfile.Slots],
+                PeakDownloadMbps = profile.PeakDownloadMbps,
+                PeakUploadMbps = profile.PeakUploadMbps,
+                ValidSampleCount = profile.ValidSampleCount,
+                DaysSpanned = profile.DaysSpanned,
+                IsReliable = profile.IsReliable,
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private async Task<ScheduledTask?> FindTaskAsync(SqmCongestionProfile profile)
+    {
+        if (profile.ScheduledTaskId is int id)
+        {
+            var task = await _schedules.GetByIdAsync(id);
+            if (task != null && task.TaskType == ScheduleService.SqmLearningTaskType) return task;
+        }
+        // The id can go stale (a task deleted from the Schedule tab and a new one made); fall back
+        // to the newest learning task for this WAN.
+        var all = await _schedules.GetAllAsync();
+        return all.Where(t => t.TaskType == ScheduleService.SqmLearningTaskType)
+            .Where(t => SqmLearningTaskConfig.Parse(t.TargetConfig)?.WanNumber == profile.WanNumber)
+            .OrderByDescending(t => t.CreatedAt)
+            .FirstOrDefault();
+    }
+
+    private async Task<SqmLearningStatus> BuildStatusAsync(SqmCongestionProfile profile)
+    {
+        var task = await FindTaskAsync(profile);
+        var now = DateTime.UtcNow;
+        var samples = await _repo.GetSamplesAsync(profile.WanNumber, profile.LearningStartedAt);
+        var active = task is { Enabled: true } && profile.LearningCompletedAt == null && profile.LearningEndsAt > now;
+        return new SqmLearningStatus
+        {
+            WanNumber = profile.WanNumber,
+            Interface = profile.Interface,
+            Name = profile.Name,
+            HasProfile = profile.HasProfile,
+            IsActive = active,
+            IsCompleted = profile.LearningCompletedAt != null,
+            TaskId = task?.Id,
+            TaskEnabled = task?.Enabled ?? false,
+            IsRunning = task != null && _scheduleService.IsTaskRunning(task.Id, _siteContext.Slug),
+            StartedAt = profile.LearningStartedAt,
+            EndsAt = profile.LearningEndsAt,
+            CompletedAt = profile.LearningCompletedAt,
+            LastRunAt = task?.LastRunAt,
+            NextRunAt = active ? task?.NextRunAt : null,
+            LastSampleAt = profile.LastSampleAt,
+            LastStatus = task?.LastStatus,
+            LastSummary = task?.LastResultSummary,
+            LastError = profile.LastError ?? task?.LastErrorMessage,
+            ValidSampleCount = profile.ValidSampleCount,
+            TotalSampleCount = samples.Count,
+            CoveragePercent = profile.CoveragePercent,
+            DaysSpanned = profile.DaysSpanned,
+            IsReliable = profile.IsReliable,
+            PeakDownloadMbps = profile.PeakDownloadMbps,
+            PeakUploadMbps = profile.PeakUploadMbps,
+            DurationSeconds = profile.SampleDurationSeconds,
+            Profile = ToLearned(profile),
+        };
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningService.cs
@@ -246,6 +246,7 @@ public class SqmLearningService : ISqmLearningService
         var now = DateTime.UtcNow;
         var samples = await _repo.GetSamplesAsync(profile.WanNumber, profile.LearningStartedAt);
         var active = task is { Enabled: true } && profile.LearningCompletedAt == null && profile.LearningEndsAt > now;
+        var valid = samples.Where(s => s.Success && !s.Excluded).ToList();
         return new SqmLearningStatus
         {
             WanNumber = profile.WanNumber,
@@ -274,7 +275,11 @@ public class SqmLearningService : ISqmLearningService
             PeakDownloadMbps = profile.PeakDownloadMbps,
             PeakUploadMbps = profile.PeakUploadMbps,
             DurationSeconds = profile.SampleDurationSeconds,
-            ProbeLimitedSampleCount = samples.Count(s => s.Success && !s.Excluded && s.ProbeLimited),
+            ObservedMinDownloadMbps = valid.Count > 0 ? valid.Min(s => s.DownloadMbps) : null,
+            ObservedMaxDownloadMbps = valid.Count > 0 ? valid.Max(s => s.DownloadMbps) : null,
+            ObservedMinUploadMbps = valid.Count > 0 ? valid.Min(s => s.UploadMbps) : null,
+            ObservedMaxUploadMbps = valid.Count > 0 ? valid.Max(s => s.UploadMbps) : null,
+            ProbeLimitedSampleCount = valid.Count(s => s.ProbeLimited),
             PeakIsLowerBound = profile.PeakIsLowerBound,
             LiftDownloadMbps = profile.LiftDownloadMbps,
             LiftUploadMbps = profile.LiftUploadMbps,

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningTaskConfig.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/SqmLearningTaskConfig.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// The stored configuration of an Adaptive SQM learning schedule (the task's TargetConfig JSON).
+/// The task's TargetId carries the data-path interface; everything else that identifies the WAN
+/// and bounds the run lives here.
+/// </summary>
+public sealed class SqmLearningTaskConfig
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>Default learning window.</summary>
+    public const int DefaultDays = 7;
+
+    /// <summary>Default seconds per direction handed to the binary for one sample.</summary>
+    public const int DefaultDurationSeconds = 4;
+
+    public int WanNumber { get; set; }
+    public string? WanName { get; set; }
+
+    /// <summary>UniFi WAN network group ("WAN", "WAN2"), the key the monitored counter interface resolves from.</summary>
+    public string? WanGroup { get; set; }
+
+    /// <summary>NetworkOptimizer.Sqm.Models.ConnectionType at start.</summary>
+    public int ConnectionType { get; set; }
+
+    /// <summary>When the run ends (UTC); the executor completes the profile and disables the task at this point.</summary>
+    public DateTime EndsAt { get; set; }
+
+    public int DurationSeconds { get; set; } = DefaultDurationSeconds;
+
+    /// <summary>Nominal speeds at start, so the shaper lift can be sized even before the WAN is saved or deployed.</summary>
+    public int NominalDownloadMbps { get; set; }
+    public int NominalUploadMbps { get; set; }
+    public int? LinkSpeedOverrideMbps { get; set; }
+    public bool RateProportionalDownloadBurst { get; set; }
+
+    /// <summary>The sizing facts as the WAN configuration shape the lift is built from.</summary>
+    public NetworkOptimizer.Storage.Models.SqmWanConfiguration ToWanConfiguration(string? interfaceName) => new()
+    {
+        WanNumber = WanNumber,
+        Interface = interfaceName ?? "",
+        Name = WanName ?? "",
+        ConnectionType = ConnectionType,
+        NominalDownloadMbps = NominalDownloadMbps,
+        NominalUploadMbps = NominalUploadMbps,
+        LinkSpeedOverrideMbps = LinkSpeedOverrideMbps,
+        RateProportionalDownloadBurst = RateProportionalDownloadBurst,
+    };
+
+    public string ToJson() => JsonSerializer.Serialize(this, Options);
+
+    public static SqmLearningTaskConfig? Parse(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            var cfg = JsonSerializer.Deserialize<SqmLearningTaskConfig>(json, Options);
+            if (cfg == null || cfg.WanNumber <= 0) return null;
+            if (cfg.DurationSeconds <= 0) cfg.DurationSeconds = DefaultDurationSeconds;
+            if (cfg.EndsAt.Kind == DateTimeKind.Unspecified)
+                cfg.EndsAt = DateTime.SpecifyKind(cfg.EndsAt, DateTimeKind.Utc);
+            return cfg;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
@@ -1,0 +1,124 @@
+using Microsoft.EntityFrameworkCore;
+using NetworkOptimizer.Core.Enums;
+using NetworkOptimizer.Storage.Services;
+
+namespace NetworkOptimizer.Web.Services.SqmLearning;
+
+/// <summary>
+/// Whether a WAN is quiet enough to take a learning sample on. Reads the same series Live View and
+/// ISP Health show: the gateway's SNMP <c>interface_counters</c> for the WAN's counter interface,
+/// resolved live from the console and, when the console is down, from the WAN's remembered profile.
+/// The counter interface is not always the data-path interface (a VLAN or PPPoE WAN counts on
+/// the physical port), which is why this never reads the data-path name straight.
+/// </summary>
+public class WanIdleGate
+{
+    /// <summary>Below this, in both directions, the link counts as idle.</summary>
+    public const double IdleThresholdMbps = 1.0;
+
+    /// <summary>How far back a reading may be and still describe "now"; matches the live tiles' 90 s.</summary>
+    public static readonly TimeSpan MaxReadingAge = TimeSpan.FromSeconds(90);
+
+    /// <summary>Window the max is taken over: a burst anywhere in the last minute means not idle.</summary>
+    public static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
+
+    private readonly UniFiConnectionService _connectionService;
+    private readonly MonitoringInfluxClient _influx;
+    private readonly SiteDbContextFactory _siteDb;
+    private readonly SiteContextService _siteContext;
+    private readonly ILogger<WanIdleGate> _logger;
+
+    public WanIdleGate(
+        UniFiConnectionService connectionService,
+        MonitoringInfluxClient influx,
+        SiteDbContextFactory siteDb,
+        SiteContextService siteContext,
+        ILogger<WanIdleGate> logger)
+    {
+        _connectionService = connectionService;
+        _influx = influx;
+        _siteDb = siteDb;
+        _siteContext = siteContext;
+        _logger = logger;
+    }
+
+    /// <summary>A traffic reading for the WAN and where it came from.</summary>
+    public sealed record IdleReading(double DownloadMbps, double UploadMbps, string Source)
+    {
+        public bool IsIdle => DownloadMbps <= IdleThresholdMbps && UploadMbps <= IdleThresholdMbps;
+    }
+
+    /// <summary>
+    /// Peak SNMP throughput on the WAN over the last minute, or null when monitoring is off, the
+    /// WAN's counter interface cannot be resolved, or nothing fresh has been recorded - the caller
+    /// then falls back to reading the gateway directly.
+    /// </summary>
+    public async Task<IdleReading?> ReadMonitoredAsync(string wanNetworkGroup, CancellationToken ct)
+    {
+        try
+        {
+            await using (var db = _siteDb.CreateForSite(_siteContext.Slug, _siteContext.IsDefault))
+            {
+                var settings = await db.MonitoringSettings.AsNoTracking().FirstOrDefaultAsync(ct);
+                if (settings is not { Enabled: true })
+                    return null;
+            }
+
+            var (mac, counter) = await ResolveCounterAsync(wanNetworkGroup, ct);
+            if (string.IsNullOrEmpty(mac) || string.IsNullOrEmpty(counter))
+                return null;
+
+            var now = DateTime.UtcNow;
+            var points = await _influx.QueryGatewayWanRatesAsync(
+                mac, new[] { counter }, now - MaxReadingAge, now,
+                aggregateWindow: TimeSpan.FromSeconds(5), ct: ct);
+            var fresh = points.Where(p => p.Time >= now - Window).ToList();
+            if (fresh.Count == 0)
+                return null;
+
+            var down = fresh.Max(p => p.DownloadBps ?? 0) / 1_000_000.0;
+            var up = fresh.Max(p => p.UploadBps ?? 0) / 1_000_000.0;
+            return new IdleReading(down, up, "snmp");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read monitored WAN traffic for {Group}; falling back to the gateway counters", wanNetworkGroup);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Gateway MAC and counter interface for the WAN group: live from the console, else the WAN's
+    /// remembered profile row. Never another WAN's - an unresolved WAN reads as unknown.
+    /// </summary>
+    private async Task<(string? Mac, string? Counter)> ResolveCounterAsync(string wanNetworkGroup, CancellationToken ct)
+    {
+        string? mac = null;
+        string? counter = null;
+        try
+        {
+            var devices = await _connectionService.GetDiscoveredDevicesAsync(ct);
+            mac = devices?.FirstOrDefault(d => d.Type == DeviceType.Gateway || d.HardwareType == DeviceType.Gateway)?.Mac;
+            var ifaces = await _connectionService.GetWanInterfacesForGroupAsync(wanNetworkGroup, ct);
+            counter = ifaces?.CounterIfName;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Console did not resolve WAN {Group}'s counter interface", wanNetworkGroup);
+        }
+
+        if (string.IsNullOrEmpty(mac) || string.IsNullOrEmpty(counter))
+        {
+            await using var db = _siteDb.CreateForSite(_siteContext.Slug, _siteContext.IsDefault);
+            var profile = await db.WanProfiles.AsNoTracking()
+                .Where(w => w.WanNetworkgroup == wanNetworkGroup)
+                .OrderByDescending(w => w.UpdatedAt)
+                .FirstOrDefaultAsync(ct);
+            counter ??= profile?.CounterInterface;
+            if (string.IsNullOrEmpty(mac) && profile?.GatewayMac != null)
+                mac = profile.GatewayMac.Replace("-", ":").ToLowerInvariant();
+        }
+
+        return (mac, counter);
+    }
+}

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
@@ -13,8 +13,19 @@ namespace NetworkOptimizer.Web.Services.SqmLearning;
 /// </summary>
 public class WanIdleGate
 {
-    /// <summary>Below this, in both directions, the link counts as idle.</summary>
+    /// <summary>Floor of the idle bar: no link is asked to be quieter than this.</summary>
     public const double IdleThresholdMbps = 1.0;
+
+    /// <summary>
+    /// The idle bar scales with the line: 1 Mbps for slow lines, 1.5% of nominal once that is
+    /// larger (from 67 Mbps up), so a gigabit line that always carries a little background traffic
+    /// can still be sampled, with under 1.5% of error from it.
+    /// </summary>
+    public const double IdleFractionOfNominal = 0.015;
+
+    /// <summary>Idle bar for a direction of the given nominal speed.</summary>
+    public static double IdleThresholdFor(int nominalMbps) =>
+        Math.Max(IdleThresholdMbps, nominalMbps * IdleFractionOfNominal);
 
     /// <summary>How far back a reading may be and still describe "now"; matches the live tiles' 90 s.</summary>
     public static readonly TimeSpan MaxReadingAge = TimeSpan.FromSeconds(90);
@@ -50,7 +61,9 @@ public class WanIdleGate
     /// <summary>A traffic reading for the WAN and where it came from.</summary>
     public sealed record IdleReading(double DownloadMbps, double UploadMbps, string Source)
     {
-        public bool IsIdle => DownloadMbps <= IdleThresholdMbps && UploadMbps <= IdleThresholdMbps;
+        /// <summary>Quiet enough to sample a line with these nominal speeds.</summary>
+        public bool IsIdleFor(int nominalDownloadMbps, int nominalUploadMbps) =>
+            DownloadMbps <= IdleThresholdFor(nominalDownloadMbps) && UploadMbps <= IdleThresholdFor(nominalUploadMbps);
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
+++ b/src/NetworkOptimizer.Web/Services/SqmLearning/WanIdleGate.cs
@@ -23,24 +23,29 @@ public class WanIdleGate
     public static readonly TimeSpan Window = TimeSpan.FromSeconds(60);
 
     private readonly UniFiConnectionService _connectionService;
-    private readonly MonitoringInfluxClient _influx;
+    private readonly MonitoringInfluxRegistry _influxRegistry;
     private readonly SiteDbContextFactory _siteDb;
     private readonly SiteContextService _siteContext;
     private readonly ILogger<WanIdleGate> _logger;
 
+    // The registry rather than the scoped MonitoringInfluxClient forwarder: the schedule executor
+    // runs in a synchronously disposed scope, and the forwarder registers an async-only disposable
+    // there, which the container refuses to dispose ("type only implements IAsyncDisposable").
     public WanIdleGate(
         UniFiConnectionService connectionService,
-        MonitoringInfluxClient influx,
+        MonitoringInfluxRegistry influxRegistry,
         SiteDbContextFactory siteDb,
         SiteContextService siteContext,
         ILogger<WanIdleGate> logger)
     {
         _connectionService = connectionService;
-        _influx = influx;
+        _influxRegistry = influxRegistry;
         _siteDb = siteDb;
         _siteContext = siteContext;
         _logger = logger;
     }
+
+    private MonitoringInfluxClient Influx => _influxRegistry.GetFor(_siteContext.Slug);
 
     /// <summary>A traffic reading for the WAN and where it came from.</summary>
     public sealed record IdleReading(double DownloadMbps, double UploadMbps, string Source)
@@ -69,7 +74,7 @@ public class WanIdleGate
                 return null;
 
             var now = DateTime.UtcNow;
-            var points = await _influx.QueryGatewayWanRatesAsync(
+            var points = await Influx.QueryGatewayWanRatesAsync(
                 mac, new[] { counter }, now - MaxReadingAge, now,
                 aggregateWindow: TimeSpan.FromSeconds(5), ct: ct);
             var fresh = points.Where(p => p.Time >= now - Window).ToList();

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.8.2.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.8.2.json
@@ -1,0 +1,33 @@
+{
+  "id": "2.8.2",
+  "kind": "whats-new",
+  "title": "What's new in v2.8.2",
+  "summary": "Adaptive SQM can now learn your line's real weekly congestion pattern from brief idle-hour speed tests, and on shared media the upload rate follows the congestion schedule too.",
+  "steps": [
+    {
+      "id": "sqm-learning",
+      "level": "major",
+      "url": "/sqm",
+      "selector": "[data-tour=\"sqm-learning\"]",
+      "title": "Congestion Profile Learning",
+      "listLabel": "Learn your line's real weekly congestion pattern instead of assuming one",
+      "body": "Adaptive SQM has always shaped to a weekly congestion curve chosen by connection type. **Start Learning** builds one from your own line instead: for 7 days, once an hour when the WAN is idle, the gateway runs a 4 second speed test with the shaper lifted out of the way. Errant samples are thrown out and the curve is smoothed across neighboring hours and days, so one bad reading never becomes a dip in your schedule. Pick **Learned** under **Profile** to deploy it; **Severity** still tunes it, and the twice-daily speed tests keep calibrating against it. Most useful on cellular, satellite, and fixed wireless, where the tower, cell, or beam decides the hour-by-hour speed. The run also shows on Alerts & Schedule - Schedule.",
+      "placement": "top",
+      "requires": ["sqm-enabled"],
+      "optional": true
+    },
+    {
+      "id": "sqm-upload-strength",
+      "level": "minor",
+      "badge": "improved",
+      "url": "/sqm",
+      "selector": "[data-tour=\"sqm-congestion-profile\"]",
+      "title": "Upload Strength",
+      "listLabel": "Upload now follows the congestion schedule on shared media",
+      "body": "Upload used to be shaped at one fixed rate. On Fixed LTE/5G, Starlink, and Fixed Wireless (WISP), **Upload Strength** applies the congestion schedule to upload as well, never below half of nominal, and a latency cut takes upload down in the same proportion as download. New setups on those media start at 0.5; existing ones stay at 0 until you move the slider. **Upload Range** shows where the rate will sit over the week.",
+      "placement": "top",
+      "requires": ["sqm-enabled"],
+      "optional": true
+    }
+  ]
+}

--- a/src/NetworkOptimizer.Web/wwwroot/data/tours/2.8.2.json
+++ b/src/NetworkOptimizer.Web/wwwroot/data/tours/2.8.2.json
@@ -11,7 +11,7 @@
       "selector": "[data-tour=\"sqm-learning\"]",
       "title": "Congestion Profile Learning",
       "listLabel": "Learn your line's real weekly congestion pattern instead of assuming one",
-      "body": "Adaptive SQM has always shaped to a weekly congestion curve chosen by connection type. **Start Learning** builds one from your own line instead: for 7 days, once an hour when the WAN is idle, the gateway runs a 4 second speed test with the shaper lifted out of the way. Errant samples are thrown out and the curve is smoothed across neighboring hours and days, so one bad reading never becomes a dip in your schedule. Pick **Learned** under **Profile** to deploy it; **Severity** still tunes it, and the twice-daily speed tests keep calibrating against it. Most useful on cellular, satellite, and fixed wireless, where the tower, cell, or beam decides the hour-by-hour speed. The run also shows on Alerts & Schedule - Schedule.",
+      "body": "Adaptive SQM has always shaped to a weekly congestion curve chosen by connection type. **Start Learning** builds one from your own line instead.\n\nFor 7 days, once an hour when the WAN is idle, the gateway runs a 4 second speed test with the shaper lifted out of the way. Errant samples are thrown out and the curve is smoothed across neighboring hours and days, so one bad reading never becomes a dip in your schedule.\n\nPick **Learned** under **Profile** to deploy it. **Severity** still tunes it, and the twice-daily speed tests keep calibrating against it.\n\nMost useful on cellular, satellite, and fixed wireless: shared, limited-capacity access where the hour-by-hour speed follows how congested the tower, cell, or beam is. The run also shows on Alerts & Schedule - Schedule.",
       "placement": "top",
       "requires": ["sqm-enabled"],
       "optional": true
@@ -24,7 +24,7 @@
       "selector": "[data-tour=\"sqm-congestion-profile\"]",
       "title": "Upload Strength",
       "listLabel": "Upload now follows the congestion schedule on shared media",
-      "body": "Upload used to be shaped at one fixed rate. On Fixed LTE/5G, Starlink, and Fixed Wireless (WISP), **Upload Strength** applies the congestion schedule to upload as well, never below half of nominal, and a latency cut takes upload down in the same proportion as download. New setups on those media start at 0.5; existing ones stay at 0 until you move the slider. **Upload Range** shows where the rate will sit over the week.",
+      "body": "Upload used to be shaped at one fixed rate. On Fixed LTE/5G, Starlink, and Fixed Wireless (WISP), **Upload Strength** applies the congestion schedule to upload as well, never below half of nominal, and a latency cut takes upload down in the same proportion as download.\n\nNew setups on those media start at 0.5; existing ones stay at 0 until you move the slider. **Upload Range** shows where the rate will sit over the week.",
       "placement": "top",
       "requires": ["sqm-enabled"],
       "optional": true

--- a/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileInsightsTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileInsightsTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Sqm.Tests;
+
+public class CongestionProfileInsightsTests
+{
+    private static LearnedCongestionProfile Profile(Func<int, int, double> multiplier)
+    {
+        var p = new LearnedCongestionProfile();
+        for (var d = 0; d < 7; d++)
+            for (var h = 0; h < 24; h++)
+                p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(d, h)] = multiplier(d, h);
+        return p;
+    }
+
+    [Fact]
+    public void NamesTheSlowBand_InHoursAndPercentOfBest()
+    {
+        var learned = Profile((d, h) => h is >= 19 and <= 22 ? 0.7 : 1.0);
+
+        var insight = CongestionProfileInsights.Describe(learned, ConnectionType.CellularHome)!;
+
+        insight.StartHour.Should().Be(19);
+        insight.EndHour.Should().Be(22);
+        insight.Depth.Should().BeApproximately(0.3, 0.001);
+        insight.SlowestSentence.Should().Be("evenings (19:00 to 22:00), about 70% of your best hour");
+    }
+
+    [Fact]
+    public void LabelsWeekdaysWhenTheDipIsAWeekdayThing()
+    {
+        var learned = Profile((d, h) => h is >= 19 and <= 22 && d < 5 ? 0.6 : 1.0);
+
+        CongestionProfileInsights.Describe(learned, ConnectionType.CellularHome)!.SlowestLabel.Should().Be("weekday evenings");
+    }
+
+    [Fact]
+    public void LabelsWeekendsWhenTheDipIsAWeekendThing()
+    {
+        var learned = Profile((d, h) => h is >= 13 and <= 16 && d >= 5 ? 0.6 : 1.0);
+
+        CongestionProfileInsights.Describe(learned, ConnectionType.Starlink)!.SlowestLabel.Should().Be("weekend afternoons");
+    }
+
+    [Fact]
+    public void ABandAcrossMidnight_ReadsAsOvernight()
+    {
+        var learned = Profile((d, h) => h is 23 or 0 or 1 or 2 ? 0.75 : 1.0);
+
+        var insight = CongestionProfileInsights.Describe(learned, ConnectionType.CellularHome)!;
+
+        insight.StartHour.Should().Be(23);
+        insight.EndHour.Should().Be(2);
+        insight.SlowestLabel.Should().Be("overnight");
+    }
+
+    [Fact]
+    public void ComparesAgainstTheConnectionTypesDefaultOverTheSameHours()
+    {
+        // Cellular's built-in evening dip is well under 40%; a 60% dip reads as deeper.
+        var deeper = Profile((d, h) => h is >= 19 and <= 22 ? 0.4 : 1.0);
+        CongestionProfileInsights.Describe(deeper, ConnectionType.CellularHome)!.Comparison
+            .Should().Be(CongestionProfileInsights.Comparison.Deeper);
+
+        // GPON's default is nearly flat; a 30% learned dip is deeper than it expects.
+        var gpon = Profile((d, h) => h is >= 19 and <= 22 ? 0.7 : 1.0);
+        var g = CongestionProfileInsights.Describe(gpon, ConnectionType.Gpon)!;
+        g.Comparison.Should().Be(CongestionProfileInsights.Comparison.Deeper);
+        g.ComparisonSentence("Fiber (GPON)").Should().StartWith("dips deeper than the Fiber (GPON) default expects");
+    }
+
+    [Fact]
+    public void AFlatLine_SaysTheDefaultWasShapingHarderThanNeeded()
+    {
+        var flat = Profile((d, h) => h == 20 ? 0.97 : 1.0);
+
+        var insight = CongestionProfileInsights.Describe(flat, ConnectionType.CellularHome)!;
+
+        insight.Comparison.Should().Be(CongestionProfileInsights.Comparison.Flat);
+        insight.ComparisonSentence("Fixed LTE/5G").Should().Contain("barely varies");
+    }
+
+    [Fact]
+    public void AFlatLineOnAFlatDefault_HasNothingToSay()
+    {
+        var flat = Profile((d, h) => 1.0);
+
+        CongestionProfileInsights.Describe(flat, ConnectionType.XgsPon).Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileInsightsTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileInsightsTests.cs
@@ -80,6 +80,8 @@ public class CongestionProfileInsightsTests
 
         insight.Comparison.Should().Be(CongestionProfileInsights.Comparison.Flat);
         insight.ComparisonSentence("Fixed LTE/5G").Should().Contain("barely varies");
+        // No band is named on a flat line: it would wrap most of the clock.
+        insight.SlowestSentence.Should().Be("no slow band yet, your line stays within about 3% all day");
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
@@ -241,4 +241,30 @@ public class CongestionProfileLearnerTests
         avg[20].Should().Be(0.5);
         avg[3].Should().Be(1.0);
     }
+
+    [Fact]
+    public void DaysSpanned_CountsGatewayLocalDays_NotUtcDates()
+    {
+        // Nine hours of samples on one local afternoon and evening, stored in UTC so the dates straddle midnight.
+        var start = new DateTime(2026, 9, 7, 18, 0, 0, DateTimeKind.Utc);
+        var samples = Enumerable.Range(0, 9)
+            .Select(i => new LearningSample(i + 1, 0, 13 + i, 250, 28, start.AddHours(i)))
+            .ToList();
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        p.DaysSpanned.Should().Be(1);
+        p.HasFullDayCycle.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasFullDayCycle_OnceEveryHourHasASample()
+    {
+        var start = new DateTime(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc);
+        var samples = Enumerable.Range(0, 24)
+            .Select(i => new LearningSample(i + 1, i < 12 ? 0 : 1, i, 250, 28, start.AddHours(i)))
+            .ToList();
+
+        CongestionProfileLearner.Learn(samples).Profile.HasFullDayCycle.Should().BeTrue();
+    }
 }

--- a/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Sqm.Tests;
+
+public class CongestionProfileLearnerTests
+{
+    private static readonly DateTime Start = new(2026, 9, 7, 0, 0, 0, DateTimeKind.Utc); // a Monday
+
+    /// <summary>A full week of hourly samples following a daily curve: fast overnight, a dip in the evening.</summary>
+    private static List<LearningSample> Week(Func<int, int, double> down, Func<int, int, double>? up = null)
+    {
+        var samples = new List<LearningSample>();
+        long id = 1;
+        for (var day = 0; day < 7; day++)
+            for (var hour = 0; hour < 24; hour++)
+                samples.Add(new LearningSample(id++, day, hour, down(day, hour), (up ?? ((d, h) => down(d, h) / 10))(day, hour), Start.AddDays(day).AddHours(hour)));
+        return samples;
+    }
+
+    private static double EveningDip(int day, int hour) => hour is >= 18 and <= 22 ? 100 : 200;
+
+    [Fact]
+    public void FullWeek_IsReliable_AndBestHourIsOne()
+    {
+        var result = CongestionProfileLearner.Learn(Week(EveningDip));
+        var p = result.Profile;
+
+        p.ValidSampleCount.Should().Be(168);
+        p.Coverage.Should().Be(1.0);
+        p.DaysSpanned.Should().Be(7);
+        p.IsReliable.Should().BeTrue();
+        p.DownloadMultipliers.Max().Should().Be(1.0);
+        p.UploadMultipliers.Max().Should().Be(1.0);
+        p.PeakDownloadMbps.Should().BeApproximately(200, 1);
+        result.Exclusions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void RealEveningDip_SurvivesSmoothing()
+    {
+        var p = CongestionProfileLearner.Learn(Week(EveningDip)).Profile;
+
+        // The heart of the dip (20:00) stays near half; the shoulders blend, but the dip is unmistakable.
+        p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(2, 20)].Should().BeLessThan(0.6);
+        p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(2, 3)].Should().BeGreaterThan(0.95);
+    }
+
+    [Fact]
+    public void OneErrantLowSample_IsExcluded_AndDoesNotCarveAHole()
+    {
+        var samples = Week(EveningDip);
+        // Tuesday 03:00 measured while something was downloading: a tenth of the usual.
+        var slot = samples.First(s => s.DayOfWeek == 1 && s.Hour == 3);
+        samples[samples.IndexOf(slot)] = slot with { DownloadMbps = 20 };
+
+        var result = CongestionProfileLearner.Learn(samples);
+
+        result.Exclusions.Should().ContainSingle(e => e.SampleId == slot.Id && e.Reason.Contains("download"));
+        result.Profile.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(1, 3)].Should().BeGreaterThan(0.9);
+        result.Profile.SampleCounts[LearnedCongestionProfile.SlotIndex(1, 3)].Should().Be(0);
+    }
+
+    [Fact]
+    public void OneErrantHighSample_DoesNotSetThePeak()
+    {
+        var samples = Week(EveningDip);
+        var slot = samples.First(s => s.DayOfWeek == 4 && s.Hour == 2);
+        samples[samples.IndexOf(slot)] = slot with { DownloadMbps = 900 };
+
+        var result = CongestionProfileLearner.Learn(samples);
+
+        result.Exclusions.Should().ContainSingle(e => e.SampleId == slot.Id);
+        result.Profile.PeakDownloadMbps.Should().BeLessThan(220);
+    }
+
+    [Fact]
+    public void ErrantUpload_ExcludesTheWholeSample()
+    {
+        var samples = Week(EveningDip);
+        var slot = samples.First(s => s.DayOfWeek == 3 && s.Hour == 10);
+        samples[samples.IndexOf(slot)] = slot with { UploadMbps = 1 };
+
+        var result = CongestionProfileLearner.Learn(samples);
+
+        result.Exclusions.Should().ContainSingle(e => e.SampleId == slot.Id && e.Reason.Contains("upload"));
+        result.Profile.ValidSampleCount.Should().Be(167);
+    }
+
+    [Fact]
+    public void SingleEventOnOneEvening_IsDilutedByTheOtherSix()
+    {
+        // Sunday 20:00-21:00 collapses to a quarter (a one-off), the other evenings hold the usual dip.
+        var samples = Week((d, h) => d == 6 && h is 20 or 21 ? 25 : EveningDip(d, h));
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        // Pool median at 20:00 is 100; 25 is below 45% of it, so the event is rejected outright,
+        // and Sunday 20:00 smooths back toward the ordinary evening rather than to a quarter.
+        p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(6, 20)].Should().BeGreaterThan(0.4);
+    }
+
+    [Fact]
+    public void FewSamples_AreNotReliable_ButStillYieldACurve()
+    {
+        var samples = Week(EveningDip).Where(s => s.DayOfWeek < 2).ToList();
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        p.IsReliable.Should().BeFalse();
+        p.ValidSampleCount.Should().Be(48);
+        p.Coverage.Should().BeApproximately(48 / 168.0, 0.001);
+        // Empty days borrow the hour-of-day shape rather than reading as flat.
+        p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(5, 20)].Should().BeLessThan(
+            p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(5, 3)]);
+    }
+
+    [Fact]
+    public void OutlierRejection_WaitsForEnoughReadingsInTheHour()
+    {
+        // Three readings at 09:00: two normal, one low. Too few to judge, so all three are kept.
+        var samples = new List<LearningSample>
+        {
+            new(1, 0, 9, 200, 20, Start),
+            new(2, 1, 9, 200, 20, Start.AddDays(1)),
+            new(3, 2, 9, 40, 20, Start.AddDays(2)),
+        };
+
+        var result = CongestionProfileLearner.Learn(samples);
+
+        result.Exclusions.Should().BeEmpty();
+        result.Profile.ValidSampleCount.Should().Be(3);
+    }
+
+    [Fact]
+    public void NoThroughput_AndBadSlots_AreExcludedWithReasons()
+    {
+        var samples = new List<LearningSample>
+        {
+            new(1, 0, 9, 0, 20, Start),
+            new(2, 7, 9, 200, 20, Start),
+            new(3, 1, 24, 200, 20, Start),
+            new(4, 1, 10, 200, 20, Start),
+        };
+
+        var result = CongestionProfileLearner.Learn(samples);
+
+        result.Exclusions.Select(e => e.SampleId).Should().BeEquivalentTo(new long[] { 1, 2, 3 });
+        result.Profile.ValidSampleCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void EmptyInput_YieldsFlatUnreliableProfile()
+    {
+        var p = CongestionProfileLearner.Learn(Array.Empty<LearningSample>()).Profile;
+
+        p.IsReliable.Should().BeFalse();
+        p.ValidSampleCount.Should().Be(0);
+        p.DownloadMultipliers.Should().AllBeEquivalentTo(1.0);
+    }
+
+    [Fact]
+    public void MultipliersNeverFallBelowTheFloor()
+    {
+        var samples = Week((d, h) => h == 20 ? 2 : 200);
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        p.DownloadMultipliers.Min().Should().BeGreaterThanOrEqualTo(CongestionProfileLearner.MinMultiplier);
+    }
+
+    [Fact]
+    public void Learning_IsDeterministic()
+    {
+        var samples = Week(EveningDip);
+        var a = CongestionProfileLearner.Learn(samples).Profile;
+        var b = CongestionProfileLearner.Learn(samples).Profile;
+
+        a.DownloadMultipliers.Should().Equal(b.DownloadMultipliers);
+        a.UploadMultipliers.Should().Equal(b.UploadMultipliers);
+    }
+
+    [Fact]
+    public void ScaledPattern_ReproducesLearnedThroughput_UnderNominal()
+    {
+        var multipliers = Enumerable.Repeat(0.5, LearnedCongestionProfile.Slots).ToArray();
+        multipliers[0] = 1.0;
+
+        // Nominal equals the peak: identity.
+        var same = LearnedCongestionProfile.ScaledPattern(multipliers, 200, 200);
+        same[0, 0].Should().Be(1.0);
+        same[0, 1].Should().Be(0.5);
+
+        // Nominal set lower than the peak: the best hour caps at nominal, the dip keeps its absolute value.
+        var lower = LearnedCongestionProfile.ScaledPattern(multipliers, 200, 150);
+        lower[0, 0].Should().Be(1.0);
+        lower[0, 1].Should().BeApproximately(100.0 / 150.0, 0.0001);
+    }
+
+    [Fact]
+    public void HourOfDayAverages_AverageAcrossTheWeek()
+    {
+        var multipliers = new double[LearnedCongestionProfile.Slots];
+        for (var day = 0; day < 7; day++)
+            for (var hour = 0; hour < 24; hour++)
+                multipliers[LearnedCongestionProfile.SlotIndex(day, hour)] = hour == 20 ? 0.5 : 1.0;
+
+        var avg = LearnedCongestionProfile.HourOfDayAverages(multipliers);
+
+        avg[20].Should().Be(0.5);
+        avg[3].Should().Be(1.0);
+    }
+}

--- a/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/CongestionProfileLearnerTests.cs
@@ -151,6 +151,36 @@ public class CongestionProfileLearnerTests
     }
 
     [Fact]
+    public void ProbeLimitedSamples_ShapeTheCurve_ButNeverSetThePeak()
+    {
+        // Overnight samples clipped at a 250 lift; the rest measured the line at 200 / 100.
+        var samples = Week(EveningDip)
+            .Select(s => s.Hour is >= 1 and <= 4 ? s with { DownloadMbps = 250, ProbeLimited = true } : s)
+            .ToList();
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        p.ProbeLimitedSampleCount.Should().Be(28);
+        p.PeakIsLowerBound.Should().BeFalse();
+        // The peak is the best unclipped hour, not the lift.
+        p.PeakDownloadMbps.Should().BeLessThan(215);
+        // Clipped hours still read as at least as fast as the peak.
+        p.DownloadMultipliers[LearnedCongestionProfile.SlotIndex(2, 2)].Should().Be(1.0);
+    }
+
+    [Fact]
+    public void AllSamplesProbeLimited_MarksThePeakAsALowerBound()
+    {
+        var samples = Week(EveningDip).Select(s => s with { ProbeLimited = true }).ToList();
+
+        var p = CongestionProfileLearner.Learn(samples).Profile;
+
+        p.PeakIsLowerBound.Should().BeTrue();
+        p.ProbeLimitedSampleCount.Should().Be(168);
+        p.PeakDownloadMbps.Should().BeApproximately(200, 1);
+    }
+
+    [Fact]
     public void EmptyInput_YieldsFlatUnreliableProfile()
     {
         var p = CongestionProfileLearner.Learn(Array.Empty<LearningSample>()).Profile;

--- a/tests/NetworkOptimizer.Sqm.Tests/DynamicUploadTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/DynamicUploadTests.cs
@@ -1,0 +1,159 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Sqm.Tests;
+
+/// <summary>
+/// Dynamic upload shaping and learned profiles must be strictly additive: a configuration that does
+/// not opt in produces the scripts it always did, byte for byte.
+/// </summary>
+public class DynamicUploadTests
+{
+    private static SqmConfiguration Config(ConnectionType type = ConnectionType.CellularHome, double uploadSeverity = 0.0)
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionType = type,
+            ConnectionName = "Test WAN",
+            Interface = "eth4",
+            NominalDownloadSpeed = 200,
+            NominalUploadSpeed = 30,
+            ShapeUpload = true,
+            PingHost = "1.1.1.1",
+            UploadCongestionSeverity = uploadSeverity,
+        };
+        config.ApplyProfileSettings(1000);
+        return config;
+    }
+
+    private static Dictionary<string, string> Baseline(SqmConfiguration config) =>
+        config.GetProfile().GetHourlyBaseline(config.CongestionSeverity);
+
+    [Fact]
+    public void StrengthZero_LeavesTheScriptsUnchanged()
+    {
+        var config = Config();
+        var baseline = Baseline(config);
+        var uploadBaseline = config.GetProfile().GetHourlyUploadBaseline(0.5);
+
+        var before = new ScriptGenerator(config).GenerateAllScripts(baseline).Values.Single();
+        var withIgnoredUpload = new ScriptGenerator(config).GenerateAllScripts(baseline, uploadBaseline).Values.Single();
+
+        withIgnoredUpload.Should().Be(before);
+        before.Should().NotContain("UPLOAD_BASELINE");
+        before.Should().NotContain("MIN_UPLOAD_SPEED");
+        before.Should().Contain("update_all_tc_classes $INTERFACE $UPLOAD_SPEED");
+    }
+
+    [Fact]
+    public void DefaultConfiguration_HasStaticUpload()
+    {
+        new SqmConfiguration().UploadCongestionSeverity.Should().Be(0.0);
+        new SqmConfiguration { ShapeUpload = true }.DynamicUpload.Should().BeFalse();
+    }
+
+    [Fact]
+    public void WithStrength_ScriptsCarryTheUploadScheduleAndFloor()
+    {
+        var config = Config(uploadSeverity: 0.5);
+        var baseline = Baseline(config);
+        var uploadBaseline = config.GetProfile().GetHourlyUploadBaseline(config.UploadCongestionSeverity);
+
+        var script = new ScriptGenerator(config).GenerateAllScripts(baseline, uploadBaseline).Values.Single();
+
+        script.Should().Contain("declare -A UPLOAD_BASELINE");
+        script.Should().Contain("UPLOAD_BASELINE[0_20]=");
+        script.Should().Contain($"MIN_UPLOAD_SPEED=\"{config.MinUploadSpeed}\"");
+        // Both apply phases (speedtest result, ping adjustment) shape upload from the schedule; the
+        // speedtest's probe phase still opens upload to nominal so the measurement runs unshaped.
+        CountOf(script, "update_all_tc_classes $INTERFACE $upload_rate").Should().Be(2);
+        CountOf(script, "update_all_tc_classes $INTERFACE $UPLOAD_SPEED").Should().Be(1);
+        script.IndexOf("update_all_tc_classes $INTERFACE $UPLOAD_SPEED", StringComparison.Ordinal)
+            .Should().BeLessThan(script.IndexOf("speedtest_output=$(speedtest", StringComparison.Ordinal));
+        // The ping script also follows a latency cut and only skips when both directions are unchanged.
+        script.Should().Contain("upload_rate=$(echo \"scale=0; $upload_rate * $new_rate / $MAX_DOWNLOAD_SPEED\" | bc)");
+        script.Should().Contain("[ \"$upload_rate\" = \"$current_up_rate\" ]");
+    }
+
+    private static int CountOf(string text, string needle)
+    {
+        int count = 0, index = 0;
+        while ((index = text.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+        return count;
+    }
+
+    [Fact]
+    public void UploadScheduleNeverDropsBelowHalfNominal_OrAboveNominal()
+    {
+        var profile = new ConnectionProfile { Type = ConnectionType.Starlink, NominalDownloadMbps = 400, NominalUploadMbps = 40 };
+
+        var schedule = profile.GetHourlyUploadBaseline(1.0).Values.Select(int.Parse).ToList();
+
+        schedule.Min().Should().BeGreaterThanOrEqualTo(20);
+        schedule.Max().Should().BeLessThanOrEqualTo(40);
+        schedule.Should().HaveCount(168);
+    }
+
+    [Fact]
+    public void StrengthZero_UploadScheduleIsNominalEverywhere()
+    {
+        var profile = new ConnectionProfile { Type = ConnectionType.CellularHome, NominalDownloadMbps = 200, NominalUploadMbps = 30 };
+
+        profile.GetHourlyUploadBaseline(0.0).Values.Should().AllBe("30");
+    }
+
+    [Theory]
+    [InlineData(ConnectionType.CellularHome, true, 0.5)]
+    [InlineData(ConnectionType.Starlink, true, 0.5)]
+    [InlineData(ConnectionType.FixedWireless, true, 0.5)]
+    [InlineData(ConnectionType.Gpon, false, 0.0)]
+    [InlineData(ConnectionType.XgsPon, false, 0.0)]
+    [InlineData(ConnectionType.DocsisCable, false, 0.0)]
+    [InlineData(ConnectionType.Dsl, false, 0.0)]
+    public void MediumDefaults(ConnectionType type, bool supports, double defaultStrength)
+    {
+        ConnectionProfile.SupportsDynamicUpload(type).Should().Be(supports);
+        ConnectionProfile.DefaultUploadCongestionSeverity(type).Should().Be(defaultStrength);
+    }
+
+    [Fact]
+    public void EffectiveUploadMultiplier_ScalesTheDipAndFloorsAtHalf()
+    {
+        ConnectionProfile.EffectiveUploadMultiplier(0.5, 0.0).Should().Be(1.0);
+        ConnectionProfile.EffectiveUploadMultiplier(0.5, 0.5).Should().Be(0.75);
+        ConnectionProfile.EffectiveUploadMultiplier(0.5, 1.0).Should().Be(0.5);
+        ConnectionProfile.EffectiveUploadMultiplier(0.2, 1.0).Should().Be(ConnectionProfile.MinUploadFraction);
+    }
+
+    [Fact]
+    public void LearnedPatterns_ReplaceTheBuiltInCurve()
+    {
+        var config = Config(ConnectionType.Gpon);
+        var learned = new double[7, 24];
+        for (var d = 0; d < 7; d++)
+            for (var h = 0; h < 24; h++)
+                learned[d, h] = h == 20 ? 0.5 : 1.0;
+        config.LearnedDownloadPattern = learned;
+
+        var baseline = Baseline(config);
+
+        baseline["0_20"].Should().Be("100");
+        baseline["0_3"].Should().Be("200");
+        // Severity still tunes a learned curve.
+        config.GetProfile().GetHourlyBaseline(0.5)["0_20"].Should().Be("150");
+        // Without a learned upload curve, upload follows the learned download curve.
+        config.GetProfile().GetHourlyUploadBaseline(1.0)["0_20"].Should().Be("15");
+    }
+
+    [Fact]
+    public void ParameterSummary_NamesUploadModeAndProfileSource()
+    {
+        Config().GetParameterSummary().Should().Contain("Upload: static").And.Contain("Profile: connection type default");
+        Config(uploadSeverity: 0.5).GetParameterSummary().Should().Contain("Upload: dynamic, strength 0.50, floor 15 Mbps");
+    }
+}

--- a/tests/NetworkOptimizer.Sqm.Tests/GeneratedScriptSyntaxTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/GeneratedScriptSyntaxTests.cs
@@ -31,7 +31,7 @@ public class GeneratedScriptSyntaxTests
         {
             ConnectionType = ConnectionType.CellularHome,
             ConnectionName = "Test WAN",
-            Interface = "eth6.228",
+            Interface = "eth6.100",
             NominalDownloadSpeed = 200,
             NominalUploadSpeed = 30,
             ShapeUpload = true,
@@ -99,7 +99,7 @@ public class GeneratedScriptSyntaxTests
         var bash = BashPath();
         if (bash == null) return;
 
-        var wrapper = SqmShaperLiftScript.Wrap("/data/uwnspeedtest --interface eth6.228 -streams 10 -servers 4 -duration 4", "eth6.228", 273, 33, true);
+        var wrapper = SqmShaperLiftScript.Wrap("/data/uwnspeedtest --interface eth6.100 -streams 10 -servers 4 -duration 4", "eth6.100", 273, 33, true);
         AssertParses(bash, wrapper, "shaper-lift wrapper");
     }
 }

--- a/tests/NetworkOptimizer.Sqm.Tests/GeneratedScriptSyntaxTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/GeneratedScriptSyntaxTests.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics;
+using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
+using Xunit;
+
+namespace NetworkOptimizer.Sqm.Tests;
+
+/// <summary>
+/// Every script we hand a gateway must at least parse. Runs <c>bash -n</c> over the boot script,
+/// the speedtest and ping scripts it embeds, and the shaper-lift wrapper, for a static and a
+/// dynamic-upload configuration. Skipped silently where no bash is on the PATH.
+/// </summary>
+public class GeneratedScriptSyntaxTests
+{
+    private static string? BashPath()
+    {
+        foreach (var dir in (Environment.GetEnvironmentVariable("PATH") ?? "").Split(Path.PathSeparator))
+        {
+            foreach (var name in new[] { "bash", "bash.exe" })
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate)) return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static SqmConfiguration Config(double uploadSeverity)
+    {
+        var config = new SqmConfiguration
+        {
+            ConnectionType = ConnectionType.CellularHome,
+            ConnectionName = "Test WAN",
+            Interface = "eth6.228",
+            NominalDownloadSpeed = 200,
+            NominalUploadSpeed = 30,
+            ShapeUpload = true,
+            PingHost = "1.1.1.1",
+            UploadCongestionSeverity = uploadSeverity,
+        };
+        config.ApplyProfileSettings(1000);
+        return config;
+    }
+
+    private static string Embedded(string boot, string marker)
+    {
+        var start = boot.IndexOf($"<< '{marker}'\n", StringComparison.Ordinal);
+        start.Should().BeGreaterThan(0, $"the boot script embeds a {marker} heredoc");
+        start = boot.IndexOf('\n', start) + 1;
+        var end = boot.IndexOf($"\n{marker}\n", start, StringComparison.Ordinal);
+        end.Should().BeGreaterThan(start);
+        return boot[start..end];
+    }
+
+    // The script goes in over stdin: a WSL bash cannot open a Windows temp path, and Git Bash
+    // can, so stdin is the one route that works for whichever bash the PATH offers.
+    private static void AssertParses(string bash, string script, string label)
+    {
+        var psi = new ProcessStartInfo(bash, "-n")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        using var proc = Process.Start(psi)!;
+        proc.StandardInput.NewLine = "\n";
+        proc.StandardInput.Write(script.Replace("\r\n", "\n"));
+        proc.StandardInput.Close();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+        proc.ExitCode.Should().Be(0, $"{label} must parse: {stderr}");
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(0.5)]
+    public void BootSpeedtestAndPingScripts_ParseUnderBash(double uploadSeverity)
+    {
+        var bash = BashPath();
+        if (bash == null) return;
+
+        var config = Config(uploadSeverity);
+        var profile = config.GetProfile();
+        var boot = new ScriptGenerator(config)
+            .GenerateAllScripts(profile.GetHourlyBaseline(1.0), profile.GetHourlyUploadBaseline(uploadSeverity))
+            .Values.Single()
+            .Replace("\r\n", "\n");
+
+        AssertParses(bash, boot, "boot script");
+        AssertParses(bash, Embedded(boot, "SPEEDTEST_EOF"), "speedtest script");
+        AssertParses(bash, Embedded(boot, "PING_EOF"), "ping script");
+    }
+
+    [Fact]
+    public void ShaperLiftWrapper_ParsesUnderBash()
+    {
+        var bash = BashPath();
+        if (bash == null) return;
+
+        var wrapper = SqmShaperLiftScript.Wrap("/data/uwnspeedtest --interface eth6.228 -streams 10 -servers 4 -duration 4", "eth6.228", 273, 33, true);
+        AssertParses(bash, wrapper, "shaper-lift wrapper");
+    }
+}

--- a/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
 using Xunit;
 
 namespace NetworkOptimizer.Sqm.Tests;
@@ -25,6 +26,27 @@ public class SqmShaperLiftScriptTests
         script.IndexOf("restore_rates() {", StringComparison.Ordinal).Should().BeLessThan(script.IndexOf("\"$DOWN_PROBE\"", StringComparison.Ordinal));
         script.TrimEnd('\n').Should().EndWith("/data/uwnspeedtest --interface eth4 -duration 4");
         script.Should().NotContain("\r\n");
+    }
+
+    [Fact]
+    public void Wrap_HoldsTheProbeLock_ThePingScriptStandsDownFor()
+    {
+        var script = SqmShaperLiftScript.Wrap("true", "eth4", 273, 31, false);
+
+        script.Should().Contain("PROBE_LOCK=\"/data/sqm/probe-eth4.lock\"");
+        script.Should().Contain("pgrep -f -- '[-]ping\\.sh'");
+        script.Should().Contain("touch \"$PROBE_LOCK\"");
+        script.Should().Contain("rm -f \"$PROBE_LOCK\"");
+        // The lock is taken before the rates are read and released inside the exit trap.
+        script.IndexOf("touch \"$PROBE_LOCK\"", StringComparison.Ordinal).Should().BeLessThan(script.IndexOf("saved_down=$(read_root_rate_mbps", StringComparison.Ordinal));
+        script.IndexOf("rm -f \"$PROBE_LOCK\"", StringComparison.Ordinal).Should().BeLessThan(script.IndexOf("trap restore_rates EXIT", StringComparison.Ordinal));
+
+        var config = new SqmConfiguration { ConnectionName = "Test WAN", Interface = "eth4", PingHost = "1.1.1.1" };
+        var ping = new ScriptGenerator(config).GenerateAllScripts(new Dictionary<string, string> { ["0_12"] = "95" }).Values.Single();
+        ping.Should().Contain("PROBE_LOCK=\"/data/sqm/probe-${INTERFACE}.lock\"");
+        ping.Should().Contain($"-lt {ScriptGenerator.ProbeLockMaxAgeSeconds}");
+        // The guard precedes the result-file check, so a locked run touches nothing at all.
+        ping.IndexOf("PROBE_LOCK=", StringComparison.Ordinal).Should().BeLessThan(ping.IndexOf("Check for speedtest result", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
@@ -65,6 +65,9 @@ public class SqmShaperLiftScriptTests
         var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script));
         command.Should().Contain(b64);
         command.Should().Contain("/tmp/netopt-sqm-probe-eth4.sh");
+        // The SSH runner merges stderr into the returned output, so the script's stderr (the
+        // binary's progress lines) must be dropped on the script itself, not on the final exit.
+        command.Should().Contain("bash /tmp/netopt-sqm-probe-eth4.sh 2>/dev/null;");
         command.Should().EndWith("exit $rc");
         // No shell metacharacters from the script leak into the command line: it travels base64.
         command.Should().NotContain("echo hi");

--- a/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace NetworkOptimizer.Sqm.Tests;
+
+public class SqmShaperLiftScriptTests
+{
+    [Fact]
+    public void Wrap_ReadsRates_LiftsBothSides_AndRestoresFromAnExitTrap()
+    {
+        var script = SqmShaperLiftScript.Wrap("/data/uwnspeedtest --interface eth4 -duration 4", "eth4", 400, 60, rateProportionalDownloadBurst: true);
+
+        script.Should().StartWith("#!/bin/bash\n");
+        script.Should().Contain("IFB_DEVICE=\"ifbeth4\"");
+        script.Should().Contain("DOWN_PROBE=\"400\"");
+        script.Should().Contain("UP_PROBE=\"60\"");
+        script.Should().Contain("BURST_MODE=1");
+        script.Should().Contain("update_all_tc_classes() {");
+        script.Should().Contain("read_root_rate_mbps() {");
+        script.Should().Contain("trap restore_rates EXIT");
+        script.Should().Contain("update_all_tc_classes \"$IFB_DEVICE\" \"$DOWN_PROBE\" \"$BURST_MODE\"");
+        script.Should().Contain("update_all_tc_classes \"$INTERFACE\" \"$UP_PROBE\"");
+        // The restore runs before the lift in file order (a trap handler), and the test command is last.
+        script.IndexOf("restore_rates() {", StringComparison.Ordinal).Should().BeLessThan(script.IndexOf("\"$DOWN_PROBE\"", StringComparison.Ordinal));
+        script.TrimEnd('\n').Should().EndWith("/data/uwnspeedtest --interface eth4 -duration 4");
+        script.Should().NotContain("\r\n");
+    }
+
+    [Fact]
+    public void Wrap_OnlyTouchesRootsThatExist()
+    {
+        var script = SqmShaperLiftScript.Wrap("true", "eth4", 400, 60, false);
+
+        // Every tc write is guarded on a saved (non-empty, positive) rate for that device.
+        script.Should().Contain("if [ -n \"$saved_down\" ] && [ \"$saved_down\" -gt 0 ] 2>/dev/null; then");
+        script.Should().Contain("if [ -n \"$saved_up\" ] && [ \"$saved_up\" -gt 0 ] 2>/dev/null; then");
+    }
+
+    [Theory]
+    [InlineData("eth4; rm -rf /")]
+    [InlineData("")]
+    [InlineData("eth 4")]
+    public void Wrap_RejectsUnsafeInterfaceNames(string iface)
+    {
+        var act = () => SqmShaperLiftScript.Wrap("true", iface, 400, 60, false);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Wrap_RejectsNonPositiveProbeRates()
+    {
+        var down = () => SqmShaperLiftScript.Wrap("true", "eth4", 0, 60, false);
+        var up = () => SqmShaperLiftScript.Wrap("true", "eth4", 400, 0, false);
+        down.Should().Throw<ArgumentOutOfRangeException>();
+        up.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ToRemoteCommand_CarriesTheScriptIntact_AndReturnsItsExitCode()
+    {
+        var script = "#!/bin/bash\necho hi\n";
+        var command = SqmShaperLiftScript.ToRemoteCommand(script, "eth4");
+
+        var b64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(script));
+        command.Should().Contain(b64);
+        command.Should().Contain("/tmp/netopt-sqm-probe-eth4.sh");
+        command.Should().EndWith("exit $rc");
+        // No shell metacharacters from the script leak into the command line: it travels base64.
+        command.Should().NotContain("echo hi");
+    }
+}

--- a/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
+++ b/tests/NetworkOptimizer.Sqm.Tests/SqmShaperLiftScriptTests.cs
@@ -47,6 +47,9 @@ public class SqmShaperLiftScriptTests
         ping.Should().Contain($"-lt {ScriptGenerator.ProbeLockMaxAgeSeconds}");
         // The guard precedes the result-file check, so a locked run touches nothing at all.
         ping.IndexOf("PROBE_LOCK=", StringComparison.Ordinal).Should().BeLessThan(ping.IndexOf("Check for speedtest result", StringComparison.Ordinal));
+        // The speedtest script waits for the lock instead of skipping: a calibration is not to be lost.
+        ping.Should().Contain("Wait for a probe (congestion learning sample) to release the shaper");
+        ping.IndexOf("Wait for a probe", StringComparison.Ordinal).Should().BeLessThan(ping.IndexOf("update_all_tc_classes $IFB_DEVICE $SPEEDTEST_PROBE_RATE", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Storage.Tests/SqmLearningRepositoryTests.cs
+++ b/tests/NetworkOptimizer.Storage.Tests/SqmLearningRepositoryTests.cs
@@ -1,0 +1,93 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Storage.Repositories;
+using Xunit;
+
+namespace NetworkOptimizer.Storage.Tests;
+
+public class SqmLearningRepositoryTests : IDisposable
+{
+    private readonly NetworkOptimizerDbContext _context;
+    private readonly SqmLearningRepository _repository;
+
+    public SqmLearningRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<NetworkOptimizerDbContext>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+        _context = new NetworkOptimizerDbContext(options);
+        _repository = new SqmLearningRepository(_context, new Mock<ILogger<SqmLearningRepository>>().Object);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task SaveProfile_InsertsThenUpdatesByWanNumber()
+    {
+        await _repository.SaveProfileAsync(new SqmCongestionProfile { WanNumber = 1, Interface = "eth4", Name = "Cell" });
+        await _repository.SaveProfileAsync(new SqmCongestionProfile { WanNumber = 1, Interface = "eth4", Name = "Cell", ValidSampleCount = 12, IsReliable = true, LastError = "x" });
+
+        var all = await _repository.GetAllProfilesAsync();
+        all.Should().ContainSingle();
+        all[0].ValidSampleCount.Should().Be(12);
+        all[0].IsReliable.Should().BeTrue();
+        all[0].LastError.Should().Be("x");
+    }
+
+    [Fact]
+    public async Task Samples_RoundTrip_FilterBySince_AndOrderAscending()
+    {
+        var t0 = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc);
+        await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 1, SampledAt = t0.AddHours(2), DownloadMbps = 100, UploadMbps = 10, Success = true });
+        await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 1, SampledAt = t0, DownloadMbps = 90, UploadMbps = 9, Success = true });
+        await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 2, SampledAt = t0, DownloadMbps = 5, UploadMbps = 1, Success = true });
+
+        var all = await _repository.GetSamplesAsync(1);
+        all.Select(s => s.DownloadMbps).Should().Equal(90, 100);
+
+        var since = await _repository.GetSamplesAsync(1, t0.AddHours(1));
+        since.Should().ContainSingle(s => s.DownloadMbps == 100);
+    }
+
+    [Fact]
+    public async Task SetSampleExclusions_MarksListed_AndClearsTheRest()
+    {
+        var a = await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 1, Success = true, Excluded = true, ExclusionReason = "old" });
+        var b = await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 1, Success = true });
+
+        await _repository.SetSampleExclusionsAsync(1, new Dictionary<int, string> { [b] = "download 20 Mbps against 200 Mbps typical at 03:00" });
+
+        var samples = await _repository.GetSamplesAsync(1);
+        samples.Single(s => s.Id == a).Excluded.Should().BeFalse();
+        samples.Single(s => s.Id == a).ExclusionReason.Should().BeNull();
+        samples.Single(s => s.Id == b).Excluded.Should().BeTrue();
+        samples.Single(s => s.Id == b).ExclusionReason.Should().Contain("03:00");
+    }
+
+    [Fact]
+    public async Task DeleteProfile_RemovesRowAndSamples_ForThatWanOnly()
+    {
+        await _repository.SaveProfileAsync(new SqmCongestionProfile { WanNumber = 1 });
+        await _repository.SaveProfileAsync(new SqmCongestionProfile { WanNumber = 2 });
+        await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 1, Success = true });
+        await _repository.AddSampleAsync(new SqmLearningSample { WanNumber = 2, Success = true });
+
+        await _repository.DeleteProfileAsync(1);
+
+        (await _repository.GetProfileAsync(1)).Should().BeNull();
+        (await _repository.GetProfileAsync(2)).Should().NotBeNull();
+        (await _repository.GetSamplesAsync(1)).Should().BeEmpty();
+        (await _repository.GetSamplesAsync(2)).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void HasProfile_RequiresCurveAndSamples()
+    {
+        new SqmCongestionProfile().HasProfile.Should().BeFalse();
+        new SqmCongestionProfile { DownloadMultipliersJson = "[1]" }.HasProfile.Should().BeFalse();
+        new SqmCongestionProfile { DownloadMultipliersJson = "[1]", ValidSampleCount = 1 }.HasProfile.Should().BeTrue();
+    }
+}

--- a/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
+++ b/tests/NetworkOptimizer.UniFi.Tests/GatewayWanHelperTests.cs
@@ -225,4 +225,24 @@ public class GatewayWanHelperTests
     {
         GatewayWanHelper.ResolveWanName(network, port).Should().BeNull();
     }
+
+    [Theory]
+    [InlineData("Acme Fiber (WAN2)", "Acme Fiber", "WAN2")]
+    [InlineData("Yelcot Cable (wan4)", "Yelcot Cable", "WAN4")]
+    [InlineData("(WAN1)", null, "WAN1")]
+    [InlineData("Acme Fiber", "Acme Fiber", null)]
+    [InlineData("Acme (Fiber)", "Acme (Fiber)", null)]
+    [InlineData("  ", null, null)]
+    public void SplitWanLabelInProse_inverts_the_prose_form(string? label, string? name, string? token)
+    {
+        GatewayWanHelper.SplitWanLabelInProse(label).Should().Be((name, token));
+    }
+
+    [Fact]
+    public void SplitWanLabelInProse_round_trips_FormatWanLabelInProse()
+    {
+        var prose = GatewayWanHelper.FormatWanLabelInProse("Acme Fiber WAN2", 2);
+        prose.Should().Be("Acme Fiber (WAN2)");
+        GatewayWanHelper.SplitWanLabelInProse(prose).Should().Be(("Acme Fiber", "WAN2"));
+    }
 }

--- a/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
@@ -163,7 +163,8 @@ public class SqmLearningExecutorLiftTests
 
         // Cellular MaxDownload is 1.2x nominal (240); the speedtest probe sits 3% above that.
         lift.DownloadProbeMbps.Should().Be(247);
-        lift.UploadProbeMbps.Should().Be(31);
+        // Upload starts 10% above nominal so a line delivering its full 30 is not read as clipped.
+        lift.UploadProbeMbps.Should().Be(33);
         lift.RateProportionalDownloadBurst.Should().BeTrue();
     }
 
@@ -205,10 +206,24 @@ public class SqmLearningExecutorLiftTests
     }
 
     [Fact]
-    public void NextLift_RaisesByHalf_AndStopsAtTheCeiling()
+    public void NextLift_RaisesByTheDirectionsFactor_AndStopsAtTheCeiling()
     {
-        SqmLearningExecutor.NextLift(240, null).Should().Be(360);
-        SqmLearningExecutor.NextLift(240, 300).Should().Be(300);
+        SqmLearningExecutor.NextLift(240, null, SqmLearningExecutor.DownloadLiftRaiseFactor).Should().Be(360);
+        SqmLearningExecutor.NextLift(240, 300, SqmLearningExecutor.DownloadLiftRaiseFactor).Should().Be(300);
+        SqmLearningExecutor.NextLift(28, null, SqmLearningExecutor.UploadLiftRaiseFactor).Should().Be(35);
+    }
+
+    [Fact]
+    public void ALineAtNominalUpload_IsNotReadAsProbeLimited()
+    {
+        var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
+        {
+            ConnectionType = (int)ConnectionType.DocsisCable,
+            NominalDownloadMbps = 280,
+            NominalUploadMbps = 28,
+        })!;
+
+        SqmLearningExecutor.IsProbeLimited(28, lift.UploadProbeMbps).Should().BeFalse();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
@@ -56,6 +56,26 @@ public class GatewayInterfaceRateProbeTests
     }
 
     [Fact]
+    public void Parse_ReadsTheGatewayMinute()
+    {
+        GatewayInterfaceRateProbe.Parse("rx_bytes=0\ntx_bytes=0\nday=0\nhour=18\nminute=27\n")!.Minute.Should().Be(27);
+        GatewayInterfaceRateProbe.Parse("rx_bytes=0\ntx_bytes=0\nday=0\nhour=18\n")!.Minute.Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData(18, 27, true)]   // three minutes before the 18:30 probe
+    [InlineData(18, 30, true)]   // on the minute
+    [InlineData(18, 26, false)]  // four minutes out
+    [InlineData(5, 58, true)]    // two minutes before the 06:00 probe
+    [InlineData(12, 0, false)]
+    public void ScheduledProbeImminent_UsesTheSavedProbeTimes(int hour, int minute, bool expected)
+    {
+        var wan = new SqmWanConfiguration { SpeedtestMorningHour = 6, SpeedtestMorningMinute = 0, SpeedtestEveningHour = 18, SpeedtestEveningMinute = 30 };
+
+        SqmLearningExecutor.ScheduledProbeImminent(hour, minute, wan, 3).Should().Be(expected);
+    }
+
+    [Fact]
     public void Parse_TreatsAWrappedCounterAsBusy()
     {
         var reading = GatewayInterfaceRateProbe.Parse("rx_bytes=-5\ntx_bytes=10\nday=0\nhour=0\n");

--- a/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using NetworkOptimizer.Sqm.Models;
 using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services;
 using NetworkOptimizer.Web.Services.SqmLearning;
 using Xunit;
 
@@ -105,7 +106,7 @@ public class SqmLearningTaskConfigTests
         var sizing = back.ToWanConfiguration("eth4");
         sizing.Interface.Should().Be("eth4");
         sizing.NominalDownloadMbps.Should().Be(200);
-        SqmLearningExecutor.BuildLift(sizing)!.DownloadProbeMbps.Should().Be(400);
+        SqmLearningExecutor.BuildLift(sizing).Should().NotBeNull();
     }
 
     [Theory]
@@ -129,18 +130,20 @@ public class SqmLearningTaskConfigTests
 public class SqmLearningExecutorLiftTests
 {
     [Fact]
-    public void BuildLift_UsesTwiceNominal_AtLeastTheDeployProbe_AndTheBurstMode()
+    public void BuildLift_MatchesTheDeploysProbe_AndTheBurstMode()
     {
-        var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
+        var wan = new SqmWanConfiguration
         {
             ConnectionType = (int)ConnectionType.CellularHome,
             NominalDownloadMbps = 200,
             NominalUploadMbps = 30,
             RateProportionalDownloadBurst = true,
-        })!;
+        };
+        var lift = SqmLearningExecutor.BuildLift(wan)!;
 
-        lift.DownloadProbeMbps.Should().Be(400);
-        lift.UploadProbeMbps.Should().Be(60);
+        // Cellular MaxDownload is 1.2x nominal (240); the speedtest probe sits 3% above that.
+        lift.DownloadProbeMbps.Should().Be(247);
+        lift.UploadProbeMbps.Should().Be(31);
         lift.RateProportionalDownloadBurst.Should().BeTrue();
     }
 
@@ -150,17 +153,18 @@ public class SqmLearningExecutorLiftTests
         var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
         {
             ConnectionType = (int)ConnectionType.Gpon,
-            NominalDownloadMbps = 900,
-            NominalUploadMbps = 900,
+            NominalDownloadMbps = 990,
+            NominalUploadMbps = 990,
             LinkSpeedOverrideMbps = 1000,
         })!;
 
+        // GPON MaxDownload 1039 -> probe 1070, capped at 980; upload 1020 -> capped too.
         lift.DownloadProbeMbps.Should().Be(980);
         lift.UploadProbeMbps.Should().Be(980);
     }
 
     [Fact]
-    public void BuildLift_KeepsAMinimumUploadProbe()
+    public void BuildLift_KeepsUploadJustAboveNominal()
     {
         var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
         {
@@ -169,7 +173,33 @@ public class SqmLearningExecutorLiftTests
             NominalUploadMbps = 2,
         })!;
 
-        lift.UploadProbeMbps.Should().Be(10);
+        lift.UploadProbeMbps.Should().Be(3);
+    }
+
+    [Fact]
+    public void ProbeLimited_IsWithinFivePercentOfTheLift()
+    {
+        SqmLearningExecutor.IsProbeLimited(238, 247).Should().BeTrue();
+        SqmLearningExecutor.IsProbeLimited(230, 247).Should().BeFalse();
+        SqmLearningExecutor.IsProbeLimited(100, 0).Should().BeFalse();
+    }
+
+    [Fact]
+    public void NextLift_RaisesByHalf_AndStopsAtTheCeiling()
+    {
+        SqmLearningExecutor.NextLift(240, null).Should().Be(360);
+        SqmLearningExecutor.NextLift(240, 300).Should().Be(300);
+    }
+
+    [Fact]
+    public void RaiseLift_TakesTheRememberedLift_NeverAboveTheCeiling()
+    {
+        var baseLift = new SqmShaperLift(247, 31, false);
+
+        SqmLearningExecutor.RaiseLift(baseLift, 360, null, null).Should().Be(new SqmShaperLift(360, 31, false));
+        SqmLearningExecutor.RaiseLift(baseLift, 360, 50, 300).Should().Be(new SqmShaperLift(300, 50, false));
+        SqmLearningExecutor.RaiseLift(baseLift, 100, null, null).Should().Be(baseLift);
+        SqmLearningExecutor.RaiseLift(null, 360, 50, 300).Should().BeNull();
     }
 
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
@@ -95,6 +95,29 @@ public class GatewayInterfaceRateProbeTests
     }
 }
 
+public class WanIdleGateThresholdTests
+{
+    [Theory]
+    [InlineData(28, 1.0)]      // slow lines keep the 1 Mbps floor
+    [InlineData(66, 1.0)]
+    [InlineData(280, 4.2)]
+    [InlineData(1000, 15.0)]
+    [InlineData(1043, 15.645)]
+    public void IdleBar_IsOneMbps_ThenOnePointFivePercent(int nominal, double expected)
+    {
+        WanIdleGate.IdleThresholdFor(nominal).Should().BeApproximately(expected, 0.01);
+    }
+
+    [Fact]
+    public void BackgroundTrafficOnAGigabitLine_IsStillIdle()
+    {
+        var reading = new WanIdleGate.IdleReading(9.4, 14.0, "snmp");
+
+        reading.IsIdleFor(1043, 990).Should().BeTrue();
+        reading.IsIdleFor(280, 28).Should().BeFalse();
+    }
+}
+
 public class SqmLearningTaskConfigTests
 {
     [Fact]

--- a/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/SqmLearning/SqmLearningPiecesTests.cs
@@ -1,0 +1,181 @@
+using FluentAssertions;
+using NetworkOptimizer.Sqm.Models;
+using NetworkOptimizer.Storage.Models;
+using NetworkOptimizer.Web.Services.SqmLearning;
+using Xunit;
+
+namespace NetworkOptimizer.Web.Tests.SqmLearning;
+
+public class GatewayInterfaceRateProbeTests
+{
+    [Fact]
+    public void BuildCommand_SamplesCountersAndReportsLocalTime()
+    {
+        var cmd = GatewayInterfaceRateProbe.BuildCommand("eth4");
+
+        cmd.Should().Contain("/sys/class/net/eth4/statistics/rx_bytes");
+        cmd.Should().Contain($"sleep {GatewayInterfaceRateProbe.WindowSeconds}");
+        cmd.Should().Contain("date +%u");
+        cmd.Should().Contain("date +%-H");
+        // The pgrep pattern must not match the probe's own command line.
+        cmd.Should().Contain("pgrep -f -- '[-]speedtest\\.sh'");
+    }
+
+    [Theory]
+    [InlineData("eth4; reboot")]
+    [InlineData("../etc")]
+    public void BuildCommand_RejectsUnsafeInterface(string iface)
+    {
+        var act = () => GatewayInterfaceRateProbe.BuildCommand(iface);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Parse_ConvertsBytesOverTheWindowToMbps()
+    {
+        // 375,000 bytes over 3 s = 1 Mbps exactly.
+        var reading = GatewayInterfaceRateProbe.Parse("rx_bytes=375000\ntx_bytes=0\nday=1\nhour=9\npresent=1\nsqm_speedtest=0\n");
+
+        reading.Should().NotBeNull();
+        reading!.DownloadMbps.Should().BeApproximately(1.0, 0.0001);
+        reading.UploadMbps.Should().Be(0);
+        reading.DayOfWeek.Should().Be(1);
+        reading.Hour.Should().Be(9);
+        reading.InterfacePresent.Should().BeTrue();
+        reading.SqmSpeedtestRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Parse_FlagsRunningSpeedtestAndMissingInterface()
+    {
+        var reading = GatewayInterfaceRateProbe.Parse("rx_bytes=0\ntx_bytes=0\nday=6\nhour=23\npresent=0\nsqm_speedtest=1\n");
+
+        reading!.InterfacePresent.Should().BeFalse();
+        reading.SqmSpeedtestRunning.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Parse_TreatsAWrappedCounterAsBusy()
+    {
+        var reading = GatewayInterfaceRateProbe.Parse("rx_bytes=-5\ntx_bytes=10\nday=0\nhour=0\n");
+
+        reading!.DownloadMbps.Should().Be(double.MaxValue);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("garbage")]
+    [InlineData("rx_bytes=1\ntx_bytes=1\nday=7\nhour=0")]
+    [InlineData("rx_bytes=1\ntx_bytes=1\nday=0\nhour=24")]
+    public void Parse_RejectsMalformedOutput(string? output)
+    {
+        GatewayInterfaceRateProbe.Parse(output).Should().BeNull();
+    }
+}
+
+public class SqmLearningTaskConfigTests
+{
+    [Fact]
+    public void RoundTrips_AsCamelCaseJson()
+    {
+        var endsAt = new DateTime(2026, 9, 14, 12, 0, 0, DateTimeKind.Utc);
+        var cfg = new SqmLearningTaskConfig
+        {
+            WanNumber = 2, WanName = "Cell", WanGroup = "WAN2", ConnectionType = 5, EndsAt = endsAt, DurationSeconds = 4,
+            NominalDownloadMbps = 200, NominalUploadMbps = 30, LinkSpeedOverrideMbps = 1000, RateProportionalDownloadBurst = true,
+        };
+
+        var json = cfg.ToJson();
+        json.Should().Contain("\"wanNumber\":2").And.Contain("\"wanGroup\":\"WAN2\"").And.Contain("\"endsAt\"");
+
+        var back = SqmLearningTaskConfig.Parse(json)!;
+        back.WanNumber.Should().Be(2);
+        back.WanName.Should().Be("Cell");
+        back.WanGroup.Should().Be("WAN2");
+        back.ConnectionType.Should().Be(5);
+        back.EndsAt.Should().Be(endsAt);
+        back.EndsAt.Kind.Should().Be(DateTimeKind.Utc);
+        back.DurationSeconds.Should().Be(4);
+        back.NominalDownloadMbps.Should().Be(200);
+        back.NominalUploadMbps.Should().Be(30);
+        back.LinkSpeedOverrideMbps.Should().Be(1000);
+        back.RateProportionalDownloadBurst.Should().BeTrue();
+
+        var sizing = back.ToWanConfiguration("eth4");
+        sizing.Interface.Should().Be("eth4");
+        sizing.NominalDownloadMbps.Should().Be(200);
+        SqmLearningExecutor.BuildLift(sizing)!.DownloadProbeMbps.Should().Be(400);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json")]
+    [InlineData("{\"wanNumber\":0}")]
+    public void Parse_RejectsMissingOrUnusableConfig(string? json)
+    {
+        SqmLearningTaskConfig.Parse(json).Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_DefaultsAMissingDuration()
+    {
+        SqmLearningTaskConfig.Parse("{\"wanNumber\":1,\"endsAt\":\"2026-09-14T12:00:00Z\"}")!
+            .DurationSeconds.Should().Be(SqmLearningTaskConfig.DefaultDurationSeconds);
+    }
+}
+
+public class SqmLearningExecutorLiftTests
+{
+    [Fact]
+    public void BuildLift_UsesTwiceNominal_AtLeastTheDeployProbe_AndTheBurstMode()
+    {
+        var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
+        {
+            ConnectionType = (int)ConnectionType.CellularHome,
+            NominalDownloadMbps = 200,
+            NominalUploadMbps = 30,
+            RateProportionalDownloadBurst = true,
+        })!;
+
+        lift.DownloadProbeMbps.Should().Be(400);
+        lift.UploadProbeMbps.Should().Be(60);
+        lift.RateProportionalDownloadBurst.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildLift_NeverExceedsTheLinkCeiling()
+    {
+        var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
+        {
+            ConnectionType = (int)ConnectionType.Gpon,
+            NominalDownloadMbps = 900,
+            NominalUploadMbps = 900,
+            LinkSpeedOverrideMbps = 1000,
+        })!;
+
+        lift.DownloadProbeMbps.Should().Be(980);
+        lift.UploadProbeMbps.Should().Be(980);
+    }
+
+    [Fact]
+    public void BuildLift_KeepsAMinimumUploadProbe()
+    {
+        var lift = SqmLearningExecutor.BuildLift(new SqmWanConfiguration
+        {
+            ConnectionType = (int)ConnectionType.Dsl,
+            NominalDownloadMbps = 50,
+            NominalUploadMbps = 2,
+        })!;
+
+        lift.UploadProbeMbps.Should().Be(10);
+    }
+
+    [Fact]
+    public void BuildLift_IsNullWithoutAConfigurationToSizeFrom()
+    {
+        SqmLearningExecutor.BuildLift(null).Should().BeNull();
+        SqmLearningExecutor.BuildLift(new SqmWanConfiguration { NominalDownloadMbps = 0 }).Should().BeNull();
+    }
+}

--- a/tests/NetworkOptimizer.Web.Tests/WanSteerDeploymentServiceTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/WanSteerDeploymentServiceTests.cs
@@ -138,21 +138,21 @@ public class WanSteerDeploymentServiceTests
                 "32505:	from all fwmark 0x21960000/0x3ffe0000 lookup 202.eth0",
                 "32506:	from all iif eth1 goto 32508",
                 "32507:	from all fwmark 0x216e0000/0x3ffe0000 lookup 182.eth1",
-                "32508:	from all iif eth6.228 goto 32510",
-                "32509:	from all fwmark 0x21940000/0x3ffe0000 lookup 201.eth6.228",
+                "32508:	from all iif eth6.100 goto 32510",
+                "32509:	from all fwmark 0x21940000/0x3ffe0000 lookup 201.eth6.100",
                 "32510:	from all iif gre1 goto 32512",
                 "32511:	from all fwmark 0x216a0000/0x3ffe0000 lookup 180.gre1",
                 "32520:	from 192.0.2.10 lookup 202.eth0",
-                "32766:	from all lookup 201.eth6.228",
+                "32766:	from all lookup 201.eth6.100",
                 "32767:	from all lookup default");
 
             var result = WanSteerDeploymentService.ParseIpRules(output);
 
-            result.Should().ContainKeys("eth0", "eth1", "eth6.228", "gre1");
+            result.Should().ContainKeys("eth0", "eth1", "eth6.100", "gre1");
             result["eth1"].FWMark.Should().Be("0x216e0000");
             result["eth1"].FWMask.Should().Be("0x3ffe0000");
             result["eth1"].RouteTable.Should().Be("182.eth1");
-            result["eth6.228"].FWMark.Should().Be("0x21940000");
+            result["eth6.100"].FWMark.Should().Be("0x21940000");
         }
     }
 


### PR DESCRIPTION
Adaptive SQM learns a WAN's real weekly congestion pattern instead of assuming the connection type's curve, and can shape upload dynamically on shared media. Closes the learning-mode half of #247.

## Adaptive SQM

### Congestion Profile Learning

- **Start Learning** on a WAN card creates a one-time, hourly schedule for 7 days. Each hour, once the WAN has been idle (each direction under 1 Mbps or 1.5% of its nominal speed, whichever is larger, on its monitored SNMP counter interface, or the gateway's own counters when Monitoring is off), the gateway runs the standard WAN speed test on that WAN's data-path interface for 4 s per direction with 10 streams. A busy link retries every 10 minutes within the hour; a running or imminent (within 3 minutes of its saved time) Adaptive SQM speed test defers it. A deferred check is recorded as Waiting with the reason, never as a successful run.
- **Samples measure the line, not the shaper, without letting bufferbloat loose.** The shaper is set to the deploy's own probe rate (3% above the highest shaping rate; upload 10% above nominal) around the test and restored from an EXIT trap in the same SSH session. A sample landing within 5% of its lift is recorded as probe-limited: it still shapes the curve but never sets the peak, and the next sample lifts higher (1.5x download, 1.25x upload) up to the link ceiling. None of this surfaces on the card; the user only sees clean sample figures.
- **The shaper and the sample never fight.** A sample holds a per-interface lock; the generated ping script stands down while a fresh lock exists and the speed test script waits for it to clear (both stale-safe at 2 minutes). The deployment status sweep counts ping scripts from before the lock existed, and the card asks for a redeploy until they have it.
- **Errant samples are discarded, not averaged in.** A reading below 45% or above 180% of the median for that hour of day is excluded with a reason kept on the sample. The curve is then smoothed over the hour-of-week ring (own hour, the neighbouring hours of the same day, and the same hour on the other days), so one bad reading cannot carve a hole while a real nightly dip survives. Extra samples in an hour are averaged in with weight. The best smoothed unclipped hour becomes the peak the curve is relative to.
- The card sits directly under **Congestion Schedule** and shows day-of-7, valid samples, the last sample, the next check, three plain-language lines (**So far**: the range seen; **Slowest**: the slowest band of the week and how far below the best hour it sits; **vs default**: whether the dips run deeper, shallower, or about the same as the connection type's curve, the last two after two days of samples), an hour-of-day strip for download and upload with a per-hour tooltip, and the last problem, with **Run Sample Now**, **Stop Learning**, **Relearn**, **Clear**, and **Export JSON**. Estimated data use per sample and per week is shown before starting.
- **Profile** (Default / Learned) in **Congestion Schedule** picks which curve deploys. A learned curve is scaled to the nominal speeds; a hint offers **Use learned peaks as nominal** when they differ. **Severity** scales a learned curve the same way it scales the default one, and the twice-daily probes calibrate against it exactly as before.

### Upload Strength

- New **Upload Strength** slider (0 to 1) and **Upload Range** in **Congestion Schedule**, shown for Fixed LTE/5G, Starlink, and Fixed Wireless (WISP). It applies the congestion schedule to the upload rate, never below half of nominal upload, and the ping loop cuts upload in the same proportion as download when latency rises. Defaults to 0.5 on those media for new configurations; existing configurations stay at 0 (upload static at nominal) until changed. Fiber, DOCSIS, and DSL stay static.
- The **Larger download burst** checkbox now uses the common form checkbox style.

## Alerts & Schedule - Schedule

- New **Adaptive SQM Learning** section listing each learning run with its WAN (group tag plus the connection name), end time, last check, summary, and next check, plus **Run Now**, **Open Adaptive SQM**, and **Remove**. Remove goes through the learning service: it stops the run and takes the schedule off the tab, keeping the samples and profile. It appears only while a run exists; ended runs stay listed as Ended until removed. Status badges across the tab are capitalized (Success, Waiting, Failed).

## Guided tour

- `2.8.2.json`: **Congestion Profile Learning** (major) and **Upload Strength** (minor, improved), both gated on `sqm-enabled`.

## Behind the scenes

- Learning samples are ephemeral gateway test runs: not stored as WAN speed test results, no speed-degradation alerts, no path analysis, and the WAN Speed Test page's last result is left alone. Sample failures alert on the third in a row and then daily, not hourly.
- New tables `SqmCongestionProfiles` and `SqmLearningSamples`; two new columns on `SqmWanConfigurations` (`UploadCongestionSeverity` default 0, `UseLearnedProfile` default false); a second migration adds the probe-limit columns.
- With Upload Strength at 0 and the default profile, the generated gateway scripts differ from before only by the probe-lock guard and wait (tested: no upload schedule is emitted). The gateway test's signature only gains an optional options parameter; the schedule loop's existing task types are untouched.
- `ISqmLearningService` is a site-scoped gated service (reads Viewer, start/stop/run/clear Operator, all audited).

## Not in this PR

- Importing a shared profile (export ships; import later).
- Continued low-frequency learning after the 7 days.


