### PR TITLE
v2.8.3 Release Changes

### DIFF
--- a/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
+++ b/src/NetworkOptimizer.Alerts/DefaultAlertRules.cs
@@ -672,6 +672,17 @@ public static class DefaultAlertRules
         },
         new AlertRule
         {
+            // The console refused the channel the plan needs and offers another channel's build,
+            // so the UniFi OS step declined rather than install a build nobody chose.
+            Name = "Firmware Rollout: UniFi OS Update Refused",
+            IsEnabled = true,
+            EventTypePattern = "rollout.unifi_os_update_refused",
+            Source = "rollout",
+            MinSeverity = AlertSeverity.Warning,
+            CooldownSeconds = 0
+        },
+        new AlertRule
+        {
             Name = "Firmware Rollout: Heavier After Upgrade",
             IsEnabled = true,
             EventTypePattern = "rollout.resource_regression",

--- a/src/NetworkOptimizer.UniFi/Models/UniFiConsoleSystemInfo.cs
+++ b/src/NetworkOptimizer.UniFi/Models/UniFiConsoleSystemInfo.cs
@@ -124,6 +124,18 @@ public class UniFiConsoleController
     public UniFiConsoleControllerRollback? Rollback { get; set; }
 
     /// <summary>
+    /// The console's own install state for this application. "updateFailed" is the only word
+    /// the console says when an update it accepted died before installing anything; the version
+    /// and updateAvailable read exactly as before the attempt.
+    /// </summary>
+    [JsonPropertyName("installState")]
+    public string? InstallState { get; set; }
+
+    /// <summary>Whether the console reports the last update attempt as failed.</summary>
+    [JsonIgnore]
+    public bool UpdateFailed => string.Equals(InstallState, "updateFailed", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// This application's own auto-update schedule. Separate from the console's
     /// firmware.autoUpdate.includeApplications rider, and set independently of it, so an
     /// application can update itself while that rider reads false.

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1043,7 +1043,7 @@
             {
                 @* ===== DATA TAB ===== *@
                 <div class="tab-pane" data-tour="client-data">
-                    @if (!_tabLoading && (_dataUsage == null || (_dataUsage.Wan.Count == 0 && _dataUsage.Lan.Count == 0)))
+                    @if (!_tabLoading && !_dataUsageLoading && (_dataUsage == null || (_dataUsage.Wan.Count == 0 && _dataUsage.Lan.Count == 0)))
                     {
                         <div class="empty-state">
                             <p>No usage recorded for this time range.</p>
@@ -1053,7 +1053,7 @@
                     {
                         @* While loading, the figures stay in the layout but hidden, so the cards keep
                            their height on every breakpoint and the spinner sits over them. *@
-                        var usageLoading = _tabLoading || _dataUsage == null;
+                        var usageLoading = _tabLoading || _dataUsageLoading || _dataUsage == null;
                         var u = _dataUsage ?? new ClientDataUsage();
                         <div class="usage-grid">
                             <div class="card results-card usage-card @(_usageView == "wan" ? "is-active" : "")" @onclick="@(() => SetUsageViewAsync("wan"))">
@@ -1261,6 +1261,8 @@
     private ClientDataUsage? _dataUsage;
     // The range the totals and chart series belong to.
     private int? _dataUsageFilter;
+    private int _dataUsageGeneration;
+    private bool _dataUsageLoading;
     private IReadOnlyList<AppUsageRow> _appUsage = Array.Empty<AppUsageRow>();
     private bool _appLoading;
     // The range the rows on screen belong to; a different range clears them before its own load.
@@ -2425,7 +2427,7 @@
                     // console and the store for days at a time.
                     // Not while a tab switch is already loading it: two loads at once is how the
                     // first visit's chart came up empty.
-                    "data" => !_tabLoading && DateTime.UtcNow - _dataLoadedAt >= (_selectedTimeFilter is > 0 and <= 24
+                    "data" => !_tabLoading && !_dataUsageLoading && DateTime.UtcNow - _dataLoadedAt >= (_selectedTimeFilter is > 0 and <= 24
                         ? TimeSpan.FromSeconds(30) : TimeSpan.FromMinutes(5)),
                     _ => true,
                 };
@@ -2551,6 +2553,7 @@
     private async Task LoadDataUsageAsync(DateTime from, DateTime to)
     {
         if (_client == null) return;
+        var generation = ++_dataUsageGeneration;
         // A range changed on another tab: drop the old totals so the chart is not created from
         // their series while this loads (the tab-switch path never updates a chart it created).
         if (_dataUsageFilter != _selectedTimeFilter)
@@ -2558,25 +2561,36 @@
             _dataUsage = null;
             _dataUsageFilter = _selectedTimeFilter;
         }
+        _dataUsageLoading = true;
         // Started first so the Applications report loads alongside the totals, not after them.
         _ = LoadAppUsageAsync(from, to);
-        // Fetch the totals first and publish in one go: a render between the totals landing and
-        // the series being built created the chart empty, and the tab-switch path never updates a
-        // chart after creating it.
-        var usage = await DashboardService.GetDataUsageAsync(_client, from, to);
-        static List<SpeedChartPoint> Series(IReadOnlyList<UsageBucket> rows, Func<UsageBucket, long> pick, string name) =>
-            rows.Select(r => new SpeedChartPoint(r.Time, pick(r), name)).ToList();
-        _wanDownData = Series(usage.Wan, r => r.DownloadBytes, "download");
-        _wanUpData = Series(usage.Wan, r => r.UploadBytes, "upload");
-        _lanDownData = Series(usage.Lan, r => r.DownloadBytes, "download");
-        _lanUpData = Series(usage.Lan, r => r.UploadBytes, "upload");
-        _dataUsage = usage;
-        _dataLoadedAt = DateTime.UtcNow;
-        // A day bar is a date; a time on it only says which midnight the day began at.
-        _usageChartOptions.Tooltip!.X!.Format = usage.Bucket >= TimeSpan.FromDays(1) ? "MMM dd" : "MMM dd, HH:mm";
-        // Keep the user's pick unless that side has nothing to plot.
-        if (_usageView == "wan" && _dataUsage.Wan.Count == 0 && _dataUsage.Lan.Count > 0) _usageView = "lan";
-        else if (_usageView == "lan" && _dataUsage.Lan.Count == 0 && _dataUsage.Wan.Count > 0) _usageView = "wan";
+        try
+        {
+            // Fetch the totals first and publish in one go: a render between the totals landing and
+            // the series being built created the chart empty, and the tab-switch path never updates a
+            // chart after creating it.
+            var usage = await DashboardService.GetDataUsageAsync(_client, from, to);
+            // Only the newest request may publish, so a slow earlier range cannot overwrite a later one.
+            if (generation != _dataUsageGeneration) return;
+            static List<SpeedChartPoint> Series(IReadOnlyList<UsageBucket> rows, Func<UsageBucket, long> pick, string name) =>
+                rows.Select(r => new SpeedChartPoint(r.Time, pick(r), name)).ToList();
+            _wanDownData = Series(usage.Wan, r => r.DownloadBytes, "download");
+            _wanUpData = Series(usage.Wan, r => r.UploadBytes, "upload");
+            _lanDownData = Series(usage.Lan, r => r.DownloadBytes, "download");
+            _lanUpData = Series(usage.Lan, r => r.UploadBytes, "upload");
+            _dataUsage = usage;
+            _dataLoadedAt = DateTime.UtcNow;
+            // A day bar is a date; a time on it only says which midnight the day began at.
+            _usageChartOptions.Tooltip!.X!.Format = usage.Bucket >= TimeSpan.FromDays(1) ? "MMM dd" : "MMM dd, HH:mm";
+            // Keep the user's pick unless that side has nothing to plot.
+            if (_usageView == "wan" && _dataUsage.Wan.Count == 0 && _dataUsage.Lan.Count > 0) _usageView = "lan";
+            else if (_usageView == "lan" && _dataUsage.Lan.Count == 0 && _dataUsage.Wan.Count > 0) _usageView = "wan";
+        }
+        finally
+        {
+            // A superseded load leaves the flag to the one that replaced it.
+            if (generation == _dataUsageGeneration) _dataUsageLoading = false;
+        }
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
+++ b/src/NetworkOptimizer.Web/Components/Pages/ClientDashboard.razor
@@ -1259,6 +1259,8 @@
     private ApexChartOptions<SpeedChartPoint> _latencyChartOptions = new();
     // Data tab
     private ClientDataUsage? _dataUsage;
+    // The range the totals and chart series belong to.
+    private int? _dataUsageFilter;
     private IReadOnlyList<AppUsageRow> _appUsage = Array.Empty<AppUsageRow>();
     private bool _appLoading;
     // The range the rows on screen belong to; a different range clears them before its own load.
@@ -2549,6 +2551,13 @@
     private async Task LoadDataUsageAsync(DateTime from, DateTime to)
     {
         if (_client == null) return;
+        // A range changed on another tab: drop the old totals so the chart is not created from
+        // their series while this loads (the tab-switch path never updates a chart it created).
+        if (_dataUsageFilter != _selectedTimeFilter)
+        {
+            _dataUsage = null;
+            _dataUsageFilter = _selectedTimeFilter;
+        }
         // Started first so the Applications report loads alongside the totals, not after them.
         _ = LoadAppUsageAsync(from, to);
         // Fetch the totals first and publish in one go: a render between the totals landing and

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -1414,12 +1414,32 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         }
 
         // The channel decides which build is on offer, so it goes on before the offer is read.
-        await ApplyUniFiOsChannelAsync(plan, document, console, cancellationToken);
+        var channelInForce = await ApplyUniFiOsChannelAsync(plan, document, console, cancellationToken);
 
         var pending = await _commands.GetPendingUniFiOsUpdateAsync(cancellationToken);
         var installedOs = (await _commands.GetConsoleSystemInfoAsync(cancellationToken))?.InstalledOsVersion;
 
+        // A console that refused the channel switch offers whichever build its own channel
+        // carries. Only the build the plan captured may go through the API then; anything else
+        // is another channel's release, and installing it would put the console on a track
+        // nobody chose. Version match, not "newer": a beta on offer is newer than the planned RC.
+        var offerIsPlanned = channelInForce
+            || NetworkOptimizer.Core.Helpers.FirmwareVersionFormat.SameBuild(pending?.Version, document.UniFiOsUpdate.TargetVersion);
+        if (pending?.Version != null && !offerIsPlanned)
+        {
+            _logger.LogError(
+                "Declining the UniFi OS update on site {Site}: the console would not take the planned channel and offers {Offered}, not the planned {Planned}",
+                _siteSlug, pending.Version, document.UniFiOsUpdate.TargetVersion ?? "build");
+            await PublishAsync(
+                RolloutAlerts.UniFiOsUpdateRefused,
+                AlertSeverity.Warning,
+                $"UniFi OS Update Declined{_siteSuffix}",
+                $"The Console would not switch to the planned UniFi OS channel and is offering {ShortVersion(pending.Version) ?? pending.Version} instead of the planned {ShortVersion(document.UniFiOsUpdate.TargetVersion) ?? "build"}. It was not installed.",
+                document.ConsoleMac, document.ConsoleName, cancellationToken);
+        }
+
         var apiPathAvailable = pending?.Version != null
+            && offerIsPlanned
             && !string.IsNullOrWhiteSpace(installedOs)
             && NetworkOptimizer.Core.Helpers.FirmwareVersionFormat.IsNewer(pending.Version, installedOs);
 
@@ -1481,7 +1501,7 @@ public class FirmwareRolloutOrchestrator : BackgroundService
                 "SSH UniFi OS update also failed on site {Site}: {Reason}", _siteSlug, ssh.Message);
         }
 
-        var outcome = apiPathAvailable ? "refused" : "nothing-to-update";
+        var outcome = apiPathAvailable || (pending?.Version != null && !offerIsPlanned) ? "refused" : "nothing-to-update";
         await SettleUniFiOsAsync(plan, document, outcome, cancellationToken);
         return true;
     }
@@ -2787,29 +2807,33 @@ public class FirmwareRolloutOrchestrator : BackgroundService
     /// Puts the console's UniFi OS on the channel this rollout wants, before the pending build is
     /// read. Cloud Gateways only - the caller has already refused a self-hosted console.
     /// </summary>
-    private async Task ApplyUniFiOsChannelAsync(
+    /// <summary>
+    /// Puts the plan's UniFi OS channel in force on the console. False only when the console
+    /// refused the switch: it is then offering its own channel's build, not the plan's.
+    /// </summary>
+    private async Task<bool> ApplyUniFiOsChannelAsync(
         FirmwareRolloutPlan plan,
         RolloutPlanDocument document,
         UniFiConsoleSystemInfo? console,
         CancellationToken cancellationToken)
     {
         if (document.ConsoleChannels.UniFiOsChannel != null)
-            return;
+            return true;
 
         var settings = await _repositories.UseAsync((r, c) => r.GetSettingsAsync(c), cancellationToken);
         var channel = settings.EffectiveUniFiOsChannel;
         if (string.IsNullOrWhiteSpace(channel))
-            return;
+            return true;
 
         var current = console?.Firmware?.ReleaseChannel;
         if (RolloutChannelManager.AlreadyOn(current, channel))
-            return;
+            return true;
 
         if (string.IsNullOrWhiteSpace(current))
         {
             _logger.LogWarning(
                 "Leaving the UniFi OS channel alone on site {Site}: the console does not report the one it is on", _siteSlug);
-            return;
+            return true;
         }
 
         plan.OriginalChannelSettingsJson = await _channels.CaptureAsync(
@@ -2817,10 +2841,11 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         await PersistDocumentAsync(plan, document, cancellationToken);
 
         if (!await _channels.ApplyUniFiOsChannelAsync(channel, console, cancellationToken))
-            return;
+            return false;
 
         document.ConsoleChannels.UniFiOsChannel = channel;
         await PersistDocumentAsync(plan, document, cancellationToken);
+        return true;
     }
 
     private async Task RestoreChannelsAsync(FirmwareRolloutPlan plan, CancellationToken cancellationToken)

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutOrchestrator.cs
@@ -82,9 +82,9 @@ public class FirmwareRolloutOrchestrator : BackgroundService
 
     /// <summary>
     /// How long the UniFi Network application gets to restart into its new build. Past this the
-    /// rollout stops waiting and upgrades devices anyway.
+    /// rollout retries over SSH once, on a fresh budget, and then upgrades devices anyway.
     /// </summary>
-    public static readonly TimeSpan NetworkAppUpdateBudget = TimeSpan.FromMinutes(15);
+    public static readonly TimeSpan NetworkAppUpdateBudget = TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// No Network-app judgment before this much has passed since the trigger: the application
@@ -1154,11 +1154,17 @@ public class FirmwareRolloutOrchestrator : BackgroundService
         if (ElapsedReachable(triggeredAt) < NetworkAppJudgeDelay)
             return false;
 
+        string? installed = null;
+        var standalone = false;
+        var failed = false;
         if (!consoleDark)
         {
             // Answering is not updated: the app downloads its build and keeps answering on the old
             // version until the restart, so the reported version decides where it can be read.
-            var installed = (await _commands.GetConsoleSystemInfoAsync(cancellationToken))?.NetworkApplication?.Version;
+            var console = await _commands.GetConsoleSystemInfoAsync(cancellationToken);
+            installed = console?.NetworkApplication?.Version;
+            standalone = console?.IsStandaloneConsole == true;
+            failed = console?.NetworkApplication?.UpdateFailed == true;
             var verifiable = !string.IsNullOrWhiteSpace(installed) && !string.IsNullOrWhiteSpace(state.TargetVersion);
             if (!verifiable
                 || NetworkOptimizer.Core.Helpers.FirmwareVersionFormat.SameBuild(installed, state.TargetVersion)
@@ -1174,24 +1180,73 @@ public class FirmwareRolloutOrchestrator : BackgroundService
             }
         }
 
-        if (ElapsedReachable(triggeredAt) < NetworkAppUpdateBudget)
+        // A console that says the install failed has nothing left to wait for; otherwise the
+        // budget decides, because a console that is quietly mid-install reads the same as one
+        // that already gave up.
+        if (!failed && ElapsedReachable(triggeredAt) < NetworkAppUpdateBudget)
+            return false;
+
+        if (!consoleDark && await RetryNetworkAppOverSshAsync(plan, document, installed, standalone, failed, cancellationToken))
             return false;
 
         state.Settled = true;
         state.Outcome = "stuck";
         await PersistDocumentAsync(plan, document, cancellationToken);
 
+        var retried = state.SshRetriedAt != null ? " and an SSH retry did not finish either" : string.Empty;
         await PublishAsync(
             RolloutAlerts.NetworkAppUpdateStuck,
             AlertSeverity.Warning,
             $"UniFi Network Application Not Back{_siteSuffix}",
-            $"The UniFi Network application update has not finished after {NetworkAppUpdateBudget.TotalMinutes:0} minutes. The device upgrades are going ahead anyway.",
+            $"The UniFi Network application update has not finished after {NetworkAppUpdateBudget.TotalMinutes:0} minutes{retried}. The device upgrades are going ahead anyway.",
             null, null, cancellationToken);
 
         _logger.LogError(
             "The UniFi Network application on site {Site} has not finished its update within {Budget}; upgrading devices anyway",
             _siteSlug, NetworkAppUpdateBudget);
         return true;
+    }
+
+    /// <summary>
+    /// The console accepted the Network app command and the install died inside it: either it says
+    /// so (installState "updateFailed"; a Cloud Gateway aborts when its apt refresh fails and
+    /// keeps the old build), or it is still answering on the old build past the budget. One retry
+    /// over SSH with the package the plan captured, on a fresh budget. False when there is nothing
+    /// to retry with, or the retry was refused.
+    /// </summary>
+    private async Task<bool> RetryNetworkAppOverSshAsync(
+        FirmwareRolloutPlan plan, RolloutPlanDocument document, string? installed, bool standalone, bool failed,
+        CancellationToken cancellationToken)
+    {
+        var state = document.NetworkAppUpdate;
+        if (state.SshRetriedAt != null
+            || standalone
+            || string.IsNullOrWhiteSpace(state.Url)
+            || string.IsNullOrWhiteSpace(installed)
+            || string.IsNullOrWhiteSpace(state.TargetVersion)
+            || !NetworkOptimizer.Core.Helpers.FirmwareVersionFormat.IsNewer(state.TargetVersion, installed))
+            return false;
+
+        _logger.LogWarning(
+            "The console on site {Site} took the Network app update but {Why}; retrying over SSH ({Url})",
+            _siteSlug,
+            failed ? "reports the install failed" : $"is still on {installed} after {NetworkAppUpdateBudget}",
+            state.Url);
+
+        var ssh = await _commands.TriggerSshNetworkAppUpdateAsync(state.Url, cancellationToken);
+        state.SshRetriedAt = Now;
+        if (ssh.IsOk)
+            state.TriggeredAt = Now;
+        await PersistDocumentAsync(plan, document, cancellationToken);
+
+        if (ssh.IsOk)
+        {
+            _logger.LogInformation("SSH Network app update accepted on site {Site}", _siteSlug);
+            return true;
+        }
+
+        _logger.LogWarning("SSH Network app update also failed on site {Site}: {Reason}", _siteSlug, ssh.Message);
+        return false;
     }
 
     /// <summary>

--- a/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/FirmwareRolloutPlanningModels.cs
@@ -523,6 +523,12 @@ public class RolloutConsoleStepState
     /// <summary>Direct download URL for the SSH fallback path, captured at plan time.</summary>
     public string? Url { get; set; }
 
+    /// <summary>
+    /// When the SSH retry ran because the console took the command and never installed it.
+    /// Null until then; it runs once.
+    /// </summary>
+    public DateTime? SshRetriedAt { get; set; }
+
     /// <summary>Resource stats captured before the update was triggered.</summary>
     public string? PreStatsJson { get; set; }
 

--- a/src/NetworkOptimizer.Web/Services/Firmware/RolloutAlerts.cs
+++ b/src/NetworkOptimizer.Web/Services/Firmware/RolloutAlerts.cs
@@ -45,6 +45,12 @@ public static class RolloutAlerts
     /// </summary>
     public const string NetworkAppUpdateStuck = "rollout.network_app_update_stuck";
 
+    /// <summary>
+    /// The console would not take the UniFi OS channel the plan needs, and the build it offers
+    /// instead is another channel's. Nothing is installed through the API in that state.
+    /// </summary>
+    public const string UniFiOsUpdateRefused = "rollout.unifi_os_update_refused";
+
     /// <summary>A device's CPU or memory use moved appreciably up after the upgrade.</summary>
     public const string ResourceRegression = "rollout.resource_regression";
 

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleChannelTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleChannelTests.cs
@@ -166,6 +166,75 @@ public class RolloutConsoleChannelTests
         OriginalChannelSettings.Parse(stored!.OriginalChannelSettingsJson)!.UniFiOsChannel.Should().Be("release");
     }
 
+    /// <summary>
+    /// A console on beta whose plan wants release-candidate. Whether the offer is taken must
+    /// depend on the switch going through, not on what happens to be on offer afterwards.
+    /// </summary>
+    private static async Task<FirmwareRolloutPlan> SeedRefusedChannelPlanAsync(
+        RolloutHarness harness, string plannedOs, string offeredOs, string? plannedUrl = null)
+    {
+        harness.Commands.ConsoleInfo = Console(osChannel: "beta");
+        harness.Commands.ConsoleChannelsAccepted = false;
+        harness.Commands.PendingUniFiOs = new UniFiConsoleFirmwareRelease { Version = offeredOs };
+        await harness.WithSettingsAsync(s => s.GlobalChannel = FirmwareChannels.ReleaseCandidate);
+        var document = UniFiOsPlan();
+        document.UniFiOsUpdate.TargetVersion = plannedOs;
+        document.UniFiOsUpdate.Url = plannedUrl;
+        var plan = await harness.SeedRunningPlanAsync(document, Step(ApMac));
+        harness.Observer.Set(ApMac, Online, FromVersion, upgradeTo: ToVersion);
+        return plan;
+    }
+
+    [Fact]
+    public async Task ARefusedChannelSwitch_DoesNotInstallAnotherChannelsBuild()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await SeedRefusedChannelPlanAsync(harness, plannedOs: "v4.3.6+abc1234", offeredOs: "v5.0.0+def5678");
+
+        await harness.TickAsync();
+        await RunDeviceToLitmusAsync(harness, ApMac);
+
+        // The first write is the switch; a later one is the completed plan putting beta back.
+        harness.Commands.ConsoleChannelWrites.First().UniFiOs.Should().Be(FirmwareChannels.ReleaseCandidate);
+        harness.Commands.UniFiOsUpdateCalls.Should().Be(0, "the offer is the beta build, not the planned one");
+        harness.Commands.Calls.Should().NotContain("ssh-unifi-os-update", "the plan captured no image to fall back to");
+        var stored = Stored((await harness.PlanAsync(plan.Id))!);
+        stored.UniFiOsUpdate.Outcome.Should().Be("refused");
+        stored.ConsoleChannels.UniFiOsChannel.Should().BeNull("a refused switch is not one this rollout put in force");
+        harness.Bus.Published.Should().Contain(e => e.EventType == RolloutAlerts.UniFiOsUpdateRefused);
+    }
+
+    [Fact]
+    public async Task ARefusedChannelSwitch_FallsBackToThePlannedImageOverSsh()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await SeedRefusedChannelPlanAsync(
+            harness, plannedOs: "v4.3.6+abc1234", offeredOs: "v5.0.0+def5678", plannedUrl: "https://example.test/os-4.3.6.bin");
+
+        await harness.TickAsync();
+        await RunDeviceToLitmusAsync(harness, ApMac);
+
+        harness.Commands.UniFiOsUpdateCalls.Should().Be(0);
+        harness.Commands.Calls.Should().Contain("ssh-unifi-os-update");
+        Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate.Triggered.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task ARefusedChannelSwitch_StillInstallsWhenTheOfferIsThePlannedBuild()
+    {
+        using var harness = new RolloutHarness();
+        // Catalog shapes on both sides: the same build carries the same hash, and a comparison
+        // that trips on the hash would refuse the very build the plan chose.
+        var plan = await SeedRefusedChannelPlanAsync(harness, plannedOs: "v4.3.6+abc1234", offeredOs: "v4.3.6+abc1234");
+
+        await harness.TickAsync();
+        await RunDeviceToLitmusAsync(harness, ApMac);
+
+        harness.Commands.UniFiOsUpdateCalls.Should().Be(1, "the console is offering exactly the build the plan captured");
+        harness.Bus.Published.Should().NotContain(e => e.EventType == RolloutAlerts.UniFiOsUpdateRefused);
+        Stored((await harness.PlanAsync(plan.Id))!).UniFiOsUpdate.Triggered.Should().BeTrue();
+    }
+
     [Fact]
     public async Task AStandaloneConsole_KeepsItsUniFiOsChannel()
     {

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleUpdateTests.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutConsoleUpdateTests.cs
@@ -80,6 +80,79 @@ public class RolloutConsoleUpdateTests
         (await harness.StepAsync(plan.Id, ApMac)).State.Should().Be(FirmwareRolloutStepState.Commanded);
     }
 
+    private static async Task<FirmwareRolloutPlan> SeedNetworkAppPlanWithDebAsync(RolloutHarness harness)
+    {
+        var document = NetworkAppPlan();
+        document.NetworkAppUpdate.Url = "https://example.test/unifi-native.deb";
+        var plan = await harness.SeedScheduledPlanAsync(document, RolloutHarness.Start, Step(ApMac));
+        harness.Observer.Set(ApMac, Online, FromVersion, upgradeTo: ToVersion);
+        return plan;
+    }
+
+    [Fact]
+    public async Task NetworkAppUpdateTakenButNeverInstalled_IsRetriedOverSshOnAFreshBudget()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await SeedNetworkAppPlanWithDebAsync(harness);
+
+        // The console accepted the command and keeps answering on the old build, saying nothing:
+        // the install died inside it. The budget runs out before anything is judged.
+        await harness.TickAsync();
+        await harness.TickAsync(TimeSpan.FromMinutes(2));
+        harness.Commands.Calls.Should().NotContain("ssh-network-app-update");
+
+        await harness.TickAsync(FirmwareRolloutOrchestrator.NetworkAppUpdateBudget);
+
+        harness.Commands.Calls.Where(c => c == "ssh-network-app-update").Should().HaveCount(1);
+        harness.Bus.Published.Should().NotContain(e => e.EventType == RolloutAlerts.NetworkAppUpdateStuck);
+        harness.Commands.UpgradeCommands.Should().BeEmpty();
+        var stored = Stored((await harness.PlanAsync(plan.Id))!);
+        stored.NetworkAppUpdate.SshRetriedAt.Should().NotBeNull();
+        stored.NetworkAppUpdate.Settled.Should().BeFalse();
+
+        harness.Commands.ConsoleInfo!.NetworkApplication!.Version = "9.1.0";
+        await harness.TickAsync(TimeSpan.FromMinutes(2));
+
+        Stored((await harness.PlanAsync(plan.Id))!).NetworkAppUpdate.Outcome.Should().Be("updated");
+        (await harness.StepAsync(plan.Id, ApMac)).State.Should().Be(FirmwareRolloutStepState.Commanded);
+    }
+
+    [Fact]
+    public async Task AConsoleThatReportsTheInstallFailed_IsRetriedOverSshWithoutWaitingOutTheBudget()
+    {
+        using var harness = new RolloutHarness();
+        var plan = await SeedNetworkAppPlanWithDebAsync(harness);
+
+        await harness.TickAsync();
+        harness.Commands.ConsoleInfo!.NetworkApplication!.InstallState = "updateFailed";
+        await harness.TickAsync(TimeSpan.FromMinutes(2));
+
+        harness.Commands.Calls.Where(c => c == "ssh-network-app-update").Should().HaveCount(1);
+        harness.Bus.Published.Should().NotContain(e => e.EventType == RolloutAlerts.NetworkAppUpdateStuck);
+        Stored((await harness.PlanAsync(plan.Id))!).NetworkAppUpdate.Settled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task AnSshRetryThatAlsoFails_IsStuckAndTriedOnce()
+    {
+        using var harness = new RolloutHarness();
+        harness.Commands.SshNetworkAppResult = FirmwareCommandResult.Failed("no route to host");
+        var plan = await SeedNetworkAppPlanWithDebAsync(harness);
+
+        await harness.TickAsync();
+        harness.Commands.ConsoleInfo!.NetworkApplication!.InstallState = "updateFailed";
+        await harness.TickAsync(TimeSpan.FromMinutes(2));
+
+        harness.Commands.Calls.Where(c => c == "ssh-network-app-update").Should().HaveCount(1);
+        var alert = harness.Bus.Published.Single(e => e.EventType == RolloutAlerts.NetworkAppUpdateStuck);
+        alert.Message.Should().Contain("SSH retry");
+        Stored((await harness.PlanAsync(plan.Id))!).NetworkAppUpdate.Outcome.Should().Be("stuck");
+
+        await harness.TickAsync(TimeSpan.FromMinutes(1));
+        harness.Commands.Calls.Where(c => c == "ssh-network-app-update").Should().HaveCount(1);
+        (await harness.StepAsync(plan.Id, ApMac)).State.Should().Be(FirmwareRolloutStepState.Commanded);
+    }
+
     [Fact]
     public async Task NetworkAppUpdateNotComingBack_WarnsAndUpgradesTheDevicesAnyway()
     {

--- a/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutTestDoubles.cs
+++ b/tests/NetworkOptimizer.Web.Tests/Firmware/RolloutTestDoubles.cs
@@ -182,6 +182,9 @@ internal sealed class FakeFirmwareCommandClient : IFirmwareCommandClient
         return Task.FromResult(true);
     }
 
+    /// <summary>False models a console that answers the channel PATCH with 403, as a UCG Fiber did.</summary>
+    public bool ConsoleChannelsAccepted { get; set; } = true;
+
     /// <summary>Writes the channels through to the console info, so a later read sees them.</summary>
     public Task<bool> SetConsoleChannelsAsync(string? networkAppChannel, string? unifiOsChannel, CancellationToken cancellationToken = default)
     {
@@ -190,6 +193,8 @@ internal sealed class FakeFirmwareCommandClient : IFirmwareCommandClient
 
         ConsoleChannelWrites.Add((networkAppChannel, unifiOsChannel));
         Calls.Add("console-channels");
+        if (!ConsoleChannelsAccepted)
+            return Task.FromResult(false);
 
         if (networkAppChannel != null && ConsoleInfo?.NetworkApplication != null)
             ConsoleInfo.NetworkApplication.ReleaseChannel = networkAppChannel;


### PR DESCRIPTION
Release changes for v2.8.3: two Firmware Rollout fixes for a Console that accepts a command and then does something else, and two Client Performance Data Usage fixes for the chart keeping up with the time range.

## Firmware Rollout

- **Fix: a UniFi Network update the Console accepted but never installed** - UniFi OS can take the update, fail inside its own installer before anything changes, and show nothing for it (a UniFi OS 5.1.31 flaw, fixed in 5.1.33; updating from the UniFi Console itself fails the same way on 5.1.31). The rollout used to wait out its budget and move on. It now reads the Console's own install state, notices the failure within a couple of minutes, retries once over SSH with the plan's package on a fresh budget, and carries on once the application answers on the new build. The budget drops from 15 to 10 minutes. UniFi OS Server consoles are excluded from the retry, as at trigger time.
- **Fix: a refused UniFi OS channel switch installed the wrong build** - when the Console refused the channel PATCH (403 No permission), the OS step took whatever build the Console was offering and overwrote the planned target with it, so a plan for Release Candidate installed the Early Access build. The channel apply now reports whether the plan's channel is in force; when it is not, the offer only goes through the API if it is the same build the plan captured. Anything else is declined with a new Warning alert (Firmware Rollout: UniFi OS Update Refused) and the step falls to the existing SSH path with the planned image, or settles as refused.

## Client Performance - Data Usage

- **Fix: the chart lagged a time range picked on another tab** - returning to Data after changing the range on Speed or Signal drew the previous range's chart while the new totals loaded.
- **Fix: two quick range changes flashed the empty state** - the totals now carry a generation, so only the newest request publishes and the cards keep their spinner until it lands.

## Tests

- Firmware: the Network app step retries over SSH when the Console reports updateFailed, when the budget runs out with the Console still on the old build, and only once when the retry also fails.
- Firmware: a refused channel switch declines another channel's build, falls back to the planned image over SSH when one was captured, and still installs through the API when the offer is the planned build.
